### PR TITLE
Schema migration for changing 'metadata' to 'exec_state'

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -26,7 +26,7 @@ server_directory = join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = join(os.environ["HOME"], ".aqueduct", "ui")
 
 # Make sure to update this if there is any schema change we want to include in the upgrade.
-SCHEMA_VERSION = "9"
+SCHEMA_VERSION = "12"
 
 
 def execute_command(args, cwd=None):

--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -12,6 +12,9 @@ import (
 	_000007 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000007_workflow_dag_edge_pk"
 	_000008 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000008_delete_s3_config"
 	_000009 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000009_metadata_interface_backfill"
+	_000010 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000010_add_exec_state_column"
+	_000011 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000011_exec_state_column_backfill"
+	_000012 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000012_drop_metadata_column"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -72,5 +75,23 @@ func init() {
 		upPostgres: _000009.Up, upSqlite: _000009.Up,
 		downPostgres: _000009.Down,
 		name:         "backfill metadata in artifact_results",
+	}
+
+	registeredMigrations[10] = &migration{
+		upPostgres: _000010.UpPostgres, upSqlite: _000010.UpSqlite,
+		downPostgres: _000010.DownPostgres,
+		name:         "add exec state column to operator_result",
+	}
+
+	registeredMigrations[11] = &migration{
+		upPostgres: _000011.Up, upSqlite: _000011.Up,
+		downPostgres: _000011.Down,
+		name:         "backfill exec state column in operator_result",
+	}
+
+	registeredMigrations[12] = &migration{
+		upPostgres: _000012.UpPostgres, upSqlite: _000012.UpSqlite,
+		downPostgres: _000012.DownPostgres,
+		name:         "remove metadata in operator_result",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000004_storage_interface_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000004_storage_interface_backfill/queries.go
@@ -47,7 +47,7 @@ func updateStorageConfig(
 	db database.Database,
 ) error {
 	changes := map[string]interface{}{
-		"storage_config": storageConfig,
+		"storage_config": &storageConfig,
 	}
 	return utils.UpdateRecord(ctx, changes, "workflow_dag", "id", id, db)
 }
@@ -59,7 +59,7 @@ func updateOperatorSpec(
 	db database.Database,
 ) error {
 	changes := map[string]interface{}{
-		"spec": spec,
+		"spec": &spec,
 	}
 	return utils.UpdateRecord(ctx, changes, "operator", "id", id, db)
 }

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/down_postgres.go
@@ -1,0 +1,5 @@
+package _000010_add_exec_state_column
+
+const downPostgresScript = `
+ALTER TABLE operator_result DROP COLUMN IF EXISTS exec_state;
+`

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/down_postgres.go
@@ -1,5 +1,5 @@
 package _000010_add_exec_state_column
 
 const downPostgresScript = `
-ALTER TABLE operator_result DROP COLUMN IF EXISTS exec_state;
+ALTER TABLE operator_result DROP COLUMN IF EXISTS execution_state;
 `

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/main.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/main.go
@@ -1,0 +1,19 @@
+package _000010_add_exec_state_column
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func UpPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upPostgresScript)
+}
+
+func UpSqlite(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, sqliteScript)
+}
+
+func DownPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, downPostgresScript)
+}

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_postgres.go
@@ -2,5 +2,5 @@ package _000010_add_exec_state_column
 
 const upPostgresScript = `
 ALTER TABLE operator_result
-ADD COLUMN exec_state JSONB;
+ADD COLUMN execution_state JSONB;
 `

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_postgres.go
@@ -1,0 +1,6 @@
+package _000010_add_exec_state_column
+
+const upPostgresScript = `
+ALTER TABLE operator_result
+ADD COLUMN exec_state JSONB;
+`

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_sqlite.go
@@ -2,5 +2,5 @@ package _000010_add_exec_state_column
 
 const sqliteScript = `
 ALTER TABLE operator_result
-ADD COLUMN exec_state BLOB;
+ADD COLUMN execution_state BLOB;
 `

--- a/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000010_add_exec_state_column/up_sqlite.go
@@ -1,0 +1,6 @@
+package _000010_add_exec_state_column
+
+const sqliteScript = `
+ALTER TABLE operator_result
+ADD COLUMN exec_state BLOB;
+`

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/main.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/main.go
@@ -3,7 +3,6 @@ package _000011_exec_state_column_backfill
 import (
 	"context"
 
-	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -15,7 +14,7 @@ func Up(ctx context.Context, db database.Database) error {
 
 	for _, opResult := range opResults {
 		if !opResult.Metadata.IsNull {
-			userLogs := shared.Logs{}
+			userLogs := Logs{}
 			stdout, ok := opResult.Metadata.Logs["stdout"]
 			if ok {
 				(&userLogs).Stdout = stdout
@@ -26,9 +25,9 @@ func Up(ctx context.Context, db database.Database) error {
 				(&userLogs).StdErr = stderr
 			}
 
-			execState := shared.ExecutionState{
+			execState := ExecutionState{
 				Status: opResult.Status,
-				Error: &shared.Error{
+				Error: &Error{
 					Context: opResult.Metadata.Error,
 				},
 				UserLogs: &userLogs,

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/main.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/main.go
@@ -1,0 +1,76 @@
+package _000011_exec_state_column_backfill
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func Up(ctx context.Context, db database.Database) error {
+	opResults, err := getOpResultsWithMetadata(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, opResult := range opResults {
+		if !opResult.Metadata.IsNull {
+			userLogs := shared.Logs{}
+			stdout, ok := opResult.Metadata.Logs["stdout"]
+			if ok {
+				(&userLogs).Stdout = stdout
+			}
+
+			stderr, ok := opResult.Metadata.Logs["stderr"]
+			if ok {
+				(&userLogs).StdErr = stderr
+			}
+
+			execState := shared.ExecutionState{
+				Status: opResult.Status,
+				Error: &shared.Error{
+					Context: opResult.Metadata.Error,
+				},
+				UserLogs: &userLogs,
+			}
+
+			err = updateExecState(ctx, opResult.Id, execState, db)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func Down(ctx context.Context, db database.Database) error {
+	opResults, err := getOpResultsWithExecState(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, opResult := range opResults {
+		if !opResult.ExecState.IsNull {
+			Logs := map[string]string{}
+			if opResult.ExecState.UserLogs != nil {
+				Logs["stdout"] = opResult.ExecState.UserLogs.Stdout
+				Logs["stderr"] = opResult.ExecState.UserLogs.StdErr
+			}
+
+			errStr := ""
+			if opResult.ExecState.Error != nil {
+				errStr = opResult.ExecState.Error.Context
+			}
+
+			metadata := Metadata{Logs: Logs, Error: errStr}
+
+			err = updateMetadata(ctx, opResult.Id, metadata, db)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/main.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/main.go
@@ -34,7 +34,7 @@ func Up(ctx context.Context, db database.Database) error {
 				UserLogs: &userLogs,
 			}
 
-			err = updateExecState(ctx, opResult.Id, execState, db)
+			err = updateExecState(ctx, opResult.Id, &execState, db)
 			if err != nil {
 				return err
 			}
@@ -65,7 +65,7 @@ func Down(ctx context.Context, db database.Database) error {
 
 			metadata := Metadata{Logs: Logs, Error: errStr}
 
-			err = updateMetadata(ctx, opResult.Id, metadata, db)
+			err = updateMetadata(ctx, opResult.Id, &metadata, db)
 			if err != nil {
 				return err
 			}

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
@@ -18,7 +18,7 @@ type opResultWithMetadata struct {
 type opResultWithExecState struct {
 	Id        uuid.UUID              `db:"id" json:"id"`
 	Status    shared.ExecutionStatus `db:"status" json:"status"`
-	ExecState NullExecutionState     `db:"exec_state" json:"exec_state"`
+	ExecState NullExecutionState     `db:"execution_state" json:"execution_state"`
 }
 
 func getOpResultsWithMetadata(
@@ -39,7 +39,7 @@ func updateExecState(
 	db database.Database,
 ) error {
 	changes := map[string]interface{}{
-		"exec_state": execState,
+		"execution_state": execState,
 	}
 	return utils.UpdateRecord(ctx, changes, "operator_result", "id", id, db)
 }
@@ -48,7 +48,7 @@ func getOpResultsWithExecState(
 	ctx context.Context,
 	db database.Database,
 ) ([]opResultWithExecState, error) {
-	query := "SELECT id, status, exec_state FROM operator_result;"
+	query := "SELECT id, status, execution_state FROM operator_result;"
 
 	var response []opResultWithExecState
 	err := db.Query(ctx, &response, query)

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
@@ -1,0 +1,68 @@
+package _000011_exec_state_column_backfill
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/google/uuid"
+)
+
+type opResultWithMetadata struct {
+	Id       uuid.UUID              `db:"id" json:"id"`
+	Status   shared.ExecutionStatus `db:"status" json:"status"`
+	Metadata NullMetadata           `db:"metadata" json:"metadata"`
+}
+
+type opResultWithExecState struct {
+	Id        uuid.UUID                 `db:"id" json:"id"`
+	Status    shared.ExecutionStatus    `db:"status" json:"status"`
+	ExecState shared.NullExecutionState `db:"exec_state" json:"exec_state"`
+}
+
+func getOpResultsWithMetadata(
+	ctx context.Context,
+	db database.Database,
+) ([]opResultWithMetadata, error) {
+	query := "SELECT id, status, metadata FROM operator_result;"
+
+	var response []opResultWithMetadata
+	err := db.Query(ctx, &response, query)
+	return response, err
+}
+
+func updateExecState(
+	ctx context.Context,
+	id uuid.UUID,
+	execState shared.ExecutionState,
+	db database.Database,
+) error {
+	changes := map[string]interface{}{
+		"exec_state": execState,
+	}
+	return utils.UpdateRecord(ctx, changes, "operator_result", "id", id, db)
+}
+
+func getOpResultsWithExecState(
+	ctx context.Context,
+	db database.Database,
+) ([]opResultWithExecState, error) {
+	query := "SELECT id, status, exec_state FROM operator_result;"
+
+	var response []opResultWithExecState
+	err := db.Query(ctx, &response, query)
+	return response, err
+}
+
+func updateMetadata(
+	ctx context.Context,
+	id uuid.UUID,
+	metadata Metadata,
+	db database.Database,
+) error {
+	changes := map[string]interface{}{
+		"metadata": metadata,
+	}
+	return utils.UpdateRecord(ctx, changes, "operator_result", "id", id, db)
+}

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
@@ -35,7 +35,7 @@ func getOpResultsWithMetadata(
 func updateExecState(
 	ctx context.Context,
 	id uuid.UUID,
-	execState shared.ExecutionState,
+	execState *shared.ExecutionState,
 	db database.Database,
 ) error {
 	changes := map[string]interface{}{
@@ -58,7 +58,7 @@ func getOpResultsWithExecState(
 func updateMetadata(
 	ctx context.Context,
 	id uuid.UUID,
-	metadata Metadata,
+	metadata *Metadata,
 	db database.Database,
 ) error {
 	changes := map[string]interface{}{

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/queries.go
@@ -16,9 +16,9 @@ type opResultWithMetadata struct {
 }
 
 type opResultWithExecState struct {
-	Id        uuid.UUID                 `db:"id" json:"id"`
-	Status    shared.ExecutionStatus    `db:"status" json:"status"`
-	ExecState shared.NullExecutionState `db:"exec_state" json:"exec_state"`
+	Id        uuid.UUID              `db:"id" json:"id"`
+	Status    shared.ExecutionStatus `db:"status" json:"status"`
+	ExecState NullExecutionState     `db:"exec_state" json:"exec_state"`
 }
 
 func getOpResultsWithMetadata(
@@ -35,7 +35,7 @@ func getOpResultsWithMetadata(
 func updateExecState(
 	ctx context.Context,
 	id uuid.UUID,
-	execState *shared.ExecutionState,
+	execState *ExecutionState,
 	db database.Database,
 ) error {
 	changes := map[string]interface{}{

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/types.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/types.go
@@ -3,6 +3,7 @@ package _000011_exec_state_column_backfill
 import (
 	"database/sql/driver"
 
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/collections/utils"
 )
 
@@ -44,5 +45,58 @@ func (n *NullMetadata) Scan(value interface{}) error {
 	}
 
 	n.Metadata, n.IsNull = *metadata, false
+	return nil
+}
+
+type Logs struct {
+	Stdout string `json:"stdout"`
+	StdErr string `json:"stderr"`
+}
+
+type Error struct {
+	Context string `json:"context"`
+	Tip     string `json:"tip"`
+}
+
+type ExecutionState struct {
+	UserLogs    *Logs                  `json:"user_logs"`
+	Status      shared.ExecutionStatus `json:"status"`
+	FailureType *shared.FailureType    `json:"failure_type"`
+	Error       *Error                 `json:"error"`
+}
+
+func (e *ExecutionState) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*e)
+}
+
+func (e *ExecutionState) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, e)
+}
+
+type NullExecutionState struct {
+	ExecutionState
+	IsNull bool
+}
+
+func (n *NullExecutionState) Value() (driver.Value, error) {
+	if n.IsNull {
+		return nil, nil
+	}
+
+	return (&n.ExecutionState).Value()
+}
+
+func (n *NullExecutionState) Scan(value interface{}) error {
+	if value == nil {
+		n.IsNull = true
+		return nil
+	}
+
+	logs := &ExecutionState{}
+	if err := logs.Scan(value); err != nil {
+		return err
+	}
+
+	n.ExecutionState, n.IsNull = *logs, false
 	return nil
 }

--- a/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/types.go
+++ b/src/golang/cmd/migrator/versions/000011_exec_state_column_backfill/types.go
@@ -1,0 +1,48 @@
+package _000011_exec_state_column_backfill
+
+import (
+	"database/sql/driver"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+)
+
+type Metadata struct {
+	Error string            `json:"error"`
+	Logs  map[string]string `json:"logs"`
+}
+
+type NullMetadata struct {
+	Metadata
+	IsNull bool
+}
+
+func (m *Metadata) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*m)
+}
+
+func (m *Metadata) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, m)
+}
+
+func (n *NullMetadata) Value() (driver.Value, error) {
+	if n.IsNull {
+		return nil, nil
+	}
+
+	return (&n.Metadata).Value()
+}
+
+func (n *NullMetadata) Scan(value interface{}) error {
+	if value == nil {
+		n.IsNull = true
+		return nil
+	}
+
+	metadata := &Metadata{}
+	if err := metadata.Scan(value); err != nil {
+		return err
+	}
+
+	n.Metadata, n.IsNull = *metadata, false
+	return nil
+}

--- a/src/golang/cmd/migrator/versions/000012_drop_metadata_column/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000012_drop_metadata_column/down_postgres.go
@@ -1,0 +1,5 @@
+package _000012_drop_metadata_column
+
+const downPostgresScript = `
+ALTER TABLE op_result ADD COLUMN metadata JSONB;
+`

--- a/src/golang/cmd/migrator/versions/000012_drop_metadata_column/main.go
+++ b/src/golang/cmd/migrator/versions/000012_drop_metadata_column/main.go
@@ -1,0 +1,19 @@
+package _000012_drop_metadata_column
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func UpPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upPostgresScript)
+}
+
+func UpSqlite(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, sqliteScript)
+}
+
+func DownPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, downPostgresScript)
+}

--- a/src/golang/cmd/migrator/versions/000012_drop_metadata_column/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000012_drop_metadata_column/up_postgres.go
@@ -1,0 +1,6 @@
+package _000012_drop_metadata_column
+
+const upPostgresScript = `
+ALTER TABLE operator_result
+DROP COLUMN IF EXISTS metadata;
+`

--- a/src/golang/cmd/migrator/versions/000012_drop_metadata_column/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000012_drop_metadata_column/up_sqlite.go
@@ -1,0 +1,6 @@
+package _000012_drop_metadata_column
+
+const sqliteScript = `
+ALTER TABLE operator_result
+DROP COLUMN metadata;
+`

--- a/src/golang/lib/collections/operator_result/constants.go
+++ b/src/golang/lib/collections/operator_result/constants.go
@@ -12,7 +12,7 @@ const (
 	WorkflowDagResultIdColumn = "workflow_dag_result_id"
 	OperatorIdColumn          = "operator_id"
 	StatusColumn              = "status"
-	ExecStateColumn           = "exec_state"
+	ExecStateColumn           = "execution_state"
 )
 
 // Returns a joined string of all OperatorResult columns.

--- a/src/golang/lib/collections/operator_result/operator_result.go
+++ b/src/golang/lib/collections/operator_result/operator_result.go
@@ -13,7 +13,7 @@ type OperatorResult struct {
 	WorkflowDagResultId uuid.UUID                 `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
 	OperatorId          uuid.UUID                 `db:"operator_id" json:"operator_id"`
 	Status              shared.ExecutionStatus    `db:"status" json:"status"`
-	ExecState           shared.NullExecutionState `db:"exec_state" json:"exec_state"`
+	ExecState           shared.NullExecutionState `db:"execution_state" json:"execution_state"`
 }
 
 type Reader interface {

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -13,6 +13,7 @@ import shutil
 import requests
 import zipfile
 
+SCHEMA_VERSION = "12"
 base_directory = os.path.join(os.environ["HOME"], ".aqueduct")
 server_directory = os.path.join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = os.path.join(os.environ["HOME"], ".aqueduct", "ui")
@@ -154,7 +155,7 @@ def update_server_version():
     update_executable_permissions()
 
     execute_command(
-        [os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", "9"]
+        [os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", SCHEMA_VERSION]
     )
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds schema migration for `operator_result` table by changing `metadata` to `exec_state` based on changes introduced in #159 . We added 3 new versions to add new col, backfill, and drop old col. After this change the schema will become 12.

## Related issue number (if any)
ENG-1249

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] #161  I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] #168  If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


