### PR TITLE
Fixes UI packaging for macOS

### DIFF
--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -28,5 +28,7 @@ dist:
 	# These are bad hacks that allow us to replace the path in the production
 	# context to use the `/dist` prefix, which we use for routing purposes in the
 	# Go serer.
-	cd app/dist && sed -i "s|src=\"|src=\"/dist|g" index.html
-	cd app/dist &&  sed -i "s|href=\"|href=\"/dist|g" index.html
+	# The `.original` suffix is necessary for macOS. It specifies the file extension
+	# of the original `index.html` file.
+	cd app/dist && sed -i'.original' "s|src=\"|src=\"/dist|g" index.html
+	cd app/dist &&  sed -i'.original' "s|href=\"|href=\"/dist|g" index.html

--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -27,7 +27,7 @@ dist:
 
 	# These are bad hacks that allow us to replace the path in the production
 	# context to use the `/dist` prefix, which we use for routing purposes in the
-	# Go serer.
+	# Go server.
 	# The `.original` suffix is necessary for macOS. It specifies the file extension
 	# of the original `index.html` file.
 	cd app/dist && sed -i'.original' "s|src=\"|src=\"/dist|g" index.html

--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -29,6 +29,6 @@ dist:
 	# context to use the `/dist` prefix, which we use for routing purposes in the
 	# Go server.
 	# The `.original` suffix is necessary for macOS. It specifies the file extension
-	# of the original `index.html` file.
+	# for the copy created of the original `index.html` file.
 	cd app/dist && sed -i'.original' "s|src=\"|src=\"/dist|g" index.html
 	cd app/dist &&  sed -i'.original' "s|href=\"|href=\"/dist|g" index.html


### PR DESCRIPTION
This PR fixes UI packaging via `make dist` for macOS by adding a file extension when using `sed` with the `-i` flag.

See Stack Overflow post here for reference: https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux.

Tests:
Verified that server installation works on macOS and Linux.