### PR TITLE
[ENG-1362, 1450] Fixes bug where user got unhelpful error message when Aqueduct server was off

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -272,7 +272,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
         {serviceDialog}
 
         {errMsg && (
-          <Alert sx={{ mt: 2}} severity="error">
+          <Alert sx={{ mt: 2 }} severity="error">
             <AlertTitle>Unable to connect to {service}</AlertTitle>
             <pre>{errMsg}</pre>
           </Alert>

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -1,6 +1,7 @@
 import { LoadingButton } from '@mui/lab';
 import {
   Alert,
+  AlertTitle,
   Box,
   DialogActions,
   DialogContent,
@@ -228,6 +229,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
   const confirmConnect = () => {
     setIsConnecting(true);
     setErrMsg(null);
+
     connectIntegration(user, service, name, config)
       .then(() => {
         setShowSuccessToast(true);
@@ -263,13 +265,15 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
   const [errMsg, setErrMsg] = useState(null);
 
   return (
-    <Dialog open={true} onClose={onCloseDialog}>
+    <Dialog open={true} onClose={onCloseDialog} fullWidth maxWidth="lg">
       <DialogTitle>{dialogHeader}</DialogTitle>
       <DialogContent>
         {nameInput}
         {serviceDialog}
+
         {errMsg && (
-          <Alert severity="error">
+          <Alert sx={{ mt: 2}} severity="error">
+            <AlertTitle>Unable to connect to {service}</AlertTitle>
             <pre>{errMsg}</pre>
           </Alert>
         )}

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -12,8 +12,11 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import { handleLoadIntegrations } from '../../../reducers/integrations';
+import { AppDispatch } from '../../../stores/store';
 import UserProfile from '../../../utils/auth';
 import {
   addTable,
@@ -158,6 +161,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
   service,
   onCloseDialog,
 }) => {
+  const dispatch: AppDispatch = useDispatch();
   const navigate = useNavigate();
   const [config, setConfig] = useState<IntegrationConfig>({});
   const [disableConnect, setDisableConnect] = useState(true);
@@ -235,6 +239,13 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
         setShowSuccessToast(true);
         setSuccessMessage('Successfully connected to ' + service + '!');
         setIsConnecting(false);
+
+        // Load the list of integrations again.
+        // Force the load because we've added a new integration.
+        dispatch(
+          handleLoadIntegrations({ apiKey: user.apiKey, forceLoad: true })
+        );
+
         onCloseDialog();
         navigate('/integrations');
       })

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -236,10 +236,14 @@ export async function connectIntegration(
       throw new Error(message.error);
     }
   } catch (err) {
-    if (err instanceof TypeError) { // This happens when we fail to fetch.
-      throw new Error("Unable to connect to the Aqueduct server. Please double check that the Aqueduct server is running and accessible.")
-    } else { // This should never happen.
-      throw err
+    if (err instanceof TypeError) {
+      // This happens when we fail to fetch.
+      throw new Error(
+        'Unable to connect to the Aqueduct server. Please double check that the Aqueduct server is running and accessible.'
+      );
+    } else {
+      // This should never happen.
+      throw err;
     }
   }
 }

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -219,19 +219,28 @@ export async function connectIntegration(
       config[k] = '';
     }
   });
-  const res = await fetch(`${apiAddress}/api/integration/connect`, {
-    method: 'POST',
-    headers: {
-      'api-key': user.apiKey,
-      'integration-name': name,
-      'integration-service': service,
-      'integration-config': JSON.stringify(config),
-    },
-  });
 
-  if (!res.ok) {
-    const message = await res.json();
-    throw new Error(message.error);
+  try {
+    const res = await fetch(`${apiAddress}/api/integration/connect`, {
+      method: 'POST',
+      headers: {
+        'api-key': user.apiKey,
+        'integration-name': name,
+        'integration-service': service,
+        'integration-config': JSON.stringify(config),
+      },
+    });
+
+    if (!res.ok) {
+      const message = await res.json();
+      throw new Error(message.error);
+    }
+  } catch (err) {
+    if (err instanceof TypeError) { // This happens when we fail to fetch.
+      throw new Error("Unable to connect to the Aqueduct server. Please double check that the Aqueduct server is running and accessible.")
+    } else { // This should never happen.
+      throw err
+    }
   }
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When the user tries to connect an integration but the Aqueduct server is off, they get a very confusing error message that simply says "Failed to fetch". This PR fixes that by explicitly checking when a fetch failed to happen. It also improves the integration connection modal by making it wider, so that stack traces display more legibly.

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/867892/182254742-e111914f-66eb-47e4-a470-c48e6996ef57.png">

This PR also fixes a tiny bug that I found where the list of integrations on the UI isn't refreshed after you connect a new integration. Turns out that was already logged as ENG-1450, but I only discovered that afterwards. 🙂

## Related issue number (if any)

ENG-1362, ENG-1450

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


