### PR TITLE
Restrict supported python version to <3.10

### DIFF
--- a/sdk/setup.py
+++ b/sdk/setup.py
@@ -27,5 +27,5 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 3",
     ],
-    python_requires=">=3.7,<=3.10",
+    python_requires=">=3.7,<3.10",
 )


### PR DESCRIPTION
The expression `<=3.10` doesn't make sense since it only includes 3.10.0 and not 3.10.1, 3.10.2, etc.

It doesn't look like our current OSS even supports 3.10, I've filed a task for this: https://linear.app/aqueducthq/issue/ENG-1174/python-310-doesnt-work-with-oss

Error message:
```
Operator success_on_single_metric_input Failed! Error message:
 Traceback (most recent call last):
  File "/Users/kennethxu/.aqueduct/server/storage/operators/3fb8a254-1f92-4324-8e95-21b8ebba936f/op/model.py", line 10, in predict
    return self.func(*args)
  File "/Users/kennethxu/work/aqueduct/integration_tests/sdk/checks_test.py", line -1, in success_on_single_metric_input
SystemError: unknown opcode
```

We should address this issue soon, but in the meantime we should be less confusing with our supported python ranges.