### PR TITLE
Fix a var name in SDK 

### DIFF
--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -117,7 +117,7 @@ def _show_dag(
         operator_mapping[str(operator.id)] = {
             "inputs": [str(v) for v in operator.inputs],
             "outputs": [str(v) for v in operator.outputs],
-            "name": op.name,
+            "name": operator.name,
         }
     for artifact_uuid in dag.list_artifacts():
         artifact_by_id[str(artifact_uuid.id)] = artifact_uuid


### PR DESCRIPTION
This PR fixes a variable name in SDK's node positioning code.

## Tests
I'm able to create a wf after this fix.