### PR TITLE
Switch to a low-overhead way of authenticating S3 integration

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
@@ -19,6 +19,8 @@ class S3Connector(connector.TabularConnector):
 
     def authenticate(self) -> None:
         bucket = self.s3.Bucket(self.bucket)
+        # Below is a low-overhead way of checking if the user has access to the bucket.
+        # Source: https://stackoverflow.com/a/49817544
         if not bucket.creation_date:
             raise Exception(
                 "Bucket does not exist or you do not have permission to access the bucket."

--- a/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
@@ -20,7 +20,9 @@ class S3Connector(connector.TabularConnector):
     def authenticate(self) -> None:
         bucket = self.s3.Bucket(self.bucket)
         if not bucket.creation_date:
-            raise Exception("Bucket does not exist or you do not have permission to access the bucket.")
+            raise Exception(
+                "Bucket does not exist or you do not have permission to access the bucket."
+            )
 
     def discover(self) -> List[str]:
         raise Exception("Discover is not supported for S3.")

--- a/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
@@ -18,8 +18,9 @@ class S3Connector(connector.TabularConnector):
         self.bucket = config.bucket
 
     def authenticate(self) -> None:
-        for obj in self.s3.Bucket(self.bucket).objects.all():
-            pass
+        bucket = self.s3.Bucket(self.bucket)
+        if not bucket.creation_date:
+            raise Exception("Bucket does not exist or you do not have permission to access the bucket.")
 
     def discover(self) -> List[str]:
         raise Exception("Discover is not supported for S3.")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previously we were doing a list operation to check if the user has access to the bucket, which can be very costly if the bucket has lots of files. This low-overhead approach is borrowed from [here](https://stackoverflow.com/a/49817544) and I verified that it works.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


