### PR TITLE
Remove aqueduct-ml/sdk from any requirements.txt

### DIFF
--- a/integration_tests/sdk/operator_test.py
+++ b/integration_tests/sdk/operator_test.py
@@ -1,8 +1,9 @@
 from aqueduct.decorator import to_operator
 from constants import SENTIMENT_SQL_QUERY
-from aqueduct import op
-from utils import get_integration_name, run_sentiment_model
 from test_function import dummy_sentiment_model_function
+from utils import get_integration_name, run_sentiment_model
+
+from aqueduct import op
 
 
 def test_to_operator_local_function(client):

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -113,7 +113,7 @@ RESERVED_FILE_NAMES = [
     CONDA_VERSION_FILE_NAME,
 ]
 REQUIREMENTS_FILE = "requirements.txt"
-BLACKLISTED_REQUIREMENTS = "aqueduct"
+BLACKLISTED_REQUIREMENTS = ["aqueduct-ml", "aqueduct-sdk"]
 
 UserFunction = Callable[..., pd.DataFrame]
 MetricFunction = Callable[..., float]
@@ -297,7 +297,24 @@ def _package_files_and_requirements(
         with open(packaged_requirements_path, "x") as f:
             f.write("\n".join(_infer_requirements()))
 
+    # Prune out any blacklisted requirements.
+    _filter_out_blacklisted_requirements(packaged_requirements_path)
+
     os.chdir(current_directory_path)
+
+
+def _filter_out_blacklisted_requirements(packaged_requirements_path: str) -> None:
+    """Opens the requirements.txt file and removes any packages that we don't support."""
+    with open(packaged_requirements_path, "r") as f:
+        req_lines = f.readlines()
+
+    with open(packaged_requirements_path, "w") as f:
+        for line in req_lines:
+            if any(
+                line.startswith(blacklisted_req) for blacklisted_req in BLACKLISTED_REQUIREMENTS
+            ):
+                continue
+            f.write(line)
 
 
 def _infer_requirements() -> List[str]:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
If these are also included in the uploaded requirements.txt, installing them spews the following error message (although things still work):

```
 Stderr:
   error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/Users/kennethxu/work/aqueduct/src/python/setup.py", line 9, in <module>
          long_description = open(readme_path).read()
      FileNotFoundError: [Errno 2] No such file or directory: '/Users/kennethxu/work/aqueduct/../../README.md'
      [end of output]
```

Filtering them out fixes this


## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


