### PR TITLE
Eng 1427 fix database integration tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -42,9 +42,13 @@ test:
 	cd golang && go test -v $$(go list ./...)
 
 # Database integration tests
-test-database:
+test-db-sqlite:
 	cd golang && go test -v github.com/aqueducthq/aqueduct/lib/collections/tests -database-integration -database-type=sqlite
+
+test-db-postgres:
 	cd golang && go test -v github.com/aqueducthq/aqueduct/lib/collections/tests -database-integration -database-type=postgres
+
+test-database: test-db-sqlite test-db-postgres
 
 lint-go:
 	gofumpt -w golang/

--- a/src/golang/lib/collections/tests/main_test.go
+++ b/src/golang/lib/collections/tests/main_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	schemaVersion = 8
+	schemaVersion = 12
 
 	// Postgres config
 	postgresHost     = "localhost"

--- a/src/golang/lib/collections/tests/operator_test.go
+++ b/src/golang/lib/collections/tests/operator_test.go
@@ -125,5 +125,10 @@ func TestGetOperatorsByIntegrationId(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, len(actualOperators), 1)
 
-	requireDeepEqual(t, expectedOperator, actualOperators[0])
+	actualOperator := &actualOperators[0]
+	require.NotEqual(t, uuid.Nil, actualOperator.Id)
+
+	expectedOperator.Id = actualOperator.Id
+
+	requireDeepEqual(t, expectedOperator, actualOperator)
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes our database integration tests. One of the operator test cases was failing because we did not update the `ID` of the expected operator.

It also splits up the `make test-database` into a couple rules, so that devs can test against specific database types. More documentation for testing can be found [here](https://www.notion.so/aqueducthq/Database-Testing-df6e7c2521cb4205a20e6de22b576c45).

## Related issue number (if any)
ENG 1427

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
I tested this PR by running `make test-db-sqlite`.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


