### PR TITLE
Update to_operator() naming

### DIFF
--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -480,7 +480,7 @@ def to_operator(
     name: Optional[Union[str, UserFunction]] = None,
     description: Optional[str] = None,
     file_dependencies: Optional[List[str]] = None,
-    reqs_path: Optional[str] = None,
+    requirements: Optional[Union[str, List[str]]] = None,
 ) -> Union[Callable[..., OutputArtifact], OutputArtifact]:
     """Convert a function that returns a dataframe into an Aqueduct operator.
 
@@ -499,6 +499,6 @@ def to_operator(
             A path to file that specifies requirements for this specific operator.
     """
     func_op = op(
-        name=name, description=description, file_dependencies=file_dependencies, reqs_path=reqs_path
+        name=name, description=description, file_dependencies=file_dependencies, requirements=requirements
     )
     return func_op(func)

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -495,8 +495,13 @@ def to_operator(
             A list of relative paths to files that the function needs to access.
             Python classes/methods already imported within the function's file
             need not be included.
-        reqs_path:
-            A path to file that specifies requirements for this specific operator.
+        requirements:
+            Defines the python package requirements that this operator will run with.
+            Can be either a path to the requirements.txt file or a list of pip requirements specifiers.
+            (eg. ["transformers==4.21.0", "numpy==1.22.4"]. If not supplied, we'll first
+            look for a `requirements.txt` file in the same directory as the decorated function
+            and install those. Otherwise, we'll attempt to infer the requirements with
+            `pip freeze`.
     """
     func_op = op(
         name=name,

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -499,6 +499,9 @@ def to_operator(
             A path to file that specifies requirements for this specific operator.
     """
     func_op = op(
-        name=name, description=description, file_dependencies=file_dependencies, requirements=requirements
+        name=name,
+        description=description,
+        file_dependencies=file_dependencies,
+        requirements=requirements,
     )
     return func_op(func)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fix the naming change of to_operator(), which makes the integration test currently broke.

## Related issue number (if any)

https://linear.app/aqueducthq/issue/ENG-1318/allow-users-to-create-operators-from-existing-functions

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


