### PR TITLE
[Bugfix] Fix bug where requirements.txt was not installing

### DIFF
--- a/src/python/aqueduct_executor/operators/function_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/function_executor/spec.py
@@ -54,6 +54,4 @@ def parse_spec(spec_json: bytes) -> FunctionSpec:
     Parses a JSON string into a FunctionSpec.
     """
     data = json.loads(spec_json)
-    print("JSON Function Spec: ", data)
-
     return parse_obj_as(FunctionSpec, data)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The script `get_extract_path` cannot print out anything except the function extract path. Once it prints something out, the FUNCTION_EXTRACT_PATH gets all messed up and we're unable to do requirements installation or cleanup.

Will be adding test coverage for this as part of https://linear.app/aqueducthq/issue/ENG-1217/infer-requirements-without-pipreqsnb-in-sdk

## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


