### PR TITLE
Add ability to distinguish between warnings and error level checks on backend

### DIFF
--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -187,8 +187,8 @@ def test_check_failure_with_varying_severity(client):
     def failure_blocking_check(df):
         return False
 
-    # nonblocking_check = failure_nonblocking_check(sql_artifact)
-    # run_flow_test(client, artifacts=[sql_artifact, nonblocking_check])
+    nonblocking_check = failure_nonblocking_check(sql_artifact)
+    run_flow_test(client, artifacts=[sql_artifact, nonblocking_check])
 
     blocking_check = failure_blocking_check(sql_artifact)
     run_flow_test(client, artifacts=[sql_artifact, blocking_check], expect_success=False)

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -174,7 +174,7 @@ def test_check_with_series_output(client):
     run_flow_test(client, artifacts=[sql_artifact, passed, failed])
 
 
-def test_check_failure_with_severity(client):
+def test_check_failure_with_varying_severity(client):
     db = client.integration(name=get_integration_name())
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
 
@@ -187,8 +187,8 @@ def test_check_failure_with_severity(client):
     def failure_blocking_check(df):
         return False
 
-    _ = failure_nonblocking_check(sql_artifact)
-    run_flow_test(client, artifacts=[sql_artifact])
+    # nonblocking_check = failure_nonblocking_check(sql_artifact)
+    # run_flow_test(client, artifacts=[sql_artifact, nonblocking_check])
 
-    _ = failure_blocking_check(sql_artifact)
-    run_flow_test(client, artifacts=[sql_artifact], expect_success=False)
+    blocking_check = failure_blocking_check(sql_artifact)
+    run_flow_test(client, artifacts=[sql_artifact, blocking_check], expect_success=False)

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -96,6 +96,7 @@ def run_flow_test(
     schedule: str = "",
     num_runs: int = 1,
     delete_flow_after: bool = True,
+    expect_success: bool = True,
 ) -> Optional[Flow]:
     """
     Actually publishes the flow if tests are run with --publish flag. This flow can be deleted
@@ -120,14 +121,19 @@ def run_flow_test(
     print("Workflow registration succeeded. Workflow ID: %s" % flow.id())
 
     try:
-        wait_for_flow_runs(client, flow.id(), num_runs)
+        wait_for_flow_runs(client, flow.id(), num_runs, expect_success)
     finally:
         if delete_flow_after:
             delete_flow(client, flow.id())
     return flow
 
 
-def wait_for_flow_runs(client: aqueduct.Client, flow_id: uuid.UUID, num_runs: int = 1) -> int:
+def wait_for_flow_runs(
+    client: aqueduct.Client,
+    flow_id: uuid.UUID,
+    num_runs: int = 1,
+    expect_success: bool = True,
+) -> int:
     """
     Returns only when the specified flow has run successfully at least `num_runs` times.
     Any run failure is not tolerated. Will timeout after a few minutes.
@@ -152,7 +158,11 @@ def wait_for_flow_runs(client: aqueduct.Client, flow_id: uuid.UUID, num_runs: in
             continue
 
         statuses = [flow_run["status"] for flow_run in flow_runs]
-        assert all(status != "failed" for status in statuses), "At least one workflow run failed!"
+
+        if expect_success:
+            assert all(status != "failed" for status in statuses), "At least one workflow run failed!"
+        else:
+            assert all(status == "failed" for status in statuses), "At least one workflow succeeded!"
 
         if len(flow_runs) < num_runs:
             continue
@@ -162,7 +172,7 @@ def wait_for_flow_runs(client: aqueduct.Client, flow_id: uuid.UUID, num_runs: in
             continue
 
         print(
-            "Workflow %s was created and ran successfully at %s times!" % (flow_id, len(flow_runs))
+            "Workflow %s was created and ran successfully at least %s times!" % (flow_id, len(flow_runs))
         )
         return len(flow_runs)
     return -1

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -161,7 +161,7 @@ def wait_for_flow_runs(
         statuses = [flow_run["status"] for flow_run in flow_runs]
 
         # Continue checking as long as there are still runs pending.
-        if any(status == str(ExecutionStatus.PENDING) for status in statuses):
+        if any(status == ExecutionStatus.PENDING for status in statuses):
             continue
 
         if len(flow_runs) < num_runs:
@@ -169,12 +169,12 @@ def wait_for_flow_runs(
 
         if expect_success:
             assert all(
-                status == str(ExecutionStatus.SUCCEEDED) for status in statuses
+                status == ExecutionStatus.SUCCEEDED for status in statuses
             ), "At least one workflow run failed!"
         else:
             # We expect them all to fail.
             assert all(
-                status == str(ExecutionStatus.FAILED) for status in statuses
+                status == ExecutionStatus.FAILED for status in statuses
             ), "At least one workflow succeeded!"
 
         print(

--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -201,7 +201,7 @@ class WorkflowDagResultResponse(BaseModel):
         return {
             "run_id": str(self.id),
             "created_at": human_readable_timestamp(self.created_at),
-            "status": str(self.status),
+            "status": self.status.value,
         }
 
 

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -13,6 +13,10 @@ const (
 		githubIssueLink + " . " +
 		"We will get back to you as soon as we can."
 	TipUnknownInternalError = "Sorry, we've run into an unexpected error! " + TipCreateBugReport
+
+	// This tip is not meant to be surfaced to the user. It should be overwritten in the specific
+	// operator.GetExecState() implementation with a more helpful error message.
+	TipBlacklistedOutputError = "Operator has output a blacklisted value."
 )
 
 var ErrInvalidStorageConfig = errors.New("Invalid Storage Config")

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -108,6 +108,11 @@ type FunctionSpec struct {
 	OutputMetadataPaths []string        `json:"output_metadata_paths"  yaml:"output_metadata_paths"`
 	InputArtifactTypes  []artifact.Type `json:"input_artifact_types"  yaml:"input_artifact_types"`
 	OutputArtifactTypes []artifact.Type `json:"output_artifact_types"  yaml:"output_artifact_types"`
+
+	// If the function outputs a value that exists in this list, we will fail the entire workflow.
+	// This list contains the json-serialized version of the offending values.
+	// Must be set to nil if there are no blacklisted outputs expected.
+	BlacklistedOutputs []string `json:"blacklisted_outputs" yaml:"blacklisted_outputs"`
 }
 
 type ParamSpec struct {

--- a/src/golang/lib/workflow/artifact/artifact.go
+++ b/src/golang/lib/workflow/artifact/artifact.go
@@ -21,11 +21,6 @@ type Artifact interface {
 	Type() artifact.Type
 	Name() string
 
-	// Computed indicates whether this artifact has been computed or not. An artifact is
-	// only considered "computed" if the operator that generates it has completed
-	// successfully.
-	Computed(ctx context.Context) bool
-
 	// InitializeResult initializes the artifact in the database.
 	InitializeResult(ctx context.Context, dagResultID uuid.UUID) error
 
@@ -35,6 +30,10 @@ type Artifact interface {
 
 	// Finish is an end-of-lifecycle hook meant to do any final cleanup work.
 	Finish(ctx context.Context)
+
+	// Computed indicates whether this artifact has been computed or not.
+	// An artifact is only considered "computed" if its results have been written to storage.
+	Computed(ctx context.Context) bool
 
 	// GetMetadata fetches the metadata for this artifact.
 	// Errors if the artifact has not yet been computed.

--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -1,9 +1,16 @@
 package operator
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
+	"github.com/aqueducthq/aqueduct/lib/collections/operator/check"
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/dropbox/godropbox/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type checkOperatorImpl struct {
@@ -40,7 +47,41 @@ func newCheckOperator(base baseFunctionOperator) (Operator, error) {
 	}, nil
 }
 
+func (co *checkOperatorImpl) hasErrorSeverity() bool {
+	return co.dbOperator.Spec.Check().Level == check.ErrorLevel
+}
+
+func (co *checkOperatorImpl) GetExecState(ctx context.Context) (*shared.ExecutionState, error) {
+	execState, err := co.baseOperator.GetExecState(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// If this was a blocking check that failed, overwrite the returned tip message
+	// to be much more helpful.
+	if co.hasErrorSeverity() &&
+		execState.Status == shared.FailedExecutionStatus &&
+		execState.Error.Tip == shared.TipBlacklistedOutputError {
+		execState.Error.Tip = fmt.Sprintf("Check operator %s failed and has ERROR level severity, so the entire workflow failed.", co.Name())
+	}
+	return execState, nil
+}
+
 func (co *checkOperatorImpl) JobSpec() job.Spec {
 	fn := co.dbOperator.Spec.Check().Function
-	return co.jobSpec(&fn)
+	spec := co.jobSpec(&fn)
+
+	// This will tell the orchestration engine to fail the workflow
+	// if the check fails with sufficient severity.
+	if co.hasErrorSeverity() {
+		falseSerialized, err := json.Marshal(false)
+		if err != nil {
+			log.Errorf("Internal error: Operator %s is unable to marshal `false`")
+		}
+
+		fnSpec := spec.(*job.FunctionSpec)
+		fnSpec.BlacklistedOutputs = append(fnSpec.BlacklistedOutputs, string(falseSerialized))
+		return fnSpec
+	}
+	return spec
 }

--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -62,7 +62,7 @@ func (co *checkOperatorImpl) GetExecState(ctx context.Context) (*shared.Executio
 	if co.hasErrorSeverity() &&
 		execState.Status == shared.FailedExecutionStatus &&
 		execState.Error.Tip == shared.TipBlacklistedOutputError {
-		execState.Error.Tip = fmt.Sprintf("Check operator %s failed and has ERROR level severity, so the entire workflow failed.", co.Name())
+		execState.Error.Tip = fmt.Sprintf("Check %s did not pass and has ERROR level severity, so the entire workflow failed.", co.Name())
 	}
 	return execState, nil
 }

--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -76,7 +76,7 @@ func (co *checkOperatorImpl) JobSpec() job.Spec {
 	if co.hasErrorSeverity() {
 		falseSerialized, err := json.Marshal(false)
 		if err != nil {
-			log.Errorf("Internal error: Operator %s is unable to marshal `false`")
+			log.Errorf("Internal error: Operator %s is unable to marshal `false`", co.Name())
 		}
 
 		fnSpec := spec.(*job.FunctionSpec)

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -10,6 +10,7 @@ from aqueduct_executor.operators.function_executor.utils import OP_DIR
 from aqueduct_executor.operators.utils import utils
 from aqueduct_executor.operators.utils.enums import ExecutionStatus, FailureType
 from aqueduct_executor.operators.utils.execution import (
+    TIP_BLACKLISTED_OUTPUT,
     TIP_OP_EXECUTION,
     TIP_UNKNOWN_ERROR,
     Error,
@@ -135,9 +136,25 @@ def run(spec: FunctionSpec) -> None:
             system_metadata=system_metadata,
         )
 
-        exec_state.status = ExecutionStatus.SUCCEEDED
-        utils.write_exec_state(storage, spec.metadata_path, exec_state)
-        print(f"Succeeded! Full logs: {exec_state.json()}")
+        # Check if any of the written results were blacklisted and there should fail
+        # the workflow.
+        if spec.blacklisted_outputs is not None and any(
+            json.dumps(res) in spec.blacklisted_outputs for res in results
+        ):
+            exec_state.status = ExecutionStatus.FAILED
+            exec_state.failure_type = FailureType.USER
+            exec_state.error = Error(
+                context="",
+                tip=TIP_BLACKLISTED_OUTPUT,
+            )
+            utils.write_exec_state(storage, spec.metadata_path, exec_state)
+
+            print(f"Failed with user error. Full Logs:\n{exec_state.json()}")
+            sys.exit(1)
+        else:
+            exec_state.status = ExecutionStatus.SUCCEEDED
+            utils.write_exec_state(storage, spec.metadata_path, exec_state)
+            print(f"Succeeded! Full logs: {exec_state.json()}")
 
     except Exception as e:
         exec_state.status = ExecutionStatus.FAILED

--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Optional
 
 try:
     from typing import Literal
@@ -29,6 +29,10 @@ class FunctionSpec(BaseModel):
     output_metadata_paths: List[str]
     input_artifact_types: List[enums.InputArtifactType]
     output_artifact_types: List[enums.OutputArtifactType]
+
+    # If the function produces one of these blacklisted outputs exactly,
+    # we will error out the workflow.
+    blacklisted_outputs: Optional[List[str]] = None  # Optional for backwards compatability.
 
     class Config:
         extra = Extra.forbid

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -25,6 +25,14 @@ TIP_EXTRACT = "We couldn't execute the provided query. Please double check your 
 TIP_LOAD = "We couldn't load to the integration. Please make sure the target exists, or you have the right permission."
 TIP_DISCOVER = "We couldn't list items in the integration. Please make sure your credentials have the right permission."
 
+# This tip is not meant to be surfaced to the user, because at this level
+# we can only give a very generic error. This message should be overwritten
+# at a higher level with a more user-friendly one, specific to type of operator.
+#
+# Eg. Check operators with error severity are blacklisted from returning `false`,
+# since that signifies a failed blocking check.
+TIP_BLACKLISTED_OUTPUT = "Operator has output a blacklisted value."
+
 
 class Error(BaseModel):
     tip: str = ""  # Information about how the user could fix the error.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This is the revisit of previously closed. https://github.com/aqueducthq/aqueduct/pull/195
This is built on top of the orchestration refactor.

The approach:
- Because we want to keep our python operators generic, I introduced the concept of "Blacklisted outputs" on the function spec. For all operators except blocking checks, this field will be None. For blocking checks, we want to blacklist the output "False". That is to say, if an output matches an entry in this list, we will fail the entire workflow.
- On the read side, the python operator level is too generic to provide a very user friendly tip. So instead, it provides a generic one that is then overwritten at the `checkOp.GetExecState()` level with more specific user friendly context.

## Related issue number (if any)
ENG-1265

## Checklist before requesting a review
- [ x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ x] If this is a new feature, I have added unit tests and integration tests.
- [ x] I have run the integration tests locally and they are passing.
- [ x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


