### PR TITLE
Adds workflow_dag engine_config column

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -26,7 +26,7 @@ server_directory = join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = join(os.environ["HOME"], ".aqueduct", "ui")
 
 # Make sure to update this if there is any schema change we want to include in the upgrade.
-SCHEMA_VERSION = "12"
+SCHEMA_VERSION = "13"
 
 
 def execute_command(args, cwd=None):

--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -15,6 +15,7 @@ import (
 	_000010 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000010_add_exec_state_column"
 	_000011 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000011_exec_state_column_backfill"
 	_000012 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000012_drop_metadata_column"
+	_000013 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000013_add_workflow_dag_engine_config"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -76,7 +77,6 @@ func init() {
 		downPostgres: _000009.Down,
 		name:         "backfill metadata in artifact_results",
 	}
-
 	registeredMigrations[10] = &migration{
 		upPostgres: _000010.UpPostgres, upSqlite: _000010.UpSqlite,
 		downPostgres: _000010.DownPostgres,
@@ -93,5 +93,11 @@ func init() {
 		upPostgres: _000012.UpPostgres, upSqlite: _000012.UpSqlite,
 		downPostgres: _000012.DownPostgres,
 		name:         "remove metadata in operator_result",
+	}
+
+	registeredMigrations[13] = &migration{
+		upPostgres: _000013.UpPostgres, upSqlite: _000013.UpSqlite,
+		downPostgres: _000013.DownPostgres,
+		name:         "add workflow_dag.engine_config",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/down_postgres.go
@@ -1,0 +1,5 @@
+package _000013_add_workflow_dag_engine_config
+
+const downPostgresScript = `
+ALTER TABLE workflow_dag
+DROP COLUMN engine_config;`

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/main.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/main.go
@@ -1,0 +1,19 @@
+package _000013_add_workflow_dag_engine_config
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func UpPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upPostgresScript)
+}
+
+func DownPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, downPostgresScript)
+}
+
+func UpSqlite(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, sqliteScript)
+}

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/main.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/main.go
@@ -15,5 +15,20 @@ func DownPostgres(ctx context.Context, db database.Database) error {
 }
 
 func UpSqlite(ctx context.Context, db database.Database) error {
-	return db.Execute(ctx, sqliteScript)
+	// SQLite doesn't easily allow for inserting JSON data as a raw query,
+	// so we must split up the column add into 3 steps.
+
+	// Step 1: Add the column and allow it to take on NULL values
+	addColumnStmt := "ALTER TABLE workflow_dag ADD COLUMN engine_config BLOB;"
+	if err := db.Execute(ctx, addColumnStmt); err != nil {
+		return err
+	}
+
+	// Step 2: For each row with NULL `engine_config`, set it to the default value
+	if err := setDefaultEngineConfig(ctx, db); err != nil {
+		return err
+	}
+
+	// Step 3: Change `engine_config` to be NOT NULL
+	return makeEngineConfigNotNull(ctx, db)
 }

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/main.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/main.go
@@ -18,17 +18,27 @@ func UpSqlite(ctx context.Context, db database.Database) error {
 	// SQLite doesn't easily allow for inserting JSON data as a raw query,
 	// so we must split up the column add into 3 steps.
 
+	txn, err := db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer database.TxnRollbackIgnoreErr(ctx, txn)
+
 	// Step 1: Add the column and allow it to take on NULL values
 	addColumnStmt := "ALTER TABLE workflow_dag ADD COLUMN engine_config BLOB;"
-	if err := db.Execute(ctx, addColumnStmt); err != nil {
+	if err := txn.Execute(ctx, addColumnStmt); err != nil {
 		return err
 	}
 
 	// Step 2: For each row with NULL `engine_config`, set it to the default value
-	if err := setDefaultEngineConfig(ctx, db); err != nil {
+	if err := setDefaultEngineConfig(ctx, txn); err != nil {
 		return err
 	}
 
 	// Step 3: Change `engine_config` to be NOT NULL
-	return makeEngineConfigNotNull(ctx, db)
+	if err := makeEngineConfigNotNull(ctx, txn); err != nil {
+		return err
+	}
+
+	return txn.Commit(ctx)
 }

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/types.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/types.go
@@ -1,0 +1,28 @@
+package _000013_add_workflow_dag_engine_config
+
+import (
+	"database/sql/driver"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+)
+
+type EngineType string
+
+const (
+	AqueductEngineType EngineType = "aqueduct"
+)
+
+type EngineConfig struct {
+	Type           EngineType      `yaml:"type" json:"type"`
+	AqueductConfig *AqueductConfig `yaml:"aqueductConfig" json:"aqueduct_config,omitempty"`
+}
+
+type AqueductConfig struct{}
+
+func (e *EngineConfig) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, e)
+}
+
+func (e *EngineConfig) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*e)
+}

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_postgres.go
@@ -3,4 +3,4 @@ package _000013_add_workflow_dag_engine_config
 const upPostgresScript = `
 ALTER TABLE workflow_dag
 ADD COLUMN engine_config JSONB NOT NULL
-DEFAULT '{"type":"aqueduct", "aqueductConfig":{}}'::jsonb;`
+DEFAULT '{"type":"aqueduct", "aqueduct_config":{}}'::jsonb;`

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_postgres.go
@@ -1,0 +1,6 @@
+package _000013_add_workflow_dag_engine_config
+
+const upPostgresScript = `
+ALTER TABLE workflow_dag
+ADD COLUMN engine_config JSONB NOT NULL
+DEFAULT '{"type":"aqueduct", "aqueductConfig":{}}'::jsonb;`

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
@@ -1,0 +1,8 @@
+package _000013_add_workflow_dag_engine_config
+
+const sqliteScript = `
+ALTER TABLE workflow_dag
+ADD COLUMN engine_config BLOB
+DEFAULT '{"type":"aqueduct", "aqueductConfig":{}}'
+NOT NULL;
+`

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
@@ -1,7 +1,49 @@
 package _000013_add_workflow_dag_engine_config
 
-const sqliteScript = `
-ALTER TABLE workflow_dag
-ADD COLUMN engine_config BLOB NOT NULL
-DEFAULT '{"type":"aqueduct", "aqueduct_config":{}}';
-`
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+// setDefaultEngineConfig sets the `engine_config` column for the `workflow_dag` table
+// to the default Aqueduct engine for all rows with a NULL `engine_config`.
+func setDefaultEngineConfig(ctx context.Context, db database.Database) error {
+	query := "UPDATE workflow_dag SET engine_config = $1 WHERE engine_config = NULL;"
+
+	defaultEngineConfig := &EngineConfig{
+		Type:           AqueductEngineType,
+		AqueductConfig: &AqueductConfig{},
+	}
+	args := []interface{}{defaultEngineConfig}
+
+	return db.Execute(ctx, query, args...)
+}
+
+// makeEngineConfigNotNull changes the `engine_config` column to be NOT NULL
+func makeEngineConfigNotNull(ctx context.Context, db database.Database) error {
+	query := `
+	BEGIN TRANSACTION;
+
+	ALTER TABLE workflow_dag RENAME TO tmp_workflow_dag;
+
+	CREATE TABLE workflow_dag (
+		id BLOB NOT NULL PRIMARY KEY,
+		workflow_id BLOB NOT NULL REFERENCES workflow (id),
+		s3_config BLOB NOT NULL,
+		created_at DATETIME NOT NULL,
+		storage_config BLOB NOT NULL,
+		engine_config BLOB NOT NULL
+	);
+
+	INSERT INTO workflow_dag(id, workflow_id, s3_config, created_at, storage_config, engine_config)
+	SELECT id, workflow_id, s3_config, created_at, storage_config, engine_config
+	FROM tmp_workflow_dag;
+
+	DROP TABLE tmp_workflow_dag;
+
+	COMMIT;
+	`
+
+	return db.Execute(ctx, query)
+}

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
@@ -2,7 +2,6 @@ package _000013_add_workflow_dag_engine_config
 
 const sqliteScript = `
 ALTER TABLE workflow_dag
-ADD COLUMN engine_config BLOB
-DEFAULT '{"type":"aqueduct", "aqueductConfig":{}}'
-NOT NULL;
+ADD COLUMN engine_config BLOB NOT NULL
+DEFAULT '{"type":"aqueduct", "aqueduct_config":{}}';
 `

--- a/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000013_add_workflow_dag_engine_config/up_sqlite.go
@@ -9,7 +9,7 @@ import (
 // setDefaultEngineConfig sets the `engine_config` column for the `workflow_dag` table
 // to the default Aqueduct engine for all rows with a NULL `engine_config`.
 func setDefaultEngineConfig(ctx context.Context, db database.Database) error {
-	query := "UPDATE workflow_dag SET engine_config = $1 WHERE engine_config = NULL;"
+	query := "UPDATE workflow_dag SET engine_config = $1 WHERE engine_config IS NULL;"
 
 	defaultEngineConfig := &EngineConfig{
 		Type:           AqueductEngineType,
@@ -23,26 +23,21 @@ func setDefaultEngineConfig(ctx context.Context, db database.Database) error {
 // makeEngineConfigNotNull changes the `engine_config` column to be NOT NULL
 func makeEngineConfigNotNull(ctx context.Context, db database.Database) error {
 	query := `
-	BEGIN TRANSACTION;
-
 	ALTER TABLE workflow_dag RENAME TO tmp_workflow_dag;
 
 	CREATE TABLE workflow_dag (
 		id BLOB NOT NULL PRIMARY KEY,
 		workflow_id BLOB NOT NULL REFERENCES workflow (id),
-		s3_config BLOB NOT NULL,
 		created_at DATETIME NOT NULL,
 		storage_config BLOB NOT NULL,
 		engine_config BLOB NOT NULL
 	);
 
-	INSERT INTO workflow_dag(id, workflow_id, s3_config, created_at, storage_config, engine_config)
-	SELECT id, workflow_id, s3_config, created_at, storage_config, engine_config
+	INSERT INTO workflow_dag(id, workflow_id, created_at, storage_config, engine_config)
+	SELECT id, workflow_id, created_at, storage_config, engine_config
 	FROM tmp_workflow_dag;
 
 	DROP TABLE tmp_workflow_dag;
-
-	COMMIT;
 	`
 
 	return db.Execute(ctx, query)

--- a/src/golang/cmd/server/request/dag.go
+++ b/src/golang/cmd/server/request/dag.go
@@ -71,6 +71,12 @@ func ParseDagSummaryFromRequest(
 
 	workflowDag.Metadata.UserId = userId
 
+	// The default engine config for now is Aqueduct
+	workflowDag.EngineConfig = shared.EngineConfig{
+		Type:           shared.AqueductEngineType,
+		AqueductConfig: &shared.AqueductConfig{},
+	}
+
 	return &DagSummary{
 		Dag:                        &workflowDag,
 		FileContentsByOperatorUUID: fileContents,

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	RequiredSchemaVersion = 8
+	RequiredSchemaVersion = 13
 
 	accountOrganizationId = "aqueduct"
 )

--- a/src/golang/lib/collections/shared/engine.go
+++ b/src/golang/lib/collections/shared/engine.go
@@ -1,0 +1,28 @@
+package shared
+
+import (
+	"database/sql/driver"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+)
+
+type EngineType string
+
+const (
+	AqueductEngineType EngineType = "aqueduct"
+)
+
+type EngineConfig struct {
+	Type           EngineType      `yaml:"type" json:"type"`
+	AqueductConfig *AqueductConfig `yaml:"aqueductConfig" json:"aqueduct_config,omitempty"`
+}
+
+type AqueductConfig struct{}
+
+func (e *EngineConfig) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, e)
+}
+
+func (e *EngineConfig) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*e)
+}

--- a/src/golang/lib/collections/tests/main_test.go
+++ b/src/golang/lib/collections/tests/main_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	schemaVersion = 12
+	schemaVersion = 13
 
 	// Postgres config
 	postgresHost     = "localhost"

--- a/src/golang/lib/collections/tests/workflow_dag_test.go
+++ b/src/golang/lib/collections/tests/workflow_dag_test.go
@@ -37,6 +37,10 @@ func seedWorkflowDagWithWorkflows(t *testing.T, count int, workflowIds []uuid.UU
 					Bucket: "bucket-test",
 				},
 			},
+			&shared.EngineConfig{
+				Type:           shared.AqueductEngineType,
+				AqueductConfig: &shared.AqueductConfig{},
+			},
 			db,
 		)
 		require.Nil(t, err)
@@ -93,6 +97,7 @@ func TestCreateWorkflowDag(t *testing.T) {
 		context.Background(),
 		expectedWorkflowDag.WorkflowId,
 		&expectedWorkflowDag.StorageConfig,
+		&expectedWorkflowDag.EngineConfig,
 		db,
 	)
 	require.Nil(t, err)

--- a/src/golang/lib/collections/workflow_dag/constants.go
+++ b/src/golang/lib/collections/workflow_dag/constants.go
@@ -13,6 +13,7 @@ const (
 	WorkflowIdColumn    = "workflow_id"
 	CreatedAtColumn     = "created_at"
 	StorageConfigColumn = "storage_config"
+	EngineConfigColumn  = "engine_config"
 )
 
 // Returns a joined string of all WorkflowDag columns.

--- a/src/golang/lib/collections/workflow_dag/sqlite.go
+++ b/src/golang/lib/collections/workflow_dag/sqlite.go
@@ -30,9 +30,10 @@ func (w *sqliteWriterImpl) CreateWorkflowDag(
 	ctx context.Context,
 	workflowId uuid.UUID,
 	storageConfig *shared.StorageConfig,
+	engineConfig *shared.EngineConfig,
 	db database.Database,
 ) (*DBWorkflowDag, error) {
-	insertColumns := []string{IdColumn, WorkflowIdColumn, CreatedAtColumn, StorageConfigColumn}
+	insertColumns := []string{IdColumn, WorkflowIdColumn, CreatedAtColumn, StorageConfigColumn, EngineConfigColumn}
 	insertWorkflowDagStmt := db.PrepareInsertWithReturnAllStmt(tableName, insertColumns, allColumns())
 
 	id, err := utils.GenerateUniqueUUID(ctx, tableName, db)
@@ -40,7 +41,7 @@ func (w *sqliteWriterImpl) CreateWorkflowDag(
 		return nil, err
 	}
 
-	args := []interface{}{id, workflowId, time.Now(), storageConfig}
+	args := []interface{}{id, workflowId, time.Now(), storageConfig, engineConfig}
 
 	var workflowDag DBWorkflowDag
 	err = db.Query(ctx, &workflowDag, insertWorkflowDagStmt, args...)

--- a/src/golang/lib/collections/workflow_dag/standard.go
+++ b/src/golang/lib/collections/workflow_dag/standard.go
@@ -22,12 +22,13 @@ func (w *standardWriterImpl) CreateWorkflowDag(
 	ctx context.Context,
 	workflowId uuid.UUID,
 	storageConfig *shared.StorageConfig,
+	engineConfig *shared.EngineConfig,
 	db database.Database,
 ) (*DBWorkflowDag, error) {
-	insertColumns := []string{WorkflowIdColumn, CreatedAtColumn, StorageConfigColumn}
+	insertColumns := []string{WorkflowIdColumn, CreatedAtColumn, StorageConfigColumn, EngineConfigColumn}
 	insertWorkflowDagStmt := db.PrepareInsertWithReturnAllStmt(tableName, insertColumns, allColumns())
 
-	args := []interface{}{workflowId, time.Now(), storageConfig}
+	args := []interface{}{workflowId, time.Now(), storageConfig, engineConfig}
 
 	var workflowDag DBWorkflowDag
 	err := db.Query(ctx, &workflowDag, insertWorkflowDagStmt, args...)

--- a/src/golang/lib/collections/workflow_dag/workflow_dag.go
+++ b/src/golang/lib/collections/workflow_dag/workflow_dag.go
@@ -17,6 +17,7 @@ type DBWorkflowDag struct {
 	WorkflowId    uuid.UUID            `db:"workflow_id" json:"workflow_id"`
 	CreatedAt     time.Time            `db:"created_at" json:"created_at"`
 	StorageConfig shared.StorageConfig `db:"storage_config" json:"storage_config"`
+	EngineConfig  shared.EngineConfig  `db:"engine_config" json:"engine_config"`
 
 	/* Field not stored in DB */
 	Metadata  *workflow.Workflow                `json:"metadata"`
@@ -59,6 +60,7 @@ type Writer interface {
 		ctx context.Context,
 		workflowId uuid.UUID,
 		storageConfig *shared.StorageConfig,
+		engineConfig *shared.EngineConfig,
 		db database.Database,
 	) (*DBWorkflowDag, error)
 	UpdateWorkflowDag(

--- a/src/golang/lib/workflow/utils/utils.go
+++ b/src/golang/lib/workflow/utils/utils.go
@@ -149,6 +149,7 @@ func WriteWorkflowDagToDatabase(
 		ctx,
 		workflowId,
 		&dag.StorageConfig,
+		&dag.EngineConfig,
 		db,
 	)
 	if err != nil {

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -16,7 +16,7 @@ import distro
 import requests
 import yaml
 
-SCHEMA_VERION = "12"
+SCHEMA_VERION = "13"
 
 base_directory = os.path.join(os.environ["HOME"], ".aqueduct")
 server_directory = os.path.join(os.environ["HOME"], ".aqueduct", "server")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds an `engine_config` column to the `workflow_dag` table. This is necessary to store important information for mapping an Aqueduct workflow to the native concepts of the 3rd-party engine the workflow is set to run on, such as Airflow.


## Related issue number (if any)
ENG-1243

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


## Test
I tested this schema change by creating a workflow (and workflow_dag) before applying the schema change. Then, I applied the schema change and confirmed that the new column was created. After this, I tested that the `WorkflowDagReader` was able to successfully read the `engine_config` column.