### PR TITLE
[ENG-1219, 1365, 1440] Improves usability of Aqueduct CLI

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -10,6 +10,8 @@ import string
 import subprocess
 import sys
 import time
+from tqdm import tqdm
+import webbrowser
 import zipfile
 
 import distro
@@ -32,11 +34,12 @@ s3_server_prefix = (
 )
 s3_ui_prefix = "https://aqueduct-ai.s3.us-east-2.amazonaws.com/assets/%s/ui" % package_version
 
+login_url = "http://%s:%d/login?apiKey=%s"
 welcome_message = """
 ***************************************************
 Your API Key: %s
 
-The Web UI and the backend server are accessible at: http://%s:%d
+The Web UI and the backend server are accessible at: http://%s:%d?apiKey=%s
 ***************************************************
 """
 
@@ -245,7 +248,10 @@ def generate_welcome_message(expose, port):
     else:
         expose_ip = "<IP_ADDRESS>"
     apikey = get_apikey()
-    return welcome_message % (apikey, expose_ip, port)
+    return (
+        welcome_message % (apikey, expose_ip, port, apikey), 
+        login_url % (expose_ip, port, apikey)
+    )
 
 def is_port_in_use(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -492,7 +498,11 @@ if __name__ == "__main__":
             if terminated:
                 print("Server terminated due to an error.")
             else:
-                print(generate_welcome_message(args.expose, server_port))
+                welcome_message, url = generate_welcome_message(args.expose, server_port)
+                print(welcome_message)
+
+                if not args.expose:
+                    webbrowser.open(url)
                 popen_handle.wait()
         except (Exception, KeyboardInterrupt) as e:
             print(e)

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -261,7 +261,13 @@ def generate_welcome_message(expose, port):
     if not expose:
         expose_ip = "localhost"
     else:
-        expose_ip = "<IP_ADDRESS>"
+        try:
+            expose_ip = requests.get(
+                "http://169.254.169.254/latest/meta-data/public-ipv4",
+                timeout=0.25).content
+        except: # If you're not running on EC2, this will return an error.
+            expose_ip = "<IP_ADDRESS>"
+
     apikey = get_apikey()
     return (
         welcome_message % (apikey, expose_ip, port, apikey), 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -41,7 +41,7 @@ welcome_message = """
 ***************************************************
 Your API Key: %s
 
-The Web UI and the backend server are accessible at: http://%s:%d?apiKey=%s
+The Web UI and the backend server are accessible at: http://%s:%d/login?apiKey=%s
 ***************************************************
 """
 
@@ -100,32 +100,39 @@ def update_executable_permissions():
     os.chmod(os.path.join(server_directory, "bin", "executor"), 0o755)
     os.chmod(os.path.join(server_directory, "bin", "migrator"), 0o755)
 
+
 def _download_file(s3_url, f, prefix=None):
     response = requests.get(s3_url, stream=True)
-    total_length = response.headers.get('content-length')
+    total_length = response.headers.get("content-length")
 
-    if not total_length: # content-length header was not included
+    if not total_length:  # content-length header was not included
         f.write(response.content)
-    else: 
+    else:
         total_length = int(total_length)
-        for data in tqdm(response.iter_content(chunk_size=CHUNK_SIZE),
-                         total=math.ceil(total_length/CHUNK_SIZE),
-                         unit="KB", unit_scale=(CHUNK_SIZE / 1024),
-                         colour='#002F5E', ncols=100, desc=prefix):
+        for data in tqdm(
+            response.iter_content(chunk_size=CHUNK_SIZE),
+            total=math.ceil(total_length / CHUNK_SIZE),
+            unit="KB",
+            unit_scale=(CHUNK_SIZE / 1024),
+            colour="#002F5E",
+            ncols=100,
+            desc=prefix,
+        ):
             f.write(data)
 
 
 def download_server_binaries(architecture):
     print("Downloading server binaries...")
     with open(os.path.join(server_directory, "bin/server"), "wb") as f:
-        _download_file(os.path.join(s3_server_prefix,
-                                    f"bin/{architecture}/server"), f, "Server")
+        _download_file(os.path.join(s3_server_prefix, f"bin/{architecture}/server"), f, "Server")
     with open(os.path.join(server_directory, "bin/executor"), "wb") as f:
-        _download_file(os.path.join(s3_server_prefix,
-                                    f"bin/{architecture}/executor"), f, "Executor")
+        _download_file(
+            os.path.join(s3_server_prefix, f"bin/{architecture}/executor"), f, "Executor"
+        )
     with open(os.path.join(server_directory, "bin/migrator"), "wb") as f:
-        _download_file(os.path.join(s3_server_prefix,
-                                    f"bin/{architecture}/migrator"), f, "Migrator")
+        _download_file(
+            os.path.join(s3_server_prefix, f"bin/{architecture}/migrator"), f, "Migrator"
+        )
 
     print("Downloading integration set up scripts...")
     with open(os.path.join(server_directory, "bin/start-function-executor.sh"), "wb") as f:
@@ -171,7 +178,7 @@ def update_ui_version():
             if os.path.isdir(os.path.join(os.sep, "home", "ec2-user", "SageMaker")):
                 s3_path = os.path.join(s3_ui_prefix, "sagemaker", "ui.zip")
             else:
-                s3_path = os.path.join(s3_ui_prefix, 'default', 'ui.zip')
+                s3_path = os.path.join(s3_ui_prefix, "default", "ui.zip")
 
             _download_file(s3_path, f, "UI")
         with zipfile.ZipFile(ui_zip_path, "r") as zip:
@@ -195,7 +202,13 @@ def update_server_version():
     update_executable_permissions()
 
     execute_command(
-        [os.path.join(server_directory, "bin", "migrator"), "--type", "sqlite", "goto", SCHEMA_VERSION]
+        [
+            os.path.join(server_directory, "bin", "migrator"),
+            "--type",
+            "sqlite",
+            "goto",
+            SCHEMA_VERSION,
+        ]
     )
 
 
@@ -248,14 +261,17 @@ def update():
                 os.remove(version_file)
             exit(1)
 
+
 def execute_command(args, cwd=None):
     with subprocess.Popen(args, stdout=sys.stdout, stderr=sys.stderr, cwd=cwd) as proc:
         proc.communicate()
         if proc.returncode != 0:
             raise Exception("Error executing command: %s" % args)
 
+
 def execute_command_nonblocking(args, cwd=None):
     return subprocess.Popen(args, stdout=sys.stdout, stderr=sys.stderr, cwd=cwd)
+
 
 def generate_welcome_message(expose, port):
     if not expose:
@@ -263,20 +279,22 @@ def generate_welcome_message(expose, port):
     else:
         try:
             expose_ip = requests.get(
-                "http://169.254.169.254/latest/meta-data/public-ipv4",
-                timeout=0.25).content
-        except: # If you're not running on EC2, this will return an error.
+                "http://169.254.169.254/latest/meta-data/public-ipv4", timeout=0.25
+            ).content.decode("utf-8")
+        except:  # If you're not running on EC2, this will return an error.
             expose_ip = "<IP_ADDRESS>"
 
     apikey = get_apikey()
     return (
-        welcome_message % (apikey, expose_ip, port, apikey), 
-        login_url % (expose_ip, port, apikey)
+        welcome_message % (apikey, expose_ip, port, apikey),
+        login_url % (expose_ip, port, apikey),
     )
+
 
 def is_port_in_use(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("localhost", port)) == 0
+
 
 def start(expose, port):
     update()
@@ -286,7 +304,10 @@ def start(expose, port):
         while is_port_in_use(server_port):
             server_port += 1
         if not server_port == default_server_port:
-            print("Default port %d is occupied. Next available port is %d" % (default_server_port, server_port))
+            print(
+                "Default port %d is occupied. Next available port is %d"
+                % (default_server_port, server_port)
+            )
     else:
         server_port = int(port)
         print("Server will use the user-specified port %d" % server_port)
@@ -294,43 +315,58 @@ def start(expose, port):
     if expose:
         popen_handle = execute_command_nonblocking(
             [
-                os.path.join(server_directory, "bin", "server"), 
-                "--config", 
-                os.path.join(server_directory, "config", "config.yml"), 
+                os.path.join(server_directory, "bin", "server"),
+                "--config",
+                os.path.join(server_directory, "config", "config.yml"),
                 "--expose",
                 "--port",
                 str(server_port),
-            ], 
+            ],
         )
     else:
         popen_handle = execute_command_nonblocking(
             [
-                os.path.join(server_directory, "bin", "server"), 
-                "--config", 
+                os.path.join(server_directory, "bin", "server"),
+                "--config",
                 os.path.join(server_directory, "config", "config.yml"),
                 "--port",
                 str(server_port),
-            ], 
+            ],
         )
     return popen_handle, server_port
+
 
 def install_postgres():
     execute_command([sys.executable, "-m", "pip", "install", "psycopg2-binary"])
 
+
 def install_bigquery():
     execute_command([sys.executable, "-m", "pip", "install", "google-cloud-bigquery"])
+
 
 def install_snowflake():
     execute_command([sys.executable, "-m", "pip", "install", "snowflake-sqlalchemy"])
 
+
 def install_s3():
     execute_command([sys.executable, "-m", "pip", "install", "pyarrow"])
+
 
 def install_mysql():
     system = platform.system()
     if system == "Linux":
         if distro.id() == "ubuntu" or distro.id() == "debian":
-            execute_command(["sudo", "apt-get", "install", "-y", "python3-dev", "default-libmysqlclient-dev", "build-essential"])
+            execute_command(
+                [
+                    "sudo",
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "python3-dev",
+                    "default-libmysqlclient-dev",
+                    "build-essential",
+                ]
+            )
         elif distro.id() == "centos" or distro.id() == "rhel":
             execute_command(["sudo", "yum", "install", "-y", "python3-devel", "mysql-devel"])
         else:
@@ -339,24 +375,44 @@ def install_mysql():
         execute_command(["brew", "install", "mysql"])
     else:
         print("Unsupported operating system:", system)
-    
+
     execute_command([sys.executable, "-m", "pip", "install", "mysqlclient"])
+
 
 def install_sqlserver():
     system = platform.system()
     if system == "Linux":
         if distro.id() == "ubuntu":
-            execute_command(["bash", os.path.join(server_directory, "bin", "install_sqlserver_ubuntu.sh")])
+            execute_command(
+                ["bash", os.path.join(server_directory, "bin", "install_sqlserver_ubuntu.sh")]
+            )
         else:
             print("Unsupported distribution:", distro.id())
     elif system == "Darwin":
-        execute_command(["brew", "tap", "microsoft/mssql-release", "https://github.com/Microsoft/homebrew-mssql-release"])
+        execute_command(
+            [
+                "brew",
+                "tap",
+                "microsoft/mssql-release",
+                "https://github.com/Microsoft/homebrew-mssql-release",
+            ]
+        )
         execute_command(["brew", "update"])
-        execute_command(["HOMEBREW_NO_ENV_FILTERING=1", "ACCEPT_EULA=Y", "brew", "install", "msodbcsql17", "mssql-tools"])
+        execute_command(
+            [
+                "HOMEBREW_NO_ENV_FILTERING=1",
+                "ACCEPT_EULA=Y",
+                "brew",
+                "install",
+                "msodbcsql17",
+                "mssql-tools",
+            ]
+        )
     else:
         print("Unsupported operating system:", system)
-    
+
     execute_command([sys.executable, "-m", "pip", "install", "pyodbc"])
+
 
 def install(system):
     if system == "postgres":
@@ -374,38 +430,45 @@ def install(system):
     else:
         raise Exception("Unsupported system: %s" % system)
 
+
 def get_apikey():
     config_file = os.path.join(server_directory, "config", "config.yml")
     with open(config_file, "r") as f:
         try:
-            return yaml.safe_load(f)['apiKey']
+            return yaml.safe_load(f)["apiKey"]
         except yaml.YAMLError as exc:
             print(exc)
             exit(1)
 
+
 def apikey():
     print(get_apikey())
+
 
 def clear():
     shutil.rmtree(base_directory, ignore_errors=True)
 
+
 def version():
     print(package_version)
 
+
 def read_config():
-    with open(os.path.join(server_directory, "config", "config.yml"), 'r') as f:
+    with open(os.path.join(server_directory, "config", "config.yml"), "r") as f:
         config = yaml.safe_load(f)
     return config
 
+
 def write_config(config):
-    with open(os.path.join(server_directory, "config", "config.yml"), 'w') as f:
+    with open(os.path.join(server_directory, "config", "config.yml"), "w") as f:
         yaml.dump(config, f)
+
 
 def use_local_storage(path):
     config = read_config()
 
     path = os.path.join(server_directory, path)
-    
+
     file_config = {"directory": path}
     config["storageConfig"] = {
         "type": "file",
@@ -414,13 +477,14 @@ def use_local_storage(path):
 
     write_config(config)
 
+
 def use_s3_storage(region, bucket, creds_path, creds_profile):
     if not bucket.startswith("s3://"):
-        print('S3 path is malformed, it should be of the form s3://')
+        print("S3 path is malformed, it should be of the form s3://")
         sys.exit(1)
-        
+
     config = read_config()
-    
+
     s3_config = {
         "region": region,
         "bucket": bucket,
@@ -434,79 +498,114 @@ def use_s3_storage(region, bucket, creds_path, creds_profile):
 
     write_config(config)
 
+
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='The Aqueduct CLI')
+    parser = argparse.ArgumentParser(description="The Aqueduct CLI")
     subparsers = parser.add_subparsers(dest="command")
-    
-    start_args = subparsers.add_parser('start', help=
-                               '''This starts the Aqueduct server and the UI in a blocking
+
+    start_args = subparsers.add_parser(
+        "start",
+        help="""This starts the Aqueduct server and the UI in a blocking
                                fashion. To background the process run aqueduct start &.
 
                                Add --expose <IP_ADDRESS> to access the Aqueduct service from
                                an external server, where <IP_ADDRESS> is the
                                public IP of the server running the Aqueduct service.
-                               ''')
-    start_args.add_argument('--expose', default=False, action='store_true',
-                    help="Use this option to expose the server to the public.")
-    start_args.add_argument('--port', dest="port", help="Specify the port on which the Aqueduct server runs.")
-    server_args = subparsers.add_parser('server', help=
-                                   '''[DEPRECATED] This starts the Aqueduct server in a
+                               """,
+    )
+    start_args.add_argument(
+        "--expose",
+        default=False,
+        action="store_true",
+        help="Use this option to expose the server to the public.",
+    )
+    start_args.add_argument(
+        "--port", dest="port", help="Specify the port on which the Aqueduct server runs."
+    )
+    server_args = subparsers.add_parser(
+        "server",
+        help="""[DEPRECATED] This starts the Aqueduct server in a
                                    blocking fashion. To background the process,
-                                   run aqueduct server &.''')
-    server_args.add_argument('--expose', default=False, action='store_true',
-                    help="Use this option to expose the server to the public.")
-    ui_args = subparsers.add_parser('ui', help=
-                               '''[DEPRECATED] This starts the Aqueduct UI in a blocking
+                                   run aqueduct server &.""",
+    )
+    server_args.add_argument(
+        "--expose",
+        default=False,
+        action="store_true",
+        help="Use this option to expose the server to the public.",
+    )
+    ui_args = subparsers.add_parser(
+        "ui",
+        help="""[DEPRECATED] This starts the Aqueduct UI in a blocking
                                fashion. To background the process run aqueduct
                                ui &.
 
                                Add --expose <IP_ADDRESS> to access the UI from
                                an external server, where <IP_ADDRESS> is the
                                public IP of the server you are running on.
-                               ''')
-    ui_args.add_argument('--expose', dest="expose", 
-                    help="The IP address of the server running Aqueduct.") 
+                               """,
+    )
+    ui_args.add_argument(
+        "--expose", dest="expose", help="The IP address of the server running Aqueduct."
+    )
 
-    install_args = subparsers.add_parser('install', help=
-                             '''Install the required library dependencies for
-                             an Aqueduct connector to a third-party system.''')
-    install_args.add_argument('system', nargs=1, help="Supported integrations: postgres, mysql, sqlserver, s3, snowflake, bigquery.")
+    install_args = subparsers.add_parser(
+        "install",
+        help="""Install the required library dependencies for
+                             an Aqueduct connector to a third-party system.""",
+    )
+    install_args.add_argument(
+        "system",
+        nargs=1,
+        help="Supported integrations: postgres, mysql, sqlserver, s3, snowflake, bigquery.",
+    )
 
-    apikey_args = subparsers.add_parser('apikey', help="Display your Aqueduct API key.")
-    clear_args = subparsers.add_parser('clear', help="Erase your Aqueduct installation.")
-    version_args = subparsers.add_parser('version', help="Retrieve the package version number.")
+    apikey_args = subparsers.add_parser("apikey", help="Display your Aqueduct API key.")
+    clear_args = subparsers.add_parser("clear", help="Erase your Aqueduct installation.")
+    version_args = subparsers.add_parser("version", help="Retrieve the package version number.")
 
-    storage_args = subparsers.add_parser('storage', help=
-                               '''This changes the storage location for any new workflows created.
+    storage_args = subparsers.add_parser(
+        "storage",
+        help="""This changes the storage location for any new workflows created.
                                The change will take affect once you restart the Aqueduct server.
                                We are currently working on adding support for modifying the storage
                                location of existing workflows.
-                               ''')
-    storage_args.add_argument('--use', dest="storage_use", 
-                                choices=["local", "s3"], required=True,
-                                help="The following storage locations are supported: local, s3"
-                            )
-    storage_args.add_argument('--path', dest="storage_path", required=True, 
-                                help=
-                                '''For local storage this is the filepath of the storage directory.
+                               """,
+    )
+    storage_args.add_argument(
+        "--use",
+        dest="storage_use",
+        choices=["local", "s3"],
+        required=True,
+        help="The following storage locations are supported: local, s3",
+    )
+    storage_args.add_argument(
+        "--path",
+        dest="storage_path",
+        required=True,
+        help="""For local storage this is the filepath of the storage directory.
                                 This should be relative to the Aqueduct installation path.
                                 For S3 storage this is the S3 path, which should be of the form:
                                 s3://bucket/path/to/folder
-                                '''
-                            )
-    storage_args.add_argument('--region', dest="storage_s3_region", 
-                                help="The AWS S3 region where the bucket is located."
-                            )
-    storage_args.add_argument('--credentials', dest="storage_s3_creds", 
-                                default=aws_credentials_path,
-                                help='''The filepath to the AWS credentials to use.
-                                It defaults to ~/.aws/credentials'''
-                            )
-    storage_args.add_argument('--profile', dest="storage_s3_profile",
-                                default="default",
-                                help='''The AWS credentials profile to use. It uses default 
-                                if none is provided.'''
-                            )
+                                """,
+    )
+    storage_args.add_argument(
+        "--region", dest="storage_s3_region", help="The AWS S3 region where the bucket is located."
+    )
+    storage_args.add_argument(
+        "--credentials",
+        dest="storage_s3_creds",
+        default=aws_credentials_path,
+        help="""The filepath to the AWS credentials to use.
+                                It defaults to ~/.aws/credentials""",
+    )
+    storage_args.add_argument(
+        "--profile",
+        dest="storage_s3_profile",
+        default="default",
+        help="""The AWS credentials profile to use. It uses default 
+                                if none is provided.""",
+    )
 
     args = parser.parse_args()
     sysargs = sys.argv
@@ -527,15 +626,19 @@ if __name__ == "__main__":
                 popen_handle.wait()
         except (Exception, KeyboardInterrupt) as e:
             print(e)
-            print('\nTerminating Aqueduct service...')
+            print("\nTerminating Aqueduct service...")
             popen_handle.kill()
-            print('Aqueduct service successfully terminated.')
+            print("Aqueduct service successfully terminated.")
     elif args.command == "server":
-        print("aqueduct ui and aqueduct server have been deprecated; please use aqueduct start to run both the UI and backend servers")
+        print(
+            "aqueduct ui and aqueduct server have been deprecated; please use aqueduct start to run both the UI and backend servers"
+        )
     elif args.command == "install":
-        install(args.system[0]) # argparse makes this an array so only pass in value [0].
+        install(args.system[0])  # argparse makes this an array so only pass in value [0].
     elif args.command == "ui":
-        print("aqueduct ui and aqueduct server have been deprecated; please use aqueduct start to run both the UI and backend servers")
+        print(
+            "aqueduct ui and aqueduct server have been deprecated; please use aqueduct start to run both the UI and backend servers"
+        )
     elif args.command == "apikey":
         apikey()
     elif args.command == "clear":
@@ -557,9 +660,9 @@ if __name__ == "__main__":
                 print("--region is required when using S3 storage")
                 sys.exit(1)
             use_s3_storage(
-                args.storage_s3_region, 
-                args.storage_path, 
-                args.storage_s3_creds, 
+                args.storage_s3_region,
+                args.storage_path,
+                args.storage_s3_creds,
                 args.storage_s3_profile,
             )
         else:

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import math
 import os
 import platform
 import random
@@ -19,6 +20,7 @@ import requests
 import yaml
 
 SCHEMA_VERSION = "15"
+CHUNK_SIZE = 4096
 
 base_directory = os.path.join(os.environ["HOME"], ".aqueduct")
 server_directory = os.path.join(os.environ["HOME"], ".aqueduct", "server")
@@ -98,31 +100,42 @@ def update_executable_permissions():
     os.chmod(os.path.join(server_directory, "bin", "executor"), 0o755)
     os.chmod(os.path.join(server_directory, "bin", "migrator"), 0o755)
 
+def _download_file(s3_url, f, prefix=None):
+    response = requests.get(s3_url, stream=True)
+    total_length = response.headers.get('content-length')
+
+    if not total_length: # content-length header was not included
+        f.write(response.content)
+    else: 
+        total_length = int(total_length)
+        for data in tqdm(response.iter_content(chunk_size=CHUNK_SIZE),
+                         total=math.ceil(total_length/CHUNK_SIZE),
+                         unit="KB", unit_scale=(CHUNK_SIZE / 1024),
+                         colour='#002F5E', ncols=100, desc=prefix):
+            f.write(data)
+
 
 def download_server_binaries(architecture):
+    print("Downloading server binaries...")
     with open(os.path.join(server_directory, "bin/server"), "wb") as f:
-        f.write(requests.get(os.path.join(s3_server_prefix, f"bin/{architecture}/server")).content)
+        _download_file(os.path.join(s3_server_prefix,
+                                    f"bin/{architecture}/server"), f, "Server")
     with open(os.path.join(server_directory, "bin/executor"), "wb") as f:
-        f.write(
-            requests.get(os.path.join(s3_server_prefix, f"bin/{architecture}/executor")).content
-        )
+        _download_file(os.path.join(s3_server_prefix,
+                                    f"bin/{architecture}/executor"), f, "Executor")
     with open(os.path.join(server_directory, "bin/migrator"), "wb") as f:
-        f.write(
-            requests.get(os.path.join(s3_server_prefix, f"bin/{architecture}/migrator")).content
-        )
+        _download_file(os.path.join(s3_server_prefix,
+                                    f"bin/{architecture}/migrator"), f, "Migrator")
+
+    print("Downloading integration set up scripts...")
     with open(os.path.join(server_directory, "bin/start-function-executor.sh"), "wb") as f:
-        f.write(
-            requests.get(os.path.join(s3_server_prefix, "bin/start-function-executor.sh")).content
-        )
+        _download_file(os.path.join(s3_server_prefix, f"bin/start-function-executor.sh"), f)
     with open(os.path.join(server_directory, "bin/install_sqlserver_ubuntu.sh"), "wb") as f:
-        f.write(
-            requests.get(os.path.join(s3_server_prefix, "bin/install_sqlserver_ubuntu.sh")).content
-        )
-    print("Downloaded server binaries.")
+        _download_file(os.path.join(s3_server_prefix, f"bin/install_sqlserver_ubuntu.sh"), f)
+    print("Downloaded server binaries...")
 
 
 def setup_server_binaries():
-    print("Downloading server binaries.")
     server_bin_path = os.path.join(server_directory, "bin")
     shutil.rmtree(server_bin_path, ignore_errors=True)
     os.mkdir(server_bin_path)
@@ -145,7 +158,7 @@ def setup_server_binaries():
 
 
 def update_ui_version():
-    print("Updating UI version to %s" % package_version)
+    print("Updating UI version to %s..." % package_version)
     try:
         shutil.rmtree(ui_directory, ignore_errors=True)
         os.mkdir(ui_directory)
@@ -156,9 +169,11 @@ def update_ui_version():
             # directory /home/ec2-user/SageMaker exists. This is hacky but we couldn't find a better
             # solution at the moment.
             if os.path.isdir(os.path.join(os.sep, "home", "ec2-user", "SageMaker")):
-                f.write(requests.get(os.path.join(s3_ui_prefix, "sagemaker", "ui.zip")).content)
+                s3_path = os.path.join(s3_ui_prefix, "sagemaker", "ui.zip")
             else:
-                f.write(requests.get(os.path.join(s3_ui_prefix, "default", "ui.zip")).content)
+                s3_path = os.path.join(s3_ui_prefix, 'default', 'ui.zip')
+
+            _download_file(s3_path, f, "UI")
         with zipfile.ZipFile(ui_zip_path, "r") as zip:
             zip.extractall(ui_directory)
         os.remove(ui_zip_path)
@@ -169,7 +184,7 @@ def update_ui_version():
 
 
 def update_server_version():
-    print("Updating server version to %s" % package_version)
+    print("Updating server version to %s..." % package_version)
 
     version_file = os.path.join(server_directory, "__version__")
     if os.path.isfile(version_file):

--- a/src/ui/common/src/components/pages/LoginPage.tsx
+++ b/src/ui/common/src/components/pages/LoginPage.tsx
@@ -35,10 +35,8 @@ export const LoginPage: React.FC = () => {
   // is, then we automatically try to login with that API key.
   useEffect(() => {
     const key = searchParams.get(apiKeyQueryParam);
-    console.log('in useeffect, key is', key);
 
     if (key && key.length > 0) {
-      console.log('executing the if?');
       setApiKey(key);
       onGetStartedClicked(key);
     }


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR makes 3 quality of life improvements to the Aqueduct CLI:
* ENG-1219: To make launching Aqueduct simpler, this PR does two things -- (1) on the login page of the UI, it looks for a query parameter called `apiKey` and if such a parameter exists, attempts to auto-login with it; (2) uses the `webbrowser` package to attempt to open a browser tab with the Aqueduct UI and with the API key included as a query parameter.
* ENG-1365: Adds download bars to all of the file downloads -- especially since the server binaries are large-ish, this gives the user a sense that progress is being made.
* ENG-1440: On EC2 instances, if the `--expose` flag is passed in, we attempt to autodetect the public IP address of the machine and autopopulate it into our welcome message; if none is found, we default back to `<PUBLIC_IP>`

Still locked out of Loom, so settling for some screenshots:

<img width="872" alt="image" src="https://user-images.githubusercontent.com/867892/182453985-d0f5408b-8858-46c5-a8bc-e4e198e092ee.png">

<img width="865" alt="image" src="https://user-images.githubusercontent.com/867892/182454048-1db111cb-e24b-48f4-b1c9-0888544fdbd0.png">

There's also a bunch of formatting changes because it looks like we hadn't previously run `black` on this code.

## Related issue number (if any)

ENG-1219, ENG-1365, ENG-1440

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


