### PR TITLE
UI-finished implementation to hide success notification

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -18,7 +18,7 @@ import { useLocation } from 'react-router-dom';
 import { handleFetchNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';
 import UserProfile from '../../utils/auth';
-import { NotificationStatus } from '../../utils/notifications';
+import { NotificationStatus, NotificationLogLevel } from '../../utils/notifications';
 import NotificationsPopover from '../notifications/NotificationsPopover';
 import styles from './menu-sidebar-styles.module.css';
 
@@ -115,7 +115,8 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
   const numUnreadNotifications = useSelector(
     (state: RootState) =>
       state.notificationsReducer.notifications.filter(
-        (notification) => notification.status === NotificationStatus.Unread
+        (notification) => notification.level !== NotificationLogLevel.Success && 
+        notification.status === NotificationStatus.Unread
       ).length
   );
 

--- a/src/ui/common/src/components/notifications/NotificationsPopover.tsx
+++ b/src/ui/common/src/components/notifications/NotificationsPopover.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { handleArchiveAllNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';
 import UserProfile from '../../utils/auth';
-import { NotificationAssociation } from '../../utils/notifications';
+import { NotificationAssociation, NotificationLogLevel} from '../../utils/notifications';
 import { Notification } from '../../utils/notifications';
 import { Tab, Tabs } from '../primitives/Tabs.styles';
 import NotificationListItem from './NotificationListItem';
@@ -53,6 +53,9 @@ export const NotificationsPopover: React.FC<NotificationsPopoverProps> = ({
 
   const filteredNotifications: Notification[] = notifications
     .filter((notification: Notification) => {
+      if (notification.level === NotificationLogLevel.Success) {
+        return false
+      }
       const association = notification.association.object;
       if (activeTab === NotificationsTabs.All) {
         return true;


### PR DESCRIPTION
### This PR:
- hide success notification from user

#### Linear Discussion
- https://linear.app/aqueducthq/issue/ENG-1200/disable-success-notifications

### Test
- tested using local dev mode