### PR TITLE
[SDK] Adds parameterization to SQL queries

### DIFF
--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -196,4 +196,3 @@ def test_trigger_flow_with_different_sql_param(client):
         _check_param_vals(flow.latest()._dag, expected_vals=["customer_activity"])
     finally:
         client.delete_flow(flow.id())
-

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -116,12 +116,16 @@ def test_sql_query_user_vs_builtin_precedence(client):
     """If a user defines an expansion that collides with a built-in one, the user-defined one should take precedence."""
     db = client.integration(name=get_integration_name())
 
+    sql_artifact = db.sql(query="select * from hotel_reviews where review_date > {{today}}")
+    builtin_result = sql_artifact.get()
+
     datestring = "'2016-01-01'"
     _ = client.create_param("today", datestring)
     sql_artifact = db.sql(query="select * from hotel_reviews where review_date > {{today}}")
-    assert not sql_artifact.get().empty
+    user_param_result = sql_artifact.get()
+    assert not builtin_result.equals(user_param_result)
 
     expected_sql_artifact = db.sql(
         query="select * from hotel_reviews where review_date > %s" % datestring
     )
-    assert sql_artifact.get().equals(expected_sql_artifact.get())
+    assert user_param_result.equals(expected_sql_artifact.get())

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -1,12 +1,12 @@
 import pytest
-from aqueduct import LoadUpdateMode
-from aqueduct.error import InvalidIntegrationException
+from aqueduct import LoadUpdateMode, metric
+from aqueduct.error import InvalidIntegrationException, InvalidUserArgumentException
 
 from constants import SENTIMENT_SQL_QUERY
 from utils import (
     get_integration_name,
     run_sentiment_model,
-    generate_table_name,
+    generate_table_name, run_flow_test,
 )
 
 
@@ -47,3 +47,55 @@ def test_sql_today_tag(client):
         query="select * from hotel_reviews where review_date < {{today}}"
     )
     assert len(sql_artifact_not_today.get()) == 100
+
+
+def test_sql_query_with_parameter(client):
+    db = client.integration(name=get_integration_name())
+
+    # Missing parameters.
+    with pytest.raises(InvalidUserArgumentException):
+        _ = db.sql(query="select * from {{missing_parameter}}")
+
+    # The parameter is not a string type.
+    _ = client.create_param("table_name", default=1234)
+    with pytest.raises(InvalidUserArgumentException):
+        _ = db.sql(query="select * from {{ table_name }}")
+
+    client.create_param("table_name", default="hotel_reviews")
+    sql_artifact = db.sql(query="select * from {{ table_name }}")
+
+    expected_sql_artifact = db.sql(query="select * from hotel_reviews")
+    assert sql_artifact.get().equals(expected_sql_artifact.get())
+    expected_sql_artifact = db.sql(query="select * from customer_activity")
+    assert sql_artifact.get(parameters={"table_name": "customer_activity"}).equals(expected_sql_artifact.get())
+
+    # Trigger the parameter with invalid values.
+    with pytest.raises(InvalidUserArgumentException):
+        _ = sql_artifact.get(parameters={"table_name": ["this is the incorrect type"]})
+    with pytest.raises(InvalidUserArgumentException):
+        _ = sql_artifact.get(parameters={"non-existant parameter": "blah"})
+
+
+def test_sql_query_with_multiple_parameters(client):
+    db = client.integration(name=get_integration_name())
+
+    _ = client.create_param("table_name", default="hotel_reviews")
+    nationality = client.create_param("reviewer_nationality", default="United Kingdom")
+    sql_artifact = db.sql(
+        query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer_nationality }}' and review_date < {{ today}}"
+    )
+    expected_sql_artifact = db.sql("select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}")
+    assert sql_artifact.get().equals(expected_sql_artifact.get())
+    expected_sql_artifact = db.sql("select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}")
+    assert sql_artifact.get(parameters={"reviewer_nationality": "Australia"}).equals(expected_sql_artifact.get())
+
+    # Use the parameters in another operator.
+    @metric
+    def noop(sql_output, param):
+        return len(param)
+
+    result = noop(sql_artifact, nationality)
+    assert result.get() == len(nationality.get())
+    assert result.get(parameters={"reviewer_nationality": "Australia"}) == len("Australia")
+
+    run_flow_test(client, artifacts=[result])

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -83,9 +83,11 @@ def test_sql_query_with_multiple_parameters(client):
     db = client.integration(name=get_integration_name())
 
     _ = client.create_param("table_name", default="hotel_reviews")
-    nationality = client.create_param("reviewer_nationality", default="United Kingdom")
+    nationality = client.create_param(
+        "reviewer-nationality", default="United Kingdom"
+    )  # check that dashes work.
     sql_artifact = db.sql(
-        query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer_nationality }}' and review_date < {{ today}}"
+        query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer-nationality }}' and review_date < {{ today}}"
     )
     expected_sql_artifact = db.sql(
         "select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}"
@@ -94,7 +96,7 @@ def test_sql_query_with_multiple_parameters(client):
     expected_sql_artifact = db.sql(
         "select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}"
     )
-    assert sql_artifact.get(parameters={"reviewer_nationality": "Australia"}).equals(
+    assert sql_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
         expected_sql_artifact.get()
     )
 
@@ -105,6 +107,6 @@ def test_sql_query_with_multiple_parameters(client):
 
     result = noop(sql_artifact, nationality)
     assert result.get() == len(nationality.get())
-    assert result.get(parameters={"reviewer_nationality": "Australia"}) == len("Australia")
+    assert result.get(parameters={"reviewer-nationality": "Australia"}) == len("Australia")
 
     run_flow_test(client, artifacts=[result])

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -6,7 +6,8 @@ from constants import SENTIMENT_SQL_QUERY
 from utils import (
     get_integration_name,
     run_sentiment_model,
-    generate_table_name, run_flow_test,
+    generate_table_name,
+    run_flow_test,
 )
 
 
@@ -67,7 +68,9 @@ def test_sql_query_with_parameter(client):
     expected_sql_artifact = db.sql(query="select * from hotel_reviews")
     assert sql_artifact.get().equals(expected_sql_artifact.get())
     expected_sql_artifact = db.sql(query="select * from customer_activity")
-    assert sql_artifact.get(parameters={"table_name": "customer_activity"}).equals(expected_sql_artifact.get())
+    assert sql_artifact.get(parameters={"table_name": "customer_activity"}).equals(
+        expected_sql_artifact.get()
+    )
 
     # Trigger the parameter with invalid values.
     with pytest.raises(InvalidUserArgumentException):
@@ -84,10 +87,16 @@ def test_sql_query_with_multiple_parameters(client):
     sql_artifact = db.sql(
         query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer_nationality }}' and review_date < {{ today}}"
     )
-    expected_sql_artifact = db.sql("select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}")
+    expected_sql_artifact = db.sql(
+        "select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}"
+    )
     assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = db.sql("select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}")
-    assert sql_artifact.get(parameters={"reviewer_nationality": "Australia"}).equals(expected_sql_artifact.get())
+    expected_sql_artifact = db.sql(
+        "select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}"
+    )
+    assert sql_artifact.get(parameters={"reviewer_nationality": "Australia"}).equals(
+        expected_sql_artifact.get()
+    )
 
     # Use the parameters in another operator.
     @metric

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -482,7 +482,6 @@ class UpdateParametersDelta(DAGDelta):
                         % (param_name, type(new_val).__name__)
                     )
 
-
             # Update the parameter value and update the dag.
             assert param_op.spec.param  # for mypy
             param_op.spec.param.val = serialize_parameter_value(

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -471,6 +471,18 @@ class UpdateParametersDelta(DAGDelta):
                     % (param_name, get_operator_type(param_op))
                 )
 
+            # Any parameter that is consumed by a SQL operator must be a string type!
+            assert len(param_op.outputs) == 1
+            param_artifact_id = param_op.outputs[0]
+            ops_on_param = dag.list_operators(on_artifact_id=param_artifact_id)
+            if any(get_operator_type(op) == OperatorType.EXTRACT for op in ops_on_param):
+                if not isinstance(new_val, str):
+                    raise InvalidUserArgumentException(
+                        "Parameter %s is used by a sql query, so it must be a string type, not type %s."
+                        % (param_name, type(new_val).__name__)
+                    )
+
+
             # Update the parameter value and update the dag.
             assert param_op.spec.param  # for mypy
             param_op.spec.param.val = serialize_parameter_value(

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -152,13 +152,12 @@ class RelationalDBIntegration(Integration):
             matches = re.findall(TAG_PATTERN, extract_params.query)
             for match in matches:
                 param_name = match.strip(" {}")
-
-                # If it is a built-in tag, we can ignore it for now, since the python operators will perform the expansion.
-                if param_name in BUILT_IN_EXPANSIONS:
-                    continue
-
                 param_op = self._dag.get_operator(with_name=param_name)
                 if param_op is None:
+                    # If it is a built-in tag, we can ignore it for now, since the python operators will perform the expansion.
+                    if param_name in BUILT_IN_EXPANSIONS:
+                        continue
+
                     raise InvalidUserArgumentException(
                         "There is no parameter defined with name `%s`." % param_name,
                     )

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -167,7 +167,8 @@ class RelationalDBIntegration(Integration):
             param_val = json.loads(param_op.spec.param.val)
             if not isinstance(param_val, str):
                 raise InvalidUserArgumentException(
-                    "The parameter `%s` must be defined as a string. Instead, got type %s" % (param_name, type(param_val).__name__)
+                    "The parameter `%s` must be defined as a string. Instead, got type %s"
+                    % (param_name, type(param_val).__name__)
                 )
             assert len(param_op.outputs) == 1
             sql_input_artifact_ids.append(param_op.outputs[0])

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -1,4 +1,7 @@
+import json
+
 import pandas as pd
+import re
 from typing import Optional, Union
 
 from aqueduct.api_client import APIClient
@@ -8,6 +11,7 @@ from aqueduct.enums import (
     ServiceType,
     LoadUpdateMode,
 )
+from aqueduct.error import InvalidUserArgumentException
 from aqueduct.integrations.integration import IntegrationInfo, Integration
 from aqueduct.operators import (
     Operator,
@@ -29,6 +33,20 @@ LIST_TABLES_QUERY_SQLSERVER = (
 LIST_TABLES_QUERY_BIGQUERY = "SELECT schema_name FROM information_schema.schemata;"
 GET_TABLE_QUERY = "select * from %s"
 LIST_TABLES_QUERY_SQLITE = "SELECT name FROM sqlite_master WHERE type='table';"
+
+# Regular Expression that matches any substring appearance with
+# "{{ }}" and a word inside with optional space in front or after
+# Potential Matches: "{{today}}", "{{ today  }}""
+#
+# Duplicated in the Python operators at `src/python/aqueduct_executor/operators/connectors/tabular/extract.py`
+# Make sure the two are in sync.
+TAG_PATTERN = r"{{\s*\w+\s*}}"
+
+# A dictionary of built-in tags to their replacement0 string functions.
+#
+# Duplicated in spirit by the Python operators at `src/python/aqueduct_executor/operators/connectors/tabular/extract.py`
+# Make sure the two are in sync.
+BUILT_IN_EXPANSIONS = {"today"}
 
 
 class RelationalDBIntegration(Integration):
@@ -127,14 +145,41 @@ class RelationalDBIntegration(Integration):
                 query=extract_params,
             )
 
-        operator_id = generate_uuid()
-        output_artifact_id = generate_uuid()
+        # Find any tags that need to be expanded in the query, and add the parameters that correspond
+        # to these tags as inputs to this operator. The orchestration engine will perform the replacement at runtime.
+        sql_input_artifact_ids = []
+        matches = re.findall(TAG_PATTERN, extract_params.query)
+        for match in matches:
+            param_name = match.strip(" {}")
+
+            # If it is a built-in tag, we can ignore it for now, since the python operators will perform the expansion.
+            if param_name in BUILT_IN_EXPANSIONS:
+                continue
+
+            param_op = self._dag.get_operator(with_name=param_name)
+            if param_op is None:
+                raise InvalidUserArgumentException(
+                    "There is no parameter defined with name `%s`." % param_name,
+                )
+
+            # Check that the parameter corresponds to a string value.
+            assert param_op.spec.param is not None
+            param_val = json.loads(param_op.spec.param.val)
+            if not isinstance(param_val, str):
+                raise InvalidUserArgumentException(
+                    "The parameter `%s` must be defined as a string. Instead, got type %s" % (param_name, type(param_val).__name__)
+                )
+            assert len(param_op.outputs) == 1
+            sql_input_artifact_ids.append(param_op.outputs[0])
+
+        sql_operator_id = generate_uuid()
+        sql_output_artifact_id = generate_uuid()
         apply_deltas_to_dag(
             self._dag,
             deltas=[
                 AddOrReplaceOperatorDelta(
                     op=Operator(
-                        id=operator_id,
+                        id=sql_operator_id,
                         name=sql_op_name,
                         description=description,
                         spec=OperatorSpec(
@@ -144,23 +189,24 @@ class RelationalDBIntegration(Integration):
                                 parameters=extract_params,
                             )
                         ),
-                        outputs=[output_artifact_id],
+                        inputs=sql_input_artifact_ids,
+                        outputs=[sql_output_artifact_id],
                     ),
                     output_artifacts=[
                         Artifact(
-                            id=output_artifact_id,
+                            id=sql_output_artifact_id,
                             name=artifact_name_from_op_name(sql_op_name),
                             spec=ArtifactSpec(table={}),
                         ),
                     ],
-                )
+                ),
             ],
         )
 
         return TableArtifact(
             api_client=self._api_client,
             dag=self._dag,
-            artifact_id=output_artifact_id,
+            artifact_id=sql_output_artifact_id,
         )
 
     def config(self, table: str, update_mode: LoadUpdateMode) -> SaveConfig:

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -40,7 +40,7 @@ LIST_TABLES_QUERY_SQLITE = "SELECT name FROM sqlite_master WHERE type='table';"
 #
 # Duplicated in the Python operators at `src/python/aqueduct_executor/operators/connectors/tabular/extract.py`
 # Make sure the two are in sync.
-TAG_PATTERN = r"{{\s*\w+\s*}}"
+TAG_PATTERN = r"{{\s*[\w-]+\s*}}"
 
 # A dictionary of built-in tags to their replacement0 string functions.
 #

--- a/sdk/aqueduct/table_artifact.py
+++ b/sdk/aqueduct/table_artifact.py
@@ -44,7 +44,8 @@ from aqueduct.operators import (
     FunctionSpec,
     MetricSpec,
     SystemMetricSpec,
-    CheckSpec, get_operator_type,
+    CheckSpec,
+    get_operator_type,
 )
 from aqueduct.utils import (
     serialize_function,

--- a/sdk/aqueduct/table_artifact.py
+++ b/sdk/aqueduct/table_artifact.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Callable, Any, Optional, Dict, Union, List
+from typing import Any, Optional, Dict, Union, List
 import uuid
 
 from great_expectations.data_context.types.base import (
@@ -11,7 +11,6 @@ from great_expectations.data_context.types.base import (
 )
 from great_expectations.data_context import BaseDataContext
 
-from great_expectations import DataContext
 from great_expectations.core import ExpectationSuite, ExpectationConfiguration
 from great_expectations.core.batch import RuntimeBatchRequest
 from great_expectations.validator.validator import Validator
@@ -45,7 +44,7 @@ from aqueduct.operators import (
     FunctionSpec,
     MetricSpec,
     SystemMetricSpec,
-    CheckSpec,
+    CheckSpec, get_operator_type,
 )
 from aqueduct.utils import (
     serialize_function,
@@ -97,6 +96,11 @@ class TableArtifact(Artifact):
 
     def get(self, parameters: Optional[Dict[str, Any]] = None) -> pd.DataFrame:
         """Materializes TableArtifact into an actual dataframe.
+
+        Args:
+            parameters:
+                A map from parameter name to its custom value, to be used when evaluating
+                this artifact.
 
         Returns:
             A dataframe containing the tabular contents of this artifact.

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -1,7 +1,7 @@
 import re
-from typing import Any, Optional, Union, List, Dict
+from typing import Any, Optional, Union, Dict
 from datetime import date
-from aqueduct_executor.operators.connectors.tabular import common, models, spec
+from aqueduct_executor.operators.connectors.tabular import common, models
 
 # Regular Expression that matches any substring appearance with
 # "{{ }}" and a word inside with optional space in front or after

--- a/src/python/aqueduct_executor/operators/function_executor/execute_function.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute_function.py
@@ -105,7 +105,7 @@ def _import_invoke_method(spec: spec.FunctionSpec) -> Callable[..., DataFrame]:
 
 def _execute_function(
     spec: spec.FunctionSpec,
-    inputs: List[utils.InputArtifact],
+    inputs: List[Any],
 ) -> Tuple[Any, Dict[str, str], str, Dict[str, str]]:
     """
     Invokes the given function on the input data. Does not raise an exception on any


### PR DESCRIPTION
## Describe your changes and why you are making these changes
These are the API changes:
```
table_name_param = client.create_param("table_name", default="hotel_reviews")
sql_artifact = db.sql("select * from {table_name}")

sql_artifact.get(parameters={"table_name": "other table"})
```
 The parameter name can have underscores and dashes, but cannot have spaces. If there are spaces, it won't get picked up as a tag and the query will likely fail.


## Related issue number (if any)
ENG-1258

## Checklist before requesting a review
- [ x] I have performed a self-review of my code.
- [ x] If this is a new feature, I have added unit tests and integration tests.
- [ x ] I have manually run the integration tests and they are passing.
- [ ] All features on the UI continue to work correctly.