### PR TITLE
UI-1035-reduce text in notification

### DIFF
--- a/src/ui/common/src/components/notifications/NotificationListItem.tsx
+++ b/src/ui/common/src/components/notifications/NotificationListItem.tsx
@@ -54,7 +54,6 @@ export const NotificationListItem: React.FC<Props> = ({
               variant="body1"
               gutterBottom
               sx={{
-                fontWeight: 'light',
                 fontFamily: 'Monospace',
                 '&:hover': { textDecoration: 'underline' },
               }}

--- a/src/ui/common/src/components/notifications/NotificationListItem.tsx
+++ b/src/ui/common/src/components/notifications/NotificationListItem.tsx
@@ -54,16 +54,13 @@ export const NotificationListItem: React.FC<Props> = ({
               variant="body1"
               gutterBottom
               sx={{
+                fontWeight: 'medium',
                 fontFamily: 'Monospace',
                 '&:hover': { textDecoration: 'underline' },
               }}
             >
               {notification.workflowMetadata.name}
             </Typography>
-
-            {notification.level === NotificationLogLevel.Success
-              ? ' succeeded'
-              : ' failed'}
           </Typography>
         </Box>
       ) : (
@@ -97,24 +94,13 @@ export const NotificationListItem: React.FC<Props> = ({
           icon={faXmark}
           style={{
             cursor: 'pointer',
-            color: 'gray.600',
+            color: 'gray600',
           }}
           onClick={() =>
             dispatch(handleArchiveNotification({ user, id: notification.id }))
           }
         />
       </Box>
-
-      <Typography
-        variant="h6"
-        gutterBottom
-        sx={{
-          fontFamily: 'Monospace',
-          '&:hover': { textDecoration: 'underline' },
-        }}
-      >
-        {notification.content}
-      </Typography>
 
       <Box
         sx={{
@@ -126,18 +112,25 @@ export const NotificationListItem: React.FC<Props> = ({
         <Box>
           <Typography
             variant="body1"
-            sx={{ fontWeight: 'medium', color: 'gray600' }}
+            sx={{
+              fontWeight: 'light',
+              color: 'gray600',
+              fontFamily: 'Monospace',
+            }}
           >
             {/* Show notification associated with 'workflow_run' as 'workflow' category */}
-            {association.object === NotificationAssociation.WorkflowDagResult
-              ? NotificationAssociation.Workflow
-              : association.object}
+            {notification.level === NotificationLogLevel.Success
+              ? ' Success'
+              : ' Failure'}
           </Typography>
         </Box>
         <Box>
           <Typography
             variant="body1"
-            sx={{ fontWeight: 'light', color: 'gray600' }}
+            sx={{
+              fontWeight: 'light',
+              color: 'gray600',
+            }}
           >
             {`${dateString(notification.createdAt)}`}
           </Typography>

--- a/src/ui/common/src/components/notifications/NotificationListItem.tsx
+++ b/src/ui/common/src/components/notifications/NotificationListItem.tsx
@@ -49,12 +49,12 @@ export const NotificationListItem: React.FC<Props> = ({
             flexDirection: 'row',
           }}
         >
-          <Typography variant="body1" sx={{ color: 'gray800' }}>
+          <Typography variant="body1" sx={{ color: 'gray.800' }}>
             <Typography
               variant="body1"
               gutterBottom
               sx={{
-                fontWeight: 'medium',
+                fontWeight: 'light',
                 fontFamily: 'Monospace',
                 '&:hover': { textDecoration: 'underline' },
               }}
@@ -89,12 +89,21 @@ export const NotificationListItem: React.FC<Props> = ({
           width: '100%',
         }}
       >
-        {title}
+        <Typography
+          variant="h6"
+          gutterBottom
+          sx={{
+            fontFamily: 'Monospace',
+            '&:hover': { textDecoration: 'underline' },
+          }}
+        >
+          {notification.content}
+        </Typography>
         <FontAwesomeIcon
           icon={faXmark}
           style={{
             cursor: 'pointer',
-            color: 'gray600',
+            color: 'gray.600',
           }}
           onClick={() =>
             dispatch(handleArchiveNotification({ user, id: notification.id }))
@@ -105,36 +114,18 @@ export const NotificationListItem: React.FC<Props> = ({
       <Box
         sx={{
           display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'space-between',
+          justifyContent: 'flex-end',
         }}
       >
-        <Box>
-          <Typography
-            variant="body1"
-            sx={{
-              fontWeight: 'light',
-              color: 'gray600',
-              fontFamily: 'Monospace',
-            }}
-          >
-            {/* Show notification associated with 'workflow_run' as 'workflow' category */}
-            {notification.level === NotificationLogLevel.Success
-              ? ' Success'
-              : ' Failure'}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography
-            variant="body1"
-            sx={{
-              fontWeight: 'light',
-              color: 'gray600',
-            }}
-          >
-            {`${dateString(notification.createdAt)}`}
-          </Typography>
-        </Box>
+        <Typography
+          variant="body1"
+          sx={{
+            fontWeight: 'light',
+            color: 'gray.600',
+          }}
+        >
+          {`${dateString(notification.createdAt)}`}
+        </Typography>
       </Box>
     </Box>
   );
@@ -148,11 +139,10 @@ export const NotificationListItem: React.FC<Props> = ({
     <Link
       underline="none"
       color="inherit"
-      href={`/workflow/${
-        notification.workflowMetadata.id
-      }/?workflowDagResultId=${encodeURI(
-        notification.workflowMetadata.dag_result_id
-      )}`}
+      href={`/workflow/${notification.workflowMetadata.id
+        }/?workflowDagResultId=${encodeURI(
+          notification.workflowMetadata.dag_result_id
+        )}`}
     >
       <ListItem
         sx={{


### PR DESCRIPTION
### This PR:
- clean up the messages displayed in the notification list item card

#### Before Clean Up:
<img width="923" alt="image" src="https://user-images.githubusercontent.com/61630725/172076447-28ecec07-b052-4223-9b91-b6faa8160e76.png">

#### After Clean Up:
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/61630725/172256691-a3e12f16-8d60-4922-af72-76d612f9c4d9.png">