### PR TITLE
Make the format parameter type to the `s3.file` API string instead of enum

### DIFF
--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -57,11 +57,11 @@ class S3Integration(Integration):
             TableArtifact representing the concatenated S3 Files.
         """
         lowercased_format = format.lower()
-        if lowercased_format == "csv":
+        if lowercased_format == S3FileFormat.CSV.value.lower():
             format_enum = S3FileFormat.CSV
-        elif lowercased_format == "json":
+        elif lowercased_format == S3FileFormat.JSON.value.lower():
             format_enum = S3FileFormat.JSON
-        elif lowercased_format == "parquet":
+        elif lowercased_format == S3FileFormat.PARQUET.value.lower():
             format_enum = S3FileFormat.PARQUET
         else:
             raise Exception("Unsupport file format %s." % format)

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -29,7 +29,7 @@ class S3Integration(Integration):
     def file(
         self,
         filepaths: Union[List[str], str],
-        format: S3FileFormat,
+        format: str,
         name: Optional[str] = None,
         description: str = "",
     ) -> TableArtifact:
@@ -56,6 +56,16 @@ class S3Integration(Integration):
         Returns:
             TableArtifact representing the concatenated S3 Files.
         """
+        lowercased_format = format.lower()
+        if lowercased_format == "csv":
+            format_enum = S3FileFormat.CSV
+        elif lowercased_format == "json":
+            format_enum = S3FileFormat.JSON
+        elif lowercased_format == "parquet":
+            format_enum = S3FileFormat.PARQUET
+        else:
+            raise Exception("Unsupport file format %s." % format)
+
         integration_info = self._metadata
 
         op_name = generate_extract_op_name(self._dag, integration_info.name, name)
@@ -75,7 +85,7 @@ class S3Integration(Integration):
                                 service=integration_info.service,
                                 integration_id=integration_info.id,
                                 parameters=S3ExtractParams(
-                                    filepath=json.dumps(filepaths), format=format
+                                    filepath=json.dumps(filepaths), format=format_enum
                                 ),
                             )
                         ),

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -11,13 +11,13 @@ import string
 import subprocess
 import sys
 import time
-from tqdm import tqdm
 import webbrowser
 import zipfile
 
 import distro
 import requests
 import yaml
+from tqdm import tqdm
 
 SCHEMA_VERSION = "15"
 CHUNK_SIZE = 4096


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Since we don't have any S3 tests now, I tested manually with a notebook and verified that the user can now input upper case or lower case strings and as long as it matches one of the enums, things work.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


