### PR TITLE
[UI] fix the odd look for system metric operator node

### DIFF
--- a/src/ui/common/src/reducers/nodeSelection.ts
+++ b/src/ui/common/src/reducers/nodeSelection.ts
@@ -24,6 +24,7 @@ export const OperatorTypeToNodeTypeMap: { [key in OperatorType]: NodeType } = {
   [OperatorType.Function]: NodeType.FunctionOp,
   [OperatorType.Check]: NodeType.CheckOp,
   [OperatorType.Param]: NodeType.ParamOp,
+  [OperatorType.System_metric]: NodeType.MetricOp,
 } as const;
 
 export const ArtifactTypeToNodeTypeMap: { [key in ArtifactType]: NodeType } = {

--- a/src/ui/common/src/reducers/nodeSelection.ts
+++ b/src/ui/common/src/reducers/nodeSelection.ts
@@ -24,7 +24,7 @@ export const OperatorTypeToNodeTypeMap: { [key in OperatorType]: NodeType } = {
   [OperatorType.Function]: NodeType.FunctionOp,
   [OperatorType.Check]: NodeType.CheckOp,
   [OperatorType.Param]: NodeType.ParamOp,
-  [OperatorType.System_metric]: NodeType.MetricOp,
+  [OperatorType.SystemMetric]: NodeType.MetricOp,
 } as const;
 
 export const ArtifactTypeToNodeTypeMap: { [key in ArtifactType]: NodeType } = {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -9,6 +9,7 @@ export enum OperatorType {
   Metric = 'metric',
   Check = 'check',
   Param = 'param',
+  System_metric= "system_metric"
 }
 
 export enum FunctionType {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -9,7 +9,7 @@ export enum OperatorType {
   Metric = 'metric',
   Check = 'check',
   Param = 'param',
-  SystemMetric = 'system_metric'
+  SystemMetric = 'system_metric',
 }
 
 export enum FunctionType {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -9,7 +9,7 @@ export enum OperatorType {
   Metric = 'metric',
   Check = 'check',
   Param = 'param',
-  SystemMetric = "system_metric"
+  SystemMetric = 'system_metric'
 }
 
 export enum FunctionType {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -9,7 +9,7 @@ export enum OperatorType {
   Metric = 'metric',
   Check = 'check',
   Param = 'param',
-  System_metric= "system_metric"
+  SystemMetric = "system_metric"
 }
 
 export enum FunctionType {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
fix the odd look for system metric operator node
Before:
<img width="780" alt="image" src="https://user-images.githubusercontent.com/61630725/182939170-0d1b2254-a0ec-4d11-874c-9a58269013c8.png">

After:
<img width="852" alt="image" src="https://user-images.githubusercontent.com/61630725/182939119-3f1276ad-501e-41cc-bbb4-9441ffccf0c0.png">

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


