### PR TITLE
Add migrator for system metrics schema change

### DIFF
--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -11,6 +11,7 @@ import (
 	_000006 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000006_add_retention_policy_column"
 	_000007 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000007_workflow_dag_edge_pk"
 	_000008 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000008_delete_s3_config"
+	_000009 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000009_metadata_interface_backfill"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -65,5 +66,11 @@ func init() {
 		upPostgres: _000008.UpPostgres, upSqlite: _000008.UpSqlite,
 		downPostgres: _000008.DownPostgres,
 		name:         "delete outdated s3_config column",
+	}
+
+	registeredMigrations[9] = &migration{
+		upPostgres: _000009.Up, upSqlite: _000009.Up,
+		downPostgres: _000009.Down,
+		name:         "backfill metadata in artifact_results",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/main.go
+++ b/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/main.go
@@ -1,0 +1,45 @@
+package _000009_metadata_interface_backfill
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func Up(ctx context.Context, db database.Database) error {
+	resultMetadata, err := getAllArtifactResultOldMetadata(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, artifactResultMetadata := range resultMetadata {
+		if artifactResultMetadata.Metadata.IsNull {
+			continue
+		}
+		err := updateArtifactResultAsNewMetadata(ctx, artifactResultMetadata.Id, artifactResultMetadata.Metadata.OldMetadata, db)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func Down(ctx context.Context, db database.Database) error {
+	resultMetadata, err := getAllArtifactResultNewMetadata(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, artifactResultMetadata := range resultMetadata {
+		if artifactResultMetadata.Metadata.IsNull {
+			continue
+		}
+		err := updateArtifactResultAsOldMetadata(ctx, artifactResultMetadata.Id, artifactResultMetadata.Metadata.Metadata, db)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/queries.go
@@ -47,7 +47,7 @@ func updateArtifactResultAsNewMetadata(
 	db database.Database,
 ) error {
 	newMetadata := &Metadata{
-		Schema:         metadata,
+		Schema:        metadata,
 		SystemMetrics: make(map[string]string),
 	}
 

--- a/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/queries.go
@@ -1,0 +1,72 @@
+package _000009_metadata_interface_backfill
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/google/uuid"
+)
+
+type artifactResultOldMetadataResponse struct {
+	Id       uuid.UUID       `db:"id" json:"id"`
+	Metadata OldNullMetadata `db:"metadata" json:"metadata"`
+}
+
+type artifactResultNewMetadataResponse struct {
+	Id       uuid.UUID    `db:"id" json:"id"`
+	Metadata NullMetadata `db:"metadata" json:"metadata"`
+}
+
+func getAllArtifactResultOldMetadata(
+	ctx context.Context,
+	db database.Database,
+) ([]artifactResultOldMetadataResponse, error) {
+	query := "SELECT id, metadata FROM artifact_result;"
+
+	var response []artifactResultOldMetadataResponse
+	err := db.Query(ctx, &response, query)
+	return response, err
+}
+
+func getAllArtifactResultNewMetadata(
+	ctx context.Context,
+	db database.Database,
+) ([]artifactResultNewMetadataResponse, error) {
+	query := "SELECT id, metadata FROM artifact_result;"
+
+	var response []artifactResultNewMetadataResponse
+	err := db.Query(ctx, &response, query)
+	return response, err
+}
+
+func updateArtifactResultAsNewMetadata(
+	ctx context.Context,
+	id uuid.UUID,
+	metadata OldMetadata,
+	db database.Database,
+) error {
+	newMetadata := &Metadata{
+		Schema:         metadata,
+		SystemMetrics: make(map[string]string),
+	}
+
+	changes := map[string]interface{}{
+		"metadata": newMetadata,
+	}
+
+	return utils.UpdateRecord(ctx, changes, "artifact_result", "id", id, db)
+}
+
+func updateArtifactResultAsOldMetadata(
+	ctx context.Context,
+	id uuid.UUID,
+	metadata Metadata,
+	db database.Database,
+) error {
+	changes := map[string]interface{}{
+		"metadata": metadata.Schema,
+	}
+
+	return utils.UpdateRecord(ctx, changes, "artifact_result", "id", id, db)
+}

--- a/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/types.go
+++ b/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/types.go
@@ -9,7 +9,7 @@ import (
 type OldMetadata []map[string]string
 
 type Metadata struct {
-	Schema         []map[string]string // Table Schema from Pandas
+	Schema        []map[string]string // Table Schema from Pandas
 	SystemMetrics map[string]string   // Metadata from the system
 }
 

--- a/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/types.go
+++ b/src/golang/cmd/migrator/versions/000009_metadata_interface_backfill/types.go
@@ -1,0 +1,86 @@
+package _000009_metadata_interface_backfill
+
+import (
+	"database/sql/driver"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+)
+
+type OldMetadata []map[string]string
+
+type Metadata struct {
+	Schema         []map[string]string // Table Schema from Pandas
+	SystemMetrics map[string]string   // Metadata from the system
+}
+
+type OldNullMetadata struct {
+	OldMetadata
+	IsNull bool
+}
+
+type NullMetadata struct {
+	Metadata
+	IsNull bool
+}
+
+func (m *Metadata) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*m)
+}
+
+func (m *Metadata) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, m)
+}
+
+func (m *OldMetadata) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*m)
+}
+
+func (m *OldMetadata) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, m)
+}
+
+func (n *OldNullMetadata) Value() (driver.Value, error) {
+	if n.IsNull {
+		return nil, nil
+	}
+
+	return (&n.OldMetadata).Value()
+}
+
+func (n *OldNullMetadata) Scan(value interface{}) error {
+	if value == nil {
+		n.IsNull = true
+		return nil
+	}
+
+	metadata := &OldMetadata{}
+	if err := metadata.Scan(value); err != nil {
+		return err
+	}
+
+	n.OldMetadata, n.IsNull = *metadata, false
+	return nil
+}
+
+func (n *NullMetadata) Value() (driver.Value, error) {
+	if n.IsNull {
+		return nil, nil
+	}
+
+	return (&n.Metadata).Value()
+}
+
+func (n *NullMetadata) Scan(value interface{}) error {
+	if value == nil {
+		n.IsNull = true
+		return nil
+	}
+
+	metadata := &Metadata{}
+	if err := metadata.Scan(value); err != nil {
+		return err
+	}
+
+	n.Metadata, n.IsNull = *metadata, false
+	return nil
+}

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -129,7 +129,7 @@ def update_server_version():
     download_server_binaries()
     update_executable_permissions()
 
-    execute_command([os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "8"])
+    execute_command([os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "9"])
 
 def generate_welcome_message(expose, port):
     if not expose:


### PR DESCRIPTION
We have schema changes to the artifact result when we are introducing system metrics in this PR:
https://github.com/aqueducthq/aqueduct/pull/100
this PR has the migrator to ensure that old flows dont break in the system.