### PR TITLE
Remove parameter operator from being displayed in _show_dag()

### DIFF
--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -98,7 +98,6 @@ class DAG(BaseModel):
     def list_operators(
         self,
         filter_to: Optional[List[OperatorType]] = None,
-        exclude: Optional[List[OperatorType]] = None,
         on_artifact_id: Optional[uuid.UUID] = None,
     ) -> List[Operator]:
         """Multiple conditions can be applied to filter down the list of operators."""
@@ -106,9 +105,6 @@ class DAG(BaseModel):
 
         if filter_to is not None:
             operators = [op for op in operators if get_operator_type(op) in filter_to]
-
-        if exclude is not None:
-            operators = [op for op in operators if get_operator_type(op) not in exclude]
 
         if on_artifact_id is not None:
             operators = [op for op in operators if on_artifact_id in op.inputs]

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -98,6 +98,7 @@ class DAG(BaseModel):
     def list_operators(
         self,
         filter_to: Optional[List[OperatorType]] = None,
+        exclude: Optional[List[OperatorType]] = None,
         on_artifact_id: Optional[uuid.UUID] = None,
     ) -> List[Operator]:
         """Multiple conditions can be applied to filter down the list of operators."""
@@ -105,6 +106,9 @@ class DAG(BaseModel):
 
         if filter_to is not None:
             operators = [op for op in operators if get_operator_type(op) in filter_to]
+
+        if exclude is not None:
+            operators = [op for op in operators if get_operator_type(op) not in exclude]
 
         if on_artifact_id is not None:
             operators = [op for op in operators if on_artifact_id in op.inputs]


### PR DESCRIPTION
Parameter operators are completely unnecessary nodes. We can just remove param operators after calculating the node positions for them. Does this look weird? I kinda like how the artifacts are all in the same column.

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/6466121/173663223-cc5cd684-3e2a-4039-93d6-a4e01c952aee.png">
