### PR TITLE
ENG-1430 Fix UI Build in install_local.py

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -112,12 +112,20 @@ if __name__ == "__main__":
 
     # Build and replace UI files.
     if args.update_ui:
+        UI_PATH = "src/ui"
+        UI_COMMON_PATH = UI_PATH + "/common"
+        UI_APP_PATH = UI_PATH + "/app"
+        
         print("Updating UI files...")
-        execute_command(["npm", "install"], cwd=join(cwd, "src/ui/common"))
-        execute_command(["npm", "run", "build"], cwd=join(cwd, "src/ui/common"))
-        execute_command(["sudo", "npm", "link"], cwd=join(cwd, "src/ui/common"))
-        execute_command(["npm", "install"], cwd=join(cwd, "src/ui/app"))
-        execute_command(["npm", "link", "@aqueducthq/common"], cwd=join(cwd, "src/ui/app"))
+        execute_command(["rm", "-rf", ".parcel-cache"], cwd=join(cwd, UI_COMMON_PATH))
+        execute_command(["rm", "-rf", "dist"], cwd=join(cwd, UI_COMMON_PATH))
+        execute_command(["npm", "install"], cwd=join(cwd, UI_COMMON_PATH))
+        execute_command(["npm", "run", "build"], cwd=join(cwd, UI_COMMON_PATH))
+        execute_command(["npm", "link"], cwd=join(cwd, UI_COMMON_PATH))
+        execute_command(["rm", "-rf", ".parcel-cache"], cwd=join(cwd, UI_APP_PATH))
+        execute_command(["rm", "-rf", "dist"], cwd=join(cwd, UI_APP_PATH))
+        execute_command(["npm", "install"], cwd=join(cwd, UI_APP_PATH))
+        execute_command(["npm", "link", "@aqueducthq/common"], cwd=join(cwd, UI_APP_PATH))
         execute_command(["make", "dist"], cwd=join(cwd, "src/ui"))
 
         files = [f for f in listdir(ui_directory) if isfile(join(ui_directory, f))]


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes UI build error in install_local.py caused by running npm in sudo

This error happens because the version that npm uses when run is different when you run in sudo mode.
See this command as an example:
```
ubuntu@ip-172-31-41-179:~/repos/aqueduct$ npm --version
8.5.0
ubuntu@ip-172-31-41-179:~/repos/aqueduct$ sudo npm --version
6.14.4
```

## Related issue number (if any)
ENG-1430

https://linear.app/aqueducthq/issue/ENG-1430/fix-ui-build-error

See below for demo of successful output:

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


```
ubuntu@ip-172-31-41-179:~/repos/aqueduct$ python3 scripts/install_local.py 
Updating Golang binaries...
INFO[0000] Executing query: SELECT version,dirty,name FROM schema_version ORDER BY version DESC LIMIT 1; 
INFO[0000] The schema version is already 12.            
INFO[0000] Checking current schema version...           
INFO[0000] Executing query: SELECT version,dirty,name FROM schema_version ORDER BY version DESC LIMIT 1; 
INFO[0000] The current schema version is 000012.        
Updating UI files...
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated request-promise-native@1.0.9: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated sane@4.1.0: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
npm WARN deprecated babel-eslint@10.1.0: babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated highlight.js@9.15.10: Version no longer supported. Upgrade to @latest

> @aqueducthq/common@0.0.9 preinstall
> npx force-resolutions

Applying forced resolutions
@types/react => ^18.0.8
Finished applying forced resolutions

> @aqueducthq/common@0.0.9 prepare
> tsdx build

@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
✓ Creating entry file 2.8 secs
✓ Building modules 3.2 mins

added 1586 packages, and audited 1587 packages in 4m

229 packages are looking for funding
  run `npm fund` for details

20 vulnerabilities (2 low, 17 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

> @aqueducthq/common@0.0.9 build
> tsdx build

@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
✓ Creating entry file 2.7 secs
✓ Building modules 14.5 secs

up to date, audited 3 packages in 1s

found 0 vulnerabilities
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility

added 593 packages, and audited 594 packages in 8s

188 packages are looking for funding
  run `npm fund` for details

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.

removed 85 packages, changed 1 package, and audited 510 packages in 22s

147 packages are looking for funding
  run `npm fund` for details

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix

Run `npm audit` for details.

> @aqueducthq/ui@0.0.5 build
> parcel build --public-url /dist --dist-dir dist/default index.html

console: Skipped refractor/lang/abap.js
console: Skipped refractor/lang/actionscript.js
console: Skipped refractor/lang/ada.js
console: Skipped refractor/lang/apacheconf.js
console: Skipped refractor/lang/apl.js
console: Skipped refractor/lang/applescript.js
console: Skipped refractor/lang/arduino.js
console: Skipped refractor/lang/arff.js
console: Skipped refractor/lang/asciidoc.js
console: Skipped refractor/lang/asm6502.js
console: Skipped refractor/lang/aspnet.js
console: Skipped refractor/lang/autohotkey.js
console: Skipped refractor/lang/autoit.js
console: Skipped refractor/lang/bash.js
console: Skipped refractor/lang/basic.js
console: Skipped refractor/lang/batch.js
console: Skipped refractor/lang/bison.js
console: Skipped refractor/lang/brainfuck.js
console: Skipped refractor/lang/bro.js
console: Skipped refractor/lang/c.js
console: Skipped refractor/lang/clike.js
console: Skipped refractor/lang/clojure.js
console: Skipped refractor/lang/coffeescript.js
console: Skipped refractor/lang/cpp.js
console: Skipped refractor/lang/crystal.js
console: Skipped refractor/lang/csharp.js
console: Skipped refractor/lang/csp.js
console: Skipped refractor/lang/css-extras.js
console: Skipped refractor/lang/css.js
console: Skipped refractor/lang/d.js
console: Skipped refractor/lang/dart.js
console: Skipped refractor/lang/diff.js
console: Skipped refractor/lang/django.js
console: Skipped refractor/lang/docker.js
console: Skipped refractor/lang/eiffel.js
console: Skipped refractor/lang/elixir.js
console: Skipped refractor/lang/elm.js
console: Skipped refractor/lang/erb.js
console: Skipped refractor/lang/erlang.js
console: Skipped refractor/lang/flow.js
console: Skipped refractor/lang/fortran.js
console: Skipped refractor/lang/fsharp.js
console: Skipped refractor/lang/gedcom.js
console: Skipped refractor/lang/gherkin.js
console: Skipped refractor/lang/git.js
console: Skipped refractor/lang/glsl.js
console: Skipped refractor/lang/go.js
console: Skipped refractor/lang/graphql.js
console: Skipped refractor/lang/groovy.js
console: Skipped refractor/lang/haml.js
console: Skipped refractor/lang/handlebars.js
console: Skipped refractor/lang/haskell.js
console: Skipped refractor/lang/haxe.js
console: Skipped refractor/lang/hpkp.js
console: Skipped refractor/lang/hsts.js
console: Skipped refractor/lang/http.js
console: Skipped refractor/lang/ichigojam.js
console: Skipped refractor/lang/icon.js
console: Skipped refractor/lang/inform7.js
console: Skipped refractor/lang/ini.js
console: Skipped refractor/lang/io.js
console: Skipped refractor/lang/j.js
console: Skipped refractor/lang/java.js
console: Skipped refractor/lang/javascript.js
console: Skipped refractor/lang/jolie.js
console: Skipped refractor/lang/json.js
console: Skipped refractor/lang/jsx.js
console: Skipped refractor/lang/julia.js
console: Skipped refractor/lang/keyman.js
console: Skipped refractor/lang/kotlin.js
console: Skipped refractor/lang/latex.js
console: Skipped refractor/lang/less.js
console: Skipped refractor/lang/liquid.js
console: Skipped refractor/lang/lisp.js
console: Skipped refractor/lang/livescript.js
console: Skipped refractor/lang/lolcode.js
console: Skipped refractor/lang/lua.js
console: Skipped refractor/lang/makefile.js
console: Skipped refractor/lang/markdown.js
console: Skipped refractor/lang/markup-templating.js
console: Skipped refractor/lang/markup.js
console: Skipped refractor/lang/matlab.js
console: Skipped refractor/lang/mel.js
console: Skipped refractor/lang/mizar.js
console: Skipped refractor/lang/monkey.js
console: Skipped refractor/lang/n4js.js
console: Skipped refractor/lang/nasm.js
console: Skipped refractor/lang/nginx.js
console: Skipped refractor/lang/nim.js
console: Skipped refractor/lang/nix.js
console: Skipped refractor/lang/nsis.js
console: Skipped refractor/lang/objectivec.js
console: Skipped refractor/lang/ocaml.js
console: Skipped refractor/lang/opencl.js
console: Skipped refractor/lang/oz.js
console: Skipped refractor/lang/parigp.js
console: Skipped refractor/lang/parser.js
console: Skipped refractor/lang/pascal.js
console: Skipped refractor/lang/perl.js
console: Skipped refractor/lang/php-extras.js
console: Skipped refractor/lang/php.js
console: Skipped refractor/lang/plsql.js
console: Skipped refractor/lang/powershell.js
console: Skipped refractor/lang/processing.js
console: Skipped refractor/lang/prolog.js
console: Skipped refractor/lang/properties.js
console: Skipped refractor/lang/protobuf.js
console: Skipped refractor/lang/pug.js
console: Skipped refractor/lang/puppet.js
console: Skipped refractor/lang/pure.js
console: Skipped refractor/lang/q.js
console: Skipped refractor/lang/qore.js
console: Skipped refractor/lang/r.js
console: Skipped refractor/lang/reason.js
console: Skipped refractor/lang/renpy.js
console: Skipped refractor/lang/rest.js
console: Skipped refractor/lang/rip.js
console: Skipped refractor/lang/roboconf.js
console: Skipped refractor/lang/ruby.js
console: Skipped refractor/lang/rust.js
console: Skipped refractor/lang/sas.js
console: Skipped refractor/lang/sass.js
console: Skipped refractor/lang/scala.js
console: Skipped refractor/lang/scheme.js
console: Skipped refractor/lang/scss.js
console: Skipped refractor/lang/smalltalk.js
console: Skipped refractor/lang/smarty.js
console: Skipped refractor/lang/soy.js
console: Skipped refractor/lang/sql.js
console: Skipped refractor/lang/stylus.js
console: Skipped refractor/lang/swift.js
console: Skipped refractor/lang/tap.js
console: Skipped refractor/lang/tcl.js
console: Skipped refractor/lang/textile.js
console: Skipped refractor/lang/tsx.js
console: Skipped refractor/lang/tt2.js
console: Skipped refractor/lang/twig.js
console: Skipped refractor/lang/typescript.js
console: Skipped refractor/lang/vbnet.js
console: Skipped refractor/lang/velocity.js
console: Skipped refractor/lang/verilog.js
console: Skipped refractor/lang/vhdl.js
console: Skipped refractor/lang/vim.js
console: Skipped refractor/lang/visual-basic.js
console: Skipped refractor/lang/wasm.js
console: Skipped refractor/lang/wiki.js
console: Skipped refractor/lang/xeora.js
console: Skipped refractor/lang/xojo.js
console: Skipped refractor/lang/xquery.js
console: Skipped refractor/lang/yaml.js
✨ Built in 21.70s

dist/default/index.html                    474 B     253ms
dist/default/favicon.01ef7d64.ico      159.11 KB      18ms
dist/default/index.736fc259.js       ⚠️  2.36 MB    15.76s
dist/default/python.69f5d78b.js          2.26 KB     106ms
dist/default/core.3261745b.js           22.15 KB     417ms
dist/default/index.476eaf51.css            416 B      25ms

> @aqueducthq/ui@0.0.5 build-sagemaker
> parcel build --public-url /proxy/8080/dist --dist-dir dist/sagemaker index.html

console: Skipped refractor/lang/abap.js
console: Skipped refractor/lang/actionscript.js
console: Skipped refractor/lang/ada.js
console: Skipped refractor/lang/apacheconf.js
console: Skipped refractor/lang/apl.js
console: Skipped refractor/lang/applescript.js
console: Skipped refractor/lang/arduino.js
console: Skipped refractor/lang/arff.js
console: Skipped refractor/lang/asciidoc.js
console: Skipped refractor/lang/asm6502.js
console: Skipped refractor/lang/aspnet.js
console: Skipped refractor/lang/autohotkey.js
console: Skipped refractor/lang/autoit.js
console: Skipped refractor/lang/bash.js
console: Skipped refractor/lang/basic.js
console: Skipped refractor/lang/batch.js
console: Skipped refractor/lang/bison.js
console: Skipped refractor/lang/brainfuck.js
console: Skipped refractor/lang/bro.js
console: Skipped refractor/lang/c.js
console: Skipped refractor/lang/clike.js
console: Skipped refractor/lang/clojure.js
console: Skipped refractor/lang/coffeescript.js
console: Skipped refractor/lang/cpp.js
console: Skipped refractor/lang/crystal.js
console: Skipped refractor/lang/csharp.js
console: Skipped refractor/lang/csp.js
console: Skipped refractor/lang/css-extras.js
console: Skipped refractor/lang/css.js
console: Skipped refractor/lang/d.js
console: Skipped refractor/lang/dart.js
console: Skipped refractor/lang/diff.js
console: Skipped refractor/lang/django.js
console: Skipped refractor/lang/docker.js
console: Skipped refractor/lang/eiffel.js
console: Skipped refractor/lang/elixir.js
console: Skipped refractor/lang/elm.js
console: Skipped refractor/lang/erb.js
console: Skipped refractor/lang/erlang.js
console: Skipped refractor/lang/flow.js
console: Skipped refractor/lang/fortran.js
console: Skipped refractor/lang/fsharp.js
console: Skipped refractor/lang/gedcom.js
console: Skipped refractor/lang/gherkin.js
console: Skipped refractor/lang/git.js
console: Skipped refractor/lang/glsl.js
console: Skipped refractor/lang/go.js
console: Skipped refractor/lang/graphql.js
console: Skipped refractor/lang/groovy.js
console: Skipped refractor/lang/haml.js
console: Skipped refractor/lang/handlebars.js
console: Skipped refractor/lang/haskell.js
console: Skipped refractor/lang/haxe.js
console: Skipped refractor/lang/hpkp.js
console: Skipped refractor/lang/hsts.js
console: Skipped refractor/lang/http.js
console: Skipped refractor/lang/ichigojam.js
console: Skipped refractor/lang/icon.js
console: Skipped refractor/lang/inform7.js
console: Skipped refractor/lang/ini.js
console: Skipped refractor/lang/io.js
console: Skipped refractor/lang/j.js
console: Skipped refractor/lang/java.js
console: Skipped refractor/lang/javascript.js
console: Skipped refractor/lang/jolie.js
console: Skipped refractor/lang/json.js
console: Skipped refractor/lang/jsx.js
console: Skipped refractor/lang/julia.js
console: Skipped refractor/lang/keyman.js
console: Skipped refractor/lang/kotlin.js
console: Skipped refractor/lang/latex.js
console: Skipped refractor/lang/less.js
console: Skipped refractor/lang/liquid.js
console: Skipped refractor/lang/lisp.js
console: Skipped refractor/lang/livescript.js
console: Skipped refractor/lang/lolcode.js
console: Skipped refractor/lang/lua.js
console: Skipped refractor/lang/makefile.js
console: Skipped refractor/lang/markdown.js
console: Skipped refractor/lang/markup-templating.js
console: Skipped refractor/lang/markup.js
console: Skipped refractor/lang/matlab.js
console: Skipped refractor/lang/mel.js
console: Skipped refractor/lang/mizar.js
console: Skipped refractor/lang/monkey.js
console: Skipped refractor/lang/n4js.js
console: Skipped refractor/lang/nasm.js
console: Skipped refractor/lang/nginx.js
console: Skipped refractor/lang/nim.js
console: Skipped refractor/lang/nix.js
console: Skipped refractor/lang/nsis.js
console: Skipped refractor/lang/objectivec.js
console: Skipped refractor/lang/ocaml.js
console: Skipped refractor/lang/opencl.js
console: Skipped refractor/lang/oz.js
console: Skipped refractor/lang/parigp.js
console: Skipped refractor/lang/parser.js
console: Skipped refractor/lang/pascal.js
console: Skipped refractor/lang/perl.js
console: Skipped refractor/lang/php-extras.js
console: Skipped refractor/lang/php.js
console: Skipped refractor/lang/plsql.js
console: Skipped refractor/lang/powershell.js
console: Skipped refractor/lang/processing.js
console: Skipped refractor/lang/prolog.js
console: Skipped refractor/lang/properties.js
console: Skipped refractor/lang/protobuf.js
console: Skipped refractor/lang/pug.js
console: Skipped refractor/lang/puppet.js
console: Skipped refractor/lang/pure.js
console: Skipped refractor/lang/q.js
console: Skipped refractor/lang/qore.js
console: Skipped refractor/lang/r.js
console: Skipped refractor/lang/reason.js
console: Skipped refractor/lang/renpy.js
console: Skipped refractor/lang/rest.js
console: Skipped refractor/lang/rip.js
console: Skipped refractor/lang/roboconf.js
console: Skipped refractor/lang/ruby.js
console: Skipped refractor/lang/rust.js
console: Skipped refractor/lang/sas.js
console: Skipped refractor/lang/sass.js
console: Skipped refractor/lang/scala.js
console: Skipped refractor/lang/scheme.js
console: Skipped refractor/lang/scss.js
console: Skipped refractor/lang/smalltalk.js
console: Skipped refractor/lang/smarty.js
console: Skipped refractor/lang/soy.js
console: Skipped refractor/lang/sql.js
console: Skipped refractor/lang/stylus.js
console: Skipped refractor/lang/swift.js
console: Skipped refractor/lang/tap.js
console: Skipped refractor/lang/tcl.js
console: Skipped refractor/lang/textile.js
console: Skipped refractor/lang/tsx.js
console: Skipped refractor/lang/tt2.js
console: Skipped refractor/lang/twig.js
console: Skipped refractor/lang/typescript.js
console: Skipped refractor/lang/vbnet.js
console: Skipped refractor/lang/velocity.js
console: Skipped refractor/lang/verilog.js
console: Skipped refractor/lang/vhdl.js
console: Skipped refractor/lang/vim.js
console: Skipped refractor/lang/visual-basic.js
console: Skipped refractor/lang/wasm.js
console: Skipped refractor/lang/wiki.js
console: Skipped refractor/lang/xeora.js
console: Skipped refractor/lang/xojo.js
console: Skipped refractor/lang/xquery.js
console: Skipped refractor/lang/yaml.js
✨ Built in 21.04s

dist/sagemaker/index.html                    507 B     258ms
dist/sagemaker/favicon.01ef7d64.ico      159.11 KB      18ms
dist/sagemaker/index.631c891a.js       ⚠️  2.36 MB    15.68s
dist/sagemaker/python.443de943.js          2.26 KB     107ms
dist/sagemaker/core.391ee5ce.js           22.15 KB     424ms
dist/sagemaker/index.1d0ca3dc.css            416 B      52ms
Updating the Python SDK...
Processing /home/ubuntu/repos/aqueduct/sdk
Requirement already satisfied: IPython in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (8.1.0)
Requirement already satisfied: cloudpickle in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (2.0.0)
Requirement already satisfied: croniter in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (1.3.4)
Collecting great_expectations
  Using cached great_expectations-0.15.15-py3-none-any.whl (5.1 MB)
Requirement already satisfied: numpy in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (1.22.2)
Requirement already satisfied: pandas in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (1.4.1)
Collecting plotly
  Using cached plotly-5.9.0-py2.py3-none-any.whl (15.2 MB)
Requirement already satisfied: pydantic in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (1.9.0)
Requirement already satisfied: pyyaml in /usr/lib/python3/dist-packages (from aqueduct-sdk==0.0.5) (5.3.1)
Requirement already satisfied: requests in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5) (2.27.1)
Collecting ruamel.yaml
  Using cached ruamel.yaml-0.17.21-py3-none-any.whl (109 kB)
Requirement already satisfied: setuptools in /usr/lib/python3/dist-packages (from aqueduct-sdk==0.0.5) (45.2.0)
Requirement already satisfied: backcall in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (0.2.0)
Requirement already satisfied: pickleshare in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (0.7.5)
Requirement already satisfied: matplotlib-inline in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (0.1.3)
Requirement already satisfied: pygments>=2.4.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (2.11.2)
Requirement already satisfied: decorator in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (5.1.1)
Requirement already satisfied: traitlets>=5 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (5.1.1)
Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (3.0.28)
Requirement already satisfied: pexpect>4.3; sys_platform != "win32" in /usr/lib/python3/dist-packages (from IPython->aqueduct-sdk==0.0.5) (4.6.0)
Requirement already satisfied: jedi>=0.16 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (0.18.1)
Requirement already satisfied: stack-data in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5) (0.2.0)
Requirement already satisfied: python-dateutil in /home/ubuntu/.local/lib/python3.8/site-packages (from croniter->aqueduct-sdk==0.0.5) (2.8.2)
Collecting altair<5,>=4.0.0
  Using cached altair-4.2.0-py3-none-any.whl (812 kB)
Requirement already satisfied: jsonpatch>=1.22 in /usr/lib/python3/dist-packages (from great_expectations->aqueduct-sdk==0.0.5) (1.22)
Collecting cryptography>=3.2
  Using cached cryptography-37.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.2 MB)
Collecting tqdm>=4.59.0
  Using cached tqdm-4.64.0-py2.py3-none-any.whl (78 kB)
Collecting nbformat>=5.0
  Using cached nbformat-5.4.0-py3-none-any.whl (73 kB)
Collecting packaging
  Using cached packaging-21.3-py3-none-any.whl (40 kB)
Collecting scipy>=0.19.0
  Using cached scipy-1.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (41.6 MB)
Collecting notebook>=6.4.10
  Using cached notebook-6.4.12-py3-none-any.whl (9.9 MB)
Collecting termcolor>=1.1.0
  Using cached termcolor-1.1.0.tar.gz (3.9 kB)
Requirement already satisfied: pytz>=2021.3 in /home/ubuntu/.local/lib/python3.8/site-packages (from great_expectations->aqueduct-sdk==0.0.5) (2021.3)
Requirement already satisfied: jsonschema>=2.5.1 in /usr/lib/python3/dist-packages (from great_expectations->aqueduct-sdk==0.0.5) (3.2.0)
Requirement already satisfied: typing-extensions>=3.10.0.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great_expectations->aqueduct-sdk==0.0.5) (4.1.1)
Collecting tzlocal>=1.2
  Using cached tzlocal-4.2-py3-none-any.whl (19 kB)
Requirement already satisfied: urllib3<1.27,>=1.25.4 in /usr/lib/python3/dist-packages (from great_expectations->aqueduct-sdk==0.0.5) (1.25.8)
Collecting pyparsing<3,>=2.4
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Collecting importlib-metadata>=1.7.0
  Using cached importlib_metadata-4.12.0-py3-none-any.whl (21 kB)
Requirement already satisfied: jinja2>=2.10 in /usr/lib/python3/dist-packages (from great_expectations->aqueduct-sdk==0.0.5) (2.10.1)
Collecting Click>=7.1.2
  Using cached click-8.1.3-py3-none-any.whl (96 kB)
Requirement already satisfied: colorama>=0.4.3 in /usr/lib/python3/dist-packages (from great_expectations->aqueduct-sdk==0.0.5) (0.4.3)
Collecting ipywidgets>=7.5.1
  Using cached ipywidgets-7.7.1-py2.py3-none-any.whl (123 kB)
Collecting mistune>=0.8.4
  Using cached mistune-2.0.4-py2.py3-none-any.whl (24 kB)
Collecting tenacity>=6.2.0
  Using cached tenacity-8.0.1-py3-none-any.whl (24 kB)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests->aqueduct-sdk==0.0.5) (2019.11.28)
Requirement already satisfied: idna<4,>=2.5; python_version >= "3" in /usr/lib/python3/dist-packages (from requests->aqueduct-sdk==0.0.5) (2.8)
Requirement already satisfied: charset-normalizer~=2.0.0; python_version >= "3" in /home/ubuntu/.local/lib/python3.8/site-packages (from requests->aqueduct-sdk==0.0.5) (2.0.12)
Collecting ruamel.yaml.clib>=0.2.6; platform_python_implementation == "CPython" and python_version < "3.11"
  Using cached ruamel.yaml.clib-0.2.6-cp38-cp38-manylinux1_x86_64.whl (570 kB)
Requirement already satisfied: wcwidth in /home/ubuntu/.local/lib/python3.8/site-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->IPython->aqueduct-sdk==0.0.5) (0.2.5)
Requirement already satisfied: parso<0.9.0,>=0.8.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from jedi>=0.16->IPython->aqueduct-sdk==0.0.5) (0.8.3)
Requirement already satisfied: executing in /home/ubuntu/.local/lib/python3.8/site-packages (from stack-data->IPython->aqueduct-sdk==0.0.5) (0.8.2)
Requirement already satisfied: pure-eval in /home/ubuntu/.local/lib/python3.8/site-packages (from stack-data->IPython->aqueduct-sdk==0.0.5) (0.2.2)
Requirement already satisfied: asttokens in /home/ubuntu/.local/lib/python3.8/site-packages (from stack-data->IPython->aqueduct-sdk==0.0.5) (2.0.5)
Requirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil->croniter->aqueduct-sdk==0.0.5) (1.14.0)
Requirement already satisfied: entrypoints in /usr/lib/python3/dist-packages (from altair<5,>=4.0.0->great_expectations->aqueduct-sdk==0.0.5) (0.3)
Collecting toolz
  Using cached toolz-0.12.0-py3-none-any.whl (55 kB)
Collecting cffi>=1.12
  Using cached cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (442 kB)
Collecting jupyter-core
  Using cached jupyter_core-4.11.1-py3-none-any.whl (88 kB)
Collecting fastjsonschema
  Using cached fastjsonschema-2.16.1-py3-none-any.whl (22 kB)
Collecting jupyter-client>=5.3.4
  Using cached jupyter_client-7.3.4-py3-none-any.whl (132 kB)
Collecting argon2-cffi
  Using cached argon2_cffi-21.3.0-py3-none-any.whl (14 kB)
Collecting ipykernel
  Using cached ipykernel-6.15.1-py3-none-any.whl (132 kB)
Collecting tornado>=6.1
  Using cached tornado-6.2-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (423 kB)
Collecting terminado>=0.8.3
  Using cached terminado-0.15.0-py3-none-any.whl (16 kB)
Collecting Send2Trash>=1.8.0
  Using cached Send2Trash-1.8.0-py3-none-any.whl (18 kB)
Collecting prometheus-client
  Using cached prometheus_client-0.14.1-py3-none-any.whl (59 kB)
Collecting nbconvert>=5
  Using cached nbconvert-6.5.0-py3-none-any.whl (561 kB)
Collecting ipython-genutils
  Using cached ipython_genutils-0.2.0-py2.py3-none-any.whl (26 kB)
Collecting nest-asyncio>=1.5
  Using cached nest_asyncio-1.5.5-py3-none-any.whl (5.2 kB)
Collecting pyzmq>=17
  Using cached pyzmq-23.2.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.1 MB)
Collecting pytz-deprecation-shim
  Using cached pytz_deprecation_shim-0.1.0.post0-py2.py3-none-any.whl (15 kB)
Collecting backports.zoneinfo; python_version < "3.9"
  Using cached backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl (74 kB)
Requirement already satisfied: zipp>=0.5 in /usr/lib/python3/dist-packages (from importlib-metadata>=1.7.0->great_expectations->aqueduct-sdk==0.0.5) (1.0.0)
Collecting jupyterlab-widgets>=1.0.0; python_version >= "3.6"
  Using cached jupyterlab_widgets-1.1.1-py3-none-any.whl (245 kB)
Collecting widgetsnbextension~=3.6.0
  Using cached widgetsnbextension-3.6.1-py2.py3-none-any.whl (1.6 MB)
Collecting pycparser
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Collecting argon2-cffi-bindings
  Using cached argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (86 kB)
Collecting psutil
  Using cached psutil-5.9.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (284 kB)
Collecting debugpy>=1.0
  Using cached debugpy-1.6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.8 MB)
Collecting ptyprocess; os_name != "nt"
  Using cached ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
Collecting tinycss2
  Using cached tinycss2-1.1.1-py3-none-any.whl (21 kB)
Collecting jupyterlab-pygments
  Using cached jupyterlab_pygments-0.2.2-py2.py3-none-any.whl (21 kB)
Collecting bleach
  Using cached bleach-5.0.1-py3-none-any.whl (160 kB)
Collecting beautifulsoup4
  Using cached beautifulsoup4-4.11.1-py3-none-any.whl (128 kB)
Collecting pandocfilters>=1.4.1
  Using cached pandocfilters-1.5.0-py2.py3-none-any.whl (8.7 kB)
Collecting MarkupSafe>=2.0
  Using cached MarkupSafe-2.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)
Collecting defusedxml
  Using cached defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)
Collecting nbclient>=0.5.0
  Using cached nbclient-0.6.6-py3-none-any.whl (71 kB)
Collecting tzdata; python_version >= "3.6"
  Using cached tzdata-2022.1-py2.py3-none-any.whl (339 kB)
Collecting webencodings>=0.4
  Using cached webencodings-0.5.1-py2.py3-none-any.whl (11 kB)
Collecting soupsieve>1.2
  Using cached soupsieve-2.3.2.post1-py3-none-any.whl (37 kB)
Building wheels for collected packages: aqueduct-sdk, termcolor
  Building wheel for aqueduct-sdk (setup.py) ... done
  Created wheel for aqueduct-sdk: filename=aqueduct_sdk-0.0.5-py3-none-any.whl size=74079 sha256=7113306a10beeaddbd028240ff04ac57b56f5093d2717e04a88dd833c8f52d53
  Stored in directory: /tmp/pip-ephem-wheel-cache-5ug_eqj_/wheels/d4/17/0f/2be7973b80e567ec70a9eaeb2e07ffbfda551709e6a0c49eeb
  Building wheel for termcolor (setup.py) ... done
  Created wheel for termcolor: filename=termcolor-1.1.0-py3-none-any.whl size=4830 sha256=55661281c32334606110e4e8f5b67da522ec13f88c2e43c86545d83145097d35
  Stored in directory: /home/ubuntu/.cache/pip/wheels/a0/16/9c/5473df82468f958445479c59e784896fa24f4a5fc024b0f501
Successfully built aqueduct-sdk termcolor
ERROR: nbclient 0.6.6 has requirement traitlets>=5.2.2, but you'll have traitlets 5.1.1 which is incompatible.
ERROR: nbconvert 6.5.0 has requirement jinja2>=3.0, but you'll have jinja2 2.10.1 which is incompatible.
ERROR: nbconvert 6.5.0 has requirement mistune<2,>=0.8.1, but you'll have mistune 2.0.4 which is incompatible.
ERROR: great-expectations 0.15.15 has requirement ruamel.yaml<0.17.18,>=0.16, but you'll have ruamel-yaml 0.17.21 which is incompatible.
Installing collected packages: toolz, altair, pycparser, cffi, cryptography, tqdm, jupyter-core, fastjsonschema, nbformat, pyparsing, packaging, scipy, nest-asyncio, tornado, pyzmq, jupyter-client, argon2-cffi-bindings, argon2-cffi, psutil, debugpy, ipykernel, ptyprocess, terminado, Send2Trash, prometheus-client, webencodings, tinycss2, jupyterlab-pygments, bleach, mistune, soupsieve, beautifulsoup4, pandocfilters, MarkupSafe, defusedxml, nbclient, nbconvert, ipython-genutils, notebook, termcolor, tzdata, backports.zoneinfo, pytz-deprecation-shim, tzlocal, importlib-metadata, Click, jupyterlab-widgets, widgetsnbextension, ipywidgets, ruamel.yaml.clib, ruamel.yaml, great-expectations, tenacity, plotly, aqueduct-sdk
Successfully installed Click-8.1.3 MarkupSafe-2.1.1 Send2Trash-1.8.0 altair-4.2.0 aqueduct-sdk-0.0.5 argon2-cffi-21.3.0 argon2-cffi-bindings-21.2.0 backports.zoneinfo-0.2.1 beautifulsoup4-4.11.1 bleach-5.0.1 cffi-1.15.1 cryptography-37.0.4 debugpy-1.6.2 defusedxml-0.7.1 fastjsonschema-2.16.1 great-expectations-0.15.15 importlib-metadata-4.12.0 ipykernel-6.15.1 ipython-genutils-0.2.0 ipywidgets-7.7.1 jupyter-client-7.3.4 jupyter-core-4.11.1 jupyterlab-pygments-0.2.2 jupyterlab-widgets-1.1.1 mistune-2.0.4 nbclient-0.6.6 nbconvert-6.5.0 nbformat-5.4.0 nest-asyncio-1.5.5 notebook-6.4.12 packaging-21.3 pandocfilters-1.5.0 plotly-5.9.0 prometheus-client-0.14.1 psutil-5.9.1 ptyprocess-0.7.0 pycparser-2.21 pyparsing-2.4.7 pytz-deprecation-shim-0.1.0.post0 pyzmq-23.2.0 ruamel.yaml-0.17.21 ruamel.yaml.clib-0.2.6 scipy-1.8.1 soupsieve-2.3.2.post1 tenacity-8.0.1 termcolor-1.1.0 terminado-0.15.0 tinycss2-1.1.1 toolz-0.12.0 tornado-6.2 tqdm-4.64.0 tzdata-2022.1 tzlocal-4.2 webencodings-0.5.1 widgetsnbextension-3.6.1
Updating the Python executor...
Processing /home/ubuntu/repos/aqueduct/src/python
/home/ubuntu/.local/lib/python3.8/site-packages/cryptography/hazmat/backends/openssl/x509.py:14: CryptographyDeprecationWarning: This version of cryptography contains a temporary pyOpenSSL fallback path. Upgrade pyOpenSSL now.
  warnings.warn(
Collecting SQLAlchemy
  Using cached SQLAlchemy-1.4.39-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.6 MB)
Requirement already satisfied: aqueduct-sdk==0.0.5 in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-ml==0.0.5) (0.0.5)
Collecting boto3
  Using cached boto3-1.24.35-py3-none-any.whl (132 kB)
Requirement already satisfied: cloudpickle in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-ml==0.0.5) (2.0.0)
Requirement already satisfied: distro in /usr/lib/python3/dist-packages (from aqueduct-ml==0.0.5) (1.4.0)
Requirement already satisfied: numpy in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-ml==0.0.5) (1.22.2)
Requirement already satisfied: pandas in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-ml==0.0.5) (1.4.1)
Requirement already satisfied: pydantic in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-ml==0.0.5) (1.9.0)
Requirement already satisfied: pyyaml in /usr/lib/python3/dist-packages (from aqueduct-ml==0.0.5) (5.3.1)
Requirement already satisfied: typing_extensions in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-ml==0.0.5) (4.1.1)
Collecting greenlet!=0.4.17; python_version >= "3" and (platform_machine == "aarch64" or (platform_machine == "ppc64le" or (platform_machine == "x86_64" or (platform_machine == "amd64" or (platform_machine == "AMD64" or (platform_machine == "win32" or platform_machine == "WIN32"))))))
  Using cached greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (156 kB)
Requirement already satisfied: IPython in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (8.1.0)
Requirement already satisfied: plotly in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (5.9.0)
Requirement already satisfied: requests in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.27.1)
Requirement already satisfied: croniter in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.3.4)
Requirement already satisfied: setuptools in /usr/lib/python3/dist-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (45.2.0)
Requirement already satisfied: great-expectations in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.15.15)
Requirement already satisfied: ruamel.yaml in /home/ubuntu/.local/lib/python3.8/site-packages (from aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.17.21)
Collecting botocore<1.28.0,>=1.27.35
  Using cached botocore-1.27.35-py3-none-any.whl (9.0 MB)
Collecting jmespath<2.0.0,>=0.7.1
  Using cached jmespath-1.0.1-py3-none-any.whl (20 kB)
Collecting s3transfer<0.7.0,>=0.6.0
  Using cached s3transfer-0.6.0-py3-none-any.whl (79 kB)
Requirement already satisfied: pytz>=2020.1 in /home/ubuntu/.local/lib/python3.8/site-packages (from pandas->aqueduct-ml==0.0.5) (2021.3)
Requirement already satisfied: python-dateutil>=2.8.1 in /home/ubuntu/.local/lib/python3.8/site-packages (from pandas->aqueduct-ml==0.0.5) (2.8.2)
Requirement already satisfied: stack-data in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.0)
Requirement already satisfied: matplotlib-inline in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.1.3)
Requirement already satisfied: pygments>=2.4.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.11.2)
Requirement already satisfied: decorator in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (5.1.1)
Requirement already satisfied: traitlets>=5 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (5.1.1)
Requirement already satisfied: pickleshare in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.7.5)
Requirement already satisfied: prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (3.0.28)
Requirement already satisfied: jedi>=0.16 in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.18.1)
Requirement already satisfied: pexpect>4.3; sys_platform != "win32" in /usr/lib/python3/dist-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.6.0)
Requirement already satisfied: backcall in /home/ubuntu/.local/lib/python3.8/site-packages (from IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.0)
Requirement already satisfied: tenacity>=6.2.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from plotly->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (8.0.1)
Requirement already satisfied: idna<4,>=2.5; python_version >= "3" in /usr/lib/python3/dist-packages (from requests->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.8)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2019.11.28)
Requirement already satisfied: charset-normalizer~=2.0.0; python_version >= "3" in /home/ubuntu/.local/lib/python3.8/site-packages (from requests->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.0.12)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in /usr/lib/python3/dist-packages (from requests->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.25.8)
Requirement already satisfied: Click>=7.1.2 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (8.1.3)
Requirement already satisfied: importlib-metadata>=1.7.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.12.0)
Requirement already satisfied: jinja2>=2.10 in /usr/lib/python3/dist-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.10.1)
Requirement already satisfied: nbformat>=5.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (5.4.0)
Requirement already satisfied: scipy>=0.19.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.8.1)
Requirement already satisfied: tqdm>=4.59.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.64.0)
Requirement already satisfied: mistune>=0.8.4 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.0.4)
Requirement already satisfied: notebook>=6.4.10 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (6.4.12)
Requirement already satisfied: jsonschema>=2.5.1 in /usr/lib/python3/dist-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (3.2.0)
Requirement already satisfied: tzlocal>=1.2 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.2)
Requirement already satisfied: termcolor>=1.1.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.1.0)
Requirement already satisfied: ipywidgets>=7.5.1 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (7.7.1)
Requirement already satisfied: cryptography>=3.2 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (37.0.4)
Requirement already satisfied: colorama>=0.4.3 in /usr/lib/python3/dist-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.4.3)
Requirement already satisfied: jsonpatch>=1.22 in /usr/lib/python3/dist-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.22)
Requirement already satisfied: pyparsing<3,>=2.4 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.4.7)
Requirement already satisfied: packaging in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (21.3)
Requirement already satisfied: altair<5,>=4.0.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.2.0)
Requirement already satisfied: ruamel.yaml.clib>=0.2.6; platform_python_implementation == "CPython" and python_version < "3.11" in /home/ubuntu/.local/lib/python3.8/site-packages (from ruamel.yaml->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.6)
Requirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil>=2.8.1->pandas->aqueduct-ml==0.0.5) (1.14.0)
Requirement already satisfied: pure-eval in /home/ubuntu/.local/lib/python3.8/site-packages (from stack-data->IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.2)
Requirement already satisfied: executing in /home/ubuntu/.local/lib/python3.8/site-packages (from stack-data->IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.8.2)
Requirement already satisfied: asttokens in /home/ubuntu/.local/lib/python3.8/site-packages (from stack-data->IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.0.5)
Requirement already satisfied: wcwidth in /home/ubuntu/.local/lib/python3.8/site-packages (from prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0->IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.5)
Requirement already satisfied: parso<0.9.0,>=0.8.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from jedi>=0.16->IPython->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.8.3)
Requirement already satisfied: zipp>=0.5 in /usr/lib/python3/dist-packages (from importlib-metadata>=1.7.0->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.0.0)
Requirement already satisfied: fastjsonschema in /home/ubuntu/.local/lib/python3.8/site-packages (from nbformat>=5.0->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.16.1)
Requirement already satisfied: jupyter-core in /home/ubuntu/.local/lib/python3.8/site-packages (from nbformat>=5.0->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.11.1)
Requirement already satisfied: pyzmq>=17 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (23.2.0)
Requirement already satisfied: nest-asyncio>=1.5 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.5.5)
Requirement already satisfied: terminado>=0.8.3 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.15.0)
Requirement already satisfied: Send2Trash>=1.8.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.8.0)
Requirement already satisfied: jupyter-client>=5.3.4 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (7.3.4)
Requirement already satisfied: nbconvert>=5 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (6.5.0)
Requirement already satisfied: prometheus-client in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.14.1)
Requirement already satisfied: tornado>=6.1 in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (6.2)
Requirement already satisfied: ipykernel in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (6.15.1)
Requirement already satisfied: argon2-cffi in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (21.3.0)
Requirement already satisfied: ipython-genutils in /home/ubuntu/.local/lib/python3.8/site-packages (from notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.0)
Requirement already satisfied: pytz-deprecation-shim in /home/ubuntu/.local/lib/python3.8/site-packages (from tzlocal>=1.2->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.1.0.post0)
Requirement already satisfied: backports.zoneinfo; python_version < "3.9" in /home/ubuntu/.local/lib/python3.8/site-packages (from tzlocal>=1.2->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.1)
Requirement already satisfied: widgetsnbextension~=3.6.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from ipywidgets>=7.5.1->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (3.6.1)
Requirement already satisfied: jupyterlab-widgets>=1.0.0; python_version >= "3.6" in /home/ubuntu/.local/lib/python3.8/site-packages (from ipywidgets>=7.5.1->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.1.1)
Requirement already satisfied: cffi>=1.12 in /home/ubuntu/.local/lib/python3.8/site-packages (from cryptography>=3.2->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.15.1)
Requirement already satisfied: entrypoints in /usr/lib/python3/dist-packages (from altair<5,>=4.0.0->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.3)
Requirement already satisfied: toolz in /home/ubuntu/.local/lib/python3.8/site-packages (from altair<5,>=4.0.0->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.12.0)
Requirement already satisfied: ptyprocess; os_name != "nt" in /home/ubuntu/.local/lib/python3.8/site-packages (from terminado>=0.8.3->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.7.0)
Requirement already satisfied: bleach in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (5.0.1)
Requirement already satisfied: pandocfilters>=1.4.1 in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.5.0)
Requirement already satisfied: nbclient>=0.5.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.6.6)
Requirement already satisfied: MarkupSafe>=2.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.1.1)
Requirement already satisfied: beautifulsoup4 in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (4.11.1)
Requirement already satisfied: tinycss2 in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.1.1)
Requirement already satisfied: jupyterlab-pygments in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.2.2)
Requirement already satisfied: defusedxml in /home/ubuntu/.local/lib/python3.8/site-packages (from nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.7.1)
Requirement already satisfied: psutil in /home/ubuntu/.local/lib/python3.8/site-packages (from ipykernel->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (5.9.1)
Requirement already satisfied: debugpy>=1.0 in /home/ubuntu/.local/lib/python3.8/site-packages (from ipykernel->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (1.6.2)
Requirement already satisfied: argon2-cffi-bindings in /home/ubuntu/.local/lib/python3.8/site-packages (from argon2-cffi->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (21.2.0)
Requirement already satisfied: tzdata; python_version >= "3.6" in /home/ubuntu/.local/lib/python3.8/site-packages (from pytz-deprecation-shim->tzlocal>=1.2->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2022.1)
Requirement already satisfied: pycparser in /home/ubuntu/.local/lib/python3.8/site-packages (from cffi>=1.12->cryptography>=3.2->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.21)
Requirement already satisfied: webencodings in /home/ubuntu/.local/lib/python3.8/site-packages (from bleach->nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (0.5.1)
Requirement already satisfied: soupsieve>1.2 in /home/ubuntu/.local/lib/python3.8/site-packages (from beautifulsoup4->nbconvert>=5->notebook>=6.4.10->great-expectations->aqueduct-sdk==0.0.5->aqueduct-ml==0.0.5) (2.3.2.post1)
Building wheels for collected packages: aqueduct-ml
  Building wheel for aqueduct-ml (setup.py) ... done
  Created wheel for aqueduct-ml: filename=aqueduct_ml-0.0.5-py3-none-any.whl size=54583 sha256=b27c855b512d2b9ec43521620aaaf989ba481738e3a4cf5d4117fbf8d62a2b1f
  Stored in directory: /tmp/pip-ephem-wheel-cache-kwr3uh6e/wheels/fa/49/e9/78300d34496814ac377ba23ae351eb8fd3175163a83ef5b98b
Successfully built aqueduct-ml
Installing collected packages: greenlet, SQLAlchemy, jmespath, botocore, s3transfer, boto3, aqueduct-ml
Successfully installed SQLAlchemy-1.4.39 aqueduct-ml-0.0.5 boto3-1.24.35 botocore-1.27.35 greenlet-1.1.2 jmespath-1.0.1 s3transfer-0.6.0
Successfully installed aqueduct from local repo!
```