### PR TITLE
Fixes typing.Literal import for Python 3.7

### DIFF
--- a/sdk/aqueduct/operators.py
+++ b/sdk/aqueduct/operators.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Any, Literal
+from typing import List, Optional, Union
 import uuid
 
 from pydantic import BaseModel

--- a/src/python/aqueduct_executor/operators/connectors/tabular/spec.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/spec.py
@@ -1,4 +1,10 @@
-from typing import Literal, Union
+from typing import Union
+
+try:
+    from typing import Literal
+except ImportError:
+    # Python 3.7 does not support Literal
+    from typing_extensions import Literal
 
 from pydantic import validator
 

--- a/src/python/aqueduct_executor/operators/connectors/tabular/spec.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/spec.py
@@ -3,7 +3,7 @@ from typing import Union
 try:
     from typing import Literal
 except ImportError:
-    # Python 3.7 does not support Literal
+    # Python 3.7 does not support typing.Literal
     from typing_extensions import Literal
 
 from pydantic import validator

--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -4,7 +4,7 @@ from typing import List
 try:
     from typing import Literal
 except ImportError:
-    # Python 3.7 does not support Literal
+    # Python 3.7 does not support typing.Literal
     from typing_extensions import Literal
 
 from pydantic import BaseModel, Extra, parse_obj_as, validator

--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -4,6 +4,7 @@ from typing import List
 try:
     from typing import Literal
 except ImportError:
+    # Python 3.7 does not support Literal
     from typing_extensions import Literal
 
 from pydantic import BaseModel, Extra, parse_obj_as, validator

--- a/src/python/aqueduct_executor/operators/param_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/param_executor/spec.py
@@ -4,9 +4,9 @@ from pydantic import BaseModel, parse_obj_as
 try:
     from typing import Literal
 except ImportError:
-    # Python 3.7 does not support Literal
+    # Python 3.7 does not support typing.Literal
     from typing_extensions import Literal
-    
+
 from aqueduct_executor.operators.utils import enums
 from aqueduct_executor.operators.utils.storage import config
 

--- a/src/python/aqueduct_executor/operators/param_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/param_executor/spec.py
@@ -1,8 +1,12 @@
 import json
 from pydantic import BaseModel, parse_obj_as
 
-from typing import List, Literal
-
+try:
+    from typing import Literal
+except ImportError:
+    # Python 3.7 does not support Literal
+    from typing_extensions import Literal
+    
 from aqueduct_executor.operators.utils import enums
 from aqueduct_executor.operators.utils.storage import config
 


### PR DESCRIPTION
This PR:
- Fixes the `ImportError` for `typing.Literal` for Python 3.7, by using `typing_extensions.Literal` as a fallback