### PR TITLE
Enable single CLI command to launch both the server and the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,11 @@ To get started with Aqueduct:
     ```bash
     pip3 install aqueduct-ml
     ```
-3. Launch the server by running: 
+3. Launch both the server and the UI by running: 
     ```bash
-    aqueduct server &
+    aqueduct start
     ```
-4. Launch the web-ui by running:
-    ```bash
-    aqueduct ui &
-    ```
-5. Get your API Key by running:
+4. Get your API Key by running:
     ```bash
     aqueduct apikey
     ```

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -8,6 +8,7 @@ import shutil
 import string
 import subprocess
 import sys
+import time
 import yaml
 
 import distro
@@ -17,6 +18,16 @@ server_directory = os.path.join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = os.path.join(os.environ["HOME"], ".aqueduct", "ui")
 
 package_version = "0.0.1"
+
+welcome_message = """
+***************************************************
+Your API Key: %s
+
+The Web UI is accessible at: http://%s:3000
+
+You can connect to the backend server from your SDK at: http://%s:8080
+***************************************************
+"""
 
 def update_config_yaml(file):
     s=string.ascii_uppercase+string.digits
@@ -135,16 +146,7 @@ def generate_welcome_message(expose_ip):
     if not expose_ip:
         expose_ip = "localhost"
     apikey = get_apikey()
-    message = f"""
-***************************************************
-Your API Key: {apikey}
-
-The Web UI is accessible at: http://{expose_ip}:3000
-
-You can connect to the backend server from your SDK at: http://{expose_ip}:8080
-***************************************************
-"""
-    return message
+    return welcome_message % (apikey, expose_ip, expose_ip)
 
 def server(expose_ip):
     if not os.path.isdir(server_directory):
@@ -333,6 +335,7 @@ if __name__ == "__main__":
         try:
             server_popen = server(args.expose)
             ui_popen = ui(args.expose)
+            time.sleep(2)
             print(generate_welcome_message(args.expose))
             server_popen.wait()
             ui_popen.wait()

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -139,11 +139,9 @@ def generate_welcome_message(expose_ip):
 ***************************************************
 Your API Key: {apikey}
 
-Visit this address in a web browser to see your workflows
-Web UI Address: http://{expose_ip}:3000
+The Web UI is accessible at: http://{expose_ip}:3000
 
-Use this address and to connect your Aqueduct SDK Client 
-Server Address: http://{expose_ip}:8080
+You can connect to the backend server from your SDK at: http://{expose_ip}:8080
 ***************************************************
 """
     return message
@@ -276,7 +274,7 @@ def get_apikey():
             print(exc)
             exit(1)
 
-def apiKey():
+def apikey():
     print(get_apikey())
 
 def clear():
@@ -345,17 +343,19 @@ if __name__ == "__main__":
             ui_popen.kill()
             print('Aqueduct service successfully terminated.')
     elif args.command == "server":
-        print("Command [aqueduct server] has been deprecated in favor of [aqueduct start]")
+        print("aqueduct ui and aqueduct server have been deprecated; please use aqueduct start to run both the UI and backend servers")
     elif args.command == "install":
         install(args.system[0]) # argparse makes this an array so only pass in value [0].
     elif args.command == "ui":
-        print("Command [aqueduct ui] has been deprecated in favor of [aqueduct start]")
+        print("aqueduct ui and aqueduct server have been deprecated; please use aqueduct start to run both the UI and backend servers")
     elif args.command == "apikey":
-        apiKey()
+        apikey()
     elif args.command == "clear":
         clear()
     elif args.command == "version":
         version()
+    elif args.command is None:
+        parser.print_help()
     else:
         print("Unsupported command:", args.command)
         sys.exit(1)

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -52,6 +52,9 @@ def execute_command(args, cwd=None):
         if proc.returncode != 0:
             raise Exception("Error executing command: %s" % args)
 
+def execute_command_nonblocking(args, cwd=None):
+    return subprocess.Popen(args, stdout=sys.stdout, stderr=sys.stderr, cwd=cwd)
+
 def update_executable_permissions():
     execute_command(["chmod", "755", os.path.join(server_directory, "bin", "server")])
     execute_command(["chmod", "755", os.path.join(server_directory, "bin", "executor")])
@@ -128,7 +131,24 @@ def update_server_version():
 
     execute_command([os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "8"])
 
-def server(expose):
+def generate_welcome_message(expose_ip):
+    if not expose_ip:
+        expose_ip = "localhost"
+    apikey = get_apikey()
+    message = f"""
+***************************************************
+Your API Key: {apikey}
+
+Visit this address in a web browser to see your workflows
+Web UI Address: http://{expose_ip}:3000
+
+Use this address and to connect your Aqueduct SDK Client 
+Server Address: http://{expose_ip}:8080
+***************************************************
+"""
+    return message
+
+def server(expose_ip):
     if not os.path.isdir(server_directory):
         try:
             directories = [
@@ -165,10 +185,11 @@ def server(expose):
                 execute_command(["rm", os.path.join(server_directory, "__version__")])
             exit(1)
 
-    if expose:
-        execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml"), "--expose"])
+    if expose_ip:
+        server_popen = execute_command_nonblocking([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml"), "--expose"])
     else:
-        execute_command([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml")])
+        server_popen = execute_command_nonblocking([os.path.join(server_directory, "bin", "server"), "--config", os.path.join(server_directory, "config", "config.yml")])
+    return server_popen
 
 def install_postgres():
     execute_command([sys.executable, "-m", "pip", "install", "psycopg2-binary"])
@@ -244,16 +265,19 @@ def ui(expose_ip):
         server_ip = "localhost"
 
     generate_env_local(server_ip)
-    execute_command(["npm", "run", "start"], os.path.join(ui_directory, "app"))
+    return execute_command_nonblocking(["npm", "run", "start"], os.path.join(ui_directory, "app"))
 
-def apiKey():
+def get_apikey():
     config_file = os.path.join(server_directory, "config", "config.yml")
     with open(config_file, "r") as f:
         try:
-            print(yaml.safe_load(f)['apiKey'])
+            return yaml.safe_load(f)['apiKey']
         except yaml.YAMLError as exc:
             print(exc)
             exit(1)
+
+def apiKey():
+    print(get_apikey())
 
 def clear():
     execute_command(["rm", "-rf", base_directory])
@@ -265,6 +289,16 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='The Aqueduct CLI')
     subparsers = parser.add_subparsers(dest="command")
     
+    start_args = subparsers.add_parser('start', help=
+                               '''This starts the Aqueduct backend server and the UI server in a blocking
+                               fashion. To background the process run aqueduct start &.
+
+                               Add --expose <IP_ADDRESS> to access the Aqueduct service from
+                               an external server, where <IP_ADDRESS> is the
+                               public IP of the server running the Aqueduct service.
+                               ''')
+    start_args.add_argument('--expose', dest="expose", 
+                    help="The IP address of the server running Aqueduct.") 
     server_args = subparsers.add_parser('server', help=
                                    '''This starts the Aqueduct server in a
                                    blocking fashion. To background the process,
@@ -297,12 +331,25 @@ if __name__ == "__main__":
     if not os.path.isdir(base_directory):
         os.mkdir(base_directory)
     
-    if args.command == "server":
-        server(args.expose)
+    if args.command == "start":
+        try:
+            server_popen = server(args.expose)
+            ui_popen = ui(args.expose)
+            print(generate_welcome_message(args.expose))
+            server_popen.wait()
+            ui_popen.wait()
+        except (Exception, KeyboardInterrupt) as e:
+            print(e)
+            print('\nTerminating Aqueduct service...')
+            server_popen.kill()
+            ui_popen.kill()
+            print('Aqueduct service successfully terminated.')
+    elif args.command == "server":
+        print("Command [aqueduct server] has been deprecated in favor of [aqueduct start]")
     elif args.command == "install":
         install(args.system[0]) # argparse makes this an array so only pass in value [0].
     elif args.command == "ui":
-        ui(args.expose)
+        print("Command [aqueduct ui] has been deprecated in favor of [aqueduct start]")
     elif args.command == "apikey":
         apiKey()
     elif args.command == "clear":

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -290,7 +290,7 @@ if __name__ == "__main__":
     subparsers = parser.add_subparsers(dest="command")
     
     start_args = subparsers.add_parser('start', help=
-                               '''This starts the Aqueduct backend server and the UI server in a blocking
+                               '''This starts the Aqueduct server and the UI in a blocking
                                fashion. To background the process run aqueduct start &.
 
                                Add --expose <IP_ADDRESS> to access the Aqueduct service from


### PR DESCRIPTION
Now the users can use `aqueduct start [--expose=<PUBLIC_IP>]` to launch both the server and the UI. When pressing `CTRL-C`, we will terminate both processes as below:
```
Terminating Aqueduct service...
Aqueduct service successfully terminated.
```

At the beginning of running `aqueduct start`, we also show:
```
***************************************************
Your API Key: xxx

Visit this address in a web browser to see your workflows
Web UI Address: http://<IP>:3000

Use this address and to connect your Aqueduct SDK Client 
Server Address: http://<IP>:8080
***************************************************

```