### PR TITLE
[Quality of life] Print the error context in the preview execution exception

### DIFF
--- a/integration_tests/sdk/error_handling_test.py
+++ b/integration_tests/sdk/error_handling_test.py
@@ -25,23 +25,19 @@ TIP_OP_EXECUTION = "Error executing operator. Please refer to the stack trace fo
 def test_handle_relational_query_error(client):
     db = client.integration(name=get_integration_name())
     sql_artifact = db.sql(query=BAD_QUERY)
-    stdout_log = io.StringIO()
-    with redirect_stdout(stdout_log), pytest.raises(AqueductError):
-        sql_artifact.get()
 
-    stdout_log.seek(0)
-    stdout_contents = stdout_log.read()
-    assert TIP_EXTRACT in stdout_contents
+    try:
+        sql_artifact.get()
+    except AqueductError as e:
+        assert TIP_EXTRACT in e.message
 
 
 def test_handle_bad_op_error(client):
     db = client.integration(name=get_integration_name())
     sql_artifact = db.sql(query=GOOD_QUERY)
     processed_artifact = bad_op(sql_artifact)
-    stdout_log = io.StringIO()
-    with redirect_stdout(stdout_log), pytest.raises(AqueductError):
-        processed_artifact.get()
 
-    stdout_log.seek(0)
-    stdout_contents = stdout_log.read()
-    assert TIP_OP_EXECUTION in stdout_contents
+    try:
+        processed_artifact.get()
+    except AqueductError as e:
+        assert TIP_OP_EXECUTION in e.message

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -37,7 +37,7 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
             If something unexpected happened in our system.
     """
     # There can be multiple operator failures, one for each entry.
-    op_errmsgs: List[str] = []
+    op_err_msgs: List[str] = []
 
     # Creates the message to show the user in the error.
     def _construct_failure_error_msg(op_name: str, op_result: OperatorResult) -> str:
@@ -64,7 +64,7 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
                 print("")
 
             if curr_op_result.error is not None:
-                op_errmsgs.append(_construct_failure_error_msg(curr_op.name, curr_op_result))
+                op_err_msgs.append(_construct_failure_error_msg(curr_op.name, curr_op_result))
 
             else:
                 # Continue traversing, marking operators added to the queue as "seen"
@@ -81,8 +81,8 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
         raise InternalAqueductError("Preview route should not be returning PENDING status.")
 
     if preview_resp.status == ExecutionStatus.FAILED:
-        failureErrMsg = "\n".join(op_errmsgs)
-        raise AqueductError(f"Preview Execution Failed:\n" f"\n" f"{failureErrMsg}\n")
+        failure_err_msg = "\n".join(op_err_msgs)
+        raise AqueductError(f"Preview Execution Failed:\n\n{failure_err_msg}\n")
 
 
 class APIClient:

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -17,6 +17,7 @@ from aqueduct.operators import Operator
 from aqueduct.responses import (
     GetWorkflowResponse,
     ListWorkflowResponseEntry,
+    OperatorResult,
     PreviewResponse,
     RegisterWorkflowResponse,
 )
@@ -24,8 +25,31 @@ from aqueduct.responses import (
 from aqueduct import utils
 
 
-def _print_preview_logs(preview_resp: PreviewResponse, dag: DAG) -> None:
-    """Prints all the logs generated during preview, in BFS order."""
+def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
+    """
+    Prints all the logs generated during preview, in BFS order.
+
+    Raises:
+        AqueductError:
+            If the preview execution has failed. This error will have the context
+            and error message of every failed operator in it.
+        InternalAqueductError:
+            If something unexpected happened in our system.
+    """
+    # There can be multiple operator failures, one for each entry.
+    op_errmsgs: List[str] = []
+
+    # Creates the message to show the user in the error.
+    def _construct_failure_error_msg(op_name: str, op_result: OperatorResult) -> str:
+        assert op_result.error is not None
+        return (
+            f"Operator {op_name} failed!\n"
+            f"{op_result.error.context}\n"
+            f"\n"
+            f"{op_result.error.tip}\n"
+            f"\n"
+        )
+
     q: List[Operator] = dag.list_root_operators()
     seen_op_ids = set(op.id for op in q)
     while len(q) > 0:
@@ -40,8 +64,7 @@ def _print_preview_logs(preview_resp: PreviewResponse, dag: DAG) -> None:
                 print("")
 
             if curr_op_result.error is not None:
-                print(curr_op_result.error.tip)
-                print(curr_op_result.error.context)
+                op_errmsgs.append(_construct_failure_error_msg(curr_op.name, curr_op_result))
 
             else:
                 # Continue traversing, marking operators added to the queue as "seen"
@@ -53,6 +76,13 @@ def _print_preview_logs(preview_resp: PreviewResponse, dag: DAG) -> None:
                     ]
                     q.extend(next_operators)
                     seen_op_ids.union(set(op.id for op in next_operators))
+
+    if preview_resp.status == ExecutionStatus.PENDING:
+        raise InternalAqueductError("Preview route should not be returning PENDING status.")
+
+    if preview_resp.status == ExecutionStatus.FAILED:
+        failureErrMsg = "\n".join(op_errmsgs)
+        raise AqueductError(f"Preview Execution Failed:\n" f"\n" f"{failureErrMsg}\n")
 
 
 class APIClient:
@@ -217,13 +247,7 @@ class APIClient:
         utils.raise_errors(resp)
 
         preview_resp = PreviewResponse(**resp.json())
-        _print_preview_logs(preview_resp, dag)
-        if preview_resp.status == ExecutionStatus.PENDING:
-            raise InternalAqueductError("Preview route should not be returning PENDING status.")
-        if preview_resp.status == ExecutionStatus.FAILED:
-            raise AqueductError(
-                "Preview execution failed. See console logs for error message and trace."
-            )
+        _handle_preview_resp(preview_resp, dag)
         return preview_resp
 
     def register_workflow(

--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -12,7 +12,7 @@ from .flow_run import FlowRun
 from .logger import Logger
 from .operators import OperatorSpec, ParamSpec
 from .responses import WorkflowDagResponse, WorkflowDagResultResponse
-from .utils import generate_ui_url, parse_user_supplied_id, format_header_for_print
+from .utils import format_header_for_print, generate_ui_url, parse_user_supplied_id
 
 
 class Flow:

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -1,20 +1,20 @@
 import textwrap
 import uuid
 from textwrap import wrap
-from typing import Dict, Any, Mapping, Optional, Union, List
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 import plotly.graph_objects as go
 from aqueduct.api_client import APIClient
 from aqueduct.artifact import Artifact, get_artifact_type
 from aqueduct.check_artifact import CheckArtifact
 from aqueduct.dag import DAG
-from aqueduct.enums import OperatorType, DisplayNodeType, ExecutionStatus, ArtifactType
+from aqueduct.enums import ArtifactType, DisplayNodeType, ExecutionStatus, OperatorType
 from aqueduct.error import InternalAqueductError
 from aqueduct.metric_artifact import MetricArtifact
 from aqueduct.operators import Operator
 from aqueduct.param_artifact import ParamArtifact
 from aqueduct.table_artifact import TableArtifact
-from aqueduct.utils import generate_ui_url, human_readable_timestamp, format_header_for_print
+from aqueduct.utils import format_header_for_print, generate_ui_url, human_readable_timestamp
 
 
 class FlowRun:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
For every preview execution error, we return the phrase "See console logs for error message" in the error. It makes more sense to put the logs directly in the error message itself.

Examples:
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/6466121/180095862-e44b5e7c-8a99-4383-9fb8-412209c9be53.png">

![image](https://user-images.githubusercontent.com/6466121/180096393-07a0af12-f774-453f-977d-240eaf79c2d9.png)


## Related issue number (if any)
ENG-1396

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x ] I have performed a self-review of my code.
- [x ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A ] If this is a new feature, I have added unit tests and integration tests.
- [ x] I have run the integration tests locally and they are passing.
- [ x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


