### PR TITLE
Allows user to specify S3 credentials for Airflow integration

### DIFF
--- a/src/golang/lib/backend/airflow/config.go
+++ b/src/golang/lib/backend/airflow/config.go
@@ -7,9 +7,11 @@ import (
 )
 
 type config struct {
-	Host     string `json:"host"  yaml:"host"`
-	Username string `json:"username"  yaml:"username"`
-	Password string `json:"password"  yaml:"password"`
+	Host                 string `json:"host"  yaml:"host"`
+	Username             string `json:"username"  yaml:"username"`
+	Password             string `json:"password"  yaml:"password"`
+	S3CredentialsPath    string `json:"s3_credentials_path"  yaml:"s3CredentialsPath"`
+	S3CredentialsProfile string `json:"s3_credentials_profile"  yaml:"s3CredentialsProfile"`
 }
 
 // parseConfig takes in an auth.Config and parses into a config struct.

--- a/src/ui/common/src/components/integrations/cards/airflowCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/airflowCard.tsx
@@ -20,6 +20,14 @@ export const AirflowCard: React.FC<Props> = ({ integration }) => {
         <strong>Username: </strong>
         {config.username}
       </Typography>
+      <Typography variant="body1">
+        <strong>S3 Credentials Path: </strong>
+        {config.s3_credentials_path}
+      </Typography>
+      <Typography variant="body1">
+        <strong>S3 Credentials Profile: </strong>
+        {config.s3_credentials_profile}
+      </Typography>
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -30,8 +30,13 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
       username: username,
       password: password,
       s3_credentials_path: s3CredsPath,
-      s3_credentials_profile: s3CredsProfile,
+      s3_credentials_profile: 'default',
     };
+
+    if (s3CredsProfile && s3CredsProfile !== 'default') {
+      config.s3_credentials_profile = s3CredsProfile;
+    }
+
     setDialogConfig(config);
   }, [address, username, password, s3CredsPath, s3CredsProfile]);
 

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -8,7 +8,7 @@ const Placeholders: AirflowConfig = {
   host: 'http://localhost/api/v1',
   username: 'aqueduct',
   password: '********',
-  s3_credentials_path : '/home/user/.aws/credentials',
+  s3_credentials_path: '/home/user/.aws/credentials',
   s3_credentials_profile: 'default',
 };
 
@@ -22,7 +22,6 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [password, setPassword] = useState<string>(null);
   const [s3CredsPath, setS3CredsPath] = useState<string>(null);
   const [s3CredsProfile, setS3CredsProfile] = useState<string>(null);
-
 
   useEffect(() => {
     const config: AirflowConfig = {

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -8,6 +8,8 @@ const Placeholders: AirflowConfig = {
   host: 'http://localhost/api/v1',
   username: 'aqueduct',
   password: '********',
+  s3_credentials_path : '/home/user/.aws/credentials',
+  s3_credentials_profile: 'default',
 };
 
 type Props = {
@@ -18,12 +20,17 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [address, setAddress] = useState<string>(null);
   const [username, setUsername] = useState<string>(null);
   const [password, setPassword] = useState<string>(null);
+  const [s3CredsPath, setS3CredsPath] = useState<string>(null);
+  const [s3CredsProfile, setS3CredsProfile] = useState<string>(null);
+
 
   useEffect(() => {
     const config: AirflowConfig = {
       host: address,
       username: username,
       password: password,
+      s3_credentials_path: s3CredsPath,
+      s3_credentials_profile: s3CredsProfile,
     };
     setDialogConfig(config);
   }, [address, username, password]);
@@ -59,6 +66,26 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
         type="password"
         onChange={(event) => setPassword(event.target.value)}
         value={password}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="S3 Credentials Path *"
+        description="The filepath on the Airflow server to the AWS credentials for the S3 bucket used as storage."
+        placeholder={Placeholders.s3_credentials_path}
+        onChange={(event) => setS3CredsPath(event.target.value)}
+        value={s3CredsPath}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={false}
+        label="S3 Credentials Profile"
+        description="The profile to use for the AWS credentials above."
+        placeholder={Placeholders.s3_credentials_profile}
+        onChange={(event) => setS3CredsProfile(event.target.value)}
+        value={s3CredsProfile}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -33,7 +33,7 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
       s3_credentials_profile: s3CredsProfile,
     };
     setDialogConfig(config);
-  }, [address, username, password]);
+  }, [address, username, password, s3CredsPath, s3CredsProfile]);
 
   return (
     <Box sx={{ mt: 2 }}>
@@ -72,7 +72,7 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
         spellCheck={false}
         required={true}
         label="S3 Credentials Path *"
-        description="The filepath on the Airflow server to the AWS credentials for the S3 bucket used as storage."
+        description="The path to the AWS credentials for the S3 bucket used for Aqueduct storage. This path should be specific to the Airflow server."
         placeholder={Placeholders.s3_credentials_path}
         onChange={(event) => setS3CredsPath(event.target.value)}
         value={s3CredsPath}

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -32,6 +32,16 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
       s3_credentials_profile: 'default',
     };
 
+    if (address && address.startsWith("http://")) {
+      // Backend requires the protocol to be stripped
+      config.host = address.substring(7);
+    }
+
+    if (address && address.startsWith("https://")) {
+      // Backend requires the protocol to be stripped
+      config.host = address.substring(8);
+    }
+
     if (s3CredsProfile && s3CredsProfile !== 'default') {
       config.s3_credentials_profile = s3CredsProfile;
     }

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -76,7 +76,7 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
         spellCheck={false}
         required={true}
         label="S3 Credentials Path *"
-        description="The path to the AWS credentials for the S3 bucket used for Aqueduct storage. This path should be specific to the Airflow server."
+        description="The path on the Airflow server to the AWS credentials that have access to the same S3 bucket configured for Aqueduct storage."
         placeholder={Placeholders.s3_credentials_path}
         onChange={(event) => setS3CredsPath(event.target.value)}
         value={s3CredsPath}
@@ -86,7 +86,7 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
         spellCheck={false}
         required={false}
         label="S3 Credentials Profile"
-        description="The profile to use for the AWS credentials above."
+        description="The profile to use for the AWS credentials above. The default profile will be used if none is provided."
         placeholder={Placeholders.s3_credentials_profile}
         onChange={(event) => setS3CredsProfile(event.target.value)}
         value={s3CredsProfile}

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -32,12 +32,12 @@ export const AirflowDialog: React.FC<Props> = ({ setDialogConfig }) => {
       s3_credentials_profile: 'default',
     };
 
-    if (address && address.startsWith("http://")) {
+    if (address && address.startsWith('http://')) {
       // Backend requires the protocol to be stripped
       config.host = address.substring(7);
     }
 
-    if (address && address.startsWith("https://")) {
+    if (address && address.startsWith('https://')) {
       // Backend requires the protocol to be stripped
       config.host = address.substring(8);
     }

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -91,6 +91,8 @@ export type AirflowConfig = {
   host: string;
   username: string;
   password: string;
+  s3_credentials_path: string;
+  s3_credentials_profile: string;
 };
 
 export type IntegrationConfig =


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds some UI changes to require the user to specify the AWS credentials location and profile name for the S3 bucket that will be used by the Airflow server they are connecting. This is necessary for the Airflow runtime to communicate asynchronously with the Aqueduct server via S3, since that is where operator metadata and artifact content is stored.

## Related issue number (if any)
ENG 1435

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

Demo: https://www.loom.com/share/2a96172a005047f3b8d1bc590fb89367


