### PR TITLE
Allow operators to start their own execution if necessary

### DIFF
--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -303,7 +303,6 @@ func (eng *aqEngine) ExecuteWorkflow(
 		dag,
 		workflowRunMetadata,
 		timeConfig,
-		engineJobManager,
 		true, // should persist results
 	)
 	if err != nil {
@@ -375,7 +374,6 @@ func (eng *aqEngine) PreviewWorkflow(
 		dag,
 		workflowRunMetadata,
 		timeConfig,
-		jobManager,
 		false, // should not persist results
 	)
 	if err != nil {
@@ -689,7 +687,6 @@ func (eng *aqEngine) execute(
 	workflowDag dag_utils.WorkflowDag,
 	workflowRunMetadata *workflowRunMetadata,
 	timeConfig *AqueductTimeConfig,
-	jobManager job.JobManager,
 	shouldPersistResults bool,
 ) error {
 	// These are the operators of immediate interest. They either need to be scheduled or polled on.
@@ -726,8 +723,7 @@ func (eng *aqEngine) execute(
 			}
 
 			if execState.Status == shared.PendingExecutionStatus {
-				spec := op.JobSpec()
-				err = jobManager.Launch(ctx, spec.JobName(), spec)
+				err = op.Launch(ctx)
 				if err != nil {
 					return errors.Wrapf(err, "Unable to schedule operator %s.", op.Name())
 				}

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -78,6 +78,10 @@ func unknownSystemFailureExecState(err error, logMsg string) *shared.ExecutionSt
 	}
 }
 
+func (bo *baseOperator) launch(ctx context.Context, spec job.Spec) error {
+	return bo.jobManager.Launch(ctx, spec.JobName(), spec)
+}
+
 // fetchExecState assumes that the operator has been computed already.
 func (bo *baseOperator) fetchExecState(ctx context.Context) *shared.ExecutionState {
 	var execState shared.ExecutionState

--- a/src/golang/lib/workflow/operator/check.go
+++ b/src/golang/lib/workflow/operator/check.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/dropbox/godropbox/errors"
@@ -43,4 +45,8 @@ func newCheckOperator(base baseFunctionOperator) (Operator, error) {
 func (co *checkOperatorImpl) JobSpec() job.Spec {
 	fn := co.dbOperator.Spec.Check().Function
 	return co.jobSpec(&fn, &co.dbOperator.Spec.Check().Level)
+}
+
+func (co *checkOperatorImpl) Launch(ctx context.Context) error {
+	return co.launch(ctx, co.JobSpec())
 }

--- a/src/golang/lib/workflow/operator/extract.go
+++ b/src/golang/lib/workflow/operator/extract.go
@@ -77,3 +77,7 @@ func (eo *extractOperatorImpl) JobSpec() job.Spec {
 		OutputMetadataPath: eo.outputMetadataPaths[0],
 	}
 }
+
+func (eo *extractOperatorImpl) Launch(ctx context.Context) error {
+	return eo.launch(ctx, eo.JobSpec())
+}

--- a/src/golang/lib/workflow/operator/function.go
+++ b/src/golang/lib/workflow/operator/function.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
@@ -48,4 +49,8 @@ func newFunctionOperator(
 func (fo *functionOperatorImpl) JobSpec() job.Spec {
 	fn := fo.dbOperator.Spec.Function()
 	return fo.jobSpec(fn, nil /* checkSeverity */)
+}
+
+func (fo *functionOperatorImpl) Launch(ctx context.Context) error {
+	return fo.launch(ctx, fo.JobSpec())
 }

--- a/src/golang/lib/workflow/operator/load.go
+++ b/src/golang/lib/workflow/operator/load.go
@@ -72,3 +72,7 @@ func (lo *loadOperatorImpl) JobSpec() job.Spec {
 		InputMetadataPath: lo.inputMetadataPaths[0],
 	}
 }
+
+func (lo *loadOperatorImpl) Launch(ctx context.Context) error {
+	return lo.launch(ctx, lo.JobSpec())
+}

--- a/src/golang/lib/workflow/operator/metric.go
+++ b/src/golang/lib/workflow/operator/metric.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/dropbox/godropbox/errors"
@@ -43,4 +45,8 @@ func newMetricOperator(base baseFunctionOperator) (Operator, error) {
 func (mo *metricOperatorImpl) JobSpec() job.Spec {
 	fn := mo.dbOperator.Spec.Metric().Function
 	return mo.jobSpec(&fn, nil /* checkSeverity */)
+}
+
+func (mo *metricOperatorImpl) Launch(ctx context.Context) error {
+	return mo.launch(ctx, mo.JobSpec())
 }

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -23,6 +23,10 @@ type Operator interface {
 	JobSpec() job.Spec
 	MetadataPath() string
 
+	// Launch kicks off the execution of this operator, using operator's job spec.
+	// Poll on `GetExecState()` afterwards to determine when this operator has completed.
+	Launch(ctx context.Context) error
+
 	// GetExecState performs a non-blocking fetch for the execution state of this operator.
 	GetExecState(ctx context.Context) (*shared.ExecutionState, error)
 

--- a/src/golang/lib/workflow/operator/param.go
+++ b/src/golang/lib/workflow/operator/param.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
@@ -52,4 +53,8 @@ func (po *paramOperatorImpl) JobSpec() job.Spec {
 		OutputMetadataPath: po.outputMetadataPaths[0],
 		OutputContentPath:  po.outputContentPaths[0],
 	}
+}
+
+func (po *paramOperatorImpl) Launch(ctx context.Context) error {
+	return po.launch(ctx, po.JobSpec())
 }

--- a/src/golang/lib/workflow/operator/system_metric.go
+++ b/src/golang/lib/workflow/operator/system_metric.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/aqueducthq/aqueduct/lib/job"
@@ -48,4 +49,8 @@ func (smo *systemMetricOperatorImpl) JobSpec() job.Spec {
 		OutputMetadataPath: smo.outputMetadataPaths[0],
 		MetricName:         smo.dbOperator.Spec.SystemMetric().MetricName,
 	}
+}
+
+func (smo *systemMetricOperatorImpl) Launch(ctx context.Context) error {
+	return smo.launch(ctx, smo.JobSpec())
 }

--- a/src/golang/lib/workflow/operator/utils.go
+++ b/src/golang/lib/workflow/operator/utils.go
@@ -1,6 +1,8 @@
 package operator
 
-import "github.com/dropbox/godropbox/errors"
+import (
+	"github.com/dropbox/godropbox/errors"
+)
 
 var (
 	errWrongNumInputs  = errors.New("Wrong number of operator inputs")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Moves the `JobSpec()` then `JobManger.Launch()` pattern into `Operator.Launch()`. This sets us up for the caching layer to be inserted within `Operator.Launch()`.

`JobSpec()` will need to stay around because Airflow uses it.

## Related issue number (if any)
ENG-1497

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


