### PR TITLE
[UI] fix metric operator node image being super small

### DIFF
--- a/src/ui/common/src/components/workflows/nodes/BaseNode.styles.tsx
+++ b/src/ui/common/src/components/workflows/nodes/BaseNode.styles.tsx
@@ -11,7 +11,8 @@ const BaseNode = styled(Box)({
   borderWidth: '2px',
   padding: '10px',
   maxWidth: '250px',
-  height: '140px',
+  minHeight: '140px',
+  maxHeight: '250px',
 });
 
 export { BaseNode };

--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -90,8 +90,7 @@ export const Node: React.FC<Props> = ({
           maxWidth: '200px',
           minWidth: '140px',
           overflow: 'clip',
-          textOverflow: 'wrap',
-          overflowWrap: 'normal',
+          overflowWrap: 'break-word',
           textAlign: 'center',
         }}
       >

--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -88,6 +88,7 @@ export const Node: React.FC<Props> = ({
         sx={{
           fontSize: '18px',
           maxWidth: '200px',
+          minWidth: '140px',
           overflow: 'clip',
           textOverflow: 'wrap',
           overflowWrap: 'normal',


### PR DESCRIPTION
## Describe your changes and why you are making these changes

fixes the unusually looking metric operator node image

Before change:
<img width="698" alt="image" src="https://user-images.githubusercontent.com/61630725/182215659-08bab914-3d8a-4469-b57b-0979da5443d4.png">

After change:
<img width="704" alt="image" src="https://user-images.githubusercontent.com/61630725/182215540-76ad6eaa-b192-48cc-8a94-d156b26d4dca.png">

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


