### PR TITLE
Adds aqueduct storage command to CLI

### DIFF
--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/aqueducthq/aqueduct/lib/logging"
-	"github.com/aqueducthq/aqueduct/lib/storage"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
 	"github.com/dropbox/godropbox/errors"
@@ -93,13 +92,8 @@ func NewAqServer(conf *config.ServerConfiguration) *AqServer {
 	}
 
 	s := &AqServer{
-		Router: chi.NewRouter(),
-		StorageConfig: &shared.StorageConfig{
-			Type: shared.FileStorageType,
-			FileConfig: &shared.FileConfig{
-				Directory: path.Join(aqPath, storage.DefaultFileStorageDir),
-			},
-		},
+		Router:        chi.NewRouter(),
+		StorageConfig: conf.StorageConfig,
 		Database:      db,
 		GithubManager: github.NewUnimplementedManager(),
 		JobManager:    jobManager,

--- a/src/golang/config/config.go
+++ b/src/golang/config/config.go
@@ -3,16 +3,19 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"path"
 
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
 type ServerConfiguration struct {
-	AqPath             string `yaml:"aqPath" json:"aq_path"`
-	EncryptionKey      string `yaml:"encryptionKey" json:"encryption_key"`
-	RetentionJobPeriod string `yaml:"retentionJobPeriod"`
-	ApiKey             string `yaml:"apiKey"`
+	AqPath             string                `yaml:"aqPath" json:"aq_path"`
+	EncryptionKey      string                `yaml:"encryptionKey" json:"encryption_key"`
+	RetentionJobPeriod string                `yaml:"retentionJobPeriod"`
+	ApiKey             string                `yaml:"apiKey"`
+	StorageConfig      *shared.StorageConfig `yaml:"storageConfig"`
 }
 
 func ParseServerConfiguration(confPath string) *ServerConfiguration {
@@ -27,6 +30,18 @@ func ParseServerConfiguration(confPath string) *ServerConfiguration {
 	if err != nil {
 		log.Fatal("Unable to correctly parse server config.yml. Please check the config file and retry: ", err)
 		os.Exit(1)
+	}
+
+	if config.StorageConfig == nil {
+		// StorageConfig was not provided so the FileStorage is used by default
+		defaultStoragePath := path.Join(os.Getenv("HOME"), ".aqueduct", "server", "storage")
+
+		config.StorageConfig = &shared.StorageConfig{
+			Type: shared.FileStorageType,
+			FileConfig: &shared.FileConfig{
+				Directory: defaultStoragePath,
+			},
+		}
 	}
 
 	return &config

--- a/src/golang/lib/collections/shared/storage.go
+++ b/src/golang/lib/collections/shared/storage.go
@@ -20,8 +20,10 @@ type StorageConfig struct {
 }
 
 type S3Config struct {
-	Region string `yaml:"region" json:"region"`
-	Bucket string `yaml:"bucket" json:"bucket"`
+	Region             string `yaml:"region" json:"region"`
+	Bucket             string `yaml:"bucket" json:"bucket"`
+	CredentialsPath    string `yaml:"credentialsPath" json:"credentials_path"`
+	CredentialsProfile string `yaml:"credentialsProfile"  json:"credentials_profile"`
 }
 
 type FileConfig struct {

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -9,8 +9,6 @@ import (
 )
 
 const (
-	DefaultFileStorageDir = "storage/"
-
 	filePermissionCode = 0o664
 )
 

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -3,9 +3,12 @@ package storage
 import (
 	"bytes"
 	"context"
+	"net/url"
+	"path"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -21,19 +24,39 @@ func newS3Storage(s3Config *shared.S3Config) *s3Storage {
 	}
 }
 
+// parseBucketAndKey takes the bucket in the form of s3://bucket/path
+// and a key and parses the bucket name and the key.
+func (s *s3Storage) parseBucketAndKey(key string) (string, string, error) {
+	u, err := url.Parse(s.s3Config.Bucket)
+	if err != nil {
+		return "", "", err
+	}
+
+	bucket := u.Host
+	key = path.Join(u.Path, key)
+
+	return bucket, key, nil
+}
+
 func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
-	sess, err := CreateS3Session(s.s3Config.Region)
+	sess, err := CreateS3Session(s.s3Config)
 	if err != nil {
 		return nil, err
 	}
 
 	buff := &aws.WriteAtBuffer{}
 	downloader := s3manager.NewDownloader(sess)
+
+	bucket, key, err := s.parseBucketAndKey(key)
+	if err != nil {
+		return nil, err
+	}
+
 	_, err = downloader.DownloadWithContext(
 		ctx,
 		buff,
 		&s3.GetObjectInput{
-			Bucket: aws.String(s.s3Config.Bucket),
+			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 		})
 	if err != nil {
@@ -43,7 +66,7 @@ func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
-	sess, err := CreateS3Session(s.s3Config.Region)
+	sess, err := CreateS3Session(s.s3Config)
 	if err != nil {
 		return err
 	}
@@ -51,10 +74,16 @@ func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
 	file := bytes.NewReader(value)
 
 	uploader := s3manager.NewUploader(sess)
+
+	bucket, key, err := s.parseBucketAndKey(key)
+	if err != nil {
+		return err
+	}
+
 	_, err = uploader.UploadWithContext(
 		ctx,
 		&s3manager.UploadInput{
-			Bucket: aws.String(s.s3Config.Bucket),
+			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 			Body:   file,
 		})
@@ -65,25 +94,35 @@ func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
 }
 
 func (s *s3Storage) Delete(ctx context.Context, key string) error {
-	sess, err := CreateS3Session(s.s3Config.Region)
+	sess, err := CreateS3Session(s.s3Config)
 	if err != nil {
 		return err
 	}
 
 	s3Client := s3.New(sess)
+
+	bucket, key, err := s.parseBucketAndKey(key)
+	if err != nil {
+		return err
+	}
+
 	_, err = s3Client.DeleteObjectWithContext(
 		ctx,
 		&s3.DeleteObjectInput{
-			Bucket: aws.String(s.s3Config.Bucket),
+			Bucket: aws.String(bucket),
 			Key:    aws.String(key),
 		},
 	)
 	return err
 }
 
-func CreateS3Session(awsRegion string) (*session.Session, error) {
+func CreateS3Session(s3Config *shared.S3Config) (*session.Session, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(awsRegion),
+		Region: aws.String(s3Config.Region),
+		Credentials: credentials.NewSharedCredentials(
+			s3Config.CredentialsPath,
+			s3Config.CredentialsProfile,
+		),
 	})
 	if err != nil {
 		return nil, err

--- a/src/golang/lib/storage/s3_test.go
+++ b/src/golang/lib/storage/s3_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBucketAndKey(t *testing.T) {
+	config := &shared.S3Config{
+		Region:             "us-east-2",
+		Bucket:             "s3://aqueduct/test/folder",
+		CredentialsPath:    "/home/users/aqueduct/.aws",
+		CredentialsProfile: "default",
+	}
+	storage := s3Storage{
+		s3Config: config,
+	}
+
+	bucket, key, err := storage.parseBucketAndKey("key")
+	require.Nil(t, err)
+	require.Equal(t, "aqueduct", bucket)
+	require.Equal(t, "/test/folder/key", key)
+}

--- a/src/python/aqueduct_executor/operators/utils/storage/config.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/config.py
@@ -17,6 +17,8 @@ class FileStorageConfig(BaseModel):
 class S3StorageConfig(BaseModel):
     region: str
     bucket: str
+    credentials_path: str
+    credentials_profile: str
 
 
 class StorageConfig(BaseModel):

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -1,9 +1,11 @@
-from typing import Any
+import os
+from typing import Any, Tuple
 
 import boto3
+from botocore.config import Config as BotoConfig
+
 from aqueduct_executor.operators.utils.storage.config import S3StorageConfig
 from aqueduct_executor.operators.utils.storage.storage import Storage
-from botocore.config import Config as BotoConfig
 
 
 class S3Storage(Storage):
@@ -11,13 +13,29 @@ class S3Storage(Storage):
     _config: S3StorageConfig
 
     def __init__(self, config: S3StorageConfig):
+        # Boto3 uses an environment variable to determine the credentials filepath and profile
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = config.credentials_path
+        os.environ["AWS_PROFILE"] = config.credentials_profile
+
         self._client = boto3.client("s3", config=BotoConfig(region_name=config.region))
         self._config = config
 
+        bucket, key_prefix = parse_s3_path(self._config.bucket)
+        self._bucket = bucket
+        self._key_prefix = key_prefix
+
     def put(self, key: str, value: bytes) -> None:
+        key = self._key_prefix + "/" + key
         print(f"writing to s3: {key}")
-        self._client.put_object(Bucket=self._config.bucket, Key=key, Body=value)
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=value)
 
     def get(self, key: str) -> bytes:
+        key = self._key_prefix + "/" + key
         print(f"reading from s3: {key}")
-        return self._client.get_object(Bucket=self._config.bucket, Key=key)["Body"].read()  # type: ignore
+        return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read() # type: ignore
+    
+def parse_s3_path(s3_path: str) -> Tuple[str, str]:
+    path_parts=s3_path.replace("s3://","").split("/")
+    bucket=path_parts.pop(0)
+    key="/".join(path_parts)
+    return bucket, key

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -2,10 +2,9 @@ import os
 from typing import Any, Tuple
 
 import boto3
-from botocore.config import Config as BotoConfig
-
 from aqueduct_executor.operators.utils.storage.config import S3StorageConfig
 from aqueduct_executor.operators.utils.storage.storage import Storage
+from botocore.config import Config as BotoConfig
 
 
 class S3Storage(Storage):
@@ -32,10 +31,11 @@ class S3Storage(Storage):
     def get(self, key: str) -> bytes:
         key = self._key_prefix + "/" + key
         print(f"reading from s3: {key}")
-        return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read() # type: ignore
-    
+        return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()  # type: ignore
+
+
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:
-    path_parts=s3_path.replace("s3://","").split("/")
-    bucket=path_parts.pop(0)
-    key="/".join(path_parts)
+    path_parts = s3_path.replace("s3://", "").split("/")
+    bucket = path_parts.pop(0)
+    key = "/".join(path_parts)
     return bucket, key

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -388,7 +388,7 @@ def use_local_storage(path):
     write_config(config)
 
 def use_s3_storage(region, bucket, creds_path, creds_profile):
-    if bucket[:5] != "s3://":
+    if not bucket.startswith("s3://"):
         print('S3 path is malformed, it should be of the form s3://')
         sys.exit(1)
         

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -388,6 +388,10 @@ def use_local_storage(path):
     write_config(config)
 
 def use_s3_storage(region, bucket, creds_path, creds_profile):
+    if bucket[:5] != "s3://":
+        print('S3 path is malformed, it should be of the form s3://')
+        sys.exit(1)
+        
     config = read_config()
     
     s3_config = {

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -521,6 +521,10 @@ if __name__ == "__main__":
                     sys.exit(1)
             use_local_storage(args.storage_path)
         elif args.storage_use == "s3":
+            # Ensure that required S3 args are provided
+            if "--region" not in sysargs:
+                print("--region is required when using S3 storage")
+                sys.exit(1)
             use_s3_storage(
                 args.storage_s3_region, 
                 args.storage_path, 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -455,18 +455,16 @@ if __name__ == "__main__":
                                 choices=["local", "s3"], required=True,
                                 help="The following storage locations are supported: local, s3"
                             )
-    storage_args.add_argument('--path', dest="storage_local_path", default='storage', 
+    storage_args.add_argument('--path', dest="storage_path", required=True, 
                                 help=
-                                '''The filepath of the local storage directory.
+                                '''For local storage this is the filepath of the storage directory.
                                 This should be relative to the Aqueduct installation path.
-                                It defaults to storage/.
+                                For S3 storage this is the S3 path, which should be of the form:
+                                s3://bucket/path/to/folder
                                 '''
                             )
     storage_args.add_argument('--region', dest="storage_s3_region", 
                                 help="The AWS S3 region where the bucket is located."
-                            )
-    storage_args.add_argument('--bucket', dest="storage_s3_bucket", 
-                                help="The AWS S3 bucket to use for storage."
                             )
     storage_args.add_argument('--credentials', dest="storage_s3_creds", 
                                 default=aws_credentials_path,
@@ -480,6 +478,7 @@ if __name__ == "__main__":
                             )
 
     args = parser.parse_args()
+    sysargs = sys.argv
 
     if args.command == "start":
         try:
@@ -510,11 +509,17 @@ if __name__ == "__main__":
         version()
     elif args.command == "storage":
         if args.storage_use == "local":
-            use_local_storage(args.storage_local_path)
+            # Ensure that S3 args are not provided for local storage
+            s3_args = ["--region", "--credentials", "--profile"]
+            for s3_arg in s3_args:
+                if s3_arg in sysargs:
+                    print("{} should not be used with local storage".format(s3_arg))
+                    sys.exit(1)
+            use_local_storage(args.storage_path)
         elif args.storage_use == "s3":
             use_s3_storage(
                 args.storage_s3_region, 
-                args.storage_s3_bucket, 
+                args.storage_path, 
                 args.storage_s3_creds, 
                 args.storage_s3_profile,
             )

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -363,6 +363,42 @@ def clear():
 def version():
     print(package_version)
 
+def read_config():
+    with open(os.path.join(server_directory, "config", "config.yml"), 'r') as f:
+        config = yaml.safe_load(f)
+    return config
+
+def write_config(config):
+    with open(os.path.join(server_directory, "config", "config.yml"), 'w') as f:
+        yaml.dump(config, f)
+
+def use_local_storage(path):
+    config = read_config()
+    
+    file_config = {"directory": path}
+    config["storageConfig"] = {
+        "type": "file",
+        "fileConfig": file_config,
+    }
+
+    write_config(config)
+
+def use_s3_storage(region, bucket, creds_path, creds_profile):
+    config = read_config()
+    
+    s3_config = {
+        "region": region,
+        "bucket": bucket,
+        "credentialsPath": creds_path,
+        "credentialsProfile": creds_profile,
+    }
+    config["storageConfig"] = {
+        "type": "s3",
+        "s3Config": s3_config,
+    }
+
+    write_config(config)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='The Aqueduct CLI')
     subparsers = parser.add_subparsers(dest="command")
@@ -405,6 +441,40 @@ if __name__ == "__main__":
     clear_args = subparsers.add_parser('clear', help="Erase your Aqueduct installation.")
     version_args = subparsers.add_parser('version', help="Retrieve the package version number.")
 
+    storage_args = subparsers.add_parser('storage', help=
+                               '''This changes the storage location for any new workflows created.
+                               The change will take affect once you restart the Aqueduct server.
+                               We are currently working on adding support for modifying the storage
+                               location of existing workflows.
+                               ''')
+    storage_args.add_argument('--use', dest="storage_use", 
+                                choices=["local", "s3"], required=True,
+                                help="The following storage locations are supported: local, s3"
+                            )
+    storage_args.add_argument('--path', dest="storage_local_path", default='storage', 
+                                help=
+                                '''The filepath of the local storage directory.
+                                This should be relative to the Aqueduct installation path.
+                                It defaults to storage/.
+                                '''
+                            )
+    storage_args.add_argument('--region', dest="storage_s3_region", 
+                                help="The AWS S3 region where the bucket is located."
+                            )
+    storage_args.add_argument('--bucket', dest="storage_s3_bucket", 
+                                help="The AWS S3 bucket to use for storage."
+                            )
+    storage_args.add_argument('--credentials', dest="storage_s3_creds", 
+                                default="~/.aws/credentials",
+                                help='''The filepath to the AWS credentials to use.
+                                It defaults to ~/.aws/credentials'''
+                            )
+    storage_args.add_argument('--profile', dest="storage_s3_profile",
+                                default="default",
+                                help='''The AWS credentials profile to use. It uses default 
+                                if none is provided.'''
+                            )
+
     args = parser.parse_args()
 
     if args.command == "start":
@@ -434,6 +504,19 @@ if __name__ == "__main__":
         clear()
     elif args.command == "version":
         version()
+    elif args.command == "storage":
+        if args.storage_use == "local":
+            use_local_storage(args.storage_local_path)
+        elif args.storage_use == "s3":
+            use_s3_storage(
+                args.storage_s3_region, 
+                args.storage_s3_bucket, 
+                args.storage_s3_creds, 
+                args.storage_s3_profile,
+            )
+        else:
+            print("Unsupported storage type: ", args.storage_use)
+            sys.exit(1)
     elif args.command is None:
         parser.print_help()
     else:

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -23,6 +23,8 @@ server_directory = os.path.join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = os.path.join(os.environ["HOME"], ".aqueduct", "ui")
 
 package_version = "0.0.4"
+aws_credentials_path = os.path.join(os.environ["HOME"], ".aws", "credentials")
+
 default_server_port = 8080
 
 s3_server_prefix = (
@@ -374,6 +376,8 @@ def write_config(config):
 
 def use_local_storage(path):
     config = read_config()
+
+    path = os.path.join(server_directory, path)
     
     file_config = {"directory": path}
     config["storageConfig"] = {
@@ -465,7 +469,7 @@ if __name__ == "__main__":
                                 help="The AWS S3 bucket to use for storage."
                             )
     storage_args.add_argument('--credentials', dest="storage_s3_creds", 
-                                default="~/.aws/credentials",
+                                default=aws_credentials_path,
                                 help='''The filepath to the AWS credentials to use.
                                 It defaults to ~/.aws/credentials'''
                             )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds an `aqueduct storage` command to the CLI. This is necessary to allow users to modify the storage config globally for all subsequently created workflows. This will not affect existing workflows. Users will be able to access artifacts from previous workflows even after they modify the storage config.

## Related issue number (if any)
ENG 1310 

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

## Demo
Part 1: https://www.loom.com/share/58b40eb6a4504aa6902ddfa32badce0d (End the video after 5:15, there is an error, so the next video picks up from this spot)
Part 2: https://www.loom.com/share/edaec344a5c34bc9966b00c01124231e


