### PR TITLE
ENG-1401: Fixes menu sidebar link to homepage

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -170,10 +170,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
     </Avatar>
   );
 
+  const pathPrefix = getPathPrefix();
   const sidebarContent = (
     <>
       <Box className={styles['menu-sidebar-popover-container']}>
-        <Link href={`${getPathPrefix() ?? '/'}`} underline="none">
+        <Link href={`${pathPrefix.length > 0 ? pathPrefix : '/'}`} underline="none">
           <Typography variant="h3" sx={{ color: 'white' }}>
             Aqueduct
           </Typography>


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Previously, the link to the home page on the menu sidebar was broken because we were using an `undefined` guard on the path prefix, so the link was linking to `''`. This PR tests whether there is a path prefix instead and links to `/` otherwise.

## Related issue number (if any)

ENG-1401

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [N/A] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


