### PR TITLE
Remove unnecessary triggers and reporting from integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,16 +3,6 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches: [ main ]
-    paths:
-      - 'src/golang/**'
-      - 'src/python/**'
-      - 'integration_tests/**'
-      - 'sdk/aqueduct/**'
-      - '.github/workflows/integration-tests.yml'
-  issue_comment:
-    types: [ created ]
 
 jobs:
   run-tests:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -96,16 +96,3 @@ jobs:
         with:
           name: Executor Logs
           path: ~/.aqueduct/server/logs/*
-
-      - name: Report to Slack on Failure
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: ''
-          message_format: '{emoji} *{workflow}* has {status_message}'
-          footer: '{run_url}'
-          notify_when: 'failure,warnings'
-          mention_users: 'U025MDH5KS6'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/pre-merge-ci.yml
+++ b/.github/workflows/pre-merge-ci.yml
@@ -3,13 +3,6 @@ name: Pre-Merge Integration tests
 on: 
   pull_request:
     types: [ labeled, opened, synchronize, reopened ]
-    paths:
-      - 'src/golang/**'
-      - 'src/python/**'
-      - 'integration_tests/**'
-      - 'sdk/aqueduct/**'
-      - '.github/workflows/integration-tests.yml'
-      - '.github/workflows/pre-merge-ci.yml'
 
 jobs:
   trigger-integration-tests:

--- a/.github/workflows/pre-merge-ci.yml
+++ b/.github/workflows/pre-merge-ci.yml
@@ -3,6 +3,13 @@ name: Pre-Merge Integration tests
 on: 
   pull_request:
     types: [ labeled, opened, synchronize, reopened ]
+    paths:
+      - 'src/golang/**'
+      - 'src/python/**'
+      - 'integration_tests/**'
+      - 'sdk/aqueduct/**'
+      - '.github/workflows/integration-tests.yml'
+      - '.github/workflows/pre-merge-ci.yml'
 
 jobs:
   trigger-integration-tests:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The slack reporting is unnecessary since integration tests are blocking PRs now. I don't have to go tell people to roll things back anymore.

The push and comment triggers should also be unnecessary now right?

## Related issue number (if any)

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x ] I have performed a self-review of my code.
- [ N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ N/A] If this is a new feature, I have added unit tests and integration tests.
- [ N/A] I have manually run the integration tests and they are passing.
- [ N/A] All features on the UI continue to work correctly.
