### PR TITLE
[ENG-1412, 1413, 1414] Fixes CSV upload modal bugs

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -28,7 +28,7 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     const allRows = file.data.split(/\r?\n/);
     const parsedHeader = ['id'];
     parsedHeader.push(...allRows[0].split(/,/));
-    
+
     const width = 25;
     const parsedColumns = parsedHeader.map((headerName) => {
       let hideColumn = false;
@@ -51,10 +51,10 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
         if (headerName === 'id') {
           parsedRow[headerName] = id;
         } else {
-          parsedRow[headerName] = row[i-1];
+          parsedRow[headerName] = row[i - 1];
         }
       });
-      
+
       return parsedRow;
     });
 

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -28,6 +28,7 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     const allRows = file.data.split(/\r?\n/);
     const parsedHeader = ['id'];
     parsedHeader.push(...allRows[0].split(/,/));
+    console.log('header is', parsedHeader);
     const width = 25;
     const parsedColumns = parsedHeader.map((headerName) => {
       let hideColumn = false;
@@ -35,6 +36,12 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
         hideColumn = true;
       }
 
+      console.log({
+        field: headerName,
+        headerName: headerName,
+        width: width * headerName.length,
+        hide: hideColumn,
+      });
       return {
         field: headerName,
         headerName: headerName,
@@ -42,10 +49,23 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
         hide: hideColumn,
       };
     });
+
     const parsedRows = allRows.slice(1).map((line, id) => {
       const row = line.split(/,/);
-      const parsedRow = { id: id };
-      parsedHeader.forEach((headerName, i) => (parsedRow[headerName] = row[i]));
+      const parsedRow = {};
+      parsedHeader.forEach((headerName, i) => {
+        if (headerName === 'id') {
+          parsedRow[headerName] = id;
+        } else {
+          parsedRow[headerName] = row[i-1];
+        }
+      });
+      
+      if (id === 0) {
+        console.log(row)
+        console.log(parsedHeader);
+        console.log(parsedRow);
+      }
       return parsedRow;
     });
 

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -28,7 +28,7 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     const allRows = file.data.split(/\r?\n/);
     const parsedHeader = ['id'];
     parsedHeader.push(...allRows[0].split(/,/));
-    console.log('header is', parsedHeader);
+    
     const width = 25;
     const parsedColumns = parsedHeader.map((headerName) => {
       let hideColumn = false;
@@ -36,12 +36,6 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
         hideColumn = true;
       }
 
-      console.log({
-        field: headerName,
-        headerName: headerName,
-        width: width * headerName.length,
-        hide: hideColumn,
-      });
       return {
         field: headerName,
         headerName: headerName,
@@ -61,11 +55,6 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
         }
       });
       
-      if (id === 0) {
-        console.log(row)
-        console.log(parsedHeader);
-        console.log(parsedRow);
-      }
       return parsedRow;
     });
 

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -30,10 +30,16 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     parsedHeader.push(...allRows[0].split(/,/));
     const width = 25;
     const parsedColumns = parsedHeader.map((headerName) => {
+      let hideColumn = false;
+      if (headerName === 'id') {
+        hideColumn = true;
+      }
+
       return {
         field: headerName,
         headerName: headerName,
         width: width * headerName.length,
+        hide: hideColumn,
       };
     });
     const parsedRows = allRows.slice(1).map((line, id) => {

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -108,7 +108,7 @@ export const AddTableDialog: React.FC<AddTableDialogProps> = ({
   };
 
   return (
-    <Dialog open={true} onClose={onCloseDialog}>
+    <Dialog open={true} onClose={onCloseDialog} fullWidth maxWidth="lg">
       <DialogTitle>{dialogHeader}</DialogTitle>
       <DialogContent>
         {serviceDialog}

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -292,7 +292,10 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             user={user}
             integrationId={selectedIntegration.id}
             onCloseDialog={() => setShowDialog(false)}
-            onConnect={() => forceLoadTableList()}
+            onConnect={() => {
+              forceLoadTableList();
+              setShowDialog(false);
+            }}
           />
         )}
       </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes

The CSV upload modal had a few bugs that made it confusing to use. This PR fixes the following:
* ENG-1412: The modal was way too narrow, so you couldn't see any of the data you uploaded.
* ENG-1413: The modal didn't close after upload, so it seemed like nothing actually uploaded.
* ENG-1414: The preview showed an ID column that wasn't included in the original data.

<img width="2160" alt="image" src="https://user-images.githubusercontent.com/867892/181384730-ee5998b2-f255-4028-b402-3dea4c7633c0.png">

There's still a tiny bug where I'd like to have the dialog expand to show the full 5 rows, but I couldn't fix that quickly.

## Related issue number (if any)

See above

## Checklist before requesting a review
- [X] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [X] I have performed a self-review of my code.
- [X] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [N/A] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [X] All features on the UI continue to work correctly.
- [X] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


