### PR TITLE
Port input in config

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/tabular/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/config.py
@@ -24,7 +24,7 @@ class PostgresConfig(models.BaseConfig):
     password: str
     database: str
     host: str
-    port: Optional[str] = "5432"
+    port: str
 
 
 class S3Config(models.BaseConfig):

--- a/src/ui/common/src/components/integrations/dialogs/postgresDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/postgresDialog.tsx
@@ -5,7 +5,8 @@ import { IntegrationConfig, PostgresConfig } from '../../../utils/integrations';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: PostgresConfig = {
-  host: '127.0.0.1:5432',
+  host: '127.0.0.1',
+  port: '5432',
   database: 'aqueduct-db',
   username: 'aqueduct',
   password: '********',
@@ -16,20 +17,22 @@ type Props = {
 };
 
 export const PostgresDialog: React.FC<Props> = ({ setDialogConfig }) => {
-  const [address, setAddress] = useState<string>(null);
+  const [host, setHost] = useState<string>(null);
+  const [port, setPort] = useState<string>(null);
   const [database, setDatabase] = useState<string>(null);
   const [username, setUsername] = useState<string>(null);
   const [password, setPassword] = useState<string>(null);
 
   useEffect(() => {
     const config: PostgresConfig = {
-      host: address,
+      host: host,
+      port: port,
       database: database,
       username: username,
       password: password,
     };
     setDialogConfig(config);
-  }, [address, database, username, password]);
+  }, [host, port, database, username, password]);
 
   return (
     <Box sx={{ mt: 2 }}>
@@ -39,8 +42,18 @@ export const PostgresDialog: React.FC<Props> = ({ setDialogConfig }) => {
         label="Host *"
         description="The hostname or IP address of the Postgres server."
         placeholder={Placeholders.host}
-        onChange={(event) => setAddress(event.target.value)}
-        value={address}
+        onChange={(event) => setHost(event.target.value)}
+        value={host}
+      />
+      
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Port *"
+        description="The port number of the Postgres server."
+        placeholder={Placeholders.port}
+        onChange={(event) => setPort(event.target.value)}
+        value={port}
       />
 
       <IntegrationTextInputField

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -14,6 +14,7 @@ export type Integration = {
 
 export type PostgresConfig = {
   host: string;
+  port: string;
   database: string;
   username: string;
   password?: string;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The issues were:
- The port is hardcoded to 5432
- The host prompt is misleading (prompt was 127.0.0.1:5432 while this input was used just for the host/ip address part and the port was hardcoded to 5432 so if the user puts in 127.0.0.1:5432, the backend tries to access 127.0.0.1:5432:5432).

Manually tested it works with this input:
![image](https://user-images.githubusercontent.com/30596854/176282384-fa828d9c-04b9-4dda-8236-565fcf3a5113.png)
In the Python executor, the port is set to the user's input (not 5432) in the config and the engine url is correctly set to postgresql://test:test@127.0.0.1:4321/test.

```
"connector_config": {
        "conf": {
            "database": "test",
            "host": "127.0.0.1",
            "password": "test",
            "port": "4321",
            "username": "test"
        }
    }
```

## Related issue number (if any)
This is ENG 1277.

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
[N/A] If this is a new feature, I have added unit tests and integration tests.
[N/A] I have manually run the integration tests and they are passing.
- [x] All features on the UI continue to work correctly.