### PR TITLE
ENG-1193 Fix Hooks Errors

### DIFF
--- a/src/ui/app/pages/account.tsx
+++ b/src/ui/app/pages/account.tsx
@@ -9,28 +9,26 @@ import React from 'react';
 export { getServerSideProps } from '@aqueducthq/common/src/components/pages/getServerSideProps';
 
 const Account: React.FC = () => {
+    const router = useRouter();
     const { user, loading, success } = useUser();
-    if (loading) {
-        return null;
-    }
-
-    if (!success) {
-        const router = useRouter();
-        router.push('/login');
-        return null;
-    }
-
     const { apiAddress } = useAqueductConsts();
-
     const serverAddress = apiAddress ? `${apiAddress}` : '<server address>';
-
     const apiConnectionSnippet = `import aqueduct
 client = aqueduct.Client(
     "${user.apiKey}",
     "${serverAddress}"
 )`;
-
     const maxContentWidth = '600px';
+
+    if (loading) {
+        return null;
+    }
+
+    if (!success) {
+        router.push('/login');
+        return null;
+    }
+
     return (
         <DefaultLayout user={user}>
             <Head>

--- a/src/ui/app/pages/data/index.tsx
+++ b/src/ui/app/pages/data/index.tsx
@@ -6,13 +6,13 @@ import React from 'react';
 export { getServerSideProps } from '@aqueducthq/common/src/components/pages/getServerSideProps';
 
 const Data: React.FC = () => {
+    const router = useRouter();
     const { user, loading, success } = useUser();
     if (loading) {
         return null;
     }
 
-    const router = useRouter();
-    if (!success) {
+    if (!user || !success) {
         router.push('/login');
         return null;
     }

--- a/src/ui/app/pages/index.tsx
+++ b/src/ui/app/pages/index.tsx
@@ -6,13 +6,14 @@ import React from 'react';
 export { getServerSideProps } from '@aqueducthq/common/src/components/pages/getServerSideProps';
 
 const Home: React.FC = () => {
+    const router = useRouter();
     const { user, loading, success } = useUser();
+
     if (loading) {
         return null;
     }
 
     if (!success) {
-        const router = useRouter();
         router.push('/login');
         return null;
     }

--- a/src/ui/app/pages/integrations/index.tsx
+++ b/src/ui/app/pages/integrations/index.tsx
@@ -5,12 +5,13 @@ import React from 'react';
 export { getServerSideProps } from '@aqueducthq/common/src/components/pages/getServerSideProps';
 
 const Integrations: React.FC = () => {
+    const router = useRouter();
     const { user, loading, success } = useUser();
+
     if (loading) {
         return null;
     }
 
-    const router = useRouter();
     if (!success) {
         router.push('/login');
         return null;

--- a/src/ui/app/pages/workflow/[id]/index.tsx
+++ b/src/ui/app/pages/workflow/[id]/index.tsx
@@ -5,18 +5,19 @@ import React from 'react';
 export { getServerSideProps } from '@aqueducthq/common/src/components/pages/getServerSideProps';
 
 const Workflow: React.FC = () => {
+    const router = useRouter();
+    const workflowId = router.query.id as string;
     const { user, loading, success } = useUser();
+
     if (loading) {
         return null;
     }
 
-    const router = useRouter();
-    if (!success) {
+    if (!user || !success) {
         router.push('/login');
         return null;
     }
 
-    const workflowId = router.query.id as string;
     return <WorkflowPage user={user} workflowId={workflowId} />;
 };
 

--- a/src/ui/app/pages/workflows/index.tsx
+++ b/src/ui/app/pages/workflows/index.tsx
@@ -5,13 +5,14 @@ import React from 'react';
 export { getServerSideProps } from '@aqueducthq/common/src/components/pages/getServerSideProps';
 
 const Workflows: React.FC = () => {
+    const router = useRouter();
     const { user, loading, success } = useUser();
+
     if (loading) {
         return null;
     }
 
     if (!success) {
-        const router = useRouter();
         router.push('/login');
         return null;
     }

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -33,6 +33,7 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     (state: RootState) => state.openSideSheetReducer
   );
   const { fitView } = useReactFlow();
+  useEffect(() => { fitView() }, []);
 
   useEffect(() => {
     // NOTE(vikram): There's a timeout here because there seems to be a
@@ -42,7 +43,6 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     setTimeout(fitView, 200);
   }, [openSideSheetState]);
 
-  useEffect(fitView);
   return (
     <ReactFlow
       onPaneClick={onPaneClicked}


### PR DESCRIPTION
Resolves:
https://linear.app/aqueducthq/issue/ENG-1193/fix-bug-where-workflowid-page-does-not-show-and-crashes-app

Fixes bug where the worfklow/[id] page crashed the app. 
Also fixes console.log error where we were calling hooks out of order.