### PR TITLE
ENG- 1418 export spiraldemocard and sqlservercard

### DIFF
--- a/src/ui/app/package-lock.json
+++ b/src/ui/app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@aqueducthq/ui",
       "version": "0.0.6",
       "dependencies": {
-        "@aqueducthq/common": "^0.0.7",
+        "@aqueducthq/common": "^0.0.10",
         "@babel/preset-react": "^7.17.12",
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
@@ -57,9 +57,9 @@
       }
     },
     "node_modules/@aqueducthq/common": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@aqueducthq/common/-/common-0.0.7.tgz",
-      "integrity": "sha512-HP+aD0KLyQLQIaQXM7ZoM9MLIGM8gkoCRDQzoq8JxRCCHknG6L+weAnnXvWIrIyjXchksUB3aSG1LeZ1iBZ5TA==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@aqueducthq/common/-/common-0.0.10.tgz",
+      "integrity": "sha512-gzh/3ENKhmYZvqmJPhiw7eBJQgOF7Ep3Q2YhZHxRH7NGo2sdYqoc1BMpw6RGwa2e6wsmgsJzkgID+Ybu0bW63g==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=10"
@@ -81,6 +81,7 @@
         "query-string": "^7.1.1",
         "random-word-slugs": "^0.1.6",
         "react": "^18.1.0",
+        "react-code-blocks": "^0.0.9-0",
         "react-cookie": "^4.1.1",
         "react-dom": "^18.1.0",
         "react-flow-renderer": "^10.1.0",
@@ -678,6 +679,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "peer": true
     },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
@@ -3473,6 +3480,28 @@
         "resolve": "^1.12.0"
       }
     },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
+      }
+    },
+    "node_modules/babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "peer": true
+    },
     "node_modules/bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -3580,6 +3609,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg==",
+      "peer": true
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001358",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
@@ -3660,6 +3695,18 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.3.tgz",
       "integrity": "sha512-6dK2ke4VEJZOFx2ZfdDAl5OhEL8lvkl6EHF92IfRePfHxQTqir5NlcNVUv+2idjDqCX2NDc8m8YSAI5NI975ZQ==",
       "peer": true
+    },
+    "node_modules/clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
     },
     "node_modules/clone": {
       "version": "2.1.2",
@@ -3783,6 +3830,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -3797,6 +3853,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "peer": true,
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -4001,6 +4068,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
@@ -4996,6 +5070,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "delegate": "^3.1.2"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5770,6 +5854,12 @@
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "dev": true
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -6404,7 +6494,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6415,8 +6504,7 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/posthtml": {
       "version": "0.16.6",
@@ -6653,6 +6741,114 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react-code-blocks": {
+      "version": "0.0.9-0",
+      "resolved": "https://registry.npmjs.org/react-code-blocks/-/react-code-blocks-0.0.9-0.tgz",
+      "integrity": "sha512-jdYJVZwGtsr6WIUaqILy5fkF1acf57YV5s0V3+w5o9v3omYnqBeO6EuZi1Vf2x1hahkYGEedsp46+ofdkYlqyw==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.10.4",
+        "react-syntax-highlighter": "^12.2.1",
+        "styled-components": "^5.1.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/hastscript": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "peer": true,
+      "dependencies": {
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/highlight.js": {
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+      "deprecated": "Version no longer supported. Upgrade to @latest",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/lowlight": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+      "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+      "peer": true,
+      "dependencies": {
+        "fault": "^1.0.2",
+        "highlight.js": "~9.15.0"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "peer": true,
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "peer": true,
+      "optionalDependencies": {
+        "clipboard": "^2.0.0"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/react-syntax-highlighter": {
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
+      "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "~9.15.1",
+        "lowlight": "1.12.1",
+        "prismjs": "^1.8.4",
+        "refractor": "^2.4.1"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/react-code-blocks/node_modules/refractor": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
+      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+      "peer": true,
+      "dependencies": {
+        "hastscript": "^5.0.0",
+        "parse-entities": "^1.1.2",
+        "prismjs": "~1.17.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/react-cookie": {
@@ -7058,6 +7254,13 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -7065,6 +7268,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7322,6 +7531,37 @@
         "inline-style-parser": "0.1.1"
       }
     },
+    "node_modules/styled-components": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
@@ -7468,6 +7708,13 @@
       "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -7501,8 +7748,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -7888,9 +8134,9 @@
       }
     },
     "@aqueducthq/common": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@aqueducthq/common/-/common-0.0.7.tgz",
-      "integrity": "sha512-HP+aD0KLyQLQIaQXM7ZoM9MLIGM8gkoCRDQzoq8JxRCCHknG6L+weAnnXvWIrIyjXchksUB3aSG1LeZ1iBZ5TA==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@aqueducthq/common/-/common-0.0.10.tgz",
+      "integrity": "sha512-gzh/3ENKhmYZvqmJPhiw7eBJQgOF7Ep3Q2YhZHxRH7NGo2sdYqoc1BMpw6RGwa2e6wsmgsJzkgID+Ybu0bW63g==",
       "requires": {}
     },
     "@babel/code-frame": {
@@ -8305,6 +8551,12 @@
         "@emotion/serialize": "^1.0.4",
         "@emotion/utils": "^1.1.0"
       }
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "peer": true
     },
     "@emotion/unitless": {
       "version": "0.7.5",
@@ -10068,6 +10320,25 @@
         "resolve": "^1.12.0"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "peer": true
+    },
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -10146,6 +10417,12 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg==",
+      "peer": true
+    },
     "caniuse-lite": {
       "version": "1.0.30001358",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
@@ -10197,6 +10474,18 @@
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.3.tgz",
       "integrity": "sha512-6dK2ke4VEJZOFx2ZfdDAl5OhEL8lvkl6EHF92IfRePfHxQTqir5NlcNVUv+2idjDqCX2NDc8m8YSAI5NI975ZQ==",
       "peer": true
+    },
+    "clipboard": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.11.tgz",
+      "integrity": "sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
     },
     "clone": {
       "version": "2.1.2",
@@ -10290,6 +10579,12 @@
         "which": "^2.0.1"
       }
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "peer": true
+    },
     "css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -10301,6 +10596,17 @@
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
+      }
+    },
+    "css-to-react-native": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.0.0.tgz",
+      "integrity": "sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==",
+      "peer": true,
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "css-tree": {
@@ -10445,6 +10751,13 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true,
+      "peer": true
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -11176,6 +11489,16 @@
         "slash": "^3.0.0"
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -11688,6 +12011,12 @@
       "dev": true,
       "optional": true
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "peer": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -12167,14 +12496,12 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "posthtml": {
       "version": "0.16.6",
@@ -12346,6 +12673,95 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.3",
         "whatwg-fetch": "^3.0.0"
+      }
+    },
+    "react-code-blocks": {
+      "version": "0.0.9-0",
+      "resolved": "https://registry.npmjs.org/react-code-blocks/-/react-code-blocks-0.0.9-0.tgz",
+      "integrity": "sha512-jdYJVZwGtsr6WIUaqILy5fkF1acf57YV5s0V3+w5o9v3omYnqBeO6EuZi1Vf2x1hahkYGEedsp46+ofdkYlqyw==",
+      "peer": true,
+      "requires": {
+        "@babel/runtime": "^7.10.4",
+        "react-syntax-highlighter": "^12.2.1",
+        "styled-components": "^5.1.1",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "hastscript": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
+          "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+          "peer": true,
+          "requires": {
+            "comma-separated-tokens": "^1.0.0",
+            "hast-util-parse-selector": "^2.0.0",
+            "property-information": "^5.0.0",
+            "space-separated-tokens": "^1.0.0"
+          }
+        },
+        "highlight.js": {
+          "version": "9.15.10",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+          "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+          "peer": true
+        },
+        "lowlight": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+          "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+          "peer": true,
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.15.0"
+          }
+        },
+        "parse-entities": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+          "peer": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "prismjs": {
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+          "peer": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        },
+        "react-syntax-highlighter": {
+          "version": "12.2.1",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
+          "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+          "peer": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "~9.15.1",
+            "lowlight": "1.12.1",
+            "prismjs": "^1.8.4",
+            "refractor": "^2.4.1"
+          }
+        },
+        "refractor": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.1.tgz",
+          "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
+          "peer": true,
+          "requires": {
+            "hastscript": "^5.0.0",
+            "parse-entities": "^1.1.2",
+            "prismjs": "~1.17.0"
+          }
+        }
       }
     },
     "react-cookie": {
@@ -12625,10 +13041,23 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==",
+      "optional": true,
+      "peer": true
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "peer": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -12825,6 +13254,24 @@
         "inline-style-parser": "0.1.1"
       }
     },
+    "styled-components": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "peer": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
+        "shallowequal": "^1.1.0",
+        "supports-color": "^5.5.0"
+      }
+    },
     "stylis": {
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
@@ -12935,6 +13382,13 @@
       "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true,
+      "peer": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -12958,8 +13412,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --format table --fix"
   },
   "dependencies": {
-    "@aqueducthq/common": "^0.0.10",
+    "@aqueducthq/common": "^0.0.11",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --format table --fix"
   },
   "dependencies": {
-    "@aqueducthq/common": "^0.0.7",
+    "@aqueducthq/common": "^0.0.10",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aqueducthq/common",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aqueducthq/common",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "hasInstallScript": true,
       "devDependencies": {
         "@babel/preset-react": "^7.17.12",

--- a/src/ui/common/package.json
+++ b/src/ui/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aqueducthq/common",
   "author": "Aqueduct <hello@aqueducthq.com",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "alias": {

--- a/src/ui/common/src/components/integrations/cards/sqlServerCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/sqlServerCard.tsx
@@ -1,0 +1,32 @@
+import { Typography } from '@mui/material';
+import Box from '@mui/material/Box';
+import { Integration, SqlServerConfig } from '../../../utils/integrations';
+import React from 'react';
+
+type Props = {
+  integration: Integration;
+};
+
+export const SqlServerCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as SqlServerConfig;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body1">
+        <strong>Host: </strong>
+        {config.host}
+      </Typography>
+      <Typography variant="body1">
+        <strong>Port: </strong>
+        {config.port}
+      </Typography>
+      <Typography variant="body1">
+        <strong>User: </strong>
+        {config.username}
+      </Typography>
+      <Typography variant="body1">
+        <strong>Database: </strong>
+        {config.database}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/cards/sqlServerCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/sqlServerCard.tsx
@@ -1,7 +1,8 @@
 import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
-import { Integration, SqlServerConfig } from '../../../utils/integrations';
 import React from 'react';
+
+import { Integration, SqlServerConfig } from '../../../utils/integrations';
 
 type Props = {
   integration: Integration;

--- a/src/ui/common/src/index.tsx
+++ b/src/ui/common/src/index.tsx
@@ -13,6 +13,7 @@ import { PostgresCard } from './components/integrations/cards/postgresCard';
 import { RedshiftCard } from './components/integrations/cards/redshiftCard';
 import { S3Card } from './components/integrations/cards/s3Card';
 import { SnowflakeCard } from './components/integrations/cards/snowflakeCard';
+import { SqlServerCard } from './components/integrations/cards/sqlServerCard';
 import { ConnectedIntegrations } from './components/integrations/connectedIntegrations';
 import { BigQueryDialog } from './components/integrations/dialogs/bigqueryDialog';
 import { CSVDialog } from './components/integrations/dialogs/csvDialog';
@@ -496,6 +497,7 @@ export {
   SnowflakeConfig,
   SnowflakeDialog,
   Spec,
+  SqlServerCard,
   SqlServerConfig,
   Status,
   StatusBarHeaderHeightInPx,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR moves the SqlServer integration card over to @aqueducthq/common.

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1418/export-spiraldemocard-and-sqlservercard-from-aqueducthqcommon-library

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


