### PR TITLE
[4/4] Reorg handler codes

### DIFF
--- a/src/golang/cmd/server/handler/archive_notification.go
+++ b/src/golang/cmd/server/handler/archive_notification.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/delete_workflow.go
+++ b/src/golang/cmd/server/handler/delete_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/discover.go
+++ b/src/golang/cmd/server/handler/discover.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/edit_workflow.go
+++ b/src/golang/cmd/server/handler/edit_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"bytes"

--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/get_artifact_versions.go
+++ b/src/golang/cmd/server/handler/get_artifact_versions.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/get_node_positions.go
+++ b/src/golang/cmd/server/handler/get_node_positions.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/get_user_profile.go
+++ b/src/golang/cmd/server/handler/get_user_profile.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/get_workflow.go
+++ b/src/golang/cmd/server/handler/get_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/handler.go
+++ b/src/golang/cmd/server/handler/handler.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aqueducthq/aqueduct/cmd/server/response"
 	"github.com/dropbox/godropbox/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type RequestMethod string
@@ -24,44 +23,6 @@ const (
 
 var ErrUnsupportedAuthMethod = errors.New("Auth method is not supported.")
 
-// Logs the full internal error message and sends the external error message back to the client.
-func HandleError(
-	ctx context.Context,
-	server Server,
-	handlerName string,
-	w http.ResponseWriter,
-	r *http.Request,
-	statusCode int,
-	err error,
-) {
-	if err == nil {
-		log.Fatal("Cannot pass no error into handleError()!")
-	}
-	server.Log(ctx, handlerName, r, statusCode, err)
-
-	var externalMsg string
-	dbxErr, ok := err.(errors.DropboxError)
-	if ok {
-		// Only return the top-level error message to clients.
-		externalMsg = dbxErr.GetMessage()
-	} else {
-		externalMsg = err.Error()
-	}
-	response.SendErrorResponse(w, externalMsg, statusCode)
-}
-
-func HandleSuccess(
-	ctx context.Context,
-	server Server,
-	handler Handler,
-	w http.ResponseWriter,
-	r *http.Request,
-	resp interface{},
-) {
-	server.Log(ctx, handler.Name(), r, http.StatusOK, nil)
-	handler.SendResponse(w, resp)
-}
-
 type Handler interface {
 	Name() string
 	// Extra headers additional to those required by auth.
@@ -78,23 +39,6 @@ type Handler interface {
 	Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error)
 	// Send response back.
 	SendResponse(w http.ResponseWriter, resp interface{})
-}
-
-func ExecuteHandler(server Server, handler Handler) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		args, statusCode, err := handler.Prepare(r)
-		ctx := r.Context()
-		if err != nil {
-			HandleError(ctx, server, handler.Name(), w, r, statusCode, err)
-			return
-		}
-		resp, statusCode, err := handler.Perform(ctx, args)
-		if err != nil {
-			HandleError(ctx, server, handler.Name(), w, r, statusCode, err)
-			return
-		}
-		HandleSuccess(ctx, server, handler, w, r, resp)
-	}
 }
 
 type GetHandler struct{}

--- a/src/golang/cmd/server/handler/list_builtin_functions.go
+++ b/src/golang/cmd/server/handler/list_builtin_functions.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/list_integrations.go
+++ b/src/golang/cmd/server/handler/list_integrations.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/list_notifications.go
+++ b/src/golang/cmd/server/handler/list_notifications.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/preview.go
+++ b/src/golang/cmd/server/handler/preview.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/preview_table.go
+++ b/src/golang/cmd/server/handler/preview_table.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/refresh_workflow.go
+++ b/src/golang/cmd/server/handler/refresh_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"
@@ -17,8 +17,8 @@ import (
 	"github.com/google/uuid"
 )
 
-type refreshWorkflowArgs struct {
-	workflowId uuid.UUID
+type RefreshWorkflowArgs struct {
+	WorkflowId uuid.UUID
 }
 
 // Refresh workflow creates a new workflow version by
@@ -66,8 +66,8 @@ func (h *RefreshWorkflowHandler) Prepare(r *http.Request) (interface{}, int, err
 		return nil, http.StatusBadRequest, errors.Wrap(err, "The organization does not own this workflow.")
 	}
 
-	return &refreshWorkflowArgs{
-		workflowId: workflowId,
+	return &RefreshWorkflowArgs{
+		WorkflowId: workflowId,
 	}, http.StatusOK, nil
 }
 
@@ -76,11 +76,11 @@ func generateWorkflowJobName() string {
 }
 
 func (h *RefreshWorkflowHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
-	args := interfaceArgs.(*refreshWorkflowArgs)
+	args := interfaceArgs.(*RefreshWorkflowArgs)
 
 	workflowObject, err := h.WorkflowReader.GetWorkflow(
 		ctx,
-		args.workflowId,
+		args.WorkflowId,
 		h.Database,
 	)
 	if err != nil {

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"
@@ -199,7 +199,7 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 	} else {
 		// We should create cron jobs for newly created, non-manually triggered workflows.
 		if string(args.workflowDag.Metadata.Schedule.CronSchedule) != "" {
-			err = createWorkflowCronJob(
+			err = CreateWorkflowCronJob(
 				ctx,
 				args.workflowDag.Metadata,
 				h.Database.Config(),
@@ -225,8 +225,8 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 		WorkflowReader: h.WorkflowReader,
 	}).Perform(
 		ctx,
-		&refreshWorkflowArgs{
-			workflowId: workflowId,
+		&RefreshWorkflowArgs{
+			WorkflowId: workflowId,
 		},
 	)
 	if err != nil {
@@ -254,9 +254,9 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 	return registerWorkflowResponse{Id: workflowId}, http.StatusOK, nil
 }
 
-// createWorkflowCronJob creates a k8s cron job
+// CreateWorkflowCronJob creates a k8s cron job
 // that will run the workflow on the specified schedule.
-func createWorkflowCronJob(
+func CreateWorkflowCronJob(
 	ctx context.Context,
 	workflow *workflow.Workflow,
 	dbConfig *database.DatabaseConfig,

--- a/src/golang/cmd/server/handler/reset_api_key.go
+++ b/src/golang/cmd/server/handler/reset_api_key.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/unwatch_workflow.go
+++ b/src/golang/cmd/server/handler/unwatch_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/handler/watch_workflow.go
+++ b/src/golang/cmd/server/handler/watch_workflow.go
@@ -1,4 +1,4 @@
-package server
+package handler
 
 import (
 	"context"

--- a/src/golang/cmd/server/server/cron.go
+++ b/src/golang/cmd/server/server/cron.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/aqueducthq/aqueduct/cmd/server/handler"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 	"github.com/gorhill/cronexpr"
@@ -24,7 +25,7 @@ func (s *AqServer) triggerMissedCronJobs(
 	if lastExpectedTriggerTime > referenceTime.Unix() {
 		// This means that the workflow should have been triggered, but it wasn't.
 		// So we manually trigger the workflow here.
-		_, _, err := (&RefreshWorkflowHandler{
+		_, _, err := (&handler.RefreshWorkflowHandler{
 			Database:       s.Database,
 			JobManager:     s.JobManager,
 			GithubManager:  s.GithubManager,
@@ -32,8 +33,8 @@ func (s *AqServer) triggerMissedCronJobs(
 			WorkflowReader: s.WorkflowReader,
 		}).Perform(
 			ctx,
-			&refreshWorkflowArgs{
-				workflowId: workflowId,
+			&handler.RefreshWorkflowArgs{
+				WorkflowId: workflowId,
 			},
 		)
 		if err != nil {
@@ -101,7 +102,7 @@ func (s *AqServer) initializeWorkflowCronJobs(ctx context.Context) error {
 				wf.Schedule.CronSchedule = ""
 			}
 
-			err = createWorkflowCronJob(
+			err = handler.CreateWorkflowCronJob(
 				ctx,
 				&wf,
 				s.Database.Config(),

--- a/src/golang/cmd/server/server/execute_handler.go
+++ b/src/golang/cmd/server/server/execute_handler.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aqueducthq/aqueduct/cmd/server/handler"
+	"github.com/aqueducthq/aqueduct/cmd/server/response"
+	"github.com/dropbox/godropbox/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// Logs the full internal error message and sends the external error message back to the client.
+func HandleError(
+	ctx context.Context,
+	server Server,
+	handlerName string,
+	w http.ResponseWriter,
+	r *http.Request,
+	statusCode int,
+	err error,
+) {
+	if err == nil {
+		log.Fatal("Cannot pass no error into handleError()!")
+	}
+	server.Log(ctx, handlerName, r, statusCode, err)
+
+	var externalMsg string
+	dbxErr, ok := err.(errors.DropboxError)
+	if ok {
+		// Only return the top-level error message to clients.
+		externalMsg = dbxErr.GetMessage()
+	} else {
+		externalMsg = err.Error()
+	}
+	response.SendErrorResponse(w, externalMsg, statusCode)
+}
+
+func HandleSuccess(
+	ctx context.Context,
+	server Server,
+	handlerObj handler.Handler,
+	w http.ResponseWriter,
+	r *http.Request,
+	resp interface{},
+) {
+	server.Log(ctx, handlerObj.Name(), r, http.StatusOK, nil)
+	handlerObj.SendResponse(w, resp)
+}
+
+func ExecuteHandler(server Server, handlerObj handler.Handler) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		args, statusCode, err := handlerObj.Prepare(r)
+		ctx := r.Context()
+		if err != nil {
+			HandleError(ctx, server, handlerObj.Name(), w, r, statusCode, err)
+			return
+		}
+		resp, statusCode, err := handlerObj.Perform(ctx, args)
+		if err != nil {
+			HandleError(ctx, server, handlerObj.Name(), w, r, statusCode, err)
+			return
+		}
+		HandleSuccess(ctx, server, handlerObj, w, r, resp)
+	}
+}

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -1,22 +1,25 @@
 package server
 
-import "github.com/aqueducthq/aqueduct/cmd/server/routes"
+import (
+	"github.com/aqueducthq/aqueduct/cmd/server/handler"
+	"github.com/aqueducthq/aqueduct/cmd/server/routes"
+)
 
-func (s *AqServer) Handlers() map[string]Handler {
-	return map[string]Handler{
-		routes.ArchiveNotificationRoute: &ArchiveNotificationHandler{
+func (s *AqServer) Handlers() map[string]handler.Handler {
+	return map[string]handler.Handler{
+		routes.ArchiveNotificationRoute: &handler.ArchiveNotificationHandler{
 			NotificationReader: s.NotificationReader,
 			NotificationWriter: s.NotificationWriter,
 			Database:           s.Database,
 		},
-		routes.ConnectIntegrationRoute: &ConnectIntegrationHandler{
+		routes.ConnectIntegrationRoute: &handler.ConnectIntegrationHandler{
 			Database:          s.Database,
 			IntegrationWriter: s.IntegrationWriter,
 			JobManager:        s.JobManager,
 			Vault:             s.Vault,
 			StorageConfig:     s.StorageConfig,
 		},
-		routes.DeleteWorkflowRoute: &DeleteWorkflowHandler{
+		routes.DeleteWorkflowRoute: &handler.DeleteWorkflowHandler{
 			Database:                s.Database,
 			JobManager:              s.JobManager,
 			WorkflowReader:          s.WorkflowReader,
@@ -37,7 +40,7 @@ func (s *AqServer) Handlers() map[string]Handler {
 			ArtifactWriter:          s.ArtifactWriter,
 			ArtifactResultWriter:    s.ArtifactResultWriter,
 		},
-		routes.EditWorkflowRoute: &EditWorkflowHandler{
+		routes.EditWorkflowRoute: &handler.EditWorkflowHandler{
 			Database:       s.Database,
 			WorkflowReader: s.WorkflowReader,
 			WorkflowWriter: s.WorkflowWriter,
@@ -45,29 +48,29 @@ func (s *AqServer) Handlers() map[string]Handler {
 			Vault:          s.Vault,
 			GithubManager:  s.GithubManager,
 		},
-		routes.ExportFunctionRoute: &ExportFunctionHandler{
+		routes.ExportFunctionRoute: &handler.ExportFunctionHandler{
 			Database:          s.Database,
 			OperatorReader:    s.OperatorReader,
 			WorkflowDagReader: s.WorkflowDagReader,
 		},
-		routes.GetArtifactResultRoute: &GetArtifactResultHandler{
+		routes.GetArtifactResultRoute: &handler.GetArtifactResultHandler{
 			Database:             s.Database,
 			ArtifactReader:       s.ArtifactReader,
 			ArtifactResultReader: s.ArtifactResultReader,
 			WorkflowDagReader:    s.WorkflowDagReader,
 		},
-		routes.GetArtifactVersionsRoute: &GetArtifactVersionsHandler{
+		routes.GetArtifactVersionsRoute: &handler.GetArtifactVersionsHandler{
 			Database:     s.Database,
 			CustomReader: s.CustomReader,
 		},
-		routes.GetNodePositionsRoute: &GetNodePositionsHandler{},
-		routes.GetOperatorResultRoute: &GetOperatorResultHandler{
+		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
+		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{
 			Database:             s.Database,
 			OperatorReader:       s.OperatorReader,
 			OperatorResultReader: s.OperatorResultReader,
 		},
-		routes.GetUserProfileRoute: &GetUserProfileHandler{},
-		routes.GetWorkflowRoute: &GetWorkflowHandler{
+		routes.GetUserProfileRoute: &handler.GetUserProfileHandler{},
+		routes.GetWorkflowRoute: &handler.GetWorkflowHandler{
 			Database:                s.Database,
 			ArtifactReader:          s.ArtifactReader,
 			OperatorReader:          s.OperatorReader,
@@ -77,30 +80,30 @@ func (s *AqServer) Handlers() map[string]Handler {
 			WorkflowDagEdgeReader:   s.WorkflowDagEdgeReader,
 			WorkflowDagResultReader: s.WorkflowDagResultReader,
 		},
-		routes.ListBuiltinFunctionsRoute: &ListBuiltinFunctionsHandler{
+		routes.ListBuiltinFunctionsRoute: &handler.ListBuiltinFunctionsHandler{
 			StorageConfig: s.StorageConfig,
 		},
-		routes.ListIntegrationsRoute: &ListIntegrationsHandler{
+		routes.ListIntegrationsRoute: &handler.ListIntegrationsHandler{
 			Database:          s.Database,
 			IntegrationReader: s.IntegrationReader,
 		},
-		routes.ListNotificationsRoute: &ListNotificationsHandler{
+		routes.ListNotificationsRoute: &handler.ListNotificationsHandler{
 			Database:           s.Database,
 			NotificationReader: s.NotificationReader,
 			WorkflowReader:     s.WorkflowReader,
 		},
-		routes.ListWorkflowsRoute: &ListWorkflowsHandler{
+		routes.ListWorkflowsRoute: &handler.ListWorkflowsHandler{
 			Database:       s.Database,
 			WorkflowReader: s.WorkflowReader,
 		},
-		routes.PreviewTableRoute: &PreviewTableHandler{
+		routes.PreviewTableRoute: &handler.PreviewTableHandler{
 			Database:          s.Database,
 			IntegrationReader: s.IntegrationReader,
 			StorageConfig:     s.StorageConfig,
 			JobManager:        s.JobManager,
 			Vault:             s.Vault,
 		},
-		routes.PreviewRoute: &PreviewHandler{
+		routes.PreviewRoute: &handler.PreviewHandler{
 			Database:          s.Database,
 			IntegrationReader: s.IntegrationReader,
 			StorageConfig:     s.StorageConfig,
@@ -108,21 +111,21 @@ func (s *AqServer) Handlers() map[string]Handler {
 			JobManager:        s.JobManager,
 			Vault:             s.Vault,
 		},
-		routes.DiscoverRoute: &DiscoverHandler{
+		routes.DiscoverRoute: &handler.DiscoverHandler{
 			Database:          s.Database,
 			IntegrationReader: s.IntegrationReader,
 			StorageConfig:     s.StorageConfig,
 			JobManager:        s.JobManager,
 			Vault:             s.Vault,
 		},
-		routes.RefreshWorkflowRoute: &RefreshWorkflowHandler{
+		routes.RefreshWorkflowRoute: &handler.RefreshWorkflowHandler{
 			Database:       s.Database,
 			JobManager:     s.JobManager,
 			GithubManager:  s.GithubManager,
 			Vault:          s.Vault,
 			WorkflowReader: s.WorkflowReader,
 		},
-		routes.RegisterWorkflowRoute: &RegisterWorkflowHandler{
+		routes.RegisterWorkflowRoute: &handler.RegisterWorkflowHandler{
 			Database:      s.Database,
 			JobManager:    s.JobManager,
 			GithubManager: s.GithubManager,
@@ -141,7 +144,7 @@ func (s *AqServer) Handlers() map[string]Handler {
 			WorkflowDagEdgeWriter: s.WorkflowDagEdgeWriter,
 			WorkflowWatcherWriter: s.WorkflowWatcherWriter,
 		},
-		routes.ResetApiKeyRoute: &ResetApiKeyHandler{
+		routes.ResetApiKeyRoute: &handler.ResetApiKeyHandler{
 			Database:   s.Database,
 			UserWriter: s.UserWriter,
 		},

--- a/src/golang/cmd/server/server/server.go
+++ b/src/golang/cmd/server/server/server.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/aqueducthq/aqueduct/cmd/server/handler"
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 )
 
 type Server interface {
 	// `Handlers()` returns a map of route:handler which the server handles.
-	Handlers() map[string]Handler
+	Handlers() map[string]handler.Handler
 	// `AddHandler()` specifies how the server initialize with a particular handler.
 	// It's wrapped in `AddAllHandler()` helper and should be called before `Run()`.
-	AddHandler(route string, handler Handler)
+	AddHandler(route string, handler handler.Handler)
 	// `Log()` specifies how an outcome of http request is logged.
 	// Args:
 	//	`key`: additional identifier for the log, for example, the name of the server service.

--- a/src/golang/cmd/server/server/test_account.go
+++ b/src/golang/cmd/server/server/test_account.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 
+	"github.com/aqueducthq/aqueduct/cmd/server/handler"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/user"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
@@ -80,9 +81,9 @@ func ConnectBuiltinIntegration(
 	serviceType := integration.Sqlite
 	builtinConfig := demo.GetSqliteIntegrationConfig()
 
-	if _, err := ConnectIntegration(
+	if _, err := handler.ConnectIntegration(
 		ctx,
-		&ConnectIntegrationArgs{
+		&handler.ConnectIntegrationArgs{
 			AqContext: &aq_context.AqContext{
 				User:      *userObject,
 				RequestId: uuid.New().String(),


### PR DESCRIPTION
This PR adds slightly more clean up to `server` code base by separating out all single-handler codes from server's handler execution codes. This makes it easier to look for handler implementations vs server implementations.

## Tests
Compiles