### PR TITLE
add requirement delete unit test

### DIFF
--- a/.github/workflows/unit-tests-sdk.yml
+++ b/.github/workflows/unit-tests-sdk.yml
@@ -22,7 +22,7 @@ jobs:
         run: pip3 install .
 
       - name: Install pytest
-        run: pip3 install pytest pyyaml
+        run: pip3 install pytest
 
       - name: Run Tests
         working-directory: ./sdk

--- a/sdk/requirements/python-3-10.txt
+++ b/sdk/requirements/python-3-10.txt
@@ -8,3 +8,4 @@ croniter
 pydantic
 ipynbname
 plotly
+pyyaml

--- a/sdk/requirements/python-3-7.txt
+++ b/sdk/requirements/python-3-7.txt
@@ -8,3 +8,4 @@ croniter
 pydantic
 ipynbname
 plotly
+pyyaml

--- a/sdk/requirements/python-3-8.txt
+++ b/sdk/requirements/python-3-8.txt
@@ -8,3 +8,4 @@ croniter
 pydantic
 ipynbname
 plotly
+pyyaml

--- a/sdk/requirements/python-3-9.txt
+++ b/sdk/requirements/python-3-9.txt
@@ -8,3 +8,4 @@ croniter
 pydantic
 ipynbname
 plotly
+pyyaml


### PR DESCRIPTION
This PR follows up the ENG-1204 where I add .get_apikey() to the sdk, the edition is follow:

- Add `pyyaml` to requirement for each python verion (checked the requirement, it support >=3.6)
- Delete `pyyaml` in `unit-test-sdk` since we don't need to install it again