### PR TITLE
modify install_local scripts to only select necessary UI files 

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -14,6 +14,7 @@ takes longer to update.
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -144,6 +145,14 @@ if __name__ == "__main__":
             shutil.copytree(
                 join(cwd, "src", "ui", "app", "dist", "default"), ui_directory, dirs_exist_ok=True
             )
+
+        # To prevent unnecessary files from getting into our releases
+        # Will replace the react-code-block component soon (next week) to avoid this concern completely
+        files = [f for f in listdir(ui_directory) if isfile(join(ui_directory, f))]
+        fileNameRegex = re.compile(r'^(python|core|markup|clike|javascript|css|index|favicon)\..*(html|js|css|map|ico)$')
+        for f in files:
+            if not fileNameRegex.search(f) and not f == "__version__":
+                execute_command(["rm", f], cwd=ui_directory)
 
     # Install the local SDK.
     if args.update_sdk:


### PR DESCRIPTION
## Describe your changes and why you are making these changes

modify install_local scripts to automatically select files to put inside .aqueduct/ui 
In next week, will select another component to replace react-code-block to avoid all those issues. 

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/61630725/180584854-8bb0f51f-d60b-4f89-959b-d4d7afe96747.png">

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


