### PR TITLE
Use React Router Linking on MenuSidebar

### DIFF
--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aqueducthq/common",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aqueducthq/common",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "hasInstallScript": true,
       "devDependencies": {
         "@babel/preset-react": "^7.17.12",

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -13,7 +13,7 @@ import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation, Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router-dom';
 
 import { handleFetchNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -13,7 +13,7 @@ import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link as RouterLink } from 'react-router-dom';
 
 import { handleFetchNotifications } from '../../reducers/notifications';
 import { AppDispatch, RootState } from '../../stores/store';
@@ -175,8 +175,9 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
     <>
       <Box className={styles['menu-sidebar-popover-container']}>
         <Link
-          href={`${pathPrefix.length > 0 ? pathPrefix : '/'}`}
+          to={`${pathPrefix.length > 0 ? pathPrefix : '/'}`}
           underline="none"
+          component={RouterLink as any}
         >
           <Typography variant="h3" sx={{ color: 'white' }}>
             Aqueduct
@@ -225,9 +226,10 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           open={userPopoverOpen}
         >
           <Link
-            href={`${getPathPrefix()}/account`}
+            to={`${getPathPrefix()}/account`}
             underline="none"
             sx={{ color: 'blue.800' }}
+            component={RouterLink as any}
           >
             <MenuItem sx={{ width: '190px' }} disableRipple>
               <Box sx={{ fontSize: '20px', mr: 1 }}>
@@ -263,9 +265,10 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           />
 
           <Link
-            href={`${getPathPrefix()}/workflows`}
+            to={`${getPathPrefix()}/workflows`}
             className={styles['menu-sidebar-link']}
             underline="none"
+            component={RouterLink as any}
           >
             <SidebarButton
               icon={
@@ -280,9 +283,10 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           </Link>
 
           <Link
-            href={`${getPathPrefix()}/integrations`}
+            to={`${getPathPrefix()}/integrations`}
             className={styles['menu-sidebar-link']}
             underline="none"
+            component={RouterLink as any}
           >
             <SidebarButton
               icon={
@@ -297,9 +301,10 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           </Link>
 
           <Link
-            href={`${getPathPrefix()}/data`}
+            to={`${getPathPrefix()}/data`}
             className={styles['menu-sidebar-link']}
             underline="none"
+            component={RouterLink as any}
           >
             <SidebarButton
               icon={

--- a/src/ui/common/src/utils/getPathPrefix.ts
+++ b/src/ui/common/src/utils/getPathPrefix.ts
@@ -5,7 +5,7 @@
 //
 // If no prefix is present, `getPathPrefix` returns an empty string.
 export const getPathPrefix = () => {
-  const location = window.location.pathname;
+  const location = window && window.location ? window.location.pathname : '';
 
   const result = location.match(SageMakerProxyRegex);
   if (!result) {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Updates menuSidebar to use react-router linking. Pages no longer need to trigger a browser refresh when transitioning from one page to another and now load instantly.

Loom Demo: https://www.loom.com/share/c0312eda788f4e3d96cc36d677cd12ad

## Related issue number (if any)
N/A

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


