### PR TITLE
Fixes schema migrator create cmd

### DIFF
--- a/src/golang/cmd/migrator/migrator/create.go
+++ b/src/golang/cmd/migrator/migrator/create.go
@@ -19,7 +19,7 @@ const (
 	SqlScriptLanguage ScriptLanguage = "sql"
 	GoScriptLanguage  ScriptLanguage = "go"
 
-	migrationFilePath = "internal/migration"
+	migrationFilePath = "golang/cmd/migrator/versions"
 )
 
 type templateArgs struct {
@@ -99,7 +99,7 @@ func nextVersion() (int64, error) {
 		}
 
 		versionStr := s[0]
-		version, err := strconv.ParseInt(versionStr, 0, 64)
+		version, err := strconv.ParseInt(versionStr, 10, 64)
 		if err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
This PR:
- Fixes the `migrator` `create` command by correcting the base filepath to all of the schema change versions.

## Tests
- Tested this out my creating a new schema change template and verified that it was generated correctly in the correct location.