### PR TITLE
Use absolute file path to serve UI files

### DIFF
--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"path"
 	"time"
 
@@ -33,6 +34,8 @@ const (
 
 	accountOrganizationId = "aqueduct"
 )
+
+var uiDir = path.Join(os.Getenv("HOME"), ".aqueduct", "ui")
 
 type AqServer struct {
 	Router *chi.Mux
@@ -244,7 +247,7 @@ func (s *AqServer) Run(expose bool, port int) {
 		ip = "localhost"
 	}
 
-	static := http.FileServer(http.Dir("."))
+	static := http.FileServer(http.Dir(uiDir))
 	s.Router.Method("GET", "/dist/*", http.StripPrefix("/dist/", static))
 	s.Router.Get("/*", IndexHandler())
 
@@ -254,7 +257,7 @@ func (s *AqServer) Run(expose bool, port int) {
 
 func IndexHandler() func(w http.ResponseWriter, r *http.Request) {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "./index.html")
+		http.ServeFile(w, r, fmt.Sprintf("%s/index.html", uiDir))
 	}
 
 	return http.HandlerFunc(fn)

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -208,7 +208,6 @@ def start(expose, port):
                 "--port",
                 str(server_port),
             ], 
-            ui_directory,
         )
     else:
         popen_handle = execute_command_nonblocking(
@@ -219,7 +218,6 @@ def start(expose, port):
                 "--port",
                 str(server_port),
             ], 
-            ui_directory,
         )
     return popen_handle, server_port
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previously, we were using relative path (`.`) to serve UI files, after passing in `ui_directory` as `cwd` from the aqueduct CLI. This is a bit brittle and caused some confusion around why are we passing in the `ui_directory` as `cwd` when executing the server binary. This PR fixes this by using the absolute path instead, so that we no longer need to configure `ui_directory` as `cwd`.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have manually run the integration tests and they are passing.
- [x] All features on the UI continue to work correctly.
