### PR TITLE
Add support to let the user configure whether to expose the server to the public

### DIFF
--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -10,10 +10,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var confPath = flag.String(
-	"config",
-	"",
-	"The path to .yml config file",
+var (
+	confPath = flag.String(
+		"config",
+		"",
+		"The path to .yml config file",
+	)
+	expose = flag.Bool("expose", false, "Whether you want to expose the server to the public.")
 )
 
 func main() {
@@ -43,5 +46,5 @@ func main() {
 
 	// Start the HTTP server and listen for requests indefinitely.
 	log.Infof("You can use api key %s to connect to the server", serverConfig.ApiKey)
-	s.Run()
+	s.Run(*expose)
 }

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -230,7 +230,12 @@ func (s *AqServer) Log(ctx context.Context, key string, req *http.Request, statu
 	logging.LogRoute(ctx, key, req, excludedHeaderFields, statusCode, utils.Server, s.Name, err)
 }
 
-func (s *AqServer) Run() {
+func (s *AqServer) Run(expose bool) {
+	ip := ""
+	if !expose {
+		ip = "localhost"
+	}
+
 	log.Infof("%s Starting HTTP server on port %d\n", time.Now().Format("2006-01-02 03:04:05 PM"), connection.ServerInternalPort)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", connection.ServerInternalPort), s.Router))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", ip, connection.ServerInternalPort), s.Router))
 }

--- a/src/golang/cmd/server/server/server.go
+++ b/src/golang/cmd/server/server/server.go
@@ -21,7 +21,7 @@ type Server interface {
 	//	`err`: any error generated when handling the request, which could be nil when successful.
 	Log(ctx context.Context, key string, req *http.Request, statusCode int, err error)
 	// `Run()` should start the server service and handle requests. This will be called in `main()`.
-	Run()
+	Run(expose bool)
 }
 
 func GetAllHeaders(server Server) []string {

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -165,7 +165,6 @@ def server(expose):
                 execute_command(["rm", os.path.join(server_directory, "__version__")])
             exit(1)
 
-    print("expose flag is %s" % expose)
     if expose:
         execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml"), "--expose"])
     else:

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -128,7 +128,7 @@ def update_server_version():
 
     execute_command([os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "8"])
 
-def server():
+def server(expose):
     if not os.path.isdir(server_directory):
         try:
             directories = [
@@ -165,7 +165,11 @@ def server():
                 execute_command(["rm", os.path.join(server_directory, "__version__")])
             exit(1)
 
-    execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml")])
+    print("expose flag is %s" % expose)
+    if expose:
+        execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml"), "--expose"])
+    else:
+        execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml")])
 
 def install_postgres():
     execute_command([sys.executable, "-m", "pip", "install", "psycopg2-binary"])
@@ -266,6 +270,8 @@ if __name__ == "__main__":
                                    '''This starts the Aqueduct server in a
                                    blocking fashion. To background the process,
                                    run aqueduct server &.''')
+    server_args.add_argument('--expose', default=False, action='store_true',
+                    help="Use this option to expose the server to the public.")
     ui_args = subparsers.add_parser('ui', help=
                                '''This starts the Aqueduct UI in a blocking
                                fashion. To background the process run aqueduct
@@ -293,7 +299,7 @@ if __name__ == "__main__":
         os.mkdir(base_directory)
     
     if args.command == "server":
-        server()
+        server(args.expose)
     elif args.command == "install":
         install(args.system[0]) # argparse makes this an array so only pass in value [0].
     elif args.command == "ui":


### PR DESCRIPTION
By default, this is set to False. But if the user wants to expose the port to the public, she can do `aqueduct server --expose`.