### PR TITLE
Cleanup all expanded function folders after execution finishes

### DIFF
--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -115,7 +115,7 @@ def test_edit_param_for_flow(client):
     new_row_param = client.create_param(name="new row", default=row_to_add)
     output = append_row_to_df(sql_artifact, new_row_param)
 
-    flow_name = "Edit Parameter Test Flow"
+    flow_name = generate_new_flow_name()
     flow = run_flow_test(client, artifacts=[output], name=flow_name, delete_flow_after=False)
     flow_id = flow.id()
 

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -273,14 +273,12 @@ func (j *ProcessJobManager) Launch(
 	// For function operators, we need to set the directory path to expand the function into here.
 	var fnExtractStoragePath string
 	if spec.Type() == FunctionJobType {
-		if _, ok := spec.(*FunctionSpec); !ok {
-			return ErrInvalidJobSpec
+		if fnSpec, ok := spec.(*FunctionSpec); ok {
+			fnExtractStoragePath = path.Join(j.conf.OperatorStorageDir, uuid.New().String())
+			fnSpec.FunctionExtractPath = fnExtractStoragePath
 		}
-		fnExtractStoragePath = path.Join(j.conf.OperatorStorageDir, uuid.New().String())
-		spec.(*FunctionSpec).FunctionExtractPath = fnExtractStoragePath
+		log.Errorf("Function extract storage path: %s", spec.(*FunctionSpec).FunctionExtractPath)
 	}
-	log.Errorf("Function extract storage path: %s", fnExtractStoragePath)
-
 	cmd, err := j.mapJobTypeToCmd(name, spec)
 	if err != nil {
 		return err
@@ -328,12 +326,12 @@ func (j *ProcessJobManager) Poll(ctx context.Context, name string) (shared.Execu
 	defer func() {
 		if len(command.fnExtractStoragePath) > 0 {
 			log.Errorf("Attempting to remove %s", command.fnExtractStoragePath)
-			if _, err = os.Stat(command.fnExtractStoragePath); os.IsExist(err) {
-				err = os.Remove(command.fnExtractStoragePath)
-				if err != nil {
-					log.Errorf("Unable to remove function extraction directory %s.", command.fnExtractStoragePath)
-				}
-			}
+			//if _, err = os.Stat(command.fnExtractStoragePath); os.IsExist(err) {
+			//	err = os.Remove(command.fnExtractStoragePath)
+			//	if err != nil {
+			//		log.Errorf("Unable to remove function extraction directory %s.", command.fnExtractStoragePath)
+			//	}
+			//}
 			log.Errorf("Removed: %s", command.fnExtractStoragePath)
 		}
 		j.deleteCmd(name)

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -277,8 +277,8 @@ func (j *ProcessJobManager) Launch(
 			fnExtractStoragePath = path.Join(j.conf.OperatorStorageDir, uuid.New().String())
 			fnSpec.FunctionExtractPath = fnExtractStoragePath
 		}
-		log.Errorf("Function extract storage path: %s", spec.(*FunctionSpec).FunctionExtractPath)
 	}
+
 	cmd, err := j.mapJobTypeToCmd(name, spec)
 	if err != nil {
 		return err
@@ -325,8 +325,6 @@ func (j *ProcessJobManager) Poll(ctx context.Context, name string) (shared.Execu
 	// collect the entry in j.cmds.
 	defer func() {
 		if len(command.fnExtractStoragePath) > 0 {
-			log.Errorf("Attempting to remove %s", command.fnExtractStoragePath)
-
 			// Since this is a somewhat scary recursive deleete, instead of just checking that function
 			// extract storage path exists, we check for the presence of a particular file inside this
 			// directory. This is to help make sure that we aren't deleting a folder that we aren't supposed to.
@@ -336,7 +334,6 @@ func (j *ProcessJobManager) Poll(ctx context.Context, name string) (shared.Execu
 					log.Errorf("Unable to remove function extraction directory %s. %v", command.fnExtractStoragePath, err)
 				}
 			}
-			log.Errorf("Removed: %s", command.fnExtractStoragePath)
 		}
 		j.deleteCmd(name)
 	}()

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"os"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -27,7 +26,6 @@ func newFileStorage(fileConfig *shared.FileConfig) *fileStorage {
 func (f *fileStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	path := f.getFullPath(key)
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		log.Errorf("File object does not exist at path %s.", path)
 		return nil, ErrObjectDoesNotExist
 	}
 	return os.ReadFile(path)

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"os"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -26,6 +27,7 @@ func newFileStorage(fileConfig *shared.FileConfig) *fileStorage {
 func (f *fileStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	path := f.getFullPath(key)
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		log.Errorf("File object does not exist at path %s.", path)
 		return nil, ErrObjectDoesNotExist
 	}
 	return os.ReadFile(path)

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -83,11 +83,11 @@ func NewOperator(
 	}
 
 	if dbOperator.Spec.IsFunction() {
-		return newFunctionOperator(baseFunctionOperator{baseOp})
+		return newFunctionOperator(baseFunctionOperator{baseOp, nil})
 	} else if dbOperator.Spec.IsMetric() {
-		return newMetricOperator(baseFunctionOperator{baseOp})
+		return newMetricOperator(baseFunctionOperator{baseOp, nil})
 	} else if dbOperator.Spec.IsCheck() {
-		return newCheckOperator(baseFunctionOperator{baseOp})
+		return newCheckOperator(baseFunctionOperator{baseOp, nil})
 	} else if dbOperator.Spec.IsExtract() {
 		return newExtractOperator(ctx, baseOp)
 	} else if dbOperator.Spec.IsLoad() {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We currently don't do any deletion of the function directories that are expanded in `execute_function.py` (this is the model.py, model.pkl stuff). This means that every function execution, *even if its a preview*, leaves residue in the user's system, which is a bit silly. Once the user's function is executed, we don't need to keep the expanded directory around (we'll still have the serialized function representation if we need it - that's a separate storage path.

## Related issue number (if any)
ENG-1375

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ x] I have run the integration tests locally and they are passing.
- [ x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


