### PR TITLE
ENG-1407 Allow UI page sidebars to be passed in as prop.

### DIFF
--- a/src/ui/common/src/components/pages/AccountPage.tsx
+++ b/src/ui/common/src/components/pages/AccountPage.tsx
@@ -13,7 +13,10 @@ type AccountPageProps = {
   Layout?: React.FC<LayoutProps>;
 };
 
-const AccountPage: React.FC<AccountPageProps> = ({ user, Layout = DefaultLayout }) => {
+const AccountPage: React.FC<AccountPageProps> = ({
+  user,
+  Layout = DefaultLayout,
+}) => {
   // Set the title of the page on page load.
   useEffect(() => {
     document.title = 'Account | Aqueduct';

--- a/src/ui/common/src/components/pages/AccountPage.tsx
+++ b/src/ui/common/src/components/pages/AccountPage.tsx
@@ -6,12 +6,14 @@ import { CopyBlock, github } from 'react-code-blocks';
 import UserProfile from '../../utils/auth';
 import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import DefaultLayout from '../layouts/default';
+import { LayoutProps } from './types';
 
 type AccountPageProps = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
-const AccountPage: React.FC<AccountPageProps> = ({ user }) => {
+const AccountPage: React.FC<AccountPageProps> = ({ user, Layout = DefaultLayout }) => {
   // Set the title of the page on page load.
   useEffect(() => {
     document.title = 'Account | Aqueduct';
@@ -27,7 +29,7 @@ client = aqueduct.Client(
   const maxContentWidth = '600px';
 
   return (
-    <DefaultLayout user={user}>
+    <Layout user={user}>
       <Typography variant="h2" gutterBottom component="div">
         Account Overview
       </Typography>
@@ -62,7 +64,7 @@ client = aqueduct.Client(
           />
         </Box>
       </Box>
-    </DefaultLayout>
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/HomePage.tsx
+++ b/src/ui/common/src/components/pages/HomePage.tsx
@@ -3,22 +3,24 @@ import React, { useEffect } from 'react';
 import UserProfile from '../../utils/auth';
 import GettingStartedTutorial from '../cards/GettingStartedTutorial';
 import DefaultLayout from '../layouts/default';
+import { LayoutProps } from './types';
 
 type HomePageProps = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
-const HomePage: React.FC<HomePageProps> = ({ user }) => {
+const HomePage: React.FC<HomePageProps> = ({ user, Layout = DefaultLayout }) => {
   // Set the title of the page on page load.
   useEffect(() => {
     document.title = 'Home | Aqueduct';
   }, []);
 
   return (
-    <DefaultLayout user={user}>
+    <Layout user={user}>
       <div />
       <GettingStartedTutorial user={user} />
-    </DefaultLayout>
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/HomePage.tsx
+++ b/src/ui/common/src/components/pages/HomePage.tsx
@@ -10,7 +10,10 @@ type HomePageProps = {
   Layout?: React.FC<LayoutProps>;
 };
 
-const HomePage: React.FC<HomePageProps> = ({ user, Layout = DefaultLayout }) => {
+const HomePage: React.FC<HomePageProps> = ({
+  user,
+  Layout = DefaultLayout,
+}) => {
   // Set the title of the page on page load.
   useEffect(() => {
     document.title = 'Home | Aqueduct';

--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -15,9 +15,11 @@ import { DataPreviewInfo } from '../../../utils/data';
 import { DataCard, dataCardName } from '../../integrations/cards/card';
 import { Card } from '../../layouts/card';
 import DefaultLayout from '../../layouts/default';
+import { LayoutProps } from '../types';
 
 type Props = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
 const SearchBar = (
@@ -88,7 +90,7 @@ const SearchBar = (
   );
 };
 
-const DataPage: React.FC<Props> = ({ user }) => {
+const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   const apiKey = user.apiKey;
   const dispatch: AppDispatch = useDispatch();
 
@@ -125,7 +127,7 @@ const DataPage: React.FC<Props> = ({ user }) => {
   }, []);
 
   return (
-    <DefaultLayout user={user}>
+    <Layout user={user}>
       <div />
       <Box>
         <Typography variant="h2" gutterBottom component="div">
@@ -148,7 +150,7 @@ const DataPage: React.FC<Props> = ({ user }) => {
           </Box>
         </Box>
       </Box>
-    </DefaultLayout>
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -28,13 +28,16 @@ import UserProfile from '../../../../utils/auth';
 import { Integration } from '../../../../utils/integrations';
 import ExecutionStatus from '../../../../utils/shared';
 import { Button } from '../../../primitives/Button.styles';
+import { LayoutProps } from '../../types';
 
 type IntegrationDetailsPageProps = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
 const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
   user,
+  Layout = DefaultLayout
 }) => {
   const dispatch: AppDispatch = useDispatch();
   const integrationId: string = useParams().id;
@@ -269,7 +272,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
   }
 
   return (
-    <DefaultLayout user={user}>
+    <Layout user={user}>
       <Box>
         <Typography variant="h2" gutterBottom component="div">
           Integration Details
@@ -294,7 +297,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
         )}
       </Box>
       {preview}
-    </DefaultLayout>
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -37,7 +37,7 @@ type IntegrationDetailsPageProps = {
 
 const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
   user,
-  Layout = DefaultLayout
+  Layout = DefaultLayout,
 }) => {
   const dispatch: AppDispatch = useDispatch();
   const integrationId: string = useParams().id;

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -8,18 +8,20 @@ import { SupportedIntegrations } from '../../../utils/integrations';
 import AddIntegrations from '../../integrations/addIntegrations';
 import { ConnectedIntegrations } from '../../integrations/connectedIntegrations';
 import DefaultLayout from '../../layouts/default';
+import { LayoutProps } from '../types';
 
 type Props = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
-const IntegrationsPage: React.FC<Props> = ({ user }) => {
+const IntegrationsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   useEffect(() => {
     document.title = 'Integrations | Aqueduct';
   }, []);
 
   return (
-    <DefaultLayout user={user}>
+    <Layout user={user}>
       <Box>
         <Typography variant="h2" gutterBottom component="div">
           Integrations
@@ -40,7 +42,7 @@ const IntegrationsPage: React.FC<Props> = ({ user }) => {
           <ConnectedIntegrations user={user} />
         </Box>
       </Box>
-    </DefaultLayout>
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -15,7 +15,10 @@ type Props = {
   Layout?: React.FC<LayoutProps>;
 };
 
-const IntegrationsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
+const IntegrationsPage: React.FC<Props> = ({
+  user,
+  Layout = DefaultLayout,
+}) => {
   useEffect(() => {
     document.title = 'Integrations | Aqueduct';
   }, []);

--- a/src/ui/common/src/components/pages/types.d.ts
+++ b/src/ui/common/src/components/pages/types.d.ts
@@ -1,5 +1,5 @@
 export type LayoutProps = {
-    user: UserProfile;
-    contentWidth?: string;
-    children: React.ReactElement | React.ReactElement[];
+  user: UserProfile;
+  contentWidth?: string;
+  children: React.ReactElement | React.ReactElement[];
 };

--- a/src/ui/common/src/components/pages/types.d.ts
+++ b/src/ui/common/src/components/pages/types.d.ts
@@ -1,0 +1,5 @@
+export type LayoutProps = {
+    user: UserProfile;
+    contentWidth?: string;
+    children: React.ReactElement | React.ReactElement[];
+};

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -50,7 +50,10 @@ type WorkflowPageProps = {
   Layout?: React.FC<LayoutProps>;
 };
 
-const WorkflowPage: React.FC<WorkflowPageProps> = ({ user, Layout = DefaultLayout }) => {
+const WorkflowPage: React.FC<WorkflowPageProps> = ({
+  user,
+  Layout = DefaultLayout,
+}) => {
   const navigate = useNavigate();
   const dispatch: AppDispatch = useDispatch();
   const workflowId = useParams().id;

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -43,12 +43,14 @@ import { Button } from '../../../primitives/Button.styles';
 import ReactFlowCanvas from '../../../workflows/ReactFlowCanvas';
 import WorkflowStatusBar from '../../../workflows/StatusBar';
 import WorkflowHeader from '../../../workflows/workflowHeader';
+import { LayoutProps } from '../../types';
 
 type WorkflowPageProps = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
-const WorkflowPage: React.FC<WorkflowPageProps> = ({ user }) => {
+const WorkflowPage: React.FC<WorkflowPageProps> = ({ user, Layout = DefaultLayout }) => {
   const navigate = useNavigate();
   const dispatch: AppDispatch = useDispatch();
   const workflowId = useParams().id;
@@ -274,7 +276,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ user }) => {
   };
 
   return (
-    <DefaultLayout user={user}>
+    <Layout user={user}>
       <Box
         sx={{
           display: 'flex',
@@ -321,7 +323,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({ user }) => {
       )}
 
       <WorkflowStatusBar user={user} />
-    </DefaultLayout>
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -10,12 +10,14 @@ import UserProfile from '../../../utils/auth';
 import { LoadingStatusEnum } from '../../../utils/shared';
 import DefaultLayout from '../../layouts/default';
 import WorkflowCard from '../../workflows/workflowCard';
+import { LayoutProps } from '../types';
 
 type Props = {
   user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
-const WorkflowsPage: React.FC<Props> = ({ user }) => {
+const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   const dispatch: AppDispatch = useDispatch();
   useEffect(() => {
     document.title = 'Workflows | Aqueduct';
@@ -72,13 +74,12 @@ const WorkflowsPage: React.FC<Props> = ({ user }) => {
     );
 
   return (
-    <DefaultLayout user={user}>
-      <></>
+    <Layout user={user}>
       <Box p={2}>
         {heading}
         {workflowList}
       </Box>
-    </DefaultLayout>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Refactors sidebar and layout handling to allow sidebar layout to be passed into page components.

## Related issue number (if any)
Resolves: https://linear.app/aqueducthq/issue/ENG-1407/refactor-sidebar-and-layout-handling

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


