### PR TITLE
Adds default values for Python connectors for Postgres.port and Extract.query_is_usable

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/tabular/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/config.py
@@ -22,7 +22,7 @@ class PostgresConfig(models.BaseConfig):
     password: str
     database: str
     host: str
-    port: str
+    port: Optional[str] = "5432"
 
 
 class S3Config(models.BaseConfig):

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -27,16 +27,17 @@ BUILT_IN_EXPANSIONS = {
 
 
 class RelationalParams(models.BaseParams):
-    # The query cannot be used until `apply_placeholders()` is called on it. This flushes out
-    # any user-defined tags like `{{today}}`.
-    # _query_is_usable is not passed in via the spec, so we prefix it with an _ to ensure that
-    # Pydantic ignores the field during validation
-    _query_is_usable: bool = False
-
     query: str
 
     # TODO: Consider not including github as part of relational params when it is JSON marshalled
     github_metadata: Optional[Any]
+
+    def __init__(self):
+        super().__init__()
+
+        # The query cannot be used until `apply_placeholders()` is called on it. This flushes out
+        # any user-defined tags like `{{today}}`.
+        self._query_is_usable: bool = False
 
     def expand_placeholders(
         self,

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -73,6 +73,8 @@ class RelationalParams(models.BaseParams):
 
         Callers should check that `usable()` -> True before actually executing this query.
         """
+        # We cannot return self.query_is_usable directly, since it is an Optional
+        # and the method expects a bool to be returned.
         if self.query_is_usable:
             return True
         return False

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -29,7 +29,10 @@ BUILT_IN_EXPANSIONS = {
 class RelationalParams(models.BaseParams):
     # The query cannot be used until `apply_placeholders()` is called on it. This flushes out
     # any user-defined tags like `{{today}}`.
-    query_is_usable: Optional[bool] = False
+    # _query_is_usable is not passed in via the spec, so we prefix it with an _ to ensure that
+    # Pydantic ignores the field during validation
+    _query_is_usable: bool = False
+
     query: str
 
     # TODO: Consider not including github as part of relational params when it is JSON marshalled
@@ -65,14 +68,14 @@ class RelationalParams(models.BaseParams):
                 )
 
         print("Expanded query is `%s`." % self.query)
-        self.query_is_usable = True
+        self._query_is_usable = True
 
     def usable(self) -> bool:
         """Denotes whether all placeholders have already been expanded for this query.
 
         Callers should check that `usable()` -> True before actually executing this query.
         """
-        return self.query_is_usable
+        return self._query_is_usable
 
 
 class S3Params(models.BaseParams):

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -29,7 +29,7 @@ BUILT_IN_EXPANSIONS = {
 class RelationalParams(models.BaseParams):
     # The query cannot be used until `apply_placeholders()` is called on it. This flushes out
     # any user-defined tags like `{{today}}`.
-    query_is_usable: bool = False
+    query_is_usable: Optional[bool] = False
     query: str
 
     # TODO: Consider not including github as part of relational params when it is JSON marshalled

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -32,7 +32,7 @@ class RelationalParams(models.BaseParams):
     # TODO: Consider not including github as part of relational params when it is JSON marshalled
     github_metadata: Optional[Any]
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         # The query cannot be used until `apply_placeholders()` is called on it. This flushes out

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -29,7 +29,7 @@ BUILT_IN_EXPANSIONS = {
 class RelationalParams(models.BaseParams):
     # The query cannot be used until `apply_placeholders()` is called on it. This flushes out
     # any user-defined tags like `{{today}}`.
-    query_is_usable: Optional[bool] = False
+    # query_is_usable: Optional[bool] = False
     query: str
 
     # TODO: Consider not including github as part of relational params when it is JSON marshalled

--- a/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/extract.py
@@ -29,7 +29,7 @@ BUILT_IN_EXPANSIONS = {
 class RelationalParams(models.BaseParams):
     # The query cannot be used until `apply_placeholders()` is called on it. This flushes out
     # any user-defined tags like `{{today}}`.
-    # query_is_usable: Optional[bool] = False
+    query_is_usable: Optional[bool] = False
     query: str
 
     # TODO: Consider not including github as part of relational params when it is JSON marshalled


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a couple of default values that are necessary for backwards compatibility for workflows that were registered before we added these fields.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


