### PR TITLE
Update Integration Test Timeout

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
         run: pip3 install nltk matplotlib pytest-xdist
 
       - name: Wait for server again
-        timeout-minutes: 1
+        timeout-minutes: 5
         run: while ! echo exit | nc localhost 8080; do sleep 1; done
 
       - name: Fetch the API key


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Updates integration test timeout to wait 5 minutes instead of 1 for server to start.

Hoping that this will remedy failing test here: https://github.com/aqueducthq/aqueduct/runs/7566139306?check_suite_focus=true
per @kenxu95 's suggestion.


## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


