### PR TITLE
Fix restrictive metric typing

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
         action="store_true",
         help="Whether to build and replace the Python SDK.",
     )
-    
+
     parser.add_argument(
         "--executor",
         dest="update_executor",
@@ -107,7 +107,9 @@ if __name__ == "__main__":
         execute_command(["cp", "./src/build/migrator", join(server_directory, "bin/migrator")])
 
         # Run the migrator to update to the latest schema
-        execute_command([join(server_directory, "bin/migrator"), "--type", "sqlite", "goto", SCHEMA_VERSION])
+        execute_command(
+            [join(server_directory, "bin/migrator"), "--type", "sqlite", "goto", SCHEMA_VERSION]
+        )
 
     # Build and replace UI files.
     if args.update_ui:

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -151,7 +151,9 @@ def write_artifact(
 
     elif artifact_type == OutputArtifactType.FLOAT:
         try:
-            _write_numeric_output(storage, output_path, output_metadata_path, float(content), output_metadata)
+            float(content)
+            print("IM HERE")
+            _write_numeric_output(storage, output_path, output_metadata_path, content, output_metadata)
         except ValueError:
             raise Exception(
                 "Expected output type to be numeric, instead got %s" % type(content).__name__

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -153,7 +153,9 @@ def write_artifact(
         try:
             float(content)
             print("IM HERE")
-            _write_numeric_output(storage, output_path, output_metadata_path, content, output_metadata)
+            _write_numeric_output(
+                storage, output_path, output_metadata_path, content, output_metadata
+            )
         except ValueError:
             raise Exception(
                 "Expected output type to be numeric, instead got %s" % type(content).__name__

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -152,7 +152,6 @@ def write_artifact(
     elif artifact_type == OutputArtifactType.FLOAT:
         try:
             float(content)
-            print("IM HERE")
             _write_numeric_output(
                 storage, output_path, output_metadata_path, content, output_metadata
             )

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -150,12 +150,12 @@ def write_artifact(
         _write_tabular_output(storage, output_path, output_metadata_path, content, output_metadata)
 
     elif artifact_type == OutputArtifactType.FLOAT:
-        if not isinstance(content, float) and not isinstance(content, int):
+        try:
+            _write_numeric_output(storage, output_path, output_metadata_path, float(content), output_metadata)
+        except ValueError:
             raise Exception(
-                "Expected output type to be float or int, instead got %s" % type(content).__name__
+                "Expected output type to be numeric, instead got %s" % type(content).__name__
             )
-        _write_numeric_output(storage, output_path, output_metadata_path, content, output_metadata)
-
     elif artifact_type == OutputArtifactType.BOOL:
         if isinstance(content, bool) or isinstance(content, np.bool_):
             _write_bool_output(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
If the value can be converted to a float, it is accepted.
Supports int64, float, int, string (e.g. "4" but not "4d"), ...

## Testing
Input:
```
import aqueduct
from aqueduct import op, metric
import pandas as pd
import numpy as np
client = aqueduct.Client("VFEH916W2OMLQTB5YDCIRJ34N7S8PUXG", "3.142.105.48:8080")
warehouse = client.integration(name="aqueduct_demo")
customers_table = warehouse.sql(query="SELECT * FROM customers;")
for v in [64, 64., 64.0, 0x64, 0b010, 
          np.int64(64), np.int32(32), np.float64(64), np.float32(32),
          "64", "64.", "64.5", "64.d"]:
    try:
        @metric()
        def met(df):
            return v
        metrics = met(customers_table)
        out = metrics.get()
        print(v, "(", type(v), ")", "-->", out, "(", type(out), ")")
    except:
        print(v, "(", type(v), ")", "cannot be converted")
```
Output:
```
64 ( <class 'int'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64.0 ( <class 'float'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64.0 ( <class 'float'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
100 ( <class 'int'> ) --> 100.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
2 ( <class 'int'> ) --> 2.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64 ( <class 'numpy.int64'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
32 ( <class 'numpy.int32'> ) --> 32.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64.0 ( <class 'numpy.float64'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
32.0 ( <class 'numpy.float32'> ) --> 32.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64 ( <class 'str'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64. ( <class 'str'> ) --> 64.0 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
64.5 ( <class 'str'> ) --> 64.5 ( <class 'float'> )
Warning: You are overwriting the previously defined operator `met`. Any downstream artifacts of that operator will need to be recomputed and re-saved.
Operator met Failed! Error message: 
 Expected output type to be numeric, instead got str
64.d ( <class 'str'> ) cannot be converted
```

## Related issue number (if any)
ENG-1206
(NEW) ENG-1317
- Due to the way we pass the metric artifact back and forth, it seems that the content is coerced into a float. Not much of a problem when the input is a int or a float, but if the user passes in a "64" and gets a 64.0. We can either not allow strings, or add some part in the documentation that the metric artifact will be the output converted to a float.

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have manually run the integration tests and they are passing.
- Not sure we have tests set up for the aqueduct executor.
- [x] All features on the UI continue to work correctly.
