### PR TITLE
Adds UI for connecting Airflow integration

### DIFF
--- a/src/ui/common/src/components/integrations/cards/airflowCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/airflowCard.tsx
@@ -1,0 +1,25 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { Integration, AirflowConfig } from '../../../utils/integrations';
+
+type Props = {
+  integration: Integration;
+};
+
+export const AirflowCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as AirflowConfig;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body1">
+        <strong>Host: </strong>
+        {config.host}
+      </Typography>
+      <Typography variant="body1">
+        <strong>Username: </strong>
+        {config.username}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/cards/airflowCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/airflowCard.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 
-import { Integration, AirflowConfig } from '../../../utils/integrations';
+import { AirflowConfig, Integration } from '../../../utils/integrations';
 
 type Props = {
   integration: Integration;

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -10,6 +10,7 @@ import {
   SupportedIntegrations,
 } from '../../../utils/integrations';
 import WorkflowStatus from '../../workflows/workflowStatus';
+import { AirflowCard } from './airflowCard';
 import { AqueductDemoCard } from './aqueductDemoCard';
 import { BigQueryCard } from './bigqueryCard';
 import { LoadSpecsCard } from './loadSpecCard';
@@ -122,6 +123,9 @@ export const IntegrationCard: React.FC<IntegrationProps> = ({
     case 'S3':
       serviceCard = <S3Card integration={integration} />;
       break;
+    case 'Airflow':
+      serviceCard = <AirflowCard integration={integration} />;
+      break;  
     default:
       serviceCard = null;
   }

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -125,7 +125,7 @@ export const IntegrationCard: React.FC<IntegrationProps> = ({
       break;
     case 'Airflow':
       serviceCard = <AirflowCard integration={integration} />;
-      break;  
+      break;
     default:
       serviceCard = null;
   }

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -1,0 +1,65 @@
+import Box from '@mui/material/Box';
+import React, { useEffect, useState } from 'react';
+
+import { IntegrationConfig, AirflowConfig } from '../../../utils/integrations';
+import { IntegrationTextInputField } from './IntegrationTextInputField';
+
+const Placeholders: AirflowConfig = {
+  host: 'http://localhost/api/v1',
+  username: 'aqueduct',
+  password: '********',
+};
+
+type Props = {
+  setDialogConfig: (config: IntegrationConfig) => void;
+};
+
+export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
+  const [address, setAddress] = useState<string>(null);
+  const [username, setUsername] = useState<string>(null);
+  const [password, setPassword] = useState<string>(null);
+
+  useEffect(() => {
+    const config: AirflowConfig = {
+      host: address,
+      username: username,
+      password: password,
+    };
+    setDialogConfig(config);
+  }, [address, username, password]);
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Host *"
+        description="The hostname of the Airflow server."
+        placeholder={Placeholders.host}
+        onChange={(event) => setAddress(event.target.value)}
+        value={address}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Username *"
+        description="The username of a user with access to the above server."
+        placeholder={Placeholders.username}
+        onChange={(event) => setUsername(event.target.value)}
+        value={username}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Password *"
+        description="The password corresponding to the above username."
+        placeholder={Placeholders.password}
+        type="password"
+        onChange={(event) => setPassword(event.target.value)}
+        value={password}
+      />
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import React, { useEffect, useState } from 'react';
 
-import { IntegrationConfig, AirflowConfig } from '../../../utils/integrations';
+import { AirflowConfig, IntegrationConfig } from '../../../utils/integrations';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: AirflowConfig = {

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -23,6 +23,7 @@ import {
   Service,
   SupportedIntegrations,
 } from '../../../utils/integrations';
+import { AirflowDialog } from './airflowDialog';
 import { BigQueryDialog } from './bigqueryDialog';
 import { CSVDialog } from './csvDialog';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
@@ -217,6 +218,9 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
     case 'S3':
       serviceDialog = <S3Dialog setDialogConfig={setConfig} />;
       break;
+    case 'Airflow':
+      serviceDialog = <AirflowDialog setDialogConfig={setConfig} />;
+      break;  
     default:
       return null;
   }

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -220,7 +220,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
       break;
     case 'Airflow':
       serviceDialog = <AirflowDialog setDialogConfig={setConfig} />;
-      break;  
+      break;
     default:
       return null;
   }

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -87,6 +87,12 @@ export type S3Config = {
 
 export type AqueductDemoConfig = Record<string, never>;
 
+export type AirflowConfig = {
+  host: string;
+  username: string;
+  password: string;
+};
+
 export type IntegrationConfig =
   | PostgresConfig
   | SnowflakeConfig
@@ -98,7 +104,8 @@ export type IntegrationConfig =
   | GoogleSheetsConfig
   | SalesforceConfig
   | S3Config
-  | AqueductDemoConfig;
+  | AqueductDemoConfig
+  | AirflowConfig;
 
 export type Service =
   | 'Postgres'
@@ -109,7 +116,8 @@ export type Service =
   | 'MariaDB'
   | 'S3'
   | 'CSV'
-  | 'Aqueduct Demo';
+  | 'Aqueduct Demo'
+  | 'Airflow';
 
 type Info = {
   logo: string;
@@ -261,6 +269,10 @@ export const SupportedIntegrations: ServiceInfoMap = {
   ['SQLite']: {
     logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/sqlite_banner.png',
     activated: false,
+  },
+  ['Airflow']: {
+    logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/sqlite_banner.png',
+    activated: true,
   },
 };
 

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -268,10 +268,10 @@ export const SupportedIntegrations: ServiceInfoMap = {
   },
   ['SQLite']: {
     logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/sqlite_banner.png',
-    activated: false,
+    activated: true,
   },
   ['Airflow']: {
-    logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/sqlite_banner.png',
+    logo: 'https://spiral-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/airflow.png',
     activated: true,
   },
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR:
- Adds support for connecting to Airflow via the UI.
- It uses the same process for connecting to Airflow as the data integrations. We can create separation between data integrations and backend integrations in follow on work.

## Related issue number (if any)
ENG-1275

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


For demo see #141 