### PR TITLE
[ENG-1459] Removes need to provide API key, server address when running locally

### DIFF
--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -68,17 +68,21 @@ class Client:
 
     def __init__(
         self,
-        api_key: str,
-        aqueduct_address: str,
+        api_key: str = "",
+        aqueduct_address: str = "http://localhost:8080",
         log_level: int = logging.ERROR,
     ):
         """Creates an instance of Client.
 
         Args:
             api_key:
-                The user unique API key provided by Aqueduct.
+                The user unique API key provided by Aqueduct. If no key is
+                provided, the client attempts to read the key stored on the
+                local server and errors if non exists.
             aqueduct_address:
-                The address of the Aqueduct Server service.
+                The address of the Aqueduct Server service. If no address is
+                provided, the client attempts to connect to
+                http://localhost:8080.
             log_level:
                 A indication of what level and above to print logs from the sdk.
                 Defaults to printing error and above only. Types defined in: https://docs.python.org/3/howto/logging.html
@@ -86,6 +90,9 @@ class Client:
         Returns:
             A Client instance.
         """
+        if api_key == "":
+            api_key = get_apikey()
+
         logging.basicConfig(level=log_level)
         self._api_client = APIClient(api_key, aqueduct_address)
         self._connected_integrations: Dict[


### PR DESCRIPTION
## Describe your changes and why you are making these changes

When running on the same machine as the Aqueduct server, the user shouldn't need to provide the API key or address of the server explicitly -- we should be able to automatically detect it. This PR makes the `api_key` and `aqueduct_address` arguments optional on the API client. 

## Related issue number (if any)

ENG-1459

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


