### PR TITLE
ENG-1281 Fix IntegrationFileUploadField to be usable for csv & other filetypes

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Input, Typography } from '@mui/material';
-import { DataGrid } from '@mui/x-data-grid';
 import React, { MouseEventHandler, useEffect, useRef } from 'react';
 
+import CodeBlock from '../../../components/layouts/codeblock';
 import { theme } from '../../../styles/theme/theme';
 import { FileData } from '../../../utils/integrations';
 
@@ -14,12 +14,22 @@ type IntegrationFileUploadFieldProps = {
   file: FileData;
   placeholder: string;
   onFiles: (files: FileList) => void;
+  displayFile: null | ((file: FileData) => JSX.Element);
   onReset: MouseEventHandler<HTMLAnchorElement>;
 };
 
 export const IntegrationFileUploadField: React.FC<
   IntegrationFileUploadFieldProps
-> = ({ label, description, required, file, placeholder, onFiles, onReset }) => {
+> = ({
+  label,
+  description,
+  required,
+  file,
+  placeholder,
+  onFiles,
+  displayFile,
+  onReset,
+}) => {
   let header, contents;
   const drop = useRef(undefined);
   const [dragging, setDragging] = React.useState(false);
@@ -94,24 +104,6 @@ export const IntegrationFileUploadField: React.FC<
       </Box>
     );
 
-    const allRows = file.data.split(/\r?\n/);
-    const parsedHeader = ['id'];
-    parsedHeader.push(...allRows[0].split(/,/));
-    const width = 25;
-    const parsedColumns = parsedHeader.map((headerName) => {
-      return {
-        field: headerName,
-        headerName: headerName,
-        width: width * headerName.length,
-      };
-    });
-    const parsedRows = allRows.slice(1).map((line, id) => {
-      const row = line.split(/,/);
-      const parsedRow = { id: id };
-      parsedHeader.forEach((headerName, i) => (parsedRow[headerName] = row[i]));
-      return parsedRow;
-    });
-
     const styling = {
       margin: '16px',
       height: '25vh',
@@ -120,13 +112,11 @@ export const IntegrationFileUploadField: React.FC<
 
     contents = (
       <Box sx={styling}>
-        <DataGrid
-          rows={parsedRows}
-          columns={parsedColumns}
-          pageSize={5}
-          rowsPerPageOptions={[5]}
-          disableSelectionOnClick
-        />
+        {displayFile ? (
+          displayFile(file)
+        ) : (
+          <CodeBlock language="">{file.data}</CodeBlock>
+        )}
       </Box>
     );
   } else {

--- a/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
@@ -2,7 +2,11 @@ import { Box } from '@mui/material';
 import Link from '@mui/material/Link';
 import React, { useEffect, useState } from 'react';
 
-import { BigQueryConfig, IntegrationConfig } from '../../../utils/integrations';
+import {
+  BigQueryConfig,
+  FileData,
+  IntegrationConfig,
+} from '../../../utils/integrations';
 import { IntegrationFileUploadField } from './IntegrationFileUploadField';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
@@ -17,15 +21,18 @@ type Props = {
 export const BigQueryDialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [projectId, setProjectId] = useState<string>(null);
   const [file, setFile] = useState(null);
-  const [credentials, setCredentials] = useState<string>(null);
 
   useEffect(() => {
+    let contents = null;
+    if (file) {
+      contents = file.data;
+    }
     const config: BigQueryConfig = {
       project_id: projectId,
-      service_account_credentials: credentials,
+      service_account_credentials: contents,
     };
     setDialogConfig(config);
-  }, [projectId, credentials]);
+  }, [projectId, file]);
 
   const fileUploadDescription = (
     <>
@@ -61,12 +68,11 @@ export const BigQueryDialog: React.FC<Props> = ({ setDialogConfig }) => {
         placeholder={'Upload your service account key file.'}
         onFiles={(files) => {
           const file = files[0];
-          setFile(file);
-          readCredentialsFile(file, setCredentials);
+          readCredentialsFile(file, setFile);
         }}
+        displayFile={null}
         onReset={(_) => {
           setFile(null);
-          setCredentials(null);
         }}
       />
     </Box>
@@ -75,12 +81,12 @@ export const BigQueryDialog: React.FC<Props> = ({ setDialogConfig }) => {
 
 function readCredentialsFile(
   file: File,
-  setCredentials: (credentials: string) => void
+  setFile: (credentials: FileData) => void
 ) {
   const reader = new FileReader();
   reader.onloadend = function (event) {
     const content = event.target.result as string;
-    setCredentials(content);
+    setFile({ name: file.name, data: content });
   };
   reader.readAsText(file);
 }

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -39,9 +39,7 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     const parsedRows = allRows.slice(1).map((line, id) => {
       const row = line.split(/,/);
       const parsedRow = { id: id };
-      parsedHeader.forEach(
-        (headerName, i) => (parsedRow[headerName] = row[i])
-      );
+      parsedHeader.forEach((headerName, i) => (parsedRow[headerName] = row[i]));
       return parsedRow;
     });
 

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -24,6 +24,37 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     setDialogConfig(config);
   }, [name, csv]);
 
+  const displayFileFn = (file: FileData) => {
+    const allRows = file.data.split(/\r?\n/);
+    const parsedHeader = ['id'];
+    parsedHeader.push(...allRows[0].split(/,/));
+    const width = 25;
+    const parsedColumns = parsedHeader.map((headerName) => {
+      return {
+        field: headerName,
+        headerName: headerName,
+        width: width * headerName.length,
+      };
+    });
+    const parsedRows = allRows.slice(1).map((line, id) => {
+      const row = line.split(/,/);
+      const parsedRow = { id: id };
+      parsedHeader.forEach(
+        (headerName, i) => (parsedRow[headerName] = row[i])
+      );
+      return parsedRow;
+    });
+
+    return (
+      <DataGrid
+        rows={parsedRows}
+        columns={parsedColumns}
+        pageSize={5}
+        rowsPerPageOptions={[5]}
+        disableSelectionOnClick
+      />
+    );
+  };
   return (
     <Box sx={{ mt: 2 }}>
       <Typography>Upload a CSV file to the demo database.</Typography>
@@ -60,37 +91,7 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
             }
           }
         }}
-        displayFile={(file: FileData) => {
-          const allRows = file.data.split(/\r?\n/);
-          const parsedHeader = ['id'];
-          parsedHeader.push(...allRows[0].split(/,/));
-          const width = 25;
-          const parsedColumns = parsedHeader.map((headerName) => {
-            return {
-              field: headerName,
-              headerName: headerName,
-              width: width * headerName.length,
-            };
-          });
-          const parsedRows = allRows.slice(1).map((line, id) => {
-            const row = line.split(/,/);
-            const parsedRow = { id: id };
-            parsedHeader.forEach(
-              (headerName, i) => (parsedRow[headerName] = row[i])
-            );
-            return parsedRow;
-          });
-
-          return (
-            <DataGrid
-              rows={parsedRows}
-              columns={parsedColumns}
-              pageSize={5}
-              rowsPerPageOptions={[5]}
-              disableSelectionOnClick
-            />
-          );
-        }}
+        displayFile={displayFileFn}
         onReset={(_) => {
           setName('');
           setCSV(null);

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -1,8 +1,9 @@
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { DataGrid } from '@mui/x-data-grid';
 import React, { useEffect, useState } from 'react';
 
-import { CSVConfig } from '../../../utils/integrations';
+import { CSVConfig, FileData } from '../../../utils/integrations';
 import { IntegrationFileUploadField } from './IntegrationFileUploadField';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
@@ -58,6 +59,37 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
               reader.readAsText(file);
             }
           }
+        }}
+        displayFile={(file: FileData) => {
+          const allRows = file.data.split(/\r?\n/);
+          const parsedHeader = ['id'];
+          parsedHeader.push(...allRows[0].split(/,/));
+          const width = 25;
+          const parsedColumns = parsedHeader.map((headerName) => {
+            return {
+              field: headerName,
+              headerName: headerName,
+              width: width * headerName.length,
+            };
+          });
+          const parsedRows = allRows.slice(1).map((line, id) => {
+            const row = line.split(/,/);
+            const parsedRow = { id: id };
+            parsedHeader.forEach(
+              (headerName, i) => (parsedRow[headerName] = row[i])
+            );
+            return parsedRow;
+          });
+
+          return (
+            <DataGrid
+              rows={parsedRows}
+              columns={parsedColumns}
+              pageSize={5}
+              rowsPerPageOptions={[5]}
+              disableSelectionOnClick
+            />
+          );
         }}
         onReset={(_) => {
           setName('');


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When the user uploads a file that isn't a csv, it breaks because we try to preview it as a csv. This means it breaks for the bigquery integration file upload.

After this fix, manually tested that I can successfully upload the file to the bigquery integration popup modal and create a bigquery integration.

## Related issue number (if any)
ENG-1281

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ N/A] If this is a new feature, I have added unit tests and integration tests.
- Not a new feature.
- [ N/A] I have manually run the integration tests and they are passing.
- I don't think we have integration tests for UI.
- [x] All features on the UI continue to work correctly.