### PR TITLE
Parcel Build dist prefixing.

### DIFF
--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -23,10 +23,5 @@ dist:
 	# do this because we run the UI and the backend on the same Go server, so we
 	# don't need to specify an address when making a request.
 	cd app && echo "SERVER_ADDRESS=" > .env
-	cd app && npm run build
+	cd app && npm run build:dist
 
-	# These are bad hacks that allow us to replace the path in the production
-	# context to use the `/dist` prefix, which we use for routing purposes in the
-	# Go serer.
-	cd app/dist && sed -i "s|src=\"|src=\"/dist|g" index.html
-	cd app/dist &&  sed -i "s|href=\"|href=\"/dist|g" index.html

--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "parcel --no-cache --no-hmr index.html",
     "build": "parcel build index.html",
+    "build:dist": "parcel build index.html --public-url dist",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --format table",
     "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --format table --fix"
   },


### PR DESCRIPTION
Adds build:dist option to Makefile to allow for prefixing of all urls in parceljs builds with /dist.

Removes need for using sed after generating bundles.