### PR TITLE
Eng 1086 create syntax sugar for sql queries

### DIFF
--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -40,5 +40,7 @@ def test_invalid_destination_integration(client):
 
 def test_sugar_syntax_sql(client):
     db = client.integration(name=get_integration_name())
-    sql_artifact = db.sql(query="select * from hotel_reviews where review_date = {{today}}")
-    assert(sql_artifact.get().empty)
+    sql_artifact_today = db.sql(query="select * from hotel_reviews where review_date = {{today}}")
+    assert(sql_artifact_today.get().empty)
+    sql_artifact_not_today = db.sql(query="select * from hotel_reviews where review_date != {{today}}")
+    assert len(sql_artifact_not_today.get()) == 100

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -38,9 +38,12 @@ def test_invalid_destination_integration(client):
             config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
         )
 
+
 def test_sugar_syntax_sql(client):
     db = client.integration(name=get_integration_name())
     sql_artifact_today = db.sql(query="select * from hotel_reviews where review_date = {{today}}")
-    assert(sql_artifact_today.get().empty)
-    sql_artifact_not_today = db.sql(query="select * from hotel_reviews where review_date != {{today}}")
+    assert sql_artifact_today.get().empty
+    sql_artifact_not_today = db.sql(
+        query="select * from hotel_reviews where review_date != {{today}}"
+    )
     assert len(sql_artifact_not_today.get()) == 100

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -37,3 +37,8 @@ def test_invalid_destination_integration(client):
         output_artifact.save(
             config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
         )
+
+def test_sugar_syntax_sql(client):
+    db = client.integration(name=get_integration_name())
+    sql_artifact = db.sql(query="select * from hotel_reviews where review_date = {{today}}")
+    assert(sql_artifact.get().empty)

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -39,11 +39,11 @@ def test_invalid_destination_integration(client):
         )
 
 
-def test_sugar_syntax_sql(client):
+def test_sql_today_tag(client):
     db = client.integration(name=get_integration_name())
     sql_artifact_today = db.sql(query="select * from hotel_reviews where review_date = {{today}}")
     assert sql_artifact_today.get().empty
     sql_artifact_not_today = db.sql(
-        query="select * from hotel_reviews where review_date != {{today}}"
+        query="select * from hotel_reviews where review_date < {{today}}"
     )
     assert len(sql_artifact_not_today.get()) == 100

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -8,8 +8,8 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from aqueduct_executor.operators.connectors.tabular import connector, extract, load
 
-# Regular Expression that matches any string with "{{ }}"
-# and a word inside with optional space in front or after
+# Regular Expression that matches any substring apperance with
+# "{{ }}" and a word inside with optional space in front or after
 # Potential Matches: "{{today}}", "{{ today  }}""
 TAG_PATTERN = r"{{[\s+]*\w+[\s+]*}}"
 

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -8,6 +8,10 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from aqueduct_executor.operators.connectors.tabular import connector, extract, load
 
+# Regular Expression that matches any string with "{{ }}" 
+# and a word inside with optional space in front or after
+# Potential Matches: "{{today}}", "{{ today  }}""
+TAG_PATTERN = r"{{[\s+]*\w+[\s+]*}}"
 
 class RelationalConnector(connector.TabularConnector):
     def __init__(self, conn_engine: engine.Engine):
@@ -27,7 +31,7 @@ class RelationalConnector(connector.TabularConnector):
 
     def extract(self, params: extract.RelationalParams) -> pd.DataFrame:
         query = params.query
-        matches = re.findall(r"{{[\s+]*\w+[\s+]*}}", query)
+        matches = re.findall(TAG_PATTERN, query)
         for match in matches:
             tag = match.strip(" " "{}")
             if tag == "today":

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -8,10 +8,11 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from aqueduct_executor.operators.connectors.tabular import connector, extract, load
 
-# Regular Expression that matches any string with "{{ }}" 
+# Regular Expression that matches any string with "{{ }}"
 # and a word inside with optional space in front or after
 # Potential Matches: "{{today}}", "{{ today  }}""
 TAG_PATTERN = r"{{[\s+]*\w+[\s+]*}}"
+
 
 class RelationalConnector(connector.TabularConnector):
     def __init__(self, conn_engine: engine.Engine):

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import pandas as pd
+from datetime import date
 from sqlalchemy import engine, inspect
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -24,7 +25,12 @@ class RelationalConnector(connector.TabularConnector):
         return inspect(self.engine).get_table_names()
 
     def extract(self, params: extract.RelationalParams) -> pd.DataFrame:
-        df = pd.read_sql(params.query, con=self.engine)
+        query = params.query
+        if "{{today}}" in query:
+            today_python = date.today()
+            today_sql = "'" + today_python.strftime("%Y-%m-%d") + "'"
+            query = query.replace("{{today}}",today_sql)
+        df = pd.read_sql(query, con=self.engine)
         return df
 
     def load(self, params: load.RelationalParams, df: pd.DataFrame) -> None:

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -29,7 +29,7 @@ class RelationalConnector(connector.TabularConnector):
         if "{{today}}" in query:
             today_python = date.today()
             today_sql = "'" + today_python.strftime("%Y-%m-%d") + "'"
-            query = query.replace("{{today}}",today_sql)
+            query = query.replace("{{today}}", today_sql)
         df = pd.read_sql(query, con=self.engine)
         return df
 

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import pandas as pd
+import re
 from datetime import date
 from sqlalchemy import engine, inspect
 from sqlalchemy.exc import SQLAlchemyError
@@ -26,10 +27,13 @@ class RelationalConnector(connector.TabularConnector):
 
     def extract(self, params: extract.RelationalParams) -> pd.DataFrame:
         query = params.query
-        if "{{today}}" in query:
-            today_python = date.today()
-            today_sql = "'" + today_python.strftime("%Y-%m-%d") + "'"
-            query = query.replace("{{today}}", today_sql)
+        matches = re.findall(r"{{[\s+]*\w+[\s+]*}}",query)
+        for match in matches:
+            key_word = match.strip(" " "{}")
+            if(key_word == "today"):
+                today_python = date.today()
+                today_sql = "'" + today_python.strftime("%Y-%m-%d") + "'"
+                query = query.replace("{{today}}",today_sql)
         df = pd.read_sql(query, con=self.engine)
         return df
 

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -29,8 +29,8 @@ class RelationalConnector(connector.TabularConnector):
         query = params.query
         matches = re.findall(r"{{[\s+]*\w+[\s+]*}}", query)
         for match in matches:
-            key_word = match.strip(" " "{}")
-            if key_word == "today":
+            tag = match.strip(" " "{}")
+            if tag == "today":
                 today_python = date.today()
                 today_sql = "'" + today_python.strftime("%Y-%m-%d") + "'"
                 query = query.replace("{{today}}", today_sql)

--- a/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/relational.py
@@ -27,13 +27,13 @@ class RelationalConnector(connector.TabularConnector):
 
     def extract(self, params: extract.RelationalParams) -> pd.DataFrame:
         query = params.query
-        matches = re.findall(r"{{[\s+]*\w+[\s+]*}}",query)
+        matches = re.findall(r"{{[\s+]*\w+[\s+]*}}", query)
         for match in matches:
             key_word = match.strip(" " "{}")
-            if(key_word == "today"):
+            if key_word == "today":
                 today_python = date.today()
                 today_sql = "'" + today_python.strftime("%Y-%m-%d") + "'"
-                query = query.replace("{{today}}",today_sql)
+                query = query.replace("{{today}}", today_sql)
         df = pd.read_sql(query, con=self.engine)
         return df
 


### PR DESCRIPTION
This PR is the first attempt to create syntax sugar for sql queries, the implementation is the following:
1. In `Aqueduct_executor`, for all database connectors that take in SQL syntax, we process the query when we want to extract a dataframe from the database. If there exist `"{{today}}"` in the SQL syntax, we will replace the substring with today'date. 
2. I have created a test under `sql_integration_test.py`. I search on the dataset `hotel_reviews` based on `review_date = {{today}}`. It should return an empty dataframe. However, this test is not conclusive since there are many input that can result in empty dataframe.

Would appreciate some suggestions~!