### PR TITLE
Improve and logging in our SDK

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 10
+        timeout-minutes: 15
         working-directory: integration_tests/sdk
         env:
           SERVER_ADDRESS: localhost:8080

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -13,7 +13,7 @@ from aqueduct.error import (
     NoConnectedIntegrationsException,
 )
 from aqueduct.integrations.integration import IntegrationInfo
-from aqueduct.logger import Logger
+from aqueduct.logger import logger
 from aqueduct.operators import Operator
 from aqueduct.responses import (
     GetWorkflowResponse,
@@ -161,7 +161,9 @@ class APIClient:
         self._check_config()
         if use_https is None:
             use_https = self.use_https
-        return "%s%s" % (self.construct_base_url(use_https), route_suffix)
+        url = "%s%s" % (self.construct_base_url(use_https), route_suffix)
+        logger().debug("Constructed full URL %s", url)
+        return url
 
     def _test_connection_protocol(self, try_http: bool, try_https: bool) -> bool:
         """Returns whether the connection uses https. Raises an exception if unable to connect at all.
@@ -176,7 +178,7 @@ class APIClient:
                 self._test_url(url)
                 return True
             except Exception as e:
-                Logger.logger.info(
+                logger().info(
                     "Testing if connection is HTTPS fails with:\n{}: {}".format(type(e).__name__, e)
                 )
 
@@ -186,7 +188,7 @@ class APIClient:
                 self._test_url(url)
                 return False
             except Exception as e:
-                Logger.logger.info(
+                logger().info(
                     "Testing if connection is HTTP fails with:\n{}: {}".format(type(e).__name__, e)
                 )
 

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -34,6 +34,7 @@ from .integrations.integration import IntegrationInfo
 from .integrations.s3_integration import S3Integration
 from .integrations.salesforce_integration import SalesforceIntegration
 from .integrations.sql_integration import RelationalDBIntegration
+from .logger import logger
 from .operators import Operator, OperatorSpec, ParamSpec, serialize_parameter_value
 from .param_artifact import ParamArtifact
 from .utils import (
@@ -59,7 +60,7 @@ def get_apikey() -> str:
         try:
             return str(yaml.safe_load(f)["apiKey"])
         except yaml.YAMLError as exc:
-            print(
+            logger().error(
                 "This API works only when you are running the server and the SDK on the same machine."
             )
             exit(1)
@@ -81,7 +82,7 @@ class Client:
         self,
         api_key: str = "",
         aqueduct_address: str = "http://localhost:8080",
-        log_level: int = logging.ERROR,
+        logging_level: int = logging.WARNING,
     ):
         """Creates an instance of Client.
 
@@ -94,17 +95,18 @@ class Client:
                 The address of the Aqueduct Server service. If no address is
                 provided, the client attempts to connect to
                 http://localhost:8080.
-            log_level:
+            logging_level:
                 A indication of what level and above to print logs from the sdk.
-                Defaults to printing error and above only. Types defined in: https://docs.python.org/3/howto/logging.html
+                Defaults to printing warning and above only. Types defined in: https://docs.python.org/3/howto/logging.html
 
         Returns:
             A Client instance.
         """
+        logger().setLevel(level=logging_level)
+
         if api_key == "":
             api_key = get_apikey()
 
-        logging.basicConfig(level=log_level)
         api_client.__GLOBAL_API_CLIENT__.configure(api_key, aqueduct_address)
         self._connected_integrations: Dict[
             str, IntegrationInfo

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -11,6 +11,7 @@ from aqueduct.error import (
     InvalidUserActionException,
     InvalidUserArgumentException,
 )
+from aqueduct.logger import logger
 from aqueduct.operators import (
     Operator,
     OperatorSpec,
@@ -335,8 +336,8 @@ class AddOrReplaceOperatorDelta(DAGDelta):
                         "because it is a dependency of the new operator." % self.op.name,
                     )
 
-            print(
-                "Warning: You are overwriting the previously defined operator `%s`. Any downstream "
+            logger().info(
+                "The previously defined operator `%s` is being overwritten. Any downstream "
                 "artifacts of that operator will need to be recomputed and re-saved." % self.op.name
             )
             for op_id in downstream_op_ids:

--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -10,7 +10,7 @@ from aqueduct import api_client
 
 from .enums import ArtifactType, OperatorType
 from .flow_run import FlowRun
-from .logger import Logger
+from .logger import logger
 from .operators import OperatorSpec, ParamSpec
 from .responses import WorkflowDagResponse, WorkflowDagResultResponse
 from .utils import format_header_for_print, generate_ui_url, parse_user_supplied_id
@@ -77,7 +77,7 @@ class Flow:
 
             # Skip the parameter update if the parameter was never computed.
             if len(param_val) == 0:
-                Logger.logger.error(
+                logger().warning(
                     "The parameter %s was not successfully computed. If you triggered this flow run with custom "
                     "parameters, those parameter values will not be reflected in `FlowRun.describe()."
                     % param_artifact.name

--- a/sdk/aqueduct/logger.py
+++ b/sdk/aqueduct/logger.py
@@ -1,11 +1,12 @@
 import logging
 
 
-class Logger:
+def logger() -> logging.Logger:
     """
-    This class is the logger used by the Aqueduct SDK client.
+    This is the logger shared within the aqueduct module.
     ref: https://docs.python.org/3/howto/logging.html
 
+    The log level is configured by the Aqueduct client. If not configured, it will default
+    to level WARNING.
     """
-
-    logger = logging.getLogger(__name__)
+    return logging.getLogger(__name__)

--- a/sdk/aqueduct/tests/serialization_test.py
+++ b/sdk/aqueduct/tests/serialization_test.py
@@ -409,7 +409,6 @@ def test_load_serialization():
         ),
         inputs=[other_ids[0]],
     )
-    print(load_operator_s3.json(exclude_none=True))
     assert load_operator_s3.json(exclude_none=True) == json.dumps(
         {
             "id": str(op_id),

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -20,7 +20,7 @@ from croniter import croniter
 from .dag import DAG, RetentionPolicy, Schedule
 from .enums import TriggerType
 from .error import *
-from .logger import Logger
+from .logger import logger
 from .templates import op_file_content
 
 
@@ -269,7 +269,7 @@ def _package_files_and_requirements(
 
         if isinstance(requirements, str):
             if os.path.exists(requirements):
-                Logger.logger.error(
+                logger().info(
                     "Installing requirements found at {path}".format(path=requirements)
                 )
                 shutil.copy(requirements, packaged_requirements_path)
@@ -284,7 +284,7 @@ def _package_files_and_requirements(
 
     # If there already exists a requirements.txt in the same directory as the function.
     elif os.path.exists(REQUIREMENTS_FILE):
-        Logger.logger.info(
+        logger().info(
             "%s: requirements.txt file detected in current directory %s, will not self-generate by inferring package dependencies."
             % (os.getcwd(), func.__name__)
         )
@@ -292,7 +292,7 @@ def _package_files_and_requirements(
 
     # No requirements have been provided, so we do our best to infer.
     else:
-        Logger.logger.info(
+        logger().info(
             "%s: No requirements.txt file detected, self-generating file by inferring package dependencies."
             % func.__name__
         )
@@ -316,8 +316,8 @@ def _infer_requirements() -> List[str]:
             stderr=subprocess.PIPE,
         )
         stdout_raw, stderr_raw = process.communicate()
-        Logger.logger.debug("Inferred requirements raw stdout: %s", stdout_raw)
-        Logger.logger.debug("Inferred requirements raw stderr: %s", stderr_raw)
+        logger().debug("Inferred requirements raw stdout: %s", stdout_raw)
+        logger().debug("Inferred requirements raw stderr: %s", stderr_raw)
 
         return stdout_raw.decode("utf-8").split("\n")
     except Exception as e:

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -269,9 +269,7 @@ def _package_files_and_requirements(
 
         if isinstance(requirements, str):
             if os.path.exists(requirements):
-                logger().info(
-                    "Installing requirements found at {path}".format(path=requirements)
-                )
+                logger().info("Installing requirements found at {path}".format(path=requirements))
                 shutil.copy(requirements, packaged_requirements_path)
             else:
                 raise FileNotFoundError(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Main purpose was to address https://linear.app/aqueducthq/issue/ENG-1403/remove-warnings-about-overriding-an-existing-operator. I also took the chance to clean up our logging a little bit:
- `Logger.logger.info(...)` seemed pretty redundant. I don't see why we can't use `logger().info(..)`. We're not supposed to call functions from the root logger like `logging.info(..)`.
- Instead of adding a verbose flag, we can have the user configure the client with the correct logging level, the same way Ray does it https://docs.ray.io/en/latest/ray-core/package-ref.html#ray-remote. 

I'm also fine with us exposing a `verbose` argument and mapping that to `log.INFO`, whereas it's regularly `log.WARNING`. What do you think? I'd like to also be able to set log level to be DEBUG whenever I want, and I wasn't sure if that level should be included in verbose mode.

## Related issue number (if any)
ENG-1217

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


