### PR TITLE
Pipe executor logs to the logs directory

### DIFF
--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -94,6 +94,7 @@ def test_publish_with_schedule(sp_client):
         sp_client,
         artifacts=[output_artifact],
         schedule=aqueduct.hourly(minute=aqueduct.Minute(execute_at.minute)),
+        num_runs=2, # Wait for two runs because registering a workflow always triggers an immediate run first.
     )
 
 

--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -42,10 +42,10 @@ if __name__ == "__main__":
     execute_command(["make", "executor"], cwd=os.path.join(cwd, "src"))
     execute_command(["cp", "./src/build/executor", os.path.join(server_directory, "bin", "executor")])
 
-    # Install the local python operators.
-    execute_command(["pip", "install", "."], cwd=os.path.join(cwd, "src", "python"))
-
     # Install the local SDK.
     execute_command(["pip", "install", "."], cwd=os.path.join(cwd, "sdk"))
+
+    # Install the local python operators.
+    execute_command(["pip", "install", "."], cwd=os.path.join(cwd, "src", "python"))
 
     print("Successfully installed aqueduct from local repo!")

--- a/src/golang/cmd/executor/main.go
+++ b/src/golang/cmd/executor/main.go
@@ -4,52 +4,86 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-
 	"github.com/aqueducthq/aqueduct/cmd/executor/executor"
 	"github.com/aqueducthq/aqueduct/lib/job"
+	"github.com/dropbox/godropbox/errors"
 	log "github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
 )
 
 const (
-	jobSpecFlagKey = "spec"
+	jobSpecFlagKey      = "spec"
+	logsFilePathFlagKey = "logs-path"
 )
 
-var spec = flag.String(
+var specSerialized = flag.String(
 	jobSpecFlagKey,
 	"",
 	"The json-serialized cronjob spec to execute.",
 )
 
+var logsFilePath = flag.String(
+	logsFilePathFlagKey,
+	"",
+	"The path to the file the executor will log to. If not set, we'll log to stdout/err.")
+
 func init() {
 	flag.Parse()
 	log.SetFormatter(&log.TextFormatter{DisableQuote: true})
+
+	// Create the directory for the logs if it doesn't already exist.
+	if len(*logsFilePath) > 0 {
+		logsDir := filepath.Dir(*logsFilePath)
+		if _, err := os.Stat(logsDir); errors.IsError(err, os.ErrNotExist) {
+			_ = os.Mkdir(logsDir, os.ModePerm)
+		}
+	}
+}
+
+func redirectLogOutput(filepath string) (*os.File, error) {
+	logsFile, err := os.OpenFile(filepath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, os.ModePerm)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error opening log file.")
+	}
+	log.SetOutput(logsFile)
+	return logsFile, nil
 }
 
 func main() {
-	if err := run(); err != nil {
+	if len(*logsFilePath) > 0 {
+		logFile, err := redirectLogOutput(*logsFilePath)
+		if err != nil {
+			log.Error("Unable to redirect log output.")
+			return
+		}
+		defer logFile.Close()
+	}
+
+	spec, err := job.DecodeSpec(*specSerialized, job.GobSerializationType)
+	if err != nil {
+		log.Errorf("Unable to decode spec. %v", err)
+		return
+	}
+
+	if err := run(spec); err != nil {
 		log.Errorf("Failure when running executor: %v", err)
 	}
 }
 
-func run() error {
-	ctx := context.TODO()
-	spec, err := job.DecodeSpec(*spec, job.GobSerializationType)
-	if err != nil {
-		return err
-	}
-
+func run(spec job.Spec) error {
 	logBytes, err := json.Marshal(spec)
 	if err != nil {
 		return err
 	}
-
 	log.Info(string(logBytes))
 
 	ex, err := executor.NewExecutor(spec)
 	if err != nil {
 		return err
 	}
-
 	defer ex.Close()
+
+	ctx := context.TODO()
 	return ex.Run(ctx)
 }

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -57,10 +57,12 @@ func NewAqServer(conf *config.ServerConfiguration) *AqServer {
 		log.Fatalf("Unable to connect to database: %v", err)
 	}
 
-	jobManager, err := job.NewProcessJobManager(&job.ProcessConfig{
-		BinaryDir:          path.Join(aqPath, job.BinaryDir),
-		OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
-	})
+	jobManager, err := job.NewProcessJobManager(
+		&job.ProcessConfig{
+			BinaryDir:          path.Join(aqPath, job.BinaryDir),
+			OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
+		},
+	)
 	if err != nil {
 		db.Close()
 		log.Fatal("Unable to create job manager: ", err)

--- a/src/golang/lib/job/config.go
+++ b/src/golang/lib/job/config.go
@@ -1,6 +1,8 @@
 package job
 
-import "encoding/gob"
+import (
+	"encoding/gob"
+)
 
 type ManagerType string
 
@@ -14,6 +16,7 @@ type Config interface {
 
 type ProcessConfig struct {
 	BinaryDir             string `yaml:"binaryDir" json:"binary_dir"`
+	LogsDir               string `yaml:"logsDir" json:"logs_dir"`
 	PythonExecutorPackage string `yaml:"pythonExecutorPackage" json:"python_executor_package"`
 	OperatorStorageDir    string `yaml:"operatorStorageDir" json:"operator_storage_dir"`
 }

--- a/src/golang/lib/job/job.go
+++ b/src/golang/lib/job/job.go
@@ -12,6 +12,7 @@ var (
 	ErrNoJobSpec               = errors.New("Job spec doesn't exist.")
 	ErrJobNotExist             = errors.New("Job does not exist.")
 	ErrJobAlreadyExists        = errors.New("Job already exists.")
+	ErrPollJobTimeout          = errors.New("Reached timeout waiting for the job to finish.")
 )
 
 type JobManager interface {

--- a/src/golang/lib/job/poll.go
+++ b/src/golang/lib/job/poll.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
-	"github.com/dropbox/godropbox/errors"
 )
 
 // PollJob waits for the specified job to finish and returns its status.
@@ -33,7 +32,7 @@ func PollJob(
 				return status, nil
 			}
 		case <-timeout.C:
-			return shared.UnknownExecutionStatus, errors.New("Reached timeout waiting for the job to finish.")
+			return shared.UnknownExecutionStatus, ErrPollJobTimeout
 		}
 	}
 }

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -30,11 +30,13 @@ const (
 
 	BinaryDir          = "bin/"
 	OperatorStorageDir = "storage/operators/"
+	LogsDir            = "logs/"
 )
 
 var (
 	defaultBinaryDir          = path.Join(os.Getenv("HOME"), ".aqueduct", BinaryDir)
 	defaultOperatorStorageDir = path.Join(os.Getenv("HOME"), ".aqueduct", OperatorStorageDir)
+	defaultLogsDir            = path.Join(os.Getenv("HOME"), ".aqueduct", "server", LogsDir)
 )
 
 type Command struct {
@@ -128,7 +130,7 @@ func NewProcessJobManager(conf *ProcessConfig) (*ProcessJobManager, error) {
 	}, nil
 }
 
-func (j *ProcessJobManager) mapJobTypeToCmd(spec Spec) (*exec.Cmd, error) {
+func (j *ProcessJobManager) mapJobTypeToCmd(jobName string, spec Spec) (*exec.Cmd, error) {
 	if spec.Type() == WorkflowJobType {
 		workflowSpec, ok := spec.(*WorkflowSpec)
 		if !ok {
@@ -140,10 +142,15 @@ func (j *ProcessJobManager) mapJobTypeToCmd(spec Spec) (*exec.Cmd, error) {
 			return nil, err
 		}
 
+		logFilePath := path.Join(defaultLogsDir, jobName)
+		log.Infof("Logs for job %s are stored in %s", jobName, logFilePath)
+
 		return exec.Command(
 			fmt.Sprintf("%s/%s", j.conf.BinaryDir, workflowExecutorBinary),
 			"--spec",
 			specStr,
+			"--logs-path",
+			logFilePath,
 		), nil
 	} else if spec.Type() == FunctionJobType {
 		functionSpec, ok := spec.(*FunctionSpec)
@@ -194,12 +201,11 @@ func (j *ProcessJobManager) mapJobTypeToCmd(spec Spec) (*exec.Cmd, error) {
 func (j *ProcessJobManager) generateCronFunction(name string, jobSpec Spec) func() {
 	return func() {
 		jobName := fmt.Sprintf("%s-%d", name, time.Now().Unix())
-		log.Infof("Running cron job %s", jobName)
 		err := j.Launch(context.Background(), jobName, jobSpec)
 		if err != nil {
 			log.Errorf("Error running cron job %s: %v", jobName, err)
 		} else {
-			log.Infof("Successfully ran cron job %s", jobName)
+			log.Infof("Launched cron job %s", jobName)
 		}
 	}
 }
@@ -213,11 +219,12 @@ func (j *ProcessJobManager) Launch(
 	name string,
 	spec Spec,
 ) error {
+	log.Infof("Running %s job %s.", spec.Type(), name)
 	if _, ok := j.getCmd(name); ok {
 		return ErrJobAlreadyExists
 	}
 
-	cmd, err := j.mapJobTypeToCmd(spec)
+	cmd, err := j.mapJobTypeToCmd(name, spec)
 	cmd.Env = os.Environ()
 	if err != nil {
 		return err
@@ -256,19 +263,28 @@ func (j *ProcessJobManager) Poll(ctx context.Context, name string) (shared.Execu
 		return shared.PendingExecutionStatus, nil
 	}
 
+	// TODO(ENG-1195): function operators that fail have their exceptions caught, and so return success
+	//  execution status when it should be failure.
+	// TODO(ENG-1196): workflows that do not completely succeed still return a success execution status here.
 	err = command.cmd.Wait()
 	// After wait, we are done with this job and already consumed all of its output, so we garbage
 	// collect the entry in j.cmds.
 	defer j.deleteCmd(name)
 	if err != nil {
-		log.Errorf("Unexpected error occured while executing the job: \nStdout: %s\nStderr: %s",
+		log.Errorf("Unexpected error occured while executing job %s: %v. Stdout: \n %s \n Stderr: \n %s",
+			name,
+			err,
 			command.stdout.String(),
 			command.stderr.String(),
 		)
-
 		return shared.FailedExecutionStatus, nil
 	}
 
+	log.Infof("Job %s Stdout:\n %s \n Stderr: \n %s",
+		name,
+		command.stdout.String(),
+		command.stderr.String(),
+	)
 	return shared.SucceededExecutionStatus, nil
 }
 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -159,6 +159,7 @@ def server(expose_ip):
                 os.path.join(server_directory, "vault"),
                 os.path.join(server_directory, "bin"),
                 os.path.join(server_directory, "config"),
+                os.path.join(server_directory, "logs"),
             ]
 
             for directory in directories:


### PR DESCRIPTION
As we discussed, any jobs being run by the executor should be piped to a file in the `server/logs` directory. We do this by setting the output of the `logrus` library. The naming rules are currently:
- `logs/default`: all logs that were generated in the brief period of time before we are able to redirect logs to the correct file are here.
- `logs/<job name>`: all logs that are generated by the workflow job. Includes all the function/extract/etc logs.
- `logs/Workflow Job Retention`: all logs generated by the long-running workflow job retention job.

There are two bugs I found related to the returned execution status of a job in poll() being SUCCESS when it should have been FAIL. This seems like issues since we rely on poll() within our orchestration engine.
https://linear.app/aqueducthq/issue/ENG-1196/processjobmanagerpoll-returns-successful-execution-status-for
https://linear.app/aqueducthq/issue/ENG-1195/processjobmanagerpoll-returns-successful-execution-status-for

BELOW IS NO LONGER DIRECTLY RELATED TO THE CONTENTS OF THIS PR -------------------------------------------------------------
 
I spent the afternoon poking at the server with bad functions and trying to figure out how to get them to display in the server logs. The solution in this PR might not be the way we want to structure things long term, but it prints out all our operator errors to the console.

In order for us to be able to print the logs of a job launched by the process manager, we need to poll on it. This can be easily done to the cron job function. However, refresh_workflow currently only launches the job and then immediately returns. How will we be able to grab the logs if we don't poll? I've added a comment at the place I'd like to discuss.