### PR TITLE
[ENG-1354, 1415] Fixes bottom sidesheet and ReactFlow alignment issues

### DIFF
--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint '*/**/*.{js,ts,tsx}' --format table --fix"
   },
   "dependencies": {
-    "@aqueducthq/common": "^0.0.11",
+    "@aqueducthq/common": "^0.0.11-rc10",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/src/ui/common/package.json
+++ b/src/ui/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aqueducthq/common",
   "author": "Aqueduct <hello@aqueducthq.com",
-  "version": "0.0.11",
+  "version": "0.0.11-rc0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "alias": {

--- a/src/ui/common/src/components/layouts/sidebar/AqueductSidebar.tsx
+++ b/src/ui/common/src/components/layouts/sidebar/AqueductSidebar.tsx
@@ -151,9 +151,8 @@ export const AqueductSidebar: React.FC<Props> = ({
     // open bottom to top
     bottomAligned: {
       position: 'absolute',
-      right: bottomSideSheetOffset,
+      left: MenuSidebarOffset,
       bottom: 0,
-      mx: `${BottomSidebarMarginInPx}px`,
       transition: AllTransition,
       width: bottomSideSheetWidth,
       height: `${BottomSidebarHeightInPx}px`,

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -300,13 +300,13 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             mt: 2,
             p: 3,
             mb: contentBottomOffsetInPx,
+            width: '100%',
+            boxSizing: 'border-box',
             backgroundColor: 'gray.50',
           }}
         >
           <ReactFlowProvider>
             <ReactFlowCanvas
-              nodes={dagPosition.result?.nodes}
-              edges={dagPosition.result?.edges}
               switchSideSheet={switchSideSheet}
               onPaneClicked={onPaneClicked}
             />

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -1,4 +1,3 @@
-import { CircularProgress } from '@mui/material';
 import React, { useEffect } from 'react';
 import ReactFlow, {
   Node as ReactFlowNode,
@@ -44,13 +43,6 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     // we're not 100% sure.
     setTimeout(fitView, 200);
   }, [openSideSheetState]);
-
-  if (
-    dagPositionState.result?.nodes === undefined ||
-    dagPositionState.result?.edges === undefined
-  ) {
-    return <CircularProgress />;
-  }
 
   return (
     <ReactFlow

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -1,6 +1,6 @@
+import { CircularProgress } from '@mui/material';
 import React, { useEffect } from 'react';
 import ReactFlow, {
-  Edge,
   Node as ReactFlowNode,
   useReactFlow,
 } from 'react-flow-renderer';
@@ -19,23 +19,23 @@ type ReactFlowCanvasProps = {
     event: React.MouseEvent,
     element: ReactFlowNode<ReactFlowNodeData>
   ) => void;
-  nodes: ReactFlowNode<ReactFlowNodeData>[];
-  edges: Edge[];
 };
 
 const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
   onPaneClicked,
   switchSideSheet,
-  nodes,
-  edges,
 }) => {
   const openSideSheetState = useSelector(
     (state: RootState) => state.openSideSheetReducer
   );
-  const { fitView } = useReactFlow();
+  const dagPositionState = useSelector(
+    (state: RootState) => state.workflowReducer.selectedDagPosition
+  );
+
+  const { fitView, viewportInitialized } = useReactFlow();
   useEffect(() => {
     fitView();
-  }, []);
+  }, [dagPositionState]);
 
   useEffect(() => {
     // NOTE(vikram): There's a timeout here because there seems to be a
@@ -45,11 +45,18 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     setTimeout(fitView, 200);
   }, [openSideSheetState]);
 
+  if (
+    dagPositionState.result?.nodes === undefined ||
+    dagPositionState.result?.edges === undefined
+  ) {
+    return <CircularProgress />;
+  }
+
   return (
     <ReactFlow
       onPaneClick={onPaneClicked}
-      nodes={nodes}
-      edges={edges}
+      nodes={dagPositionState.result?.nodes}
+      edges={dagPositionState.result?.edges}
       onNodeClick={switchSideSheet}
       nodeTypes={nodeTypes}
       connectionLineStyle={connectionLineStyle}


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR fixes two bugs around the layout of the ReactFlow canvas and the bottom sidesheet:
* The fix for ENG-1354 is around calling `fitView` at the right time. Because we were previously calling `fitView` on `componentDidMount`, it didn't actually work on the first load because the nodes and edges were loaded in _after_ the component was mounted. This PR changes the `fitView` effect so that it also is called when the node/edge positions are changed, which causes the view to be fit correctly (after a small lag) on first load.
* This PR also fixes ENG-1415 simplifies absolute positioning of the bottom side sheet so that it properly aligns with the ReactFlow viewport (see screenshot below): 

(Ignore the miscolored artifacts; that's because my local backend isn't updated.)
<img width="2160" alt="image" src="https://user-images.githubusercontent.com/867892/181641431-613163c3-2d63-419d-885e-2db85e15006b.png">


## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


