### PR TITLE
Support multi file inputs from S3 integration

### DIFF
--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -30,7 +30,7 @@ class S3Integration(Integration):
 
     def file(
         self,
-        filepath: Union[List[str], str],
+        filepaths: Union[List[str], str],
         format: S3FileFormat,
         name: Optional[str] = None,
         description: str = "",
@@ -39,8 +39,8 @@ class S3Integration(Integration):
         Retrieves a file from the S3 integration.
 
         Args:
-            filepath:
-                Filepath to retrieve from. The filepath can either be:
+            filepaths:
+                Filepath to retrieve from. The filepaths can either be:
                 1) a single string that represents a file name or a directory name. The directory
                 name must ends with a `/`. In case of a file name, we attempt to retrieve that file,
                 and in case of a directory name, we do a prefix search on the directory and retrieve
@@ -74,7 +74,7 @@ class S3Integration(Integration):
                                 service=integration_info.service,
                                 integration_id=integration_info.id,
                                 parameters=S3ExtractParams(
-                                    filepath=json.dumps(filepath), format=format
+                                    filepath=json.dumps(filepaths), format=format
                                 ),
                             )
                         ),

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -40,7 +40,13 @@ class S3Integration(Integration):
 
         Args:
             filepath:
-                Filepath to retrieve from.
+                Filepath to retrieve from. The filepath can either be:
+                1) a single string that represents a file name or a directory name. The directory 
+                name must ends with a `/`. In case of a file name, we attempt to retrieve that file,
+                and in case of a directory name, we do a prefix search on the directory and retrieve
+                all matched files and concatenate them into a single file.
+                2) a list of strings representing the file name. Note that in this case, we do not
+                accept directory names in the list.
             name:
                 Name of the query.
             description:

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -41,7 +41,7 @@ class S3Integration(Integration):
         Args:
             filepath:
                 Filepath to retrieve from. The filepath can either be:
-                1) a single string that represents a file name or a directory name. The directory 
+                1) a single string that represents a file name or a directory name. The directory
                 name must ends with a `/`. In case of a file name, we attempt to retrieve that file,
                 and in case of a directory name, we do a prefix search on the directory and retrieve
                 all matched files and concatenate them into a single file.
@@ -73,7 +73,9 @@ class S3Integration(Integration):
                             extract=ExtractSpec(
                                 service=integration_info.service,
                                 integration_id=integration_info.id,
-                                parameters=S3ExtractParams(filepath=json.dumps(filepath), format=format),
+                                parameters=S3ExtractParams(
+                                    filepath=json.dumps(filepath), format=format
+                                ),
                             )
                         ),
                         outputs=[output_artifact_id],

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import json
+from typing import List, Optional, Union
 
 from aqueduct.api_client import APIClient
 from aqueduct.artifact import Artifact, ArtifactSpec
@@ -29,7 +30,7 @@ class S3Integration(Integration):
 
     def file(
         self,
-        filepath: str,
+        filepath: Union[List[str], str],
         format: S3FileFormat,
         name: Optional[str] = None,
         description: str = "",
@@ -66,7 +67,7 @@ class S3Integration(Integration):
                             extract=ExtractSpec(
                                 service=integration_info.service,
                                 integration_id=integration_info.id,
-                                parameters=S3ExtractParams(filepath=filepath, format=format),
+                                parameters=S3ExtractParams(filepath=json.dumps(filepath), format=format),
                             )
                         ),
                         outputs=[output_artifact_id],

--- a/sdk/aqueduct/operators.py
+++ b/sdk/aqueduct/operators.py
@@ -54,6 +54,8 @@ class GoogleSheetsExtractParams(BaseModel):
 
 
 class S3ExtractParams(BaseModel):
+    # Note that since we expect the path to be either a string or a list of strings, we need to json
+    # serialize the path before we pass it to initialize this field.
     filepath: str
     format: S3FileFormat
 

--- a/sdk/aqueduct/tests/serialization_test.py
+++ b/sdk/aqueduct/tests/serialization_test.py
@@ -276,7 +276,7 @@ def test_extract_serialization():
                     "service": ServiceType.S3,
                     "integration_id": str(integration_id),
                     "parameters": {
-                        "filepath": "test.csv",
+                        "filepath": json.dumps("test.csv"),
                         "format": "CSV",
                     },
                 }

--- a/sdk/aqueduct/tests/serialization_test.py
+++ b/sdk/aqueduct/tests/serialization_test.py
@@ -259,7 +259,7 @@ def test_extract_serialization():
                 service=ServiceType.S3,
                 integration_id=integration_id,
                 parameters=S3ExtractParams(
-                    filepath="test.csv",
+                    filepath=json.dumps("test.csv"),
                     format=S3FileFormat.CSV,
                 ),
             ),

--- a/src/python/aqueduct_executor/operators/connectors/tabular/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/config.py
@@ -29,7 +29,6 @@ class S3Config(models.BaseConfig):
     access_key_id: str
     secret_access_key: str
     bucket: str
-    region: Optional[str] = None
 
 
 class SnowflakeConfig(models.BaseConfig):

--- a/src/python/aqueduct_executor/operators/connectors/tabular/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/config.py
@@ -29,6 +29,7 @@ class S3Config(models.BaseConfig):
     access_key_id: str
     secret_access_key: str
     bucket: str
+    region: Optional[str] = None
 
 
 class SnowflakeConfig(models.BaseConfig):

--- a/src/python/aqueduct_executor/operators/connectors/tabular/main.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/main.py
@@ -223,9 +223,14 @@ if __name__ == "__main__":
     try:
         run(spec, storage, exec_state)
         # Write operator execution metadata
-        if exec_state.status != enums.ExecutionStatus.FAILED:
+        # Each decorator may set exec_state.status to FAILED, but if none of them did, then we are
+        # certain that the operator succeeded.
+        if exec_state.status == enums.ExecutionStatus.FAILED:
+            utils.write_exec_state(storage, spec.metadata_path, exec_state)
+            sys.exit(1)
+        else:
             exec_state.status = enums.ExecutionStatus.SUCCEEDED
-        utils.write_exec_state(storage, spec.metadata_path, exec_state)
+            utils.write_exec_state(storage, spec.metadata_path, exec_state)
     except Exception as e:
         exec_state.status = enums.ExecutionStatus.FAILED
         exec_state.failure_type = enums.FailureType.SYSTEM

--- a/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
@@ -9,53 +9,60 @@ from aqueduct_executor.operators.connectors.tabular import common, config, conne
 
 class S3Connector(connector.TabularConnector):
     def __init__(self, config: config.S3Config):
-        if config.region is None:
-            self.s3 = boto3.resource(
-                "s3",
-                aws_access_key_id=config.access_key_id,
-                aws_secret_access_key=config.secret_access_key,
-            )
-        else:
-            self.s3 = boto3.resource(
-                "s3",
-                aws_access_key_id=config.access_key_id,
-                aws_secret_access_key=config.secret_access_key,
-                region_name = config.region,
-            )
+        self.s3 = boto3.resource(
+            "s3",
+            aws_access_key_id=config.access_key_id,
+            aws_secret_access_key=config.secret_access_key,
+        )
 
         self.bucket = config.bucket
 
     def authenticate(self) -> None:
-        pass
+        for obj in self.s3.Bucket(self.bucket).objects.all():
+            pass
 
     def discover(self) -> List[str]:
         raise Exception("Discover is not supported for S3.")
 
-    def _parse_data(self, data: io.BytesIO, format: common.S3FileFormat) -> pd.DataFrame:
+    def _fetch_object(self, key: str, format: common.S3FileFormat) -> pd.DataFrame:
+        response = self.s3.Object(self.bucket, key).get()
+        data = response["Body"].read()
+        buf = io.BytesIO(data)
         if format == common.S3FileFormat.CSV:
-            return pd.read_csv(data)
+            return pd.read_csv(buf)
         elif format == common.S3FileFormat.JSON:
-            return pd.read_json(data)
+            return pd.read_json(buf)
         elif format == common.S3FileFormat.PARQUET:
-            return pd.read_parquet(data)
+            return pd.read_parquet(buf)
 
-        raise Exception("Unknown S3 file format %s" % format)
+        raise Exception("Unknown S3 file format %s." % format)
 
     def extract(self, params: extract.S3Params) -> pd.DataFrame:
-        paths = json.loads(params.filepath)
-        if not isinstance(paths, List):
-            paths = [paths]
-
-        bucket_obj = self.s3.Bucket(self.bucket)
-        dfs = []
-        for path in paths:
-            for obj in bucket_obj.objects.filter(Prefix=path):
-                response = self.s3.Object(self.bucket, obj.key).get()
-                data = response["Body"].read()
-                buf = io.BytesIO(data)
-                dfs.append(self._parse_data(buf, params.format))
-
-        return pd.concat(dfs)
+        path = json.loads(params.filepath)
+        if not isinstance(path, List):
+            if len(path) == 0:
+                raise Exception("S3 file path cannot be an empty string.")
+            if path[-1] == "/":
+                # This means the path is a directory, and we will do a prefix search.
+                dfs = []
+                for obj in self.s3.Bucket(self.bucket).objects.filter(Prefix=path):
+                    # The filter api also returns the directories, so we filter them out.
+                    if (obj.key)[-1] != "/":
+                        dfs.append(self._fetch_object(obj.key, params.format))
+                return pd.concat(dfs)
+            else:
+                # This means the path is a file name, and we do a regular file retrieval.
+                return self._fetch_object(path, params.format)
+        else:
+            # This means we have a list of file paths.
+            dfs = []
+            for key in path:
+                if len(key) == 0:
+                    raise Exception("S3 file path cannot be an empty string.")
+                if key[-1] == "/":
+                    raise Exception("Each key in the list must not be a directory, found %s." % key)
+                dfs.append(self._fetch_object(key, params.format))
+            return pd.concat(dfs)
 
     def load(self, params: load.S3Params, df: pd.DataFrame) -> None:
         buf = io.BytesIO()

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -264,7 +264,11 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
       <DialogContent>
         {nameInput}
         {serviceDialog}
-        {errMsg && <Alert severity="error"><pre>{errMsg}</pre></Alert>}
+        {errMsg && (
+          <Alert severity="error">
+            <pre>{errMsg}</pre>
+          </Alert>
+        )}
         <Snackbar
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
           open={showSuccessToast}

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -233,7 +233,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
         navigate('/integrations');
       })
       .catch((err) => {
-        setErrMsg('Unable to connect integration. ' + err.message);
+        setErrMsg(err.message);
         setIsConnecting(false);
       });
   };
@@ -264,7 +264,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
       <DialogContent>
         {nameInput}
         {serviceDialog}
-        {errMsg && <Alert severity="error">{errMsg}</Alert>}
+        {errMsg && <Alert severity="error"><pre>{errMsg}</pre></Alert>}
         <Snackbar
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
           open={showSuccessToast}

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -6,6 +6,7 @@ import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: S3Config = {
   bucket: 'aqueduct',
+  region: '',
   access_key_id: '',
   secret_access_key: '',
 };
@@ -16,24 +17,26 @@ type Props = {
 
 export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [bucket, setBucket] = useState<string>(null);
+  const [region, setRegion] = useState<string>(null);
   const [accessKeyId, setAccessKeyId] = useState<string>(null);
   const [secretAccessKey, setSecretAccessKey] = useState<string>(null);
 
   useEffect(() => {
     const config: S3Config = {
       bucket: bucket,
+      region: region,
       access_key_id: accessKeyId,
       secret_access_key: secretAccessKey,
     };
     setDialogConfig(config);
-  }, [bucket, accessKeyId, secretAccessKey]);
+  }, [bucket, region, accessKeyId, secretAccessKey]);
 
   return (
     <Box sx={{ mt: 2 }}>
       <IntegrationTextInputField
         spellCheck={false}
         required={true}
-        label="Bucket *"
+        label="Bucket*"
         description="The name of the S3 bucket."
         placeholder={Placeholders.bucket}
         onChange={(event) => setBucket(event.target.value)}
@@ -43,7 +46,17 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       <IntegrationTextInputField
         spellCheck={false}
         required={true}
-        label="AWS Access Key ID"
+        label="Region*"
+        description="The AWS region that the bucket is located in (e.g., us-east-2)."
+        placeholder={Placeholders.region}
+        onChange={(event) => setRegion(event.target.value)}
+        value={region}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="AWS Access Key ID*"
         description="The access key ID of your AWS account."
         placeholder={Placeholders.access_key_id}
         onChange={(event) => setAccessKeyId(event.target.value)}
@@ -53,7 +66,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       <IntegrationTextInputField
         spellCheck={false}
         required={true}
-        label="AWS Secret Access Key"
+        label="AWS Secret Access Key*"
         description="The secret access key of your AWS account."
         placeholder={Placeholders.secret_access_key}
         onChange={(event) => setSecretAccessKey(event.target.value)}

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -6,7 +6,6 @@ import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: S3Config = {
   bucket: 'aqueduct',
-  region: '',
   access_key_id: '',
   secret_access_key: '',
 };
@@ -17,19 +16,17 @@ type Props = {
 
 export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [bucket, setBucket] = useState<string>(null);
-  const [region, setRegion] = useState<string>(null);
   const [accessKeyId, setAccessKeyId] = useState<string>(null);
   const [secretAccessKey, setSecretAccessKey] = useState<string>(null);
 
   useEffect(() => {
     const config: S3Config = {
       bucket: bucket,
-      region: region,
       access_key_id: accessKeyId,
       secret_access_key: secretAccessKey,
     };
     setDialogConfig(config);
-  }, [bucket, region, accessKeyId, secretAccessKey]);
+  }, [bucket, accessKeyId, secretAccessKey]);
 
   return (
     <Box sx={{ mt: 2 }}>
@@ -41,16 +38,6 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
         placeholder={Placeholders.bucket}
         onChange={(event) => setBucket(event.target.value)}
         value={bucket}
-      />
-
-      <IntegrationTextInputField
-        spellCheck={false}
-        required={true}
-        label="Region*"
-        description="The AWS region that the bucket is located in (e.g., us-east-2)."
-        placeholder={Placeholders.region}
-        onChange={(event) => setRegion(event.target.value)}
-        value={region}
       />
 
       <IntegrationTextInputField

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -81,7 +81,6 @@ export type SalesforceConfig = {
 
 export type S3Config = {
   bucket: string;
-  region: string;
   access_key_id: string;
   secret_access_key: string;
 };

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -81,6 +81,7 @@ export type SalesforceConfig = {
 
 export type S3Config = {
   bucket: string;
+  region: string;
   access_key_id: string;
   secret_access_key: string;
 };

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -220,8 +220,8 @@ export async function connectIntegration(
   });
 
   if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message);
+    const message = await res.json();
+    throw new Error(message.error);
   }
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR enables user's S3 integration to extract multiple files in a concatenated form, so when they have multiple files they don't need to define a bunch of extract operators. The expected value for the SDK API is commented inline. The PR also adds an authentication step when the user registers an S3 integration by trying to list the files in the bucket.

https://www.loom.com/share/b692707630a44f3bbf0ebfa107e6334b

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


