### PR TITLE
Fix logging for workflow name / type in executor code.

### DIFF
--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -62,23 +62,23 @@ type Spec interface {
 	JobName() string
 }
 
-// baseSpec defines fields shared by all job specs.
-type baseSpec struct {
+// BaseSpec defines fields shared by all job specs.
+type BaseSpec struct {
 	Type JobType `json:"type"  yaml:"type"`
 	Name string  `json:"name"  yaml:"name"`
 }
 
-func (bs *baseSpec) JobName() string {
+func (bs *BaseSpec) JobName() string {
 	return bs.Name
 }
 
 type WorkflowRetentionSpec struct {
-	baseSpec
+	BaseSpec
 	ExecutorConfig *ExecutorConfiguration
 }
 
 type WorkflowSpec struct {
-	baseSpec
+	BaseSpec
 	WorkflowId     string               `json:"workflow_id" yaml:"workflowId"`
 	GithubManager  github.ManagerConfig `json:"github_manager" yaml:"github_manager"`
 	Parameters     map[string]string    `json:"parameters" yaml:"parameters"`
@@ -89,7 +89,7 @@ type WorkflowSpec struct {
 // These Python jobs can be one-off jobs (e.g. Authenticate, Discover)
 // or Workflow operators (e.g. Function, Extract, Load).
 type BasePythonSpec struct {
-	baseSpec
+	BaseSpec
 	StorageConfig shared.StorageConfig `json:"storage_config"  yaml:"storage_config"`
 	MetadataPath  string               `json:"metadata_path"  yaml:"metadata_path"`
 }
@@ -216,7 +216,7 @@ func NewWorkflowRetentionJobSpec(
 	jobManager Config,
 ) Spec {
 	return &WorkflowRetentionSpec{
-		baseSpec: baseSpec{
+		BaseSpec: BaseSpec{
 			Type: WorkflowRetentionType,
 			Name: WorkflowRetentionName,
 		},
@@ -240,7 +240,7 @@ func NewWorkflowSpec(
 	parameters map[string]string,
 ) Spec {
 	return &WorkflowSpec{
-		baseSpec: baseSpec{
+		BaseSpec: BaseSpec{
 			Type: WorkflowJobType,
 			Name: name,
 		},
@@ -262,7 +262,7 @@ func NewBasePythonSpec(
 	metadataPath string,
 ) BasePythonSpec {
 	return BasePythonSpec{
-		baseSpec: baseSpec{
+		BaseSpec: BaseSpec{
 			Type: jobType,
 			Name: name,
 		},
@@ -280,7 +280,7 @@ func NewAuthenticateSpec(
 ) Spec {
 	return &AuthenticateSpec{
 		BasePythonSpec: BasePythonSpec{
-			baseSpec: baseSpec{
+			BaseSpec: BaseSpec{
 				Type: AuthenticateJobType,
 				Name: name,
 			},
@@ -308,7 +308,7 @@ func NewExtractSpec(
 ) Spec {
 	return &ExtractSpec{
 		BasePythonSpec: BasePythonSpec{
-			baseSpec: baseSpec{
+			BaseSpec: BaseSpec{
 				Type: ExtractJobType,
 				Name: name,
 			},
@@ -340,7 +340,7 @@ func NewLoadTableSpec(
 ) Spec {
 	return &LoadTableSpec{
 		BasePythonSpec: BasePythonSpec{
-			baseSpec: baseSpec{
+			BaseSpec: BaseSpec{
 				Type: LoadTableJobType,
 				Name: name,
 			},
@@ -352,7 +352,7 @@ func NewLoadTableSpec(
 		CSV:             csv,
 		LoadParameters: LoadSpec{
 			BasePythonSpec: BasePythonSpec{
-				baseSpec: baseSpec{
+				BaseSpec: BaseSpec{
 					Type: LoadJobType,
 					Name: name,
 				},
@@ -379,7 +379,7 @@ func NewDiscoverSpec(
 ) Spec {
 	return &DiscoverSpec{
 		BasePythonSpec: BasePythonSpec{
-			baseSpec: baseSpec{
+			BaseSpec: BaseSpec{
 				Type: DiscoverJobType,
 				Name: name,
 			},
@@ -424,7 +424,7 @@ func DecodeSpec(specData string, serializationType SerializationType) (Spec, err
 
 	var spec Spec
 	if serializationType == JsonSerializationType {
-		var base baseSpec
+		var base BaseSpec
 		if err := json.Unmarshal(specBytes, &base); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where workflow name / type is gone when running in executor. The root cause is that the `baseSpec` is private, and we are using json serialization for logging, which hides these fields. So the fix is simply make the object public.

## Related issue number (if any)
ENG-1215

## Checklist before requesting a review
Verified type and name appears in log:
```
time=2022-07-21T18:22:44Z level=info msg={"type":"workflow","name":"test_correct_2","workflow_id":"08ae08e6-58a1-455c-a1b2-2ca02ca02353","github_manager":{},"parameters":{},"ExecutorConfig":{"metadata":{"type":"sqlite","sqlite":{"file":"/home/ubuntu/.aqueduct/server/db/aqueduct.db"}},"vault":{"directory":"/home/ubuntu/.aqueduct/server/vault","encryption_key":"H8FIU2QCDL0A3STRV5WZGPN9Y6BME7JX"},"job_manager":{"binary_dir":"/home/ubuntu/.aqueduct/server/bin","logs_dir":"","python_executor_package":"aqueduct_executor","operator_storage_dir":"/home/ubuntu/.aqueduct/server/storage/operators"}}}
```
It should be sufficient if integration tests succeeded:
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [na] If this is a new feature, I have added unit tests and integration tests.
- [ na] I have run the integration tests locally and they are passing.
- [ na] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ na] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


