### PR TITLE
Fix links in data page cards

### DIFF
--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import React from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 
 import { DataPreviewInfo } from '../../../utils/data';
 import { getPathPrefix } from '../../../utils/getPathPrefix';
@@ -44,7 +45,8 @@ export const DataCard: React.FC<DataProps> = ({ dataPreviewInfo }) => {
       <Link
         underline="none"
         color="inherit"
-        href={`/${getPathPrefix()}/workflow/${workflowId}`}
+        to={`${getPathPrefix()}/workflow/${workflowId}`}
+        component={RouterLink as any}
       >
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '900px' }}>
           <Box


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the issue where we didn't apply the right link for cards in `data/` page.

## Related issue number (if any)
ENG-1503

## Checklist before requesting a review
Before: https://www.loom.com/share/f9b4a7957c84445aabb8fb129de1e24d
After: https://www.loom.com/share/2b5a51b53f71432cb364de4fcd979aa0
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


