### PR TITLE
ENG 1297: Set up build to package UI for sagemaker

### DIFF
--- a/src/ui/Makefile
+++ b/src/ui/Makefile
@@ -24,10 +24,11 @@ dist:
 	# don't need to specify an address when making a request.
 	cd app && echo "SERVER_ADDRESS=" > .env
 	cd app && npm run build
+	
+	# This is to ensure that the server address is /proxy/8080 when running on
+	# SageMaker. We do this because SageMaker puts everything behind a proxy that
+	# we have to sub-route everything behind.
+	cd app && echo "SERVER_ADDRESS=/proxy/8080" > .env
+	cd app && npm run build-sagemaker
 
-	# These are bad hacks that allow us to replace the path in the production
-	# context to use the `/dist` prefix, which we use for routing purposes in the
-	# Go serer.
-	cd app/dist && sed -i'.original' "s|src=\"|src=\"/dist|g" index.html
-	cd app/dist &&  sed -i'.original' "s|href=\"|href=\"/dist|g" index.html
 

--- a/src/ui/app/.env.sagemaker
+++ b/src/ui/app/.env.sagemaker
@@ -1,0 +1,2 @@
+SERVER_ADDRESS=/proxy/8080
+URL_PREFIX=/proxy/8080

--- a/src/ui/app/.env.sagemaker
+++ b/src/ui/app/.env.sagemaker
@@ -1,2 +1,0 @@
-SERVER_ADDRESS=/proxy/8080
-URL_PREFIX=/proxy/8080

--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -11,8 +11,11 @@ import { getPathPrefix } from '@aqueducthq/common/src/utils/getPathPrefix';
 import '@aqueducthq/common/src/styles/globals.css';
 
 function RequireAuth({ children, user }): { children: JSX.Element, user: UserProfile | undefined } {
+  const pathPrefix = getPathPrefix();
+  let routesContent: React.ReactElement;
+
   if (!user || !user.apiKey) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to={`${pathPrefix}/login`} replace />;
   }
 
   return children;

--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -26,14 +26,14 @@ const App = () => {
   let routesContent: React.ReactElement;
   routesContent = (
     <Routes>
-      <Route path="/" element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
-      <Route path="/data" element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
-      <Route path="/integrations" element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
-      <Route path="/integration/:id" element={<RequireAuth user={user}><IntegrationDetailsPage user={user} /> </RequireAuth>} />
-      <Route path="/workflows" element={<RequireAuth user={user}><WorkflowsPage user={user} /> </RequireAuth>} />
-      <Route path="/login" element={ user && user.apiKey ? <Navigate to="/" replace /> : <LoginPage />} />
-      <Route path="/account" element={<RequireAuth user={user}><AccountPage user={user} /> </RequireAuth>} />
-      <Route path="/workflow/:id" element={<RequireAuth user={user}><WorkflowPage user={user} /> </RequireAuth>} />
+      <Route path={`${ process.env.URL_PREFIX ?? "/" }`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
+      <Route path={`/${process.env.URL_PREFIX}/data`} element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
+      <Route path={`/${process.env.URL_PREFIX}/integrations`} element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${process.env.URL_PREFIX}/integration/:id`} element={<RequireAuth user={user}><IntegrationDetailsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${process.env.URL_PREFIX}/workflows`} element={<RequireAuth user={user}><WorkflowsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${process.env.URL_PREFIX}/login`} element={ user && user.apiKey ? <Navigate to="/" replace /> : <LoginPage />} />
+      <Route path={`/${process.env.URL_PREFIX}/account`} element={<RequireAuth user={user}><AccountPage user={user} /> </RequireAuth>} />
+      <Route path={`/${process.env.URL_PREFIX}/workflow/:id`} element={<RequireAuth user={user}><WorkflowPage user={user} /> </RequireAuth>} />
     </Routes>
   );
 

--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { useUser, UserProfile } from '@aqueducthq/common';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { theme } from '@aqueducthq/common/src/styles/theme/theme';
+import { getPathPrefix } from '@aqueducthq/common/src/utils/getPathPrefix';
 import '@aqueducthq/common/src/styles/globals.css';
 
 function RequireAuth({ children, user }): { children: JSX.Element, user: UserProfile | undefined } {
@@ -23,17 +24,18 @@ const App = () => {
     return null;
   }
 
+  const pathPrefix = getPathPrefix();
   let routesContent: React.ReactElement;
   routesContent = (
     <Routes>
-      <Route path={`${ process.env.URL_PREFIX ?? "/" }`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
-      <Route path={`/${process.env.URL_PREFIX}/data`} element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
-      <Route path={`/${process.env.URL_PREFIX}/integrations`} element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
-      <Route path={`/${process.env.URL_PREFIX}/integration/:id`} element={<RequireAuth user={user}><IntegrationDetailsPage user={user} /> </RequireAuth>} />
-      <Route path={`/${process.env.URL_PREFIX}/workflows`} element={<RequireAuth user={user}><WorkflowsPage user={user} /> </RequireAuth>} />
-      <Route path={`/${process.env.URL_PREFIX}/login`} element={ user && user.apiKey ? <Navigate to="/" replace /> : <LoginPage />} />
-      <Route path={`/${process.env.URL_PREFIX}/account`} element={<RequireAuth user={user}><AccountPage user={user} /> </RequireAuth>} />
-      <Route path={`/${process.env.URL_PREFIX}/workflow/:id`} element={<RequireAuth user={user}><WorkflowPage user={user} /> </RequireAuth>} />
+      <Route path={`${ pathPrefix ?? "/" }`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/data`} element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/integrations`} element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/integration/:id`} element={<RequireAuth user={user}><IntegrationDetailsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/workflows`} element={<RequireAuth user={user}><WorkflowsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/login`} element={ user && user.apiKey ? <Navigate to="/" replace /> : <LoginPage />} />
+      <Route path={`/${pathPrefix}/account`} element={<RequireAuth user={user}><AccountPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/workflow/:id`} element={<RequireAuth user={user}><WorkflowPage user={user} /> </RequireAuth>} />
     </Routes>
   );
 

--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.3",
   "scripts": {
     "start": "parcel --no-cache --no-hmr index.html",
-    "build": "parcel build index.html",
+    "build": "parcel build --public-url /dist --dist-dir dist/default index.html",
+    "build-sagemaker": "parcel build --public-url /proxy/8080/dist --dist-dir dist/sagemaker index.html",
     "lint": "eslint '*/**/*.{js,ts,tsx}' --format table",
     "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --format table --fix"
   },

--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -12,6 +12,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import UserProfile from '../../utils/auth';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 
 const sharedCardStyling = {
   display: 'flex',
@@ -88,7 +89,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
                 <li>
                   <Typography variant="body1">
                     First go to the{' '}
-                    <Link href=`/${process.env.URL_PREFIX}/integrations`>integrations</Link> page and
+                    <Link href={`${getPathPrefix()}/integrations`}>integrations</Link> page and
                     connect a database. (If you don&apos;t have a database
                     handy, you can use the <code>aqueduct_demo</code> database
                     -- see the documentation{' '}
@@ -122,7 +123,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
 
                 <li>
                   <Typography variant="body1">
-                    Go to the <Link href=`/${process.env.URL_PREFIX}/workflows`>workflows</Link> page to
+                    Go to the <Link href={`${getPathPrefix()}/workflows`}>workflows</Link> page to
                     see a visualization of the workflow you just created.
                   </Typography>
                 </li>

--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -89,10 +89,12 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
                 <li>
                   <Typography variant="body1">
                     First go to the{' '}
-                    <Link href={`${getPathPrefix()}/integrations`}>integrations</Link> page and
-                    connect a database. (If you don&apos;t have a database
-                    handy, you can use the <code>aqueduct_demo</code> database
-                    -- see the documentation{' '}
+                    <Link href={`${getPathPrefix()}/integrations`}>
+                      integrations
+                    </Link>{' '}
+                    page and connect a database. (If you don&apos;t have a
+                    database handy, you can use the <code>aqueduct_demo</code>{' '}
+                    database -- see the documentation{' '}
                     <Link href="https://docs.aqueducthq.com/example-workflows/demo-data-warehouse">
                       here
                     </Link>
@@ -123,8 +125,10 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
 
                 <li>
                   <Typography variant="body1">
-                    Go to the <Link href={`${getPathPrefix()}/workflows`}>workflows</Link> page to
-                    see a visualization of the workflow you just created.
+                    Go to the{' '}
+                    <Link href={`${getPathPrefix()}/workflows`}>workflows</Link>{' '}
+                    page to see a visualization of the workflow you just
+                    created.
                   </Typography>
                 </li>
               </ol>

--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -88,7 +88,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
                 <li>
                   <Typography variant="body1">
                     First go to the{' '}
-                    <Link href="/integrations">integrations</Link> page and
+                    <Link href=`/${process.env.URL_PREFIX}/integrations`>integrations</Link> page and
                     connect a database. (If you don&apos;t have a database
                     handy, you can use the <code>aqueduct_demo</code> database
                     -- see the documentation{' '}
@@ -122,7 +122,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
 
                 <li>
                   <Typography variant="body1">
-                    Go to the <Link href="/workflows">workflows</Link> page to
+                    Go to the <Link href=`/${process.env.URL_PREFIX}/workflows`>workflows</Link> page to
                     see a visualization of the workflow you just created.
                   </Typography>
                 </li>

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -39,7 +39,7 @@ export const DataCard: React.FC<DataProps> = ({ dataPreviewInfo }) => {
     });
     const workflowId = dataPreviewInfo.workflow_id;
     return (
-      <Link underline="none" color="inherit" href={`/workflow/${workflowId}`}>
+      <Link underline="none" color="inherit" href={`/${process.env.URL_PREFIX}/workflow/${workflowId}`}>
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '900px' }}>
           <Box
             sx={{

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -18,6 +18,7 @@ import { PostgresCard } from './postgresCard';
 import { RedshiftCard } from './redshiftCard';
 import { S3Card } from './s3Card';
 import { SnowflakeCard } from './snowflakeCard';
+import { getPathPrefix } from '../../../utils/getPathPrefix';
 
 type DataProps = {
   dataPreviewInfo: DataPreviewInfo;
@@ -39,7 +40,7 @@ export const DataCard: React.FC<DataProps> = ({ dataPreviewInfo }) => {
     });
     const workflowId = dataPreviewInfo.workflow_id;
     return (
-      <Link underline="none" color="inherit" href={`/${process.env.URL_PREFIX}/workflow/${workflowId}`}>
+      <Link underline="none" color="inherit" href={`/${getPathPrefix()}/workflow/${workflowId}`}>
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '900px' }}>
           <Box
             sx={{

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import { DataPreviewInfo } from '../../../utils/data';
+import { getPathPrefix } from '../../../utils/getPathPrefix';
 import {
   Integration,
   SupportedIntegrations,
@@ -18,7 +19,6 @@ import { PostgresCard } from './postgresCard';
 import { RedshiftCard } from './redshiftCard';
 import { S3Card } from './s3Card';
 import { SnowflakeCard } from './snowflakeCard';
-import { getPathPrefix } from '../../../utils/getPathPrefix';
 
 type DataProps = {
   dataPreviewInfo: DataPreviewInfo;
@@ -40,7 +40,11 @@ export const DataCard: React.FC<DataProps> = ({ dataPreviewInfo }) => {
     });
     const workflowId = dataPreviewInfo.workflow_id;
     return (
-      <Link underline="none" color="inherit" href={`/${getPathPrefix()}/workflow/${workflowId}`}>
+      <Link
+        underline="none"
+        color="inherit"
+        href={`/${getPathPrefix()}/workflow/${workflowId}`}
+      >
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '900px' }}>
           <Box
             sx={{

--- a/src/ui/common/src/components/integrations/connectedIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/connectedIntegrations.tsx
@@ -9,6 +9,7 @@ import { handleLoadIntegrations } from '../../reducers/integrations';
 import { AppDispatch, RootState } from '../../stores/store';
 import { UserProfile } from '../../utils/auth';
 import { Card } from '../layouts/card';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 
 type ConnectedIntegrationsProps = {
   user: UserProfile;
@@ -47,7 +48,7 @@ export const ConnectedIntegrations: React.FC<ConnectedIntegrationsProps> = ({
               <Link
                 underline="none"
                 color="inherit"
-                href={`/${process.env.URL_PREFIX}/integration/${integration.id}`}
+                href={`${getPathPrefix()}/integration/${integration.id}`}
               >
                 <Card>
                   <IntegrationCard integration={integration} />

--- a/src/ui/common/src/components/integrations/connectedIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/connectedIntegrations.tsx
@@ -47,7 +47,7 @@ export const ConnectedIntegrations: React.FC<ConnectedIntegrationsProps> = ({
               <Link
                 underline="none"
                 color="inherit"
-                href={`/integration/${integration.id}`}
+                href={`/${process.env.URL_PREFIX}/integration/${integration.id}`}
               >
                 <Card>
                   <IntegrationCard integration={integration} />

--- a/src/ui/common/src/components/integrations/connectedIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/connectedIntegrations.tsx
@@ -8,8 +8,8 @@ import { IntegrationCard } from '../../components/integrations/cards/card';
 import { handleLoadIntegrations } from '../../reducers/integrations';
 import { AppDispatch, RootState } from '../../stores/store';
 import { UserProfile } from '../../utils/auth';
-import { Card } from '../layouts/card';
 import { getPathPrefix } from '../../utils/getPathPrefix';
+import { Card } from '../layouts/card';
 
 type ConnectedIntegrationsProps = {
   user: UserProfile;

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -172,7 +172,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
   const sidebarContent = (
     <>
       <Box className={styles['menu-sidebar-popover-container']}>
-        <Link href={'/'} underline="none">
+        <Link href={`${ process.env.URL_PREFIX ?? '/' }`} underline="none">
           <Typography variant="h3" sx={{ color: 'white' }}>
             Aqueduct
           </Typography>
@@ -219,7 +219,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           onClose={handleCloseUserPopover}
           open={userPopoverOpen}
         >
-          <Link href="/account" underline="none" sx={{ color: 'blue.800' }}>
+          <Link href=`${process.env.URL_PREFIX}/account` underline="none" sx={{ color: 'blue.800' }}>
             <MenuItem sx={{ width: '190px' }} disableRipple>
               <Box sx={{ fontSize: '20px', mr: 1 }}>
                 <FontAwesomeIcon icon={faCircleUser} />
@@ -254,7 +254,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           />
 
           <Link
-            href="/workflows"
+            href=`${process.env.URL_PREFIX}/workflows`
             className={styles['menu-sidebar-link']}
             underline="none"
           >
@@ -271,7 +271,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           </Link>
 
           <Link
-            href="/integrations"
+            href=`${process.env.URL_PREFIX}/integrations`
             className={styles['menu-sidebar-link']}
             underline="none"
           >
@@ -288,7 +288,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           </Link>
 
           <Link
-            href="/data"
+            href=`${process.env.URL_PREFIX}/data`
             className={styles['menu-sidebar-link']}
             underline="none"
           >

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -18,13 +18,13 @@ import { useLocation } from 'react-router-dom';
 import { handleFetchNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';
 import UserProfile from '../../utils/auth';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 import {
   NotificationLogLevel,
   NotificationStatus,
 } from '../../utils/notifications';
 import NotificationsPopover from '../notifications/NotificationsPopover';
 import styles from './menu-sidebar-styles.module.css';
-import { getPathPrefix } from '../../utils/getPathPrefix';
 
 export const MenuSidebarWidth = '200px';
 
@@ -173,7 +173,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
   const sidebarContent = (
     <>
       <Box className={styles['menu-sidebar-popover-container']}>
-        <Link href={`${ getPathPrefix() ?? '/' }`} underline="none">
+        <Link href={`${getPathPrefix() ?? '/'}`} underline="none">
           <Typography variant="h3" sx={{ color: 'white' }}>
             Aqueduct
           </Typography>
@@ -220,7 +220,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           onClose={handleCloseUserPopover}
           open={userPopoverOpen}
         >
-          <Link href={`${getPathPrefix()}/account`} underline="none" sx={{ color: 'blue.800' }}>
+          <Link
+            href={`${getPathPrefix()}/account`}
+            underline="none"
+            sx={{ color: 'blue.800' }}
+          >
             <MenuItem sx={{ width: '190px' }} disableRipple>
               <Box sx={{ fontSize: '20px', mr: 1 }}>
                 <FontAwesomeIcon icon={faCircleUser} />

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../utils/notifications';
 import NotificationsPopover from '../notifications/NotificationsPopover';
 import styles from './menu-sidebar-styles.module.css';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 
 export const MenuSidebarWidth = '200px';
 
@@ -172,7 +173,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
   const sidebarContent = (
     <>
       <Box className={styles['menu-sidebar-popover-container']}>
-        <Link href={`${ process.env.URL_PREFIX ?? '/' }`} underline="none">
+        <Link href={`${ getPathPrefix() ?? '/' }`} underline="none">
           <Typography variant="h3" sx={{ color: 'white' }}>
             Aqueduct
           </Typography>
@@ -219,7 +220,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           onClose={handleCloseUserPopover}
           open={userPopoverOpen}
         >
-          <Link href=`${process.env.URL_PREFIX}/account` underline="none" sx={{ color: 'blue.800' }}>
+          <Link href={`${getPathPrefix()}/account`} underline="none" sx={{ color: 'blue.800' }}>
             <MenuItem sx={{ width: '190px' }} disableRipple>
               <Box sx={{ fontSize: '20px', mr: 1 }}>
                 <FontAwesomeIcon icon={faCircleUser} />
@@ -254,7 +255,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           />
 
           <Link
-            href=`${process.env.URL_PREFIX}/workflows`
+            href={`${getPathPrefix()}/workflows`}
             className={styles['menu-sidebar-link']}
             underline="none"
           >
@@ -271,7 +272,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           </Link>
 
           <Link
-            href=`${process.env.URL_PREFIX}/integrations`
+            href={`${getPathPrefix()}/integrations`}
             className={styles['menu-sidebar-link']}
             underline="none"
           >
@@ -288,7 +289,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           </Link>
 
           <Link
-            href=`${process.env.URL_PREFIX}/data`
+            href={`${getPathPrefix()}/data`}
             className={styles['menu-sidebar-link']}
             underline="none"
           >

--- a/src/ui/common/src/components/notifications/NotificationListItem.tsx
+++ b/src/ui/common/src/components/notifications/NotificationListItem.tsx
@@ -15,6 +15,7 @@ import {
   NotificationLogLevel,
 } from '../../utils/notifications';
 import { Notification } from '../../utils/notifications';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 
 type Props = {
   user: UserProfile;
@@ -138,7 +139,7 @@ export const NotificationListItem: React.FC<Props> = ({
     <Link
       underline="none"
       color="inherit"
-      href={`/workflow/${
+      href={`${getPathPrefix()}/workflow/${
         notification.workflowMetadata.id
       }?workflowDagResultId=${encodeURI(
         notification.workflowMetadata.dag_result_id

--- a/src/ui/common/src/components/notifications/NotificationListItem.tsx
+++ b/src/ui/common/src/components/notifications/NotificationListItem.tsx
@@ -9,13 +9,13 @@ import { handleArchiveNotification } from '../../reducers/notifications';
 import { AppDispatch } from '../../stores/store';
 import { theme } from '../../styles/theme/theme';
 import UserProfile from '../../utils/auth';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 import { dateString } from '../../utils/metadata';
 import {
   NotificationAssociation,
   NotificationLogLevel,
 } from '../../utils/notifications';
 import { Notification } from '../../utils/notifications';
-import { getPathPrefix } from '../../utils/getPathPrefix';
 
 type Props = {
   user: UserProfile;

--- a/src/ui/common/src/components/pages/LoginPage.tsx
+++ b/src/ui/common/src/components/pages/LoginPage.tsx
@@ -4,8 +4,8 @@ import React, { ChangeEvent, useEffect, useState } from 'react';
 import { useCookies } from 'react-cookie';
 
 import fetchUser from '../../utils/fetchUser';
-import { Button } from '../primitives/Button.styles';
 import { getPathPrefix } from '../../utils/getPathPrefix';
+import { Button } from '../primitives/Button.styles';
 
 export const LoginPage: React.FC = () => {
   useEffect(() => {

--- a/src/ui/common/src/components/pages/LoginPage.tsx
+++ b/src/ui/common/src/components/pages/LoginPage.tsx
@@ -5,6 +5,7 @@ import { useCookies } from 'react-cookie';
 
 import fetchUser from '../../utils/fetchUser';
 import { Button } from '../primitives/Button.styles';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 
 export const LoginPage: React.FC = () => {
   useEffect(() => {
@@ -50,7 +51,7 @@ export const LoginPage: React.FC = () => {
       // doesn't give us an easy way to read the cookie state once it's
       // changed, so even though we've updated the cookie, the App will still
       // think that the user isn't logged in and will show the login page.
-      window.location.reload();
+      window.location.assign(getPathPrefix());
     }
   };
 

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -76,7 +76,7 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
   // been run.
   if (workflow['last_run_at']) {
     return (
-      <Link underline="none" color="inherit" href={`/workflow/${workflow.id}`}>
+      <Link underline="none" color="inherit" href={`/${process.env.URL_PREFIX}/workflow/${workflow.id}`}>
         {cardContent}
       </Link>
     );

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -5,10 +5,10 @@ import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 import style from '../../styles/markdown.module.css';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 import { ListWorkflowSummary } from '../../utils/workflows';
 import { Card } from '../layouts/card';
 import WorkflowStatus from './workflowStatus';
-import { getPathPrefix } from '../../utils/getPathPrefix';
 
 type Props = {
   workflow: ListWorkflowSummary;
@@ -77,7 +77,11 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
   // been run.
   if (workflow['last_run_at']) {
     return (
-      <Link underline="none" color="inherit" href={`${getPathPrefix()}/workflow/${workflow.id}`}>
+      <Link
+        underline="none"
+        color="inherit"
+        href={`${getPathPrefix()}/workflow/${workflow.id}`}
+      >
         {cardContent}
       </Link>
     );

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -8,6 +8,7 @@ import style from '../../styles/markdown.module.css';
 import { ListWorkflowSummary } from '../../utils/workflows';
 import { Card } from '../layouts/card';
 import WorkflowStatus from './workflowStatus';
+import { getPathPrefix } from '../../utils/getPathPrefix';
 
 type Props = {
   workflow: ListWorkflowSummary;
@@ -76,7 +77,7 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
   // been run.
   if (workflow['last_run_at']) {
     return (
-      <Link underline="none" color="inherit" href={`/${process.env.URL_PREFIX}/workflow/${workflow.id}`}>
+      <Link underline="none" color="inherit" href={`${getPathPrefix()}/workflow/${workflow.id}`}>
         {cardContent}
       </Link>
     );

--- a/src/ui/common/src/utils/getPathPrefix.ts
+++ b/src/ui/common/src/utils/getPathPrefix.ts
@@ -1,0 +1,18 @@
+// `getPathPrefix` is a helper function that inspects the current pathname and
+// determines any proxy prefixes that might be present. If the proxy prefix is
+// present, then `getPathPrefix` returns a string that represents the prefix
+// that should be appended to all routes.
+//
+// If no prefix is present, `getPathPrefix` returns an empty string.
+export const getPathPrefix = () => {
+  const location = window.location.pathname;
+
+  const result = location.match(SageMakerProxyRegex);
+  if (!result) {
+    return '';
+  } else {
+    return result[0]; // The regex that was matched.
+  }
+};
+
+const SageMakerProxyRegex = /\/proxy\/\d{4}/;


### PR DESCRIPTION
## Describe your changes and why you are making these changes

SageMaker doesn't expose ports directly through it's Notebook instances but rather puts them behind `proxy/{portNumber}`. In order to make our UI work on SageMaker, we need to: 1) change our static assets to load from `/proxy/8080/dist` rather than just `/dist`; 2) change all of our API calls and links within the UI to have `/proxy/8080` prepended.

1. In order to do 1, I modified `package.json` to use the `--dist-dir` and the `--public-url` flags. `npm run build` generates out default build (now in `dist/default`), and `npm run build-sagemaker` generates a SageMaker-specific build in (in `dist/sagemaker`).
2. In order to do 2, we added `getPathPrefix` helper that looks at `window.location.pathname` and uses a regex to determine whether we're running behind `/proxy/{portNumber}` or not -- if we are, `getPathPrefix` returns that prefix, otherwise it returns an empty string.

Note that this *will not* work with any ports other than 8080 -- that is a limitation of hardcoding the `--public-url` flag at runtime.

As a follow-on to this, we need to modify the CLI to detect whether we're running on SageMaker and download the correct UI build at install time.

## Related issue number (if any)

ENG-1297

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have manually run the integration tests and they are passing.
- [x] All features on the UI continue to work correctly.
