### PR TITLE
Fix bug where the schema metadata was written improperly

### DIFF
--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -146,9 +146,7 @@ def write_artifact(
                 "Expected output type to be Pandas Dataframe, but instead got %s"
                 % type(content).__name__
             )
-        output_metadata[_METADATA_SCHEMA_KEY] = json.dumps(
-            [{col: str(content[col].dtype)} for col in content]
-        )
+        output_metadata[_METADATA_SCHEMA_KEY] = [{col: str(content[col].dtype)} for col in content]
         _write_tabular_output(storage, output_path, output_metadata_path, content, output_metadata)
 
     elif artifact_type == OutputArtifactType.FLOAT:
@@ -191,7 +189,7 @@ def _write_tabular_output(
     output_path: str,
     output_metadata_path: str,
     df: pd.DataFrame,
-    output_metadata: Dict[str, str],
+    output_metadata: Dict[str, Any],
 ) -> None:
     output_str = df.to_json(orient="table", date_format="iso", index=False)
     storage.put(output_path, bytes(output_str, encoding=_DEFAULT_ENCODING))


### PR DESCRIPTION
## Describe your changes and why you are making these changes
See task for bug description. I've checked that running a basic flow now no longer produces this error.

## Related issue number (if any)
[1292
](https://linear.app/aqueducthq/issue/ENG-1292/fix-a-bug-where-we-have-artifact-serialization-error-in-workflow)
## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x ] I have performed a self-review of my code.
- [ N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ N/A] If this is a new feature, I have added unit tests and integration tests.
- [ x] I have manually run the integration tests and they are passing.
- [ N/A] All features on the UI continue to work correctly.
