### PR TITLE
Add exec state to get_artifact_result

### DIFF
--- a/integration_tests/sdk/requirement_test.py
+++ b/integration_tests/sdk/requirement_test.py
@@ -45,6 +45,7 @@ def test_invalid_path_operator(client):
     with pytest.raises(FileNotFoundError):
         invalid_path_table = sentiment_prediction_with_invalid_reqs_path(table)
 
+
 # TODO(ENG-1217): Straighten out our requirements story and testing.
 # @pytest.mark.skipif(
 #     condition=check_if_transformers_exist(),

--- a/integration_tests/sdk/requirement_test.py
+++ b/integration_tests/sdk/requirement_test.py
@@ -45,18 +45,18 @@ def test_invalid_path_operator(client):
     with pytest.raises(FileNotFoundError):
         invalid_path_table = sentiment_prediction_with_invalid_reqs_path(table)
 
-
-@pytest.mark.skipif(
-    condition=check_if_transformers_exist(),
-    reason="the transformers package already exists so the error can't be triggered.",
-)
-def test_path_operator(client):
-    db = client.integration(name=get_integration_name())
-    table = db.sql(query=SENTIMENT_SQL_QUERY)
-    # test if operator with default path will error out because of missing requirement package
-    default_path_table = sentiment_prediction_without_reqs_path(table)
-    with pytest.raises(AqueductError):
-        default_path_table.get()
-    # test if operator with valid requirement path will install the package and return the correct dataframe
-    valid_path_table = sentiment_prediction_with_valid_reqs_path(table)
-    assert valid_path_table.get().shape[0] == 100
+# TODO(ENG-1217): Straighten out our requirements story and testing.
+# @pytest.mark.skipif(
+#     condition=check_if_transformers_exist(),
+#     reason="the transformers package already exists so the error can't be triggered.",
+# )
+# def test_path_operator(client):
+#     db = client.integration(name=get_integration_name())
+#     table = db.sql(query=SENTIMENT_SQL_QUERY)
+#     # test if operator with default path will error out because of missing requirement package
+#     default_path_table = sentiment_prediction_without_reqs_path(table)
+#     with pytest.raises(AqueductError):
+#         default_path_table.get()
+#     # test if operator with valid requirement path will install the package and return the correct dataframe
+#     valid_path_table = sentiment_prediction_with_valid_reqs_path(table)
+#     assert valid_path_table.get().shape[0] == 100

--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -26,7 +26,7 @@ server_directory = join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = join(os.environ["HOME"], ".aqueduct", "ui")
 
 # Make sure to update this if there is any schema change we want to include in the upgrade.
-SCHEMA_VERSION = "13"
+SCHEMA_VERSION = "15"
 
 
 def execute_command(args, cwd=None):

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -320,7 +320,7 @@ class APIClient:
         return [ListWorkflowResponseEntry(**workflow) for workflow in response.json()]
 
     def get_artifact_result_data(self, dag_result_id: str, artifact_id: str) -> str:
-        """Returns an empty string if the artifact failed to be computed."""
+        """Returns an empty string if the operator was not successfully executed."""
         headers = utils.generate_auth_headers(self.api_key)
         url = self.construct_full_url(
             self.GET_ARTIFACT_RESULT_TEMPLATE % (dag_result_id, artifact_id)
@@ -328,7 +328,7 @@ class APIClient:
         resp = requests.get(url, headers=headers)
         utils.raise_errors(resp)
 
-        if resp.json()["status"] != ExecutionStatus.SUCCEEDED:
+        if resp.json()["exec_state"]["status"] != ExecutionStatus.SUCCEEDED:
             return ""
         return str(resp.json()["data"])
 

--- a/sdk/aqueduct/enums.py
+++ b/sdk/aqueduct/enums.py
@@ -89,7 +89,10 @@ class ExecutionStatus(str, Enum, metaclass=MetaEnum):
 
 class FailureType(Enum, metaclass=MetaEnum):
     SYSTEM = 1
-    USER = 2
+    USER_FATAL = 2
+    # For failures that don't stop execution.
+    # Eg. check operator with WARNING severity fails.
+    USER_NON_FATAL = 3
 
 
 class SalesforceExtractType(str, Enum, metaclass=MetaEnum):

--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -16,6 +16,8 @@ import (
 	_000011 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000011_exec_state_column_backfill"
 	_000012 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000012_drop_metadata_column"
 	_000013 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000013_add_workflow_dag_engine_config"
+	_000014 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result"
+	_000015 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000015_artifact_result_exec_state_column_backfill"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -77,6 +79,7 @@ func init() {
 		downPostgres: _000009.Down,
 		name:         "backfill metadata in artifact_results",
 	}
+
 	registeredMigrations[10] = &migration{
 		upPostgres: _000010.UpPostgres, upSqlite: _000010.UpSqlite,
 		downPostgres: _000010.DownPostgres,
@@ -99,5 +102,17 @@ func init() {
 		upPostgres: _000013.UpPostgres, upSqlite: _000013.UpSqlite,
 		downPostgres: _000013.DownPostgres,
 		name:         "add workflow_dag.engine_config",
+	}
+
+	registeredMigrations[14] = &migration{
+		upPostgres: _000014.UpPostgres, upSqlite: _000014.UpSqlite,
+		downPostgres: _000014.DownPostgres,
+		name:         "add exec state column to artifact result",
+	}
+
+	registeredMigrations[15] = &migration{
+		upPostgres: _000015.Up, upSqlite: _000015.Up,
+		downPostgres: _000015.Down,
+		name:         "backfill exec state column in artifact result",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/down_postgres.go
@@ -1,0 +1,5 @@
+package _00014_add_exec_state_column_to_artifact_result
+
+const downPostgresScript = `
+ALTER TABLE artifact_result DROP COLUMN IF EXISTS execution_state;
+`

--- a/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/main.go
+++ b/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/main.go
@@ -1,0 +1,19 @@
+package _00014_add_exec_state_column_to_artifact_result
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func UpPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upPostgresScript)
+}
+
+func UpSqlite(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, sqliteScript)
+}
+
+func DownPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, downPostgresScript)
+}

--- a/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/up_postgres.go
@@ -1,0 +1,6 @@
+package _00014_add_exec_state_column_to_artifact_result
+
+const upPostgresScript = `
+ALTER TABLE artifact_result 
+ADD COLUMN execution_state JSONB;
+`

--- a/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000014_add_exec_state_column_to_artifact_result/up_sqlite.go
@@ -1,0 +1,6 @@
+package _00014_add_exec_state_column_to_artifact_result
+
+const sqliteScript = `
+ALTER TABLE artifact_result 
+ADD COLUMN execution_state BLOB;
+`

--- a/src/golang/cmd/migrator/versions/000015_artifact_result_exec_state_column_backfill/main.go
+++ b/src/golang/cmd/migrator/versions/000015_artifact_result_exec_state_column_backfill/main.go
@@ -1,0 +1,52 @@
+package _00015_artifact_result_exec_state_column_backfill
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func Up(ctx context.Context, db database.Database) error {
+	execStateInfos, err := getExecStateForEachArtifactResult(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, execStateInfo := range execStateInfos {
+		if !execStateInfo.ExecState.IsNull {
+			err = updateExecStateInArtifactResult(
+				ctx,
+				execStateInfo.ArtifactResultID,
+				&execStateInfo.ExecState.ExecutionState,
+				db,
+			)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func Down(ctx context.Context, db database.Database) error {
+	// This updates the status field with the exec state fetched from the operator result.
+	// In the future, we can simply drop the status field without having to worry about downgrading. TODO(ENG-1453).
+	execStateInfos, err := getExecStateForEachArtifactResult(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, execStateInfo := range execStateInfos {
+		err = updateStatusInArtifactResult(
+			ctx,
+			execStateInfo.ArtifactResultID,
+			execStateInfo.ExecState.Status,
+			db,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/src/golang/cmd/migrator/versions/000015_artifact_result_exec_state_column_backfill/queries.go
+++ b/src/golang/cmd/migrator/versions/000015_artifact_result_exec_state_column_backfill/queries.go
@@ -1,0 +1,54 @@
+package _00015_artifact_result_exec_state_column_backfill
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/google/uuid"
+)
+
+type artifactOperatorExecState struct {
+	ArtifactResultID uuid.UUID                 `db:"id"`
+	ExecState        shared.NullExecutionState `db:"execution_state"`
+}
+
+func getExecStateForEachArtifactResult(ctx context.Context, db database.Database) ([]artifactOperatorExecState, error) {
+	query := `
+		SELECT artifact_result.id, operator_result.execution_state
+		FROM operator_result
+		INNER JOIN operator ON operator_result.operator_id=operator.id
+		INNER JOIN workflow_dag_edge ON operator.id=workflow_dag_edge.from_id
+		INNER JOIN artifact ON workflow_dag_edge.to_id=artifact.id
+		INNER JOIN artifact_result ON artifact.id=artifact_result.artifact_id;
+	`
+
+	var info []artifactOperatorExecState
+	err := db.Query(ctx, &info, query)
+	return info, err
+}
+
+func updateExecStateInArtifactResult(
+	ctx context.Context,
+	id uuid.UUID,
+	execState *shared.ExecutionState,
+	db database.Database,
+) error {
+	changes := map[string]interface{}{
+		"execution_state": execState,
+	}
+	return utils.UpdateRecord(ctx, changes, "artifact_result", "id", id, db)
+}
+
+func updateStatusInArtifactResult(
+	ctx context.Context,
+	id uuid.UUID,
+	status shared.ExecutionStatus,
+	db database.Database,
+) error {
+	changes := map[string]interface{}{
+		"status": status,
+	}
+	return utils.UpdateRecord(ctx, changes, "artifact_result", "id", id, db)
+}

--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -36,9 +36,9 @@ type getArtifactResultArgs struct {
 }
 
 type getArtifactResultResponse struct {
-	Status shared.ExecutionStatus `json:"status"`
-	Schema []map[string]string    `json:"schema"`
-	Data   string                 `json:"data"`
+	ExecState shared.ExecutionState `json:"exec_state"`
+	Schema    []map[string]string   `json:"schema"`
+	Data      string                `json:"data"`
 }
 
 type GetArtifactResultHandler struct {
@@ -116,8 +116,17 @@ func (h *GetArtifactResultHandler) Perform(ctx context.Context, interfaceArgs in
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
 	}
 
-	response := getArtifactResultResponse{
+	execState := shared.ExecutionState{
 		Status: dbArtifactResult.Status,
+	}
+	if !dbArtifactResult.ExecState.IsNull {
+		execState.FailureType = dbArtifactResult.ExecState.FailureType
+		execState.Error = dbArtifactResult.ExecState.Error
+		execState.UserLogs = dbArtifactResult.ExecState.UserLogs
+	}
+
+	response := getArtifactResultResponse{
+		ExecState: execState,
 	}
 
 	if !dbArtifactResult.Metadata.IsNull {

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	RequiredSchemaVersion = 13
+	RequiredSchemaVersion = 15
 
 	accountOrganizationId = "aqueduct"
 )

--- a/src/golang/lib/collections/artifact_result/artifact_result.go
+++ b/src/golang/lib/collections/artifact_result/artifact_result.go
@@ -9,12 +9,13 @@ import (
 )
 
 type ArtifactResult struct {
-	Id                  uuid.UUID              `db:"id" json:"id"`
-	WorkflowDagResultId uuid.UUID              `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
-	ArtifactId          uuid.UUID              `db:"artifact_id" json:"artifact_id"`
-	ContentPath         string                 `db:"content_path" json:"content_path"`
-	Status              shared.ExecutionStatus `db:"status" json:"status"`
-	Metadata            NullMetadata           `db:"metadata" json:"metadata"`
+	Id                  uuid.UUID                 `db:"id" json:"id"`
+	WorkflowDagResultId uuid.UUID                 `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
+	ArtifactId          uuid.UUID                 `db:"artifact_id" json:"artifact_id"`
+	ContentPath         string                    `db:"content_path" json:"content_path"`
+	Status              shared.ExecutionStatus    `db:"status" json:"status"`
+	ExecState           shared.NullExecutionState `db:"execution_state" json:"execution_state"`
+	Metadata            NullMetadata              `db:"metadata" json:"metadata"`
 }
 
 type Reader interface {

--- a/src/golang/lib/collections/artifact_result/artifact_result.go
+++ b/src/golang/lib/collections/artifact_result/artifact_result.go
@@ -9,13 +9,16 @@ import (
 )
 
 type ArtifactResult struct {
-	Id                  uuid.UUID                 `db:"id" json:"id"`
-	WorkflowDagResultId uuid.UUID                 `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
-	ArtifactId          uuid.UUID                 `db:"artifact_id" json:"artifact_id"`
-	ContentPath         string                    `db:"content_path" json:"content_path"`
-	Status              shared.ExecutionStatus    `db:"status" json:"status"`
-	ExecState           shared.NullExecutionState `db:"execution_state" json:"execution_state"`
-	Metadata            NullMetadata              `db:"metadata" json:"metadata"`
+	Id                  uuid.UUID `db:"id" json:"id"`
+	WorkflowDagResultId uuid.UUID `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
+	ArtifactId          uuid.UUID `db:"artifact_id" json:"artifact_id"`
+	ContentPath         string    `db:"content_path" json:"content_path"`
+
+	// TODO(ENG-1453): Remove status. This field is redundant now that ExecState exists.
+	// Avoid using status in new code.
+	Status    shared.ExecutionStatus    `db:"status" json:"status"`
+	ExecState shared.NullExecutionState `db:"execution_state" json:"execution_state"`
+	Metadata  NullMetadata              `db:"metadata" json:"metadata"`
 }
 
 type Reader interface {

--- a/src/golang/lib/collections/artifact_result/constants.go
+++ b/src/golang/lib/collections/artifact_result/constants.go
@@ -10,8 +10,13 @@ const (
 	WorkflowDagResultIdColumn = "workflow_dag_result_id"
 	ArtifactIdColumn          = "artifact_id"
 	ContentPathColumn         = "content_path"
-	StatusColumn              = "status"
-	MetadataColumn            = "metadata"
+
+	// `Status` is initialized to "PENDING" for each new artifact result.
+	StatusColumn   = "status"
+	MetadataColumn = "metadata"
+
+	// `ExecState` is initialized to nil. Expected to be set on updates only.
+	ExecStateColumn = "execution_state"
 )
 
 // Returns a joined string of all ArtifactResult columns.
@@ -24,6 +29,7 @@ func allColumns() string {
 			ContentPathColumn,
 			StatusColumn,
 			MetadataColumn,
+			ExecStateColumn,
 		},
 		",",
 	)

--- a/src/golang/lib/collections/operator_result/constants.go
+++ b/src/golang/lib/collections/operator_result/constants.go
@@ -11,8 +11,12 @@ const (
 	IdColumn                  = "id"
 	WorkflowDagResultIdColumn = "workflow_dag_result_id"
 	OperatorIdColumn          = "operator_id"
-	StatusColumn              = "status"
-	ExecStateColumn           = "execution_state"
+
+	// `Status` is initialized to "PENDING" for each new operator result.
+	StatusColumn = "status"
+
+	// `ExecState` is initialized to nil. Expected to be set on updates only.
+	ExecStateColumn = "execution_state"
 )
 
 // Returns a joined string of all OperatorResult columns.

--- a/src/golang/lib/collections/operator_result/operator_result.go
+++ b/src/golang/lib/collections/operator_result/operator_result.go
@@ -9,11 +9,14 @@ import (
 )
 
 type OperatorResult struct {
-	Id                  uuid.UUID                 `db:"id" json:"id"`
-	WorkflowDagResultId uuid.UUID                 `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
-	OperatorId          uuid.UUID                 `db:"operator_id" json:"operator_id"`
-	Status              shared.ExecutionStatus    `db:"status" json:"status"`
-	ExecState           shared.NullExecutionState `db:"execution_state" json:"execution_state"`
+	Id                  uuid.UUID `db:"id" json:"id"`
+	WorkflowDagResultId uuid.UUID `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
+	OperatorId          uuid.UUID `db:"operator_id" json:"operator_id"`
+
+	// TODO(ENG-1453): Remove status. This field is redundant now that ExecState exists.
+	//  Avoid using status in new code.
+	Status    shared.ExecutionStatus    `db:"status" json:"status"`
+	ExecState shared.NullExecutionState `db:"execution_state" json:"execution_state"`
 }
 
 type Reader interface {

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -13,10 +13,6 @@ const (
 		githubIssueLink + " . " +
 		"We will get back to you as soon as we can."
 	TipUnknownInternalError = "Sorry, we've run into an unexpected error! " + TipCreateBugReport
-
-	// This tip is not meant to be surfaced to the user. It should be overwritten in the specific
-	// operator.GetExecState() implementation with a more helpful error message.
-	TipBlacklistedOutputError = "Operator has output a blacklisted value."
 )
 
 var ErrInvalidStorageConfig = errors.New("Invalid Storage Config")
@@ -34,9 +30,13 @@ const (
 type FailureType int64
 
 const (
-	Success       FailureType = 0
-	SystemFailure FailureType = 1
-	UserFailure   FailureType = 2
+	Success          FailureType = 0
+	SystemFailure    FailureType = 1
+	UserFatalFailure FailureType = 2
+
+	// Orchestration can continue onwards, despite this failure.
+	// Eg. Check operator with WARNING severity does not pass.
+	UserNonFatalFailure FailureType = 3
 )
 
 type Logs struct {

--- a/src/golang/lib/collections/tests/main_test.go
+++ b/src/golang/lib/collections/tests/main_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	schemaVersion = 13
+	schemaVersion = 15
 
 	// Postgres config
 	postgresHost     = "localhost"

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
+	"github.com/aqueducthq/aqueduct/lib/collections/operator"
+	"github.com/aqueducthq/aqueduct/lib/collections/operator/check"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/connector"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
@@ -108,11 +110,10 @@ type FunctionSpec struct {
 	OutputMetadataPaths []string        `json:"output_metadata_paths"  yaml:"output_metadata_paths"`
 	InputArtifactTypes  []artifact.Type `json:"input_artifact_types"  yaml:"input_artifact_types"`
 	OutputArtifactTypes []artifact.Type `json:"output_artifact_types"  yaml:"output_artifact_types"`
+	OperatorType        operator.Type   `json:"operator_type" yaml:"operator_type"`
 
-	// If the function outputs a value that exists in this list, we will fail the entire workflow.
-	// This list contains the json-serialized version of the offending values.
-	// Must be set to nil if there are no blacklisted outputs expected.
-	BlacklistedOutputs []string `json:"blacklisted_outputs" yaml:"blacklisted_outputs"`
+	// Specific to the check operator. This is left unset by any other function type.
+	CheckSeverity *check.Level `json:"check_severity" yaml:"check_severity"`
 }
 
 type ParamSpec struct {

--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -1,13 +1,9 @@
 package operator
 
 import (
-	"encoding/json"
-
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
-	"github.com/aqueducthq/aqueduct/lib/collections/operator/check"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/dropbox/godropbox/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type checkOperatorImpl struct {
@@ -44,25 +40,7 @@ func newCheckOperator(base baseFunctionOperator) (Operator, error) {
 	}, nil
 }
 
-func (co *checkOperatorImpl) hasErrorSeverity() bool {
-	return co.dbOperator.Spec.Check().Level == check.ErrorLevel
-}
-
 func (co *checkOperatorImpl) JobSpec() job.Spec {
 	fn := co.dbOperator.Spec.Check().Function
-	spec := co.jobSpec(&fn)
-
-	// This will tell the orchestration engine to fail the workflow
-	// if the check fails with sufficient severity.
-	if co.hasErrorSeverity() {
-		falseSerialized, err := json.Marshal(false)
-		if err != nil {
-			log.Errorf("Internal error: Operator %s is unable to marshal `false`", co.Name())
-		}
-
-		fnSpec := spec.(*job.FunctionSpec)
-		fnSpec.BlacklistedOutputs = append(fnSpec.BlacklistedOutputs, string(falseSerialized))
-		return fnSpec
-	}
-	return spec
+	return co.jobSpec(&fn, &co.dbOperator.Spec.Check().Level)
 }

--- a/src/golang/lib/workflow/operator/function.go
+++ b/src/golang/lib/workflow/operator/function.go
@@ -50,5 +50,5 @@ func newFunctionOperator(
 
 func (fo *functionOperatorImpl) JobSpec() job.Spec {
 	fn := fo.dbOperator.Spec.Function()
-	return fo.jobSpec(fn)
+	return fo.jobSpec(fn, nil /* checkSeverity */)
 }

--- a/src/golang/lib/workflow/operator/metric.go
+++ b/src/golang/lib/workflow/operator/metric.go
@@ -42,5 +42,5 @@ func newMetricOperator(base baseFunctionOperator) (Operator, error) {
 
 func (mo *metricOperatorImpl) JobSpec() job.Spec {
 	fn := mo.dbOperator.Spec.Metric().Function
-	return mo.jobSpec(&fn)
+	return mo.jobSpec(&fn, nil /* checkSeverity */)
 }

--- a/src/golang/lib/workflow/orchestrator/orchestrator.go
+++ b/src/golang/lib/workflow/orchestrator/orchestrator.go
@@ -153,6 +153,11 @@ func opFailureError(failureType shared.FailureType, op operator.Operator) error 
 	return errors.Newf("Internal error: Unsupported failure type %v", failureType)
 }
 
+// We should only stop orchestration on system or fatal user errors.
+func shouldStopExecution(execState *shared.ExecutionState) bool {
+	return execState.Status == shared.FailedExecutionStatus && *execState.FailureType != shared.UserNonFatalFailure
+}
+
 func (orch *aqOrchestrator) execute(
 	ctx context.Context,
 	timeConfig *AqueductTimeConfig,
@@ -215,7 +220,7 @@ func (orch *aqOrchestrator) execute(
 			}
 
 			// We can continue orchestration on non-fatal errors.
-			if execState.Status == shared.FailedExecutionStatus && *execState.FailureType != shared.UserNonFatalFailure {
+			if shouldStopExecution(execState) {
 				return opFailureError(*execState.FailureType, op)
 			}
 

--- a/src/golang/lib/workflow/utils/utils.go
+++ b/src/golang/lib/workflow/utils/utils.go
@@ -27,56 +27,6 @@ type WorkflowStoragePaths struct {
 	ArtifactMetadataPaths map[uuid.UUID]string
 }
 
-func GenerateWorkflowStoragePaths(dag *workflow_dag.DBWorkflowDag) *WorkflowStoragePaths {
-	workflowStoragePaths := WorkflowStoragePaths{
-		OperatorMetadataPaths: make(map[uuid.UUID]string),
-		ArtifactPaths:         make(map[uuid.UUID]string),
-		ArtifactMetadataPaths: make(map[uuid.UUID]string),
-	}
-
-	for id := range dag.Operators {
-		workflowStoragePaths.OperatorMetadataPaths[id] = uuid.New().String()
-	}
-
-	for id := range dag.Artifacts {
-		workflowStoragePaths.ArtifactPaths[id] = uuid.New().String()
-		workflowStoragePaths.ArtifactMetadataPaths[id] = uuid.New().String()
-	}
-
-	return &workflowStoragePaths
-}
-
-func CleanupWorkflowStorageFiles(
-	ctx context.Context,
-	workflowStoragePaths *WorkflowStoragePaths,
-	storageConfig *shared.StorageConfig,
-	metadataOnly bool,
-) {
-	// Clean up generated workflow storage files.
-	// If `metadataOnly` is turned on, clean up only metadata files and preserve content files.
-	numFiles := len(workflowStoragePaths.ArtifactMetadataPaths) + len(workflowStoragePaths.OperatorMetadataPaths)
-	if !metadataOnly {
-		numFiles += len(workflowStoragePaths.ArtifactPaths)
-	}
-
-	paths := make([]string, 0, numFiles)
-	for _, path := range workflowStoragePaths.ArtifactMetadataPaths {
-		paths = append(paths, path)
-	}
-
-	for _, path := range workflowStoragePaths.OperatorMetadataPaths {
-		paths = append(paths, path)
-	}
-
-	if !metadataOnly {
-		for _, path := range workflowStoragePaths.ArtifactPaths {
-			paths = append(paths, path)
-		}
-	}
-
-	CleanupStorageFiles(ctx, storageConfig, paths)
-}
-
 func CleanupStorageFile(ctx context.Context, storageConfig *shared.StorageConfig, key string) {
 	CleanupStorageFiles(ctx, storageConfig, []string{key})
 }

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -8,7 +8,12 @@ from typing import Any, Callable, Dict, List, Tuple
 from aqueduct_executor.operators.function_executor.spec import FunctionSpec
 from aqueduct_executor.operators.function_executor.utils import OP_DIR
 from aqueduct_executor.operators.utils import utils
-from aqueduct_executor.operators.utils.enums import ExecutionStatus, FailureType, OperatorType, CheckSeverityLevel
+from aqueduct_executor.operators.utils.enums import (
+    CheckSeverityLevel,
+    ExecutionStatus,
+    FailureType,
+    OperatorType,
+)
 from aqueduct_executor.operators.utils.execution import (
     TIP_CHECK_DID_NOT_PASS,
     TIP_OP_EXECUTION,
@@ -20,9 +25,8 @@ from aqueduct_executor.operators.utils.execution import (
 )
 from aqueduct_executor.operators.utils.storage.parse import parse_storage
 from aqueduct_executor.operators.utils.timer import Timer
-from pandas import DataFrame
-
 from aqueduct_executor.operators.utils.utils import check_passed
+from pandas import DataFrame
 
 
 def _get_py_import_path(spec: FunctionSpec) -> str:

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -8,9 +8,9 @@ from typing import Any, Callable, Dict, List, Tuple
 from aqueduct_executor.operators.function_executor.spec import FunctionSpec
 from aqueduct_executor.operators.function_executor.utils import OP_DIR
 from aqueduct_executor.operators.utils import utils
-from aqueduct_executor.operators.utils.enums import ExecutionStatus, FailureType
+from aqueduct_executor.operators.utils.enums import ExecutionStatus, FailureType, OperatorType, CheckSeverityLevel
 from aqueduct_executor.operators.utils.execution import (
-    TIP_BLACKLISTED_OUTPUT,
+    TIP_CHECK_DID_NOT_PASS,
     TIP_OP_EXECUTION,
     TIP_UNKNOWN_ERROR,
     Error,
@@ -21,6 +21,8 @@ from aqueduct_executor.operators.utils.execution import (
 from aqueduct_executor.operators.utils.storage.parse import parse_storage
 from aqueduct_executor.operators.utils.timer import Timer
 from pandas import DataFrame
+
+from aqueduct_executor.operators.utils.utils import check_passed
 
 
 def _get_py_import_path(spec: FunctionSpec) -> str:
@@ -154,21 +156,26 @@ def run(spec: FunctionSpec) -> None:
             system_metadata=system_metadata,
         )
 
-        # Check if any of the written results were blacklisted and there should fail
-        # the workflow.
-        if spec.blacklisted_outputs is not None and any(
-            json.dumps(res) in spec.blacklisted_outputs for res in results
-        ):
+        # For check operators, we want to fail the operator based on the exact output of the user's function.
+        # Assumption: the check operator only has a single output.
+        if spec.operator_type == OperatorType.CHECK and not check_passed(results[0]):
+            check_severity = spec.check_severity
+            if spec.check_severity is None:
+                print("Check operator has an unspecified severity on spec. Defaulting to ERROR.")
+                check_severity = CheckSeverityLevel.ERROR
+
+            failure_type = FailureType.USER_FATAL
+            if check_severity == CheckSeverityLevel.WARNING:
+                failure_type = FailureType.USER_NON_FATAL
+
             exec_state.status = ExecutionStatus.FAILED
-            exec_state.failure_type = FailureType.USER
+            exec_state.failure_type = failure_type
             exec_state.error = Error(
                 context="",
-                tip=TIP_BLACKLISTED_OUTPUT,
+                tip=TIP_CHECK_DID_NOT_PASS,
             )
             utils.write_exec_state(storage, spec.metadata_path, exec_state)
-
-            print(f"Failed with user error. Full Logs:\n{exec_state.json()}")
-            sys.exit(1)
+            print(f"Check Operator did not pass. Full logs: {exec_state.json()}")
         else:
             exec_state.status = ExecutionStatus.SUCCEEDED
             utils.write_exec_state(storage, spec.metadata_path, exec_state)

--- a/src/python/aqueduct_executor/operators/function_executor/get_extract_path.py
+++ b/src/python/aqueduct_executor/operators/function_executor/get_extract_path.py
@@ -1,5 +1,6 @@
 import argparse
 import base64
+import json
 
 from aqueduct_executor.operators.function_executor.spec import FunctionSpec, parse_spec
 
@@ -14,7 +15,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     spec_json = base64.b64decode(args.spec)
-    spec = parse_spec(spec_json)
+    try:
+        spec = parse_spec(spec_json)
+    except Exception:
+        # Log the offending spec on failures.
+        print(json.loads(spec_json))
+        raise
+
     # The output of the print statement to stdout is captured by the calling bash script into a variable,
     # so we should not include any other print statements in this Python script.
     print(run(spec))

--- a/src/python/aqueduct_executor/operators/function_executor/get_extract_path.py
+++ b/src/python/aqueduct_executor/operators/function_executor/get_extract_path.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         spec = parse_spec(spec_json)
     except Exception:
         # Log the offending spec on failures.
-        print(json.loads(spec_json))
+        print("Failing raw spec: ", args.spec)
         raise
 
     # The output of the print statement to stdout is captured by the calling bash script into a variable,

--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -29,10 +29,10 @@ class FunctionSpec(BaseModel):
     output_metadata_paths: List[str]
     input_artifact_types: List[enums.InputArtifactType]
     output_artifact_types: List[enums.OutputArtifactType]
+    operator_type: enums.OperatorType
 
-    # If the function produces one of these blacklisted outputs exactly,
-    # we will error out the workflow.
-    blacklisted_outputs: Optional[List[str]] = None  # Optional for backwards compatability.
+    # This is specific to the check operator. This is left unset by any other function type.
+    check_severity: Optional[enums.CheckSeverityLevel]
 
     class Config:
         extra = Extra.forbid

--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -54,5 +54,6 @@ def parse_spec(spec_json: bytes) -> FunctionSpec:
     Parses a JSON string into a FunctionSpec.
     """
     data = json.loads(spec_json)
+    print("JSON Function Spec: ", data)
 
     return parse_obj_as(FunctionSpec, data)

--- a/src/python/aqueduct_executor/operators/utils/enums.py
+++ b/src/python/aqueduct_executor/operators/utils/enums.py
@@ -42,6 +42,7 @@ class FailureType(Enum, metaclass=MetaEnum):
     # Eg. check operator with WARNING severity fails.
     USER_NON_FATAL = 3
 
+
 class JobType(str, Enum, metaclass=MetaEnum):
     FUNCTION = "function"
     AUTHENTICATE = "authenticate"

--- a/src/python/aqueduct_executor/operators/utils/enums.py
+++ b/src/python/aqueduct_executor/operators/utils/enums.py
@@ -13,6 +13,21 @@ class MetaEnum(EnumMeta):
         return item in [v.value for v in cast(Iterable[Enum], cls.__members__.values())]
 
 
+class OperatorType(str, Enum, metaclass=MetaEnum):
+    FUNCTION = "function"
+    METRIC = "metric"
+    CHECK = "check"
+    EXTRACT = "extract"
+    LOAD = "load"
+    PARAM = "param"
+    SYSTEM_METRIC = "system_metric"
+
+
+class CheckSeverityLevel(str, Enum, metaclass=MetaEnum):
+    ERROR = "error"
+    WARNING = "warning"
+
+
 class ExecutionStatus(str, Enum, metaclass=MetaEnum):
     UNKNOWN = "unknown"
     PENDING = "pending"
@@ -22,8 +37,10 @@ class ExecutionStatus(str, Enum, metaclass=MetaEnum):
 
 class FailureType(Enum, metaclass=MetaEnum):
     SYSTEM = 1
-    USER = 2
-
+    USER_FATAL = 2
+    # For failures that don't stop execution.
+    # Eg. check operator with WARNING severity fails.
+    USER_NON_FATAL = 3
 
 class JobType(str, Enum, metaclass=MetaEnum):
     FUNCTION = "function"

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -26,9 +26,7 @@ TIP_LOAD = "We couldn't load to the integration. Please make sure the target exi
 TIP_DISCOVER = "We couldn't list items in the integration. Please make sure your credentials have the right permission."
 
 # Assumption: only check operators will use this tip.
-TIP_BLACKLISTED_OUTPUT = (
-    "The check did not pass and has ERROR level severity, so the entire workflow failed."
-)
+TIP_CHECK_DID_NOT_PASS = "The check operator did not pass."
 
 
 class Error(BaseModel):
@@ -85,7 +83,7 @@ class ExecutionState(BaseModel):
                     # Include the stack trace within the user's code.
                     _set_redirected_logs(stdout_log, stderr_log, self.user_logs)
                     self.status = ExecutionStatus.FAILED
-                    self.failure_type = FailureType.USER
+                    self.failure_type = FailureType.USER_FATAL
                     self.error = Error(
                         context=stack_traceback(
                             offset=1

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -134,7 +134,7 @@ def check_passed(content: Any) -> bool:
     elif isinstance(content, pd.Series) and content.dtype == "bool":
         # We only write True if every boolean in the series is True.
         series = pd.Series(content)
-        return series.size - series.sum().item() == 0
+        return bool(series.size - series.sum().item() == 0)
     else:
         raise Exception(
             "Expected output type of check to be either a bool or a series of booleans, "
@@ -175,7 +175,9 @@ def write_artifact(
                 "Expected output type to be numeric, instead got %s" % type(content).__name__
             )
     elif artifact_type == OutputArtifactType.BOOL:
-        _write_bool_output(storage, output_path, output_metadata_path, check_passed(content), output_metadata)
+        _write_bool_output(
+            storage, output_path, output_metadata_path, check_passed(content), output_metadata
+        )
 
     elif artifact_type == OutputArtifactType.JSON:
         if not isinstance(content, str):

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -127,6 +127,21 @@ def write_artifacts(
         )
 
 
+def check_passed(content: Any) -> bool:
+    """Given the output of a check operator, return whether the check passed or not."""
+    if isinstance(content, bool) or isinstance(content, np.bool_):
+        return bool(content)
+    elif isinstance(content, pd.Series) and content.dtype == "bool":
+        # We only write True if every boolean in the series is True.
+        series = pd.Series(content)
+        return series.size - series.sum().item() == 0
+    else:
+        raise Exception(
+            "Expected output type of check to be either a bool or a series of booleans, "
+            "instead got %s" % type(content).__name__
+        )
+
+
 def write_artifact(
     storage: Storage,
     artifact_type: OutputArtifactType,
@@ -160,22 +175,7 @@ def write_artifact(
                 "Expected output type to be numeric, instead got %s" % type(content).__name__
             )
     elif artifact_type == OutputArtifactType.BOOL:
-        if isinstance(content, bool) or isinstance(content, np.bool_):
-            _write_bool_output(
-                storage, output_path, output_metadata_path, bool(content), output_metadata
-            )
-        elif isinstance(content, pd.Series) and content.dtype == "bool":
-            # We only write True if every boolean in the series is True.
-            series = pd.Series(content)
-            all_true = series.size - series.sum().item() == 0
-            _write_bool_output(
-                storage, output_path, output_metadata_path, all_true, output_metadata
-            )
-        else:
-            raise Exception(
-                "Expected output type to either a bool or a series of booleans, "
-                "instead got %s" % type(content).__name__
-            )
+        _write_bool_output(storage, output_path, output_metadata_path, check_passed(content), output_metadata)
 
     elif artifact_type == OutputArtifactType.JSON:
         if not isinstance(content, str):

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -16,7 +16,7 @@ import distro
 import requests
 import yaml
 
-SCHEMA_VERION = "13"
+SCHEMA_VERSION = "15"
 
 base_directory = os.path.join(os.environ["HOME"], ".aqueduct")
 server_directory = os.path.join(os.environ["HOME"], ".aqueduct", "server")
@@ -177,7 +177,7 @@ def update_server_version():
     update_executable_permissions()
 
     execute_command(
-        [os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", SCHEMA_VERION]
+        [os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", SCHEMA_VERSION]
     )
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
As discussed with @likawind, a failing warning check is represented by the following exec state:
- status == Failed
- failure_type == UserNonFatal

The typical user failure now becomes UserFatal. Only System and UserFatal errors will stop orchestration.

Also adds ExecState to the response of `get_artifact_result`. This will be parsed by the frontend: https://github.com/aqueducthq/aqueduct/pull/245

# Database Migration
This PR includes the migration for adding `execution_state` column. The additional backfill migration will be a follow-up PR.

## Related issue number (if any)
ENG-1265

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


