### PR TITLE
Fix a bug where we couldn't execute imported functions

### DIFF
--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -57,7 +57,7 @@ def _import_invoke_method(spec: FunctionSpec) -> Callable[..., DataFrame]:
     work_dir = os.path.join(fn_path, OP_DIR)
     print(f"listdir(workdir): {os.listdir(work_dir)}")
     print(f"listdir(fn_path): {os.listdir(fn_path)}")
-    
+
     # this ensures any file manipulation happens with respect to work_dir
     os.chdir(work_dir)
     # adds work_dir to sys.path to support relative imports from work_dir

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -55,10 +55,8 @@ def _import_invoke_method(spec: FunctionSpec) -> Callable[..., DataFrame]:
 
     # work_dir should be `<storage>/operators/<id>/op`
     work_dir = os.path.join(fn_path, OP_DIR)
-    print("listdir(workdir)")
-    print(os.listdir(work_dir))
-    print("listdir(fn_path)")
-    print(os.listdir(fn_path))
+    print(f"listdir(workdir): {os.listdir(work_dir)}")
+    print(f"listdir(fn_path): {os.listdir(fn_path)}")
     
     # this ensures any file manipulation happens with respect to work_dir
     os.chdir(work_dir)

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -40,17 +40,32 @@ def _get_py_import_path(spec: FunctionSpec) -> str:
 
     if file_path.startswith("/"):
         file_path = file_path[1:]
-    return ".".join([OP_DIR, file_path.replace("/", ".")])
+    return file_path.replace("/", ".")
 
 
 def _import_invoke_method(spec: FunctionSpec) -> Callable[..., DataFrame]:
+    # `_import_invoke_method` imports the model object.
+    # it assumes the operator has been extracted to `<storage>/operators/<id>/op`
+    # and imports the route from the above path.
+
+    # fn_path should be `<storage>/operators/<id>`
     fn_path = spec.function_extract_path
-    os.chdir(os.path.join(fn_path, OP_DIR))
-    sys.path.append(fn_path)
+
+    # work_dir should be `<storage>/operators/<id>/op`
+    work_dir = os.path.join(fn_path, OP_DIR)
+    print("listdir workdir")
+    print(os.listdir(work_dir))
+    print("listdir fn path")
+    print(os.listdir(fn_path))
+    os.chdir(work_dir)
+    sys.path.append(work_dir)
+
     import_path = _get_py_import_path(spec)
+    print(f"import_path: {import_path}")
     class_name = spec.entry_point_class
     method_name = spec.entry_point_method
     custom_args_str = spec.custom_args
+
     # Invoke the function and parse out the result object.
     module = importlib.import_module(import_path)
     if not class_name:

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -44,20 +44,25 @@ def _get_py_import_path(spec: FunctionSpec) -> str:
 
 
 def _import_invoke_method(spec: FunctionSpec) -> Callable[..., DataFrame]:
-    # `_import_invoke_method` imports the model object.
-    # it assumes the operator has been extracted to `<storage>/operators/<id>/op`
-    # and imports the route from the above path.
+    """
+    `_import_invoke_method` imports the model object.
+    it assumes the operator has been extracted to `<storage>/operators/<id>/op`
+    and imports the route from the above path.
+    """
 
     # fn_path should be `<storage>/operators/<id>`
     fn_path = spec.function_extract_path
 
     # work_dir should be `<storage>/operators/<id>/op`
     work_dir = os.path.join(fn_path, OP_DIR)
-    print("listdir workdir")
+    print("listdir(workdir)")
     print(os.listdir(work_dir))
-    print("listdir fn path")
+    print("listdir(fn_path)")
     print(os.listdir(fn_path))
+    
+    # this ensures any file manipulation happens with respect to work_dir
     os.chdir(work_dir)
+    # adds work_dir to sys.path to support relative imports from work_dir
     sys.path.append(work_dir)
 
     import_path = _get_py_import_path(spec)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the bug that we couldn't execute imported functions like the following:
```
from external import func

@aqueduct.op(file_dependencies=["external.py"])
def copy_field(df):
    return func(df)

copy_field(inputs).get()
```

Specifically, we fixed the `sys.path` which we used to import user functions to make sure the dependencies also properly appears in `sys.path`. We also added a few debugging logs for the extracted operator files.

## Related issue number (if any)
ENG-1451

## Checklist before requesting a review
Verified the code snippet above works after fix
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [na] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [na] If this is a new feature, I have added unit tests and integration tests.
- [na] (in-PR tests should be sufficient) I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [na] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


