### PR TITLE
Follows up 1306 to change workflow branch to main

### DIFF
--- a/.github/workflows/skip-pre-merge-ci.yml
+++ b/.github/workflows/skip-pre-merge-ci.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   trigger-integration-tests:
-    uses: aqueducthq/aqueduct/.github/workflows/skipped-integration-tests.yml@eng-1306-remove-need-to-run-tests-on-non-code
+    uses: aqueducthq/aqueduct/.github/workflows/skipped-integration-tests.yml@main


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Earlier, skip-integrations-test.yml didn't exist on the main branch so the workflow would fail. Now that it exists on main + skipping tests on changes that only touch .github/workflows/*, we no longer need to have these follow up PRs. (If users want to test their changes on GA, they can manually trigger the runs via the Action tab + particular branch)
## Related issue number (if any)
1306
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [n/a] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [n/a] If this is a new feature, I have added unit tests and integration tests.
- [x] I have manually run the integration tests and they are passing.
- [n/a] All features on the UI continue to work correctly.
