### PR TITLE
ENG-868-Add `describe()` method to each of the relational integrations.

### DIFF
--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -236,4 +236,4 @@ class RelationalDBIntegration(Integration):
         print("Integration Information:")
         self._metadata.describe()
         print("Integration Table List Preview:")
-        print(self.list_tables()["name"].head())
+        print(self.list_tables()["name"].head().to_string())

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -233,4 +233,7 @@ class RelationalDBIntegration(Integration):
         Prints out a human-readable description of the SQL integration.
         """
         print("==================== SQL Integration =============================")
+        print("Integration Information:")
         self._metadata.describe()
+        print("Integration Table List Preview:")
+        print(self.list_tables()["name"].head())

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -237,3 +237,4 @@ class RelationalDBIntegration(Integration):
         self._metadata.describe()
         print("Integration Table List Preview:")
         print(self.list_tables()["name"].head().to_string())
+        print("(only first 5 tables are shown)")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR seeks to add a describe() functionality for relational integrations. The existing relational integration has a describe() method that prints out the integration information. Thereafter, I add a display of list of table inside the integration. The table name displayed is limited to the number of display from df.head() because if there are large number of tables, this method is not user friendly.
<img width="983" alt="Screen Shot 2022-07-07 at 5 29 30 PM" src="https://user-images.githubusercontent.com/78303449/177892924-3fa6fa7f-6edc-4d46-99fc-285a09cb5da9.png">

## Update
<img width="690" alt="Screen Shot 2022-07-08 at 12 54 56 PM" src="https://user-images.githubusercontent.com/78303449/178061677-d411835d-7d28-4b47-bce5-13c0dca39640.png">


## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-868/add-describe-method-to-each-of-the-relational-integrations
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


