### PR TITLE
Fails workflow that have a failing error severity check

### DIFF
--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -145,31 +145,29 @@ def test_check_wrong_number_of_inputs(client):
         check_artifact.get()
 
 
-@check(severity=CheckSeverity.ERROR)
-def success_check_return_numpy_bool(df):
-    return df["total_charges"].mean() < 2500
-
-
 def test_check_with_numpy_bool_output(client):
     db = client.integration(name=get_integration_name())
     sql_artifact = db.sql(query=CHURN_SQL_QUERY)
+
+    @check()
+    def success_check_return_numpy_bool(df):
+        return df["total_charges"].mean() < 2500
+
     check_artifact = success_check_return_numpy_bool(sql_artifact)
     assert check_artifact.get()
-
-
-@check(severity=CheckSeverity.ERROR)
-def success_check_return_series_of_booleans(df):
-    return pd.Series([True, True, True])
-
-
-@check()
-def failure_check_return_series_of_booleans(df):
-    return pd.Series([True, False, True])
 
 
 def test_check_with_series_output(client):
     db = client.integration(name=get_integration_name())
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+
+    @check()
+    def success_check_return_series_of_booleans(df):
+        return pd.Series([True, True, True])
+
+    @check()
+    def failure_check_return_series_of_booleans(df):
+        return pd.Series([True, False, True])
 
     passed = success_check_return_series_of_booleans(sql_artifact)
     assert passed.get()
@@ -178,3 +176,24 @@ def test_check_with_series_output(client):
     assert not failed.get()
 
     run_flow_test(client, artifacts=[sql_artifact, passed, failed])
+
+
+def test_check_failure_with_severity(client):
+    db = client.integration(name=get_integration_name())
+    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+
+    # An error check will fail the workflow, but a warning check will not.
+    @check(severity=CheckSeverity.WARNING)
+    def failure_nonblocking_check(df):
+        return False
+
+    @check(severity=CheckSeverity.ERROR)
+    def failure_blocking_check(df):
+        return False
+
+    _ = failure_nonblocking_check(sql_artifact)
+    run_flow_test(client, artifacts=[sql_artifact])
+
+    _ = failure_blocking_check(sql_artifact)
+    run_flow_test(client, artifacts=[sql_artifact], expect_success=False)
+

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -103,6 +103,9 @@ type FunctionSpec struct {
 	OutputMetadataPaths []string        `json:"output_metadata_paths"  yaml:"output_metadata_paths"`
 	InputArtifactTypes  []artifact.Type `json:"input_artifact_types"  yaml:"input_artifact_types"`
 	OutputArtifactTypes []artifact.Type `json:"output_artifact_types"  yaml:"output_artifact_types"`
+
+	// If the function outputs any of these blacklisted values, we will fail workflow execution.
+	BlacklistedOutputs []string `json:"blacklisted_outputs" yaml:"blacklisted_outputs"`
 }
 
 type ParamSpec struct {
@@ -266,6 +269,7 @@ func NewFunctionSpec(
 	outputMetadataPaths []string,
 	inputArtifactTypes []artifact.Type,
 	outputArtifactTypes []artifact.Type,
+	blacklistedOutputs []string,
 ) Spec {
 	return &FunctionSpec{
 		basePythonSpec: basePythonSpec{
@@ -287,6 +291,7 @@ func NewFunctionSpec(
 		OutputMetadataPaths: outputMetadataPaths,
 		InputArtifactTypes:  inputArtifactTypes,
 		OutputArtifactTypes: outputArtifactTypes,
+		BlacklistedOutputs:  blacklistedOutputs,
 	}
 }
 

--- a/src/golang/lib/workflow/scheduler/function.go
+++ b/src/golang/lib/workflow/scheduler/function.go
@@ -34,6 +34,7 @@ func ScheduleFunction(
 	outputArtifactTypes []artifact.Type,
 	storageConfig *shared.StorageConfig,
 	jobManager job.JobManager,
+	blacklistedOutputs []string,
 ) (string, error) {
 	entryPoint := fn.EntryPoint
 	if entryPoint == nil {
@@ -61,6 +62,7 @@ func ScheduleFunction(
 		outputMetadataPaths,
 		inputArtifactTypes,
 		outputArtifactTypes,
+		blacklistedOutputs,
 	)
 
 	err := jobManager.Launch(ctx, jobName, jobSpec)

--- a/src/python/aqueduct_executor/operators/function_executor/execute_function.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute_function.py
@@ -128,6 +128,18 @@ def run(spec: FunctionSpec) -> None:
         if not isinstance(results, list):
             results = [results]
 
+        # Check if any of the results should be blacklisted.
+        for res in results:
+            if json.dumps(res) in spec.blacklisted_outputs:
+                exec_state.status = ExecutionStatus.FAILED
+                exec_state.failure_type = FailureType.USER
+                exec_state.error = Error(
+                    context="",
+                    tip="The check %s has severity=ERROR and did not pass." % spec.name,
+                )
+                utils.write_exec_state(storage, spec.metadata_path, exec_state)
+                sys.exit(1)
+
         utils.write_artifacts(
             storage,
             spec.output_artifact_types,

--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -30,6 +30,10 @@ class FunctionSpec(BaseModel):
     input_artifact_types: List[enums.InputArtifactType]
     output_artifact_types: List[enums.OutputArtifactType]
 
+    # If the function produces one of these blacklisted outputs exactly, we will fail the
+    # entire workflow. This is currently used to implement SEVERITY=error checks.
+    blacklisted_outputs: List[str]
+
     class Config:
         extra = Extra.forbid
 

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -26,7 +26,6 @@ TIP_EXTRACT = "We couldn't execute the provided query. Please double check your 
 TIP_LOAD = "We couldn't load to the integration. Please make sure the target exists, or you have the right permission."
 TIP_DISCOVER = "We couldn't list items in the integration. Please make sure your credentials have the right permission."
 
-
 class Error(BaseModel):
     tip: str = ""  # Information about how the user could fix the error.
     context: str = ""  # More details about the error. Typically a stack trace.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
I tried to make this as generic as possible for the python operators. This means supplying a "blacklisted output" list on the FunctionSpec. If the function's output matches an entry in this list, we will fail the operation and thus the workflow execution.

This blacklisted output field is currently only used by the check operator, but it seemed like a reasonable generic concept that didn't involve building check-specific logic into `execute_function.py`.


## Related issue number (if any)
ENG-1265

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x] I have performed a self-review of my code.
- [ N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


