### PR TITLE
Improves usage of ci tests by not relying on github paths

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,8 @@
 - [ ] If this is a new feature, I have added unit tests and integration tests.
 - [ ] I have run the integration tests locally and they are passing.
 - [ ] All features on the UI continue to work correctly.
-- [ ] I have added the appropriate CI label to the PR.
+- [ ] Added one of the following CI labels:
+    - `run_integration_test`: Runs integration tests
+    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,6 @@
 - [ ] I have performed a self-review of my code.
 - [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
 - [ ] If this is a new feature, I have added unit tests and integration tests.
-- [ ] I have manually run the integration tests and they are passing.
+- [ ] I have run the integration tests locally and they are passing.
 - [ ] All features on the UI continue to work correctly.
+- [ ] I have added the appropriate CI label to the PR.

--- a/.github/workflows/pre-merge-ci.yml
+++ b/.github/workflows/pre-merge-ci.yml
@@ -3,11 +3,6 @@ name: Pre-Merge Integration tests
 on: 
   pull_request:
     types: [ labeled, opened, synchronize, reopened ]
-    paths:
-      - 'src/golang/**'
-      - 'src/python/**'
-      - 'integration_tests/**'
-      - 'sdk/aqueduct/**'
 
 jobs:
   trigger-integration-tests:

--- a/.github/workflows/skip-pre-merge-ci.yml
+++ b/.github/workflows/skip-pre-merge-ci.yml
@@ -3,12 +3,8 @@ name: Skip Pre-Merge Integration tests
 on: 
   pull_request:
     types: [ labeled, opened, synchronize, reopened ]
-    paths-ignore:
-      - 'src/golang/**'
-      - 'src/python/**'
-      - 'integration_tests/**'
-      - 'sdk/aqueduct/**'
 
 jobs:
   trigger-integration-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'skip_integration_test')
     uses: aqueducthq/aqueduct/.github/workflows/skipped-integration-tests.yml@main


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The [path/ignore path conditions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths) used by Github Actions are very broad for our use cases. Often times users will update documentation in the same PR that they make code changes in, and this will trigger both the testing/skip-testing workflows. The best way to configure this is to leave it up to the developer to decide when to run/skip the tests. The new behavior is as follows:

- Add `run_integration_test` label: Runs integration tests
- Add `skip_integration_test` label: Skips integration tests (Should be used when changes are ONLY documentation/UI)

One of these labels must be added in order to merge the PR.
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1304/fix-issues-with-integration-test-ci
## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [n/a] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [n/a] If this is a new feature, I have added unit tests and integration tests.
- [x] I have manually run the integration tests and they are passing.
- [n/a] All features on the UI continue to work correctly.
