### PR TITLE
Fix error message for error severity check not passing

### DIFF
--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -1,13 +1,9 @@
 package operator
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/check"
-	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/dropbox/godropbox/errors"
 	log "github.com/sirupsen/logrus"
@@ -49,22 +45,6 @@ func newCheckOperator(base baseFunctionOperator) (Operator, error) {
 
 func (co *checkOperatorImpl) hasErrorSeverity() bool {
 	return co.dbOperator.Spec.Check().Level == check.ErrorLevel
-}
-
-func (co *checkOperatorImpl) GetExecState(ctx context.Context) (*shared.ExecutionState, error) {
-	execState, err := co.baseOperator.GetExecState(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// If this was a blocking check that failed, overwrite the returned tip message
-	// to be much more helpful.
-	if co.hasErrorSeverity() &&
-		execState.Status == shared.FailedExecutionStatus &&
-		execState.Error.Tip == shared.TipBlacklistedOutputError {
-		execState.Error.Tip = fmt.Sprintf("Check %s did not pass and has ERROR level severity, so the entire workflow failed.", co.Name())
-	}
-	return execState, nil
 }
 
 func (co *checkOperatorImpl) JobSpec() job.Spec {

--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"encoding/json"
+
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/check"
 	"github.com/aqueducthq/aqueduct/lib/job"

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -25,13 +25,8 @@ TIP_EXTRACT = "We couldn't execute the provided query. Please double check your 
 TIP_LOAD = "We couldn't load to the integration. Please make sure the target exists, or you have the right permission."
 TIP_DISCOVER = "We couldn't list items in the integration. Please make sure your credentials have the right permission."
 
-# This tip is not meant to be surfaced to the user, because at this level
-# we can only give a very generic error. This message should be overwritten
-# at a higher level with a more user-friendly one, specific to type of operator.
-#
-# Eg. Check operators with error severity are blacklisted from returning `false`,
-# since that signifies a failed blocking check.
-TIP_BLACKLISTED_OUTPUT = "Operator has output a blacklisted value."
+# Assumption: only check operators will use this tip.
+TIP_BLACKLISTED_OUTPUT = "The check did not pass and has ERROR level severity, so the entire workflow failed."
 
 
 class Error(BaseModel):

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -26,7 +26,9 @@ TIP_LOAD = "We couldn't load to the integration. Please make sure the target exi
 TIP_DISCOVER = "We couldn't list items in the integration. Please make sure your credentials have the right permission."
 
 # Assumption: only check operators will use this tip.
-TIP_BLACKLISTED_OUTPUT = "The check did not pass and has ERROR level severity, so the entire workflow failed."
+TIP_BLACKLISTED_OUTPUT = (
+    "The check did not pass and has ERROR level severity, so the entire workflow failed."
+)
 
 
 class Error(BaseModel):


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Instead of doing something too complicated in `get_operator_result`, lets just alter the error message in the python operator. It should make it slightly easier for you to refactor the check operator.

Demo:
<img width="487" alt="image" src="https://user-images.githubusercontent.com/6466121/180577444-96b6dfb4-f68f-44f6-a7cb-d4a422e4d12f.png">


## Related issue number (if any)


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


