### PR TITLE
Implement support for version upgrade

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -61,13 +61,14 @@ def generate_version_file(file_path):
     with open(file_path, 'w') as f:
         f.write(package_version)
 
+# Returns a bool indicating whether we need to perform a version upgrade.
 def require_update(file_path):
     if not os.path.isfile(file_path):
         return True
     with open(file_path, 'r') as f:
         current_version = f.read()
         if package_version < current_version:
-            raise Exception("Attempting to install an older version %s but found existing installation %s" % (package_version, current_version))
+            raise Exception("Attempting to install an older version %s but found existing newer version %s" % (package_version, current_version))
         elif package_version == current_version:
             return False
         else:

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -57,6 +57,76 @@ def update_executable_permissions():
     execute_command(["chmod", "755", os.path.join(server_directory, "bin", "executor")])
     execute_command(["chmod", "755", os.path.join(server_directory, "bin", "migrator")])
 
+def generate_version_file(file_path):
+    with open(file_path, 'w') as f:
+        f.write(package_version)
+
+def require_update(file_path):
+    if not os.path.isfile(file_path):
+        return True
+    with open(file_path, 'r') as f:
+        current_version = f.read()
+        if package_version < current_version:
+            raise Exception("Attempting to install an older version %s but found existing installation %s" % (package_version, current_version))
+        elif package_version == current_version:
+            return False
+        else:
+            return True
+
+def update_ui_version():
+    print("Updating UI version to %s" % package_version)
+    try:
+        execute_command(["rm", "-rf", ui_directory])
+        os.mkdir(ui_directory)
+        generate_version_file(os.path.join(ui_directory, "__version__"))
+        s3_prefix = "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/%s/ui" % package_version
+        execute_command(["curl", os.path.join(s3_prefix, "ui.zip"), "--output", os.path.join(ui_directory, "ui.zip")])
+        execute_command(["unzip", os.path.join(ui_directory, "ui.zip"), "-d", ui_directory])
+        execute_command(["rm", os.path.join(ui_directory, "ui.zip")])
+        execute_command(["npm", "install"], os.path.join(ui_directory, "app"))
+        execute_command(["npm", "run", "build"], os.path.join(ui_directory, "app"))
+    except Exception as e:
+        print(e)
+        execute_command(["rm", "-rf", ui_directory])
+        exit(1)
+
+def download_golang_binaries(s3_prefix):
+    system = platform.system()
+    arch = platform.machine()
+    if system == "Linux" and arch == "x86_64":
+        print("Operating system is Linux with architecture amd64.")
+        execute_command(["curl", os.path.join(s3_prefix, "bin/linux_amd64/server"), "--output", os.path.join(server_directory, "bin/server")])
+        execute_command(["curl", os.path.join(s3_prefix, "bin/linux_amd64/executor"), "--output", os.path.join(server_directory, "bin/executor")])
+        execute_command(["curl", os.path.join(s3_prefix, "bin/linux_amd64/migrator"), "--output", os.path.join(server_directory, "bin/migrator")])
+    elif system == "Darwin" and arch == "x86_64":
+        print("Operating system is Mac with architecture amd64.")
+        execute_command(["curl", os.path.join(s3_prefix, "bin/darwin_amd64/server"), "--output", os.path.join(server_directory, "bin/server")])
+        execute_command(["curl", os.path.join(s3_prefix, "bin/darwin_amd64/executor"), "--output", os.path.join(server_directory, "bin/executor")])
+        execute_command(["curl", os.path.join(s3_prefix, "bin/darwin_amd64/migrator"), "--output", os.path.join(server_directory, "bin/migrator")])
+    elif system == "Darwin" and arch == "arm64":
+        print("Operating system is Mac with architecture arm64.")
+        execute_command(["curl", os.path.join(s3_prefix, "bin/darwin_arm64/server"), "--output", os.path.join(server_directory, "bin/server")])
+        execute_command(["curl", os.path.join(s3_prefix, "bin/darwin_arm64/executor"), "--output", os.path.join(server_directory, "bin/executor")])
+        execute_command(["curl", os.path.join(s3_prefix, "bin/darwin_arm64/migrator"), "--output", os.path.join(server_directory, "bin/migrator")])
+    else:
+        raise Exception("Unsupported operating system and architecture combination: %s, %s" % (system, arch))
+
+def update_server_version():
+    print("Updating server version to %s" % package_version)
+    if os.path.isfile(os.path.join(server_directory, "__version__")):
+        execute_command(["rm", os.path.join(server_directory, "__version__")])
+    generate_version_file(os.path.join(server_directory, "__version__"))
+
+    s3_prefix = "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/%s/server" % package_version
+    download_golang_binaries(s3_prefix)
+    update_executable_permissions()
+
+    execute_command(["curl", os.path.join(s3_prefix, "bin/start-function-executor.sh"), "--output", os.path.join(server_directory, "bin/start-function-executor.sh")])
+    execute_command(["curl", os.path.join(s3_prefix, "bin/install_sqlserver_ubuntu.sh"), "--output", os.path.join(server_directory, "bin/install_sqlserver_ubuntu.sh")])
+    execute_command(["curl", os.path.join(s3_prefix, "db/demo.db"), "--output", os.path.join(server_directory, "db/demo.db")])
+
+    execute_command([os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "8"])
+
 def server():
     if not os.path.isdir(server_directory):
         try:
@@ -73,41 +143,25 @@ def server():
             for directory in directories:
                 os.mkdir(directory)
 
-            system = platform.system()
-            arch = platform.machine()
-            if system == "Linux" and arch == "x86_64":
-                print("Operating system is Linux with architecture amd64.")
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/linux_amd64/server", "--output", os.path.join(server_directory, "bin", "server")])
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/linux_amd64/executor", "--output", os.path.join(server_directory, "bin", "executor")])
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/linux_amd64/migrator", "--output", os.path.join(server_directory, "bin", "migrator")])
-            elif system == "Darwin" and arch == "x86_64":
-                print("Operating system is Mac with architecture amd64.")
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/darwin_amd64/server", "--output", os.path.join(server_directory, "bin", "server")])
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/darwin_amd64/executor", "--output", os.path.join(server_directory, "bin", "executor")])
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/darwin_amd64/migrator", "--output", os.path.join(server_directory, "bin", "migrator")])
-            elif system == "Darwin" and arch == "arm64":
-                print("Operating system is Mac with architecture arm64.")
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/darwin_arm64/server", "--output", os.path.join(server_directory, "bin", "server")])
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/darwin_arm64/executor", "--output", os.path.join(server_directory, "bin", "executor")])
-                execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/darwin_arm64/migrator", "--output", os.path.join(server_directory, "bin", "migrator")])
-            else:
-                raise Exception("Unsupported operating system and architecture combination: %s, %s" % (system, arch))
-            
-            update_executable_permissions()
+            update_server_version()
 
-            execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/start-function-executor.sh", "--output", os.path.join(server_directory, "bin", "start-function-executor.sh")])
-            execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/bin/install_sqlserver_ubuntu.sh", "--output", os.path.join(server_directory, "bin", "install_sqlserver_ubuntu.sh")])
-            execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/db/demo.db", "--output", os.path.join(server_directory, "db", "demo.db")])
-            execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/config/config.yml", "--output", os.path.join(server_directory, "config", "config.yml")])
-
+            s3_prefix = "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/%s/server" % package_version
+            execute_command(["curl", os.path.join(s3_prefix, "config/config.yml"), "--output", os.path.join(server_directory, "config/config.yml")])
             update_config_yaml(os.path.join(server_directory, "config", "config.yml"))
-
-            execute_command([os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "8"])
 
             print("Finished initializing Aqueduct base directory.")
         except Exception as e:
             print(e)
             execute_command(["rm", "-rf", server_directory])
+            exit(1)
+
+    if require_update(os.path.join(server_directory, "__version__")):
+        try:
+            update_server_version()
+        except Exception as e:
+            print(e)
+            if os.path.isfile(os.path.join(server_directory, "__version__")):
+                execute_command(["rm", os.path.join(server_directory, "__version__")])
             exit(1)
 
     execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml")])
@@ -172,22 +226,15 @@ def install(system):
     else:
         raise Exception("Unsupported system: %s" % system)
 
-def ui(exposeIp):
+def ui(expose_ip):
     if not os.path.isdir(ui_directory):
-        try:
-            os.mkdir(ui_directory)
-            execute_command(["curl", "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/ui/ui.zip", "--output", os.path.join(ui_directory, "ui.zip")])
-            execute_command(["unzip", os.path.join(ui_directory, "ui.zip"), "-d", ui_directory])
-            execute_command(["rm", os.path.join(ui_directory, "ui.zip")])
-            execute_command(["npm", "install"], os.path.join(ui_directory, "app"))
-            execute_command(["npm", "run", "build"], os.path.join(ui_directory, "app"))
-        except Exception as e:
-            print(e)
-            execute_command(["rm", "-rf", ui_directory])
-            exit(1)
+        update_ui_version()
 
-    if exposeIp:
-        server_ip = exposeIp
+    if require_update(os.path.join(ui_directory, "__version__")):
+        update_ui_version()
+
+    if expose_ip:
+        server_ip = expose_ip
         print("The Aqueduct server at " + server_ip + " will be externally accessible.")
     else:
         server_ip = "localhost"


### PR DESCRIPTION
This PR enables our users to update OSS package versions. When they perform `pip3 install --upgrade aqueduct-ml`, if we have a newer version, then when they subsequently execute `aqueduct server` or `aqueduct ui`, we will detect that their current version is older than the package version and fetch the latest binaries from S3. Their existing database state will be untouched.

## Test
Made a dummy version 0.0.2 and verified that the version upgrading from 0.0.1 to 0.0.2 worked.