### PR TITLE
Fixes run linter scripts when running commands

### DIFF
--- a/scripts/run_linters.py
+++ b/scripts/run_linters.py
@@ -29,11 +29,11 @@ def lint_python(cwd):
     execute_command(["black", join(cwd, "src/python"), "--line-length=100"])
     execute_command(["black", join(cwd, "sdk"), "--line-length=100"])
     execute_command(["black", join(cwd, "integration_tests"), "--line-length=100"])
-    execute_command(["isort", ".", "-l 100", "--profile black"])
+    execute_command(["isort", ".", "-l", "100", "--profile", "black"])
     execute_command(
         [
             "mypy",
-            ".",
+            "aqueduct",
             "--ignore-missing-imports",
             "--strict",
             "--exclude",
@@ -45,14 +45,14 @@ def lint_python(cwd):
     execute_command(
         [
             "mypy",
-            ".",
+            "aqueduct_executor",
             "--ignore-missing-imports",
             "--strict",
             "--exclude",
             "tests",
             "--implicit-reexport",
         ],
-        join(cwd, "src/python"),
+        join(cwd, "src", "python"),
     )
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes run linter scripts where we should do `exec_command(["cmd", "--args", "val"])` instead of `exec_command(["cmd", "--args val"])`, where in the 2nd case the entire '--args val' will be treated as one string. This may has something to do with either OS or python version.

Also fixed mypy issue to run on specific module, otherwise we would encounter multiple-module errors which might be caused by the existence of egg.

## Related issue number (if any)

## Checklist before requesting a review
Run the linter successfully on #144 
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


