### PR TITLE
Report to our slack channel when tests or notebooks fail

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,14 +109,13 @@ jobs:
           name: Server Logs
           path: logs/
 
-      # TODO(ENG-686): Instead of tagging @kenxu on every failure, tag the offending author.
       - name: Report to Slack on Failure
         if: always()
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
           notification_title: ''
-          message_format: '{emoji} *{workflow}* for recent push has {status_message}'
+          message_format: '{emoji} *{workflow}* has {status_message}'
           footer: '{run_url}'
           notify_when: 'failure,warnings'
           mention_users: 'U025MDH5KS6'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -104,8 +104,21 @@ jobs:
         run: pytest . -rP --publish -n 5
 
       - uses: actions/upload-artifact@v3
-        if: ${{ always() }}
+        if: always()
         with:
           name: Server Logs
           path: logs/
 
+      # TODO(ENG-686): Instead of tagging @kenxu on every failure, tag the offending author.
+      - name: Report to Slack on Failure
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notification_title: ''
+          message_format: '{emoji} *{workflow}* for recent push has {status_message}'
+          footer: '{run_url}'
+          notify_when: 'failure,warnings'
+          mention_users: 'U025MDH5KS6'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -83,3 +83,16 @@ jobs:
         with:
           name: Server Logs
           path: server_logs
+
+      - name: Report to Slack on Failure
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notification_title: ''
+          message_format: '{emoji} *{workflow}* has {status_message}'
+          footer: '{run_url}'
+          notify_when: 'failure,warnings'
+          mention_users: 'U025MDH5KS6,U01JEUX1J2Y,U01J8Q1HUBC'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}


### PR DESCRIPTION
Same as what we do in enterprise. When one of these tests fail, the github channel is notified (tagging me)