### PR TITLE
Fix inflexible sleep in favor of a poll for Github Action integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,8 +72,12 @@ jobs:
         working-directory: src/python
         run: pip3 install .
 
-      - name: Startup the server and wait for it to initialize
-        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &) && sleep 10
+      - name: Start the server
+        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
+
+      - name: Wait for server
+        timeout-minutes: 1
+        run: while ! echo exit | nc localhost 8080; do sleep 1; done
 
       # Grabs the pid of the process bound to port 8080 and kills it.
       - name: Kill the server
@@ -83,11 +87,15 @@ jobs:
       - name: Update aqueduct with latest code
         run: python3 scripts/install_local.py
 
-      - name: Start aqueduct server
-        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &) && sleep 10
+      - name: Start the server again
+        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install packages needed for testing
         run: pip3 install nltk matplotlib pytest-xdist
+
+      - name: Wait for server again
+        timeout-minutes: 1
+        run: while ! echo exit | nc localhost 8080; do sleep 1; done
 
       - name: Fetch the API key
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ name: Integration Tests
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ main, fix_gh_timeouts ] # TODO: REMOVE
     paths:
       - 'src/golang/**'
       - 'src/python/**'

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -41,8 +41,12 @@ jobs:
         working-directory: src/python
         run: pip3 install .
 
-      - name: Startup the server and wait for it to initialize
-        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &) && sleep 10
+      - name: Start the server
+        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
+
+      - name: Wait for server
+        timeout-minutes: 1
+        run: while ! echo exit | nc localhost 8080; do sleep 1; done
 
       # Grabs the pid of the process bound to port 8080 and kills it.
       - name: Kill the server
@@ -52,11 +56,15 @@ jobs:
       - name: Update aqueduct with latest code
         run: python3 scripts/install_local.py
 
-      - name: Start aqueduct server
-        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &) && sleep 10
+      - name: Start the server again
+        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install Packages needed by the notebooks
         run: pip3 install sklearn transformers torch
+
+      - name: Wait for server again
+        timeout-minutes: 1
+        run: while ! echo exit | nc localhost 8080; do sleep 1; done
 
       - name: Fetch the API key
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV


### PR DESCRIPTION
Trying to estimate how long to sleep to wait for server initialization is brittle and broke again today. We should instead just poll for the server at localhost:8080 until a connection can be established.

Taken from the top comment here: https://unix.stackexchange.com/questions/5277/how-do-i-tell-a-script-to-wait-for-a-process-to-start-accepting-requests-on-a-po

Tested and it works.
