### PR TITLE
[UI] Add ability to trigger a flow with custom parameters

### DIFF
--- a/src/golang/cmd/server/request/parameters.go
+++ b/src/golang/cmd/server/request/parameters.go
@@ -2,8 +2,9 @@ package request
 
 import (
 	"encoding/json"
-	"github.com/dropbox/godropbox/errors"
 	"net/http"
+
+	"github.com/dropbox/godropbox/errors"
 )
 
 const (

--- a/src/golang/cmd/server/request/parameters.go
+++ b/src/golang/cmd/server/request/parameters.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"github.com/dropbox/godropbox/errors"
 	"net/http"
 )
 
@@ -25,5 +26,16 @@ func ExtractParamsfromRequest(r *http.Request) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	for param_name, param_val := range params {
+		if !IsJSON(param_val) {
+			return nil, errors.Newf("The value %s provided for parameter %s is not in a valid json format.", param_val, param_name)
+		}
+	}
 	return params, nil
+}
+
+func IsJSON(str string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(str), &js) == nil
 }

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -122,7 +122,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
           This will a run of <code>{name}</code> immediately.
         </Box>
 
-        {paramNameToDefault.length > 0 && <Typography sx={{ mb: 1 }} style={{ fontWeight: 'bold'}}> Parameters </Typography>}
+        {Object.keys(paramNameToDefault).length > 0 && <Typography sx={{ mb: 1 }} style={{ fontWeight: 'bold'}}> Parameters </Typography>}
         {Object.keys(paramNameToDefault).map((paramName, idx) => {
             return (
               <Box>

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -19,6 +19,7 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import VersionSelector from './version_selector';
 import WorkflowSettings from './WorkflowSettings';
+import TextField from "@mui/material/TextField";
 
 type Props = {
   user: UserProfile;
@@ -101,8 +102,27 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
     >
       <DialogTitle>Trigger a Workflow Run?</DialogTitle>
       <DialogContent>
-        This will a run of <code>{name}</code> immediately.
+        <Box sx={{ mb: 2 }}>
+          This will a run of <code>{name}</code> immediately.
+        </Box>
 
+        <Typography sx={{ mb: 1 }} style={{ fontWeight: 'bold'}}> Parameters </Typography>
+        <Box>
+          <Typography><small>Parameter Name</small></Typography>
+          <TextField
+              fullWidth
+              placeholder="Default parameter here"
+              size="small"
+          />
+        </Box>
+        <Box>
+          <Typography><small>Parameter Name</small></Typography>
+          <TextField
+              fullWidth
+              placeholder="Default parameter here"
+              size="small"
+          />
+        </Box>
 
       </DialogContent>
       <DialogActions>

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -6,6 +6,7 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import TextField from '@mui/material/TextField';
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSelector } from 'react-redux';
@@ -19,7 +20,6 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import VersionSelector from './version_selector';
 import WorkflowSettings from './WorkflowSettings';
-import TextField from "@mui/material/TextField";
 
 type Props = {
   user: UserProfile;
@@ -72,18 +72,25 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
     );
   }
 
-  const paramNameToDefault = Object.assign({}, ...Object.values(workflowDag.operators).filter((operator) =>{
-    return operator.spec.param !== undefined;
-  }).map((operator) => {
-    return {[operator.name]: operator.spec.param.val};
-  }));
+  const paramNameToDefault = Object.assign(
+    {},
+    ...Object.values(workflowDag.operators)
+      .filter((operator) => {
+        return operator.spec.param !== undefined;
+      })
+      .map((operator) => {
+        return { [operator.name]: operator.spec.param.val };
+      })
+  );
 
   // This records all the parameters and values that the user wants to overwrite with.
-  const [paramNameToValMap, setParamNameToValMap] = useState<{[key: string]: string}>({});
+  const [paramNameToValMap, setParamNameToValMap] = useState<{
+    [key: string]: string;
+  }>({});
 
   const triggerWorkflowRun = () => {
-    const parameters = new FormData()
-    parameters.append("parameters", JSON.stringify(paramNameToValMap))
+    const parameters = new FormData();
+    parameters.append('parameters', JSON.stringify(paramNameToValMap));
 
     setShowRunWorkflowDialog(false);
     fetch(`${apiAddress}/api/workflow/${workflowDag.workflow_id}/refresh`, {
@@ -108,7 +115,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
       });
 
     // Reset the overriding parameters map on dialog close.
-    setParamNameToValMap({})
+    setParamNameToValMap({});
   };
 
   const runWorkflowDialog = (
@@ -122,25 +129,30 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
           This will a run of <code>{name}</code> immediately.
         </Box>
 
-        {Object.keys(paramNameToDefault).length > 0 && <Typography sx={{ mb: 1 }} style={{ fontWeight: 'bold'}}> Parameters </Typography>}
-        {Object.keys(paramNameToDefault).map((paramName, idx) => {
-            return (
-              <Box>
-                <Typography><small>{paramName}</small></Typography>
-                <TextField
-                    fullWidth
-                    placeholder={paramNameToDefault[paramName]}
-                    onChange={(e) => {
-                      paramNameToValMap[paramName] = e.target.value;
-                      setParamNameToValMap(paramNameToValMap);
-                    }}
-                    size="small"
-                />
-              </Box>
-            )
-          })
-        }
-
+        {Object.keys(paramNameToDefault).length > 0 && (
+          <Typography sx={{ mb: 1 }} style={{ fontWeight: 'bold' }}>
+            {' '}
+            Parameters{' '}
+          </Typography>
+        )}
+        {Object.keys(paramNameToDefault).map((paramName) => {
+          return (
+            <Box key={paramName}>
+              <Typography>
+                <small>{paramName}</small>
+              </Typography>
+              <TextField
+                fullWidth
+                placeholder={paramNameToDefault[paramName]}
+                onChange={(e) => {
+                  paramNameToValMap[paramName] = e.target.value;
+                  setParamNameToValMap(paramNameToValMap);
+                }}
+                size="small"
+              />
+            </Box>
+          );
+        })}
       </DialogContent>
       <DialogActions>
         <Button

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -72,6 +72,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
     );
   }
 
+
   const triggerWorkflowRun = () => {
     setShowRunWorkflowDialog(false);
     fetch(`${apiAddress}/api/workflow/${workflowDag.workflow_id}/refresh`, {
@@ -95,6 +96,8 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
       });
   };
 
+  const paramNames = ["param1", "param2"]
+
   const runWorkflowDialog = (
     <Dialog
       open={showRunWorkflowDialog}
@@ -107,22 +110,20 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
         </Box>
 
         <Typography sx={{ mb: 1 }} style={{ fontWeight: 'bold'}}> Parameters </Typography>
-        <Box>
-          <Typography><small>Parameter Name</small></Typography>
-          <TextField
-              fullWidth
-              placeholder="Default parameter here"
-              size="small"
-          />
-        </Box>
-        <Box>
-          <Typography><small>Parameter Name</small></Typography>
-          <TextField
-              fullWidth
-              placeholder="Default parameter here"
-              size="small"
-          />
-        </Box>
+        {
+          paramNames.map((paramName) => {
+            return (
+              <Box>
+                <Typography><small>Parameter Name</small></Typography>
+                <TextField
+                    fullWidth
+                    placeholder="Default parameter here"
+                    size="small"
+                />
+              </Box>
+            )
+          })
+        }
 
       </DialogContent>
       <DialogActions>

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -101,7 +101,9 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
     >
       <DialogTitle>Trigger a Workflow Run?</DialogTitle>
       <DialogContent>
-        Do you want to trigger a run of <code>{name}</code> immediately?
+        This will a run of <code>{name}</code> immediately.
+
+
       </DialogContent>
       <DialogActions>
         <Button

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -104,6 +104,10 @@ export type Load = {
   parameters: LoadParameters;
 };
 
+export type Param = {
+  val: string;
+};
+
 export type OperatorSpec = {
   type: OperatorType;
   function?: FunctionOp;
@@ -111,6 +115,7 @@ export type OperatorSpec = {
   extract?: Extract;
   load?: Load;
   check?: Check;
+  param?: Param,
 };
 
 export type Operator = {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -115,7 +115,7 @@ export type OperatorSpec = {
   extract?: Extract;
   load?: Load;
   check?: Check;
-  param?: Param,
+  param?: Param;
 };
 
 export type Operator = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Builds a "parameters" form into the workflow trigger dialog. These text fields have the parameter default value as the placeholder. Any value in entered in here will be packaged up and sent to `refresh_workflow` to trigger the flow with the new parameters. Text fields left empty are ignored. Text fields that have a non-jsonable string in them will be rejected with an appropriate error message.

Demo Vid:
https://www.loom.com/share/c61881ab0f3448a0890b40bccae42519

## Related issue number (if any)
ENG-1295

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have manually run the integration tests and they are passing.
- [ x] All features on the UI continue to work correctly.
