### PR TITLE
[UI] Fix data page search bar bug showing 'undefined' and not cancel properly

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -18,7 +18,10 @@ import { useLocation } from 'react-router-dom';
 import { handleFetchNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';
 import UserProfile from '../../utils/auth';
-import { NotificationStatus, NotificationLogLevel } from '../../utils/notifications';
+import {
+  NotificationLogLevel,
+  NotificationStatus,
+} from '../../utils/notifications';
 import NotificationsPopover from '../notifications/NotificationsPopover';
 import styles from './menu-sidebar-styles.module.css';
 
@@ -115,8 +118,9 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
   const numUnreadNotifications = useSelector(
     (state: RootState) =>
       state.notificationsReducer.notifications.filter(
-        (notification) => notification.level !== NotificationLogLevel.Success && 
-        notification.status === NotificationStatus.Unread
+        (notification) =>
+          notification.level !== NotificationLogLevel.Success &&
+          notification.status === NotificationStatus.Unread
       ).length
   );
 

--- a/src/ui/common/src/components/notifications/NotificationsPopover.tsx
+++ b/src/ui/common/src/components/notifications/NotificationsPopover.tsx
@@ -8,7 +8,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { handleArchiveAllNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';
 import UserProfile from '../../utils/auth';
-import { NotificationAssociation, NotificationLogLevel} from '../../utils/notifications';
+import {
+  NotificationAssociation,
+  NotificationLogLevel,
+} from '../../utils/notifications';
 import { Notification } from '../../utils/notifications';
 import { Tab, Tabs } from '../primitives/Tabs.styles';
 import NotificationListItem from './NotificationListItem';
@@ -54,7 +57,7 @@ export const NotificationsPopover: React.FC<NotificationsPopoverProps> = ({
   const filteredNotifications: Notification[] = notifications
     .filter((notification: Notification) => {
       if (notification.level === NotificationLogLevel.Success) {
-        return false
+        return false;
       }
       const association = notification.association.object;
       if (activeTab === NotificationsTabs.All) {

--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -20,13 +20,31 @@ type Props = {
   user: UserProfile;
 };
 
-const SearchBar = (options: DataPreviewInfo[], onChangeFn: (any) => void) => {
+const SearchBar = (
+  options: DataPreviewInfo[],
+  onChangeFn: (v: string) => void,
+) => {
   return (
     <Autocomplete
       sx={{ width: 300 }}
       options={options}
+      onInputChange={(_, val, reason) => {
+        if (reason === "clear") {
+          onChangeFn("")
+        }
+
+        onChangeFn(val)
+      }}
       freeSolo
-      getOptionLabel={dataCardName}
+      getOptionLabel={(option) => {
+        // When option string is invalid, non of 'options' will be selected
+        // and the component will try to directly render the input string.
+        // This check prevents applying `dataCardName` to the string.
+        if(typeof option === 'string') {
+          return option;
+        }
+        return dataCardName(option);
+      }}
       renderInput={(params) => {
         params['InputProps']['startAdornment'] = (
           <InputAdornment position="start">
@@ -38,7 +56,7 @@ const SearchBar = (options: DataPreviewInfo[], onChangeFn: (any) => void) => {
             {...params}
             label="Search"
             variant="standard"
-            onChange={onChangeFn}
+            onChange={(e) => onChangeFn(e.target.value)}
           />
         );
       }}
@@ -113,8 +131,9 @@ const DataPage: React.FC<Props> = ({ user }) => {
         <Typography variant="h2" gutterBottom component="div">
           Data
         </Typography>
-        {SearchBar(Object.values(dataCardsInfo.data.latest_versions), (e) =>
-          setFilterText(e.target.value)
+        {SearchBar(
+          Object.values(dataCardsInfo.data.latest_versions),
+          (v) => setFilterText(v),
         )}
 
         <Box sx={{ my: 3, ml: 1 }}>
@@ -126,8 +145,7 @@ const DataPage: React.FC<Props> = ({ user }) => {
               my: 1,
             }}
           >
-            {dataCards.length === 0 && noDataText}
-            {dataCards}
+            {dataCards.length === 0 ? noDataText : dataCards}
           </Box>
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -22,25 +22,25 @@ type Props = {
 
 const SearchBar = (
   options: DataPreviewInfo[],
-  onChangeFn: (v: string) => void,
+  onChangeFn: (v: string) => void
 ) => {
   return (
     <Autocomplete
       sx={{ width: 300 }}
       options={options}
       onInputChange={(_, val, reason) => {
-        if (reason === "clear") {
-          onChangeFn("")
+        if (reason === 'clear') {
+          onChangeFn('');
         }
 
-        onChangeFn(val)
+        onChangeFn(val);
       }}
       freeSolo
       getOptionLabel={(option) => {
         // When option string is invalid, non of 'options' will be selected
         // and the component will try to directly render the input string.
         // This check prevents applying `dataCardName` to the string.
-        if(typeof option === 'string') {
+        if (typeof option === 'string') {
           return option;
         }
         return dataCardName(option);
@@ -131,9 +131,8 @@ const DataPage: React.FC<Props> = ({ user }) => {
         <Typography variant="h2" gutterBottom component="div">
           Data
         </Typography>
-        {SearchBar(
-          Object.values(dataCardsInfo.data.latest_versions),
-          (v) => setFilterText(v),
+        {SearchBar(Object.values(dataCardsInfo.data.latest_versions), (v) =>
+          setFilterText(v)
         )}
 
         <Box sx={{ my: 3, ml: 1 }}>


### PR DESCRIPTION
This PR fixes data page search bar bugs where we show 'undefined: undefined' if user types something random. We also slightly improve the UX by showing all tables if the user cancels search.

Resolves: https://linear.app/aqueducthq/issue/ENG-1229/fix-bug-where-typing-blah-in-the-data-search-box-and-pressing-return

Demo:
https://www.loom.com/share/86c2f81fef85409fb50558b0d6f1398d