### PR TITLE
Refactors S3 storage implementation to use user provided credentials

### DIFF
--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/aqueducthq/aqueduct/lib/logging"
-	"github.com/aqueducthq/aqueduct/lib/storage"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
 	"github.com/dropbox/godropbox/errors"
@@ -93,13 +92,8 @@ func NewAqServer(conf *config.ServerConfiguration) *AqServer {
 	}
 
 	s := &AqServer{
-		Router: chi.NewRouter(),
-		StorageConfig: &shared.StorageConfig{
-			Type: shared.FileStorageType,
-			FileConfig: &shared.FileConfig{
-				Directory: path.Join(aqPath, storage.DefaultFileStorageDir),
-			},
-		},
+		Router:        chi.NewRouter(),
+		StorageConfig: conf.StorageConfig,
 		Database:      db,
 		GithubManager: github.NewUnimplementedManager(),
 		JobManager:    jobManager,

--- a/src/golang/config/config.go
+++ b/src/golang/config/config.go
@@ -4,15 +4,20 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
 type ServerConfiguration struct {
-	AqPath             string `yaml:"aqPath" json:"aq_path"`
-	EncryptionKey      string `yaml:"encryptionKey" json:"encryption_key"`
-	RetentionJobPeriod string `yaml:"retentionJobPeriod"`
-	ApiKey             string `yaml:"apiKey"`
+	AqPath             string                `yaml:"aqPath" json:"aq_path"`
+	EncryptionKey      string                `yaml:"encryptionKey" json:"encryption_key"`
+	RetentionJobPeriod string                `yaml:"retentionJobPeriod"`
+	ApiKey             string                `yaml:"apiKey"`
+	StorageConfig      *shared.StorageConfig `yaml:"storageConfig"`
+}
+
+type Storage struct {
 }
 
 func ParseServerConfiguration(confPath string) *ServerConfiguration {

--- a/src/golang/config/config.go
+++ b/src/golang/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/ioutil"
 	"os"
+	"path"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	log "github.com/sirupsen/logrus"
@@ -17,9 +18,6 @@ type ServerConfiguration struct {
 	StorageConfig      *shared.StorageConfig `yaml:"storageConfig"`
 }
 
-type Storage struct {
-}
-
 func ParseServerConfiguration(confPath string) *ServerConfiguration {
 	bts, err := ioutil.ReadFile(confPath)
 	if err != nil {
@@ -32,6 +30,18 @@ func ParseServerConfiguration(confPath string) *ServerConfiguration {
 	if err != nil {
 		log.Fatal("Unable to correctly parse server config.yml. Please check the config file and retry: ", err)
 		os.Exit(1)
+	}
+
+	if config.StorageConfig == nil {
+		// StorageConfig was not provided so the FileStorage is used by default
+		defaultStoragePath := path.Join(os.Getenv("HOME"), ".aqueduct", "server", "storage")
+
+		config.StorageConfig = &shared.StorageConfig{
+			Type: shared.FileStorageType,
+			FileConfig: &shared.FileConfig{
+				Directory: defaultStoragePath,
+			},
+		}
 	}
 
 	return &config

--- a/src/golang/lib/collections/shared/storage.go
+++ b/src/golang/lib/collections/shared/storage.go
@@ -23,7 +23,7 @@ type S3Config struct {
 	Region             string `yaml:"region" json:"region"`
 	Bucket             string `yaml:"bucket" json:"bucket"`
 	CredentialsPath    string `yaml:"credentialsPath" json:"credentials_path"`
-	CredentialsProfile string `json:"credentialsProfile"  yaml:"credentials_profile"`
+	CredentialsProfile string `yaml:"credentialsProfile"  json:"credentials_profile"`
 }
 
 type FileConfig struct {

--- a/src/golang/lib/collections/shared/storage.go
+++ b/src/golang/lib/collections/shared/storage.go
@@ -20,8 +20,10 @@ type StorageConfig struct {
 }
 
 type S3Config struct {
-	Region string `yaml:"region" json:"region"`
-	Bucket string `yaml:"bucket" json:"bucket"`
+	Region             string `yaml:"region" json:"region"`
+	Bucket             string `yaml:"bucket" json:"bucket"`
+	CredentialsPath    string `yaml:"credentials_path" json:"credentials_path"`
+	CredentialsProfile string `json:"credentials_profile"  yaml:"credentials_profile"`
 }
 
 type FileConfig struct {

--- a/src/golang/lib/collections/shared/storage.go
+++ b/src/golang/lib/collections/shared/storage.go
@@ -22,8 +22,8 @@ type StorageConfig struct {
 type S3Config struct {
 	Region             string `yaml:"region" json:"region"`
 	Bucket             string `yaml:"bucket" json:"bucket"`
-	CredentialsPath    string `yaml:"credentials_path" json:"credentials_path"`
-	CredentialsProfile string `json:"credentials_profile"  yaml:"credentials_profile"`
+	CredentialsPath    string `yaml:"credentialsPath" json:"credentials_path"`
+	CredentialsProfile string `json:"credentialsProfile"  yaml:"credentials_profile"`
 }
 
 type FileConfig struct {

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -9,8 +9,6 @@ import (
 )
 
 const (
-	DefaultFileStorageDir = "storage/"
-
 	filePermissionCode = 0o664
 )
 

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -22,7 +23,7 @@ func newS3Storage(s3Config *shared.S3Config) *s3Storage {
 }
 
 func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
-	sess, err := CreateS3Session(s.s3Config.Region)
+	sess, err := CreateS3Session(s.s3Config)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +44,7 @@ func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
-	sess, err := CreateS3Session(s.s3Config.Region)
+	sess, err := CreateS3Session(s.s3Config)
 	if err != nil {
 		return err
 	}
@@ -65,7 +66,7 @@ func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
 }
 
 func (s *s3Storage) Delete(ctx context.Context, key string) error {
-	sess, err := CreateS3Session(s.s3Config.Region)
+	sess, err := CreateS3Session(s.s3Config)
 	if err != nil {
 		return err
 	}
@@ -81,9 +82,13 @@ func (s *s3Storage) Delete(ctx context.Context, key string) error {
 	return err
 }
 
-func CreateS3Session(awsRegion string) (*session.Session, error) {
+func CreateS3Session(s3Config *shared.S3Config) (*session.Session, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(awsRegion),
+		Region: aws.String(s3Config.Region),
+		Credentials: credentials.NewSharedCredentials(
+			s3Config.CredentialsPath,
+			s3Config.CredentialsProfile,
+		),
 	})
 	if err != nil {
 		return nil, err

--- a/src/golang/lib/storage/s3_test.go
+++ b/src/golang/lib/storage/s3_test.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBucketAndKey(t *testing.T) {
+	config := &shared.S3Config{
+		Region:             "us-east-2",
+		Bucket:             "s3://aqueduct/test/folder",
+		CredentialsPath:    "/home/users/aqueduct/.aws",
+		CredentialsProfile: "default",
+	}
+	storage := s3Storage{
+		s3Config: config,
+	}
+
+	bucket, key, err := storage.parseBucketAndKey("key")
+	require.Nil(t, err)
+	require.Equal(t, "aqueduct", bucket)
+	require.Equal(t, "/test/folder/key", key)
+}

--- a/src/python/aqueduct_executor/operators/utils/storage/config.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/config.py
@@ -17,6 +17,8 @@ class FileStorageConfig(BaseModel):
 class S3StorageConfig(BaseModel):
     region: str
     bucket: str
+    credentials_path: str
+    credentials_profile: str
 
 
 class StorageConfig(BaseModel):

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -32,7 +32,7 @@ class S3Storage(Storage):
     def get(self, key: str) -> bytes:
         key = self._key_prefix + "/" + key
         print(f"reading from s3: {key}")
-        return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()
+        return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read() # type: ignore
     
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:
     path_parts=s3_path.replace("s3://","").split("/")

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import boto3
@@ -11,6 +12,10 @@ class S3Storage(Storage):
     _config: S3StorageConfig
 
     def __init__(self, config: S3StorageConfig):
+        # Boto3 uses an environment variable to determine the credentials filepath and profile
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = self._config.credentials_path
+        os.environ["AWS_PROFILE"] = self._config.credentials_profile
+
         self._client = boto3.client("s3", config=BotoConfig(region_name=config.region))
         self._config = config
 

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -13,8 +13,8 @@ class S3Storage(Storage):
 
     def __init__(self, config: S3StorageConfig):
         # Boto3 uses an environment variable to determine the credentials filepath and profile
-        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = self._config.credentials_path
-        os.environ["AWS_PROFILE"] = self._config.credentials_profile
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = config.credentials_path
+        os.environ["AWS_PROFILE"] = config.credentials_profile
 
         self._client = boto3.client("s3", config=BotoConfig(region_name=config.region))
         self._config = config

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -25,12 +25,14 @@ class S3Storage(Storage):
         self._key_prefix = key_prefix
 
     def put(self, key: str, value: bytes) -> None:
+        key = self._key_prefix + "/" + key
         print(f"writing to s3: {key}")
-        self._client.put_object(Bucket=self._bucket, Key="/".join(self._key_prefix, key), Body=value)
+        self._client.put_object(Bucket=self._bucket, Key=key, Body=value)
 
     def get(self, key: str) -> bytes:
+        key = self._key_prefix + "/" + key
         print(f"reading from s3: {key}")
-        return self._client.get_object(Bucket=self._bucket, Key="/".join(self._key_prefix, key))["Body"].read()
+        return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()
     
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:
     path_parts=s3_path.replace("s3://","").split("/")

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -1,10 +1,11 @@
 import os
-from typing import Any
+from typing import Any, Tuple
 
 import boto3
+from botocore.config import Config as BotoConfig
+
 from aqueduct_executor.operators.utils.storage.config import S3StorageConfig
 from aqueduct_executor.operators.utils.storage.storage import Storage
-from botocore.config import Config as BotoConfig
 
 
 class S3Storage(Storage):
@@ -19,10 +20,20 @@ class S3Storage(Storage):
         self._client = boto3.client("s3", config=BotoConfig(region_name=config.region))
         self._config = config
 
+        bucket, key_prefix = parse_s3_path(self._config.bucket)
+        self._bucket = bucket
+        self._key_prefix = key_prefix
+
     def put(self, key: str, value: bytes) -> None:
         print(f"writing to s3: {key}")
-        self._client.put_object(Bucket=self._config.bucket, Key=key, Body=value)
+        self._client.put_object(Bucket=self._bucket, Key="/".join(self._key_prefix, key), Body=value)
 
     def get(self, key: str) -> bytes:
         print(f"reading from s3: {key}")
-        return self._client.get_object(Bucket=self._config.bucket, Key=key)["Body"].read()  # type: ignore
+        return self._client.get_object(Bucket=self._bucket, Key="/".join(self._key_prefix, key))["Body"].read()
+    
+def parse_s3_path(s3_path: str) -> Tuple[str, str]:
+    path_parts=s3_path.replace("s3://","").split("/")
+    bucket=path_parts.pop(0)
+    key="/".join(path_parts)
+    return bucket, key


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR changes the Aqueduct server start behavior to use the storage config found in the config.yml file, instead of defaulting to file storage each time.

It also refactors all access to S3 for storage to use the AWS credentials provided by the user. Previously, the access was performed without explicitly specifying where to find the AWS credentials.

## Related issue number (if any)
ENG 1311

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

See #193 for demo 


