### PR TITLE
Cleanup unzipped function directories properly on OSX

### DIFF
--- a/src/python/aqueduct_executor/operators/function_executor/get_extract_path.py
+++ b/src/python/aqueduct_executor/operators/function_executor/get_extract_path.py
@@ -1,13 +1,11 @@
 import argparse
 import base64
-import os
 
 from aqueduct_executor.operators.function_executor.spec import FunctionSpec, parse_spec
-from aqueduct_executor.operators.function_executor.utils import OP_DIR
 
 
 def run(spec: FunctionSpec) -> str:
-    return os.path.join(spec.function_extract_path, OP_DIR)
+    return spec.function_extract_path
 
 
 if __name__ == "__main__":

--- a/src/python/aqueduct_executor/start-function-executor.sh
+++ b/src/python/aqueduct_executor/start-function-executor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 JOB_SPEC=$1
-OP_PATH=$(python3 -m aqueduct_executor.operators.function_executor.get_extract_path --spec "$JOB_SPEC")
+FUNCTION_EXTRACT_PATH=$(python3 -m aqueduct_executor.operators.function_executor.get_extract_path --spec "$JOB_SPEC")
 EXIT_CODE=$?
 if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
 
@@ -8,13 +8,11 @@ python3 -m aqueduct_executor.operators.function_executor.extract_function --spec
 EXIT_CODE=$?
 if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
 
-if test -f "$OP_PATH/requirements.txt"; then pip3 install -r "$OP_PATH/requirements.txt" --no-cache-dir; fi
+if test -f "$FUNCTION_EXTRACT_PATH/op/requirements.txt"; then pip3 install -r "$FUNCTION_EXTRACT_PATH/op/requirements.txt" --no-cache-dir; fi
 
 python3 -m aqueduct_executor.operators.function_executor.main --spec "$JOB_SPEC"
 EXIT_CODE=$?
 
-# Remove the /op suffix.
-FUNCTION_EXTRACT_PATH=${OP_PATH::-3}
 # Double check to make sure the path doesn't contain something dangerous.
 if [ ! -z "$FUNCTION_EXTRACT_PATH" -a "$FUNCTION_EXTRACT_PATH" != *"*"* ]
 then

--- a/temp.sh
+++ b/temp.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+OP_PATH="/aslkdjf/op"
+echo ${OP_PATH::-3}
+
+

--- a/temp.sh
+++ b/temp.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-OP_PATH="/aslkdjf/op"
-echo ${OP_PATH::-3}
-
-


### PR DESCRIPTION
## Describe your changes and why you are making these changes
start_function_executor.sh errors on OSX operating systems because of the "${OP_PATH::-3}" expression. 

We remove the need for this expression, and thus allow for cleanup of these expanded functions on Macs.


## Related issue number (if any)
ENG-1375

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


