### PR TITLE
Creates pre-merge integration test check

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,7 @@
 name: Integration Tests
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: [ main ]
@@ -14,28 +15,9 @@ on:
     types: [ created ]
 
 jobs:
-  check-comment-trigger:
-    name: Check Comment Trigger
-    runs-on: ubuntu-latest
-    outputs:
-      is-comment-triggered: ${{ steps.check_comment.outputs.triggered }}
-    timeout-minutes: 5
-    steps:
-      - name: Check for Comment triggers
-        if: ${{ github.event_name == 'issue_comment' }}
-        uses: khan/pull-request-comment-trigger@master
-        id: check_comment
-        with:
-          trigger: 'ci'
-          prefix_only: 'true'
-          reaction: rocket
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
   run-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: check-comment-trigger
-    if: ${{ github.event_name != 'issue_comment' || needs.check-comment-trigger.outputs.is-comment-triggered == 'true' }}
     strategy:
       matrix:
         # These are all the Python versions that we support.

--- a/.github/workflows/pre-merge-ci.yml
+++ b/.github/workflows/pre-merge-ci.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   trigger-integration-tests:
-    uses: aqueducthq/aqueduct/.github/workflows/integration-tests.yml@main
+    uses: aqueducthq/aqueduct/.github/workflows/integration-tests.yml@eng-1024-block-prs-from-merging-unless
     if: contains(github.event.pull_request.labels.*.name, 'run_integration_test')

--- a/.github/workflows/pre-merge-ci.yml
+++ b/.github/workflows/pre-merge-ci.yml
@@ -5,15 +5,6 @@ on:
     types: [ labeled, opened, synchronize, reopened ]
 
 jobs:
-  pre-merge-integration-test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Not labeled - Don't run integration test
-        if: contains(github.event.pull_request.labels.*.name, 'run_integration_test') == false
-        run: |
-          exit 1
-        env:
-          NUMBER: ${{ github.event.issue.number }}
-      - name: Run integration test
-        if: contains(github.event.pull_request.labels.*.name, 'run_integration_test')
-        uses: aqueducthq/aqueduct/.github/workflows/integration-tests.yml@main
+  trigger-integration-tests:
+    uses: aqueducthq/aqueduct/.github/workflows/integration-tests.yml@main
+    if: contains(github.event.pull_request.labels.*.name, 'run_integration_test')

--- a/.github/workflows/pre-merge-ci.yml
+++ b/.github/workflows/pre-merge-ci.yml
@@ -1,0 +1,19 @@
+name: Pre-Merge Integration tests
+
+on: 
+  pull_request:
+    types: [ labeled, opened, synchronize, reopened ]
+
+jobs:
+  pre-merge-integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Not labeled - Don't run integration test
+        if: contains(github.event.pull_request.labels.*.name, 'run_integration_test') == false
+        run: |
+          exit 1
+        env:
+          NUMBER: ${{ github.event.issue.number }}
+      - name: Run integration test
+        if: contains(github.event.pull_request.labels.*.name, 'run_integration_test')
+        uses: aqueducthq/aqueduct/.github/workflows/integration-tests.yml@main


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR adds ability to trigger integration tests via the label "run_integration_test". After changing repo settings this will block PRs from being merged unless the test passes.

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1024/block-prs-from-merging-unless-integration-tests-pass

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have manually run the integration tests and they are passing.
- [x] All features on the UI continue to work correctly.