### PR TITLE
Add `verbose` mode so that by default only error logs are shown in the terminal

### DIFF
--- a/src/golang/cmd/server/handler/archive_notification.go
+++ b/src/golang/cmd/server/handler/archive_notification.go
@@ -17,8 +17,10 @@ import (
 // Method: POST
 // Params: notificationId
 // Request:
+//
 //	Headers:
 //		`api-key`: user's API Key
+//
 // Response: none
 type ArchiveNotificationHandler struct {
 	PostHandler

--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -20,12 +20,17 @@ import (
 // Route: /artifact_result/{workflowDagResultId}/{artifactId}
 // Method: GET
 // Params:
+//
 //	`workflowDagResultId`: ID for `workflow_dag_result` object
 //	`artifactId`: ID for `artifact` object
+//
 // Request:
+//
 //	Headers:
 //		`api-key`: user's API Key
+//
 // Response:
+//
 //	Body:
 //		serialized `getArtifactResultResponse`,
 //		metadata and content of the result of `artifactId` on the given workflow_dag_result object.

--- a/src/golang/cmd/server/handler/get_node_positions.go
+++ b/src/golang/cmd/server/handler/get_node_positions.go
@@ -70,10 +70,11 @@ func (*GetNodePositionsHandler) Prepare(r *http.Request) (interface{}, int, erro
 // where we compute the DAG topology for rendering its layout.
 
 // It takes a list of operators and returns the following:
-// - Layers, which is a list of layers, where each layer is a list of opId
-// - Number of active edges for each layer. 'active edges' stands for any edges at this layer, that doesn't starts
-// 	from the previous layer, nor ends at current layer. This is used to compute how much `room` one layer
-// 	need to save for rendering edges.
+//   - Layers, which is a list of layers, where each layer is a list of opId
+//   - Number of active edges for each layer. 'active edges' stands for any edges at this layer, that doesn't starts
+//     from the previous layer, nor ends at current layer. This is used to compute how much `room` one layer
+//     need to save for rendering edges.
+//
 // The canvas is assumed to be infinite and spacing between nodes are at an arbitrary constant.
 // The positions may need to be resized or shifted if the canvas view does not automatically adjust to contain everything.
 func orderNodes(operatorIdToInputOutput map[uuid.UUID]request.OperatorMapping) ([][]uuid.UUID, []int) {

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -18,12 +18,17 @@ import (
 // Route: /operator_result/{workflowDagResultId}/{operatorId}
 // Method: GET
 // Params:
+//
 //	`workflowDagResultId`: ID for `workflow_dag_result` object
 //	`operatorId`: ID for `operator` object
+//
 // Request:
+//
 //	Headers:
 //		`api-key`: user's API Key
+//
 // Response:
+//
 //	Body:
 //		serialized `getOperatorResultResponse`,
 //		metadata and content of the result of `operatorId` on the given workflow_dag_result object.

--- a/src/golang/cmd/server/handler/list_notifications.go
+++ b/src/golang/cmd/server/handler/list_notifications.go
@@ -16,9 +16,12 @@ import (
 // Method: GET
 // Params: None
 // Request:
+//
 //	Headers:
 //		`api-key`: user's API Key
+//
 // Response:
+//
 //	Body:
 //		serialized `listNotificationsResponse`, a list of notifications for the user
 type ListNotificationsHandler struct {

--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -22,7 +22,7 @@ var (
 	expose        = flag.Bool("expose", false, "Whether the server will be exposed to the public.")
 	verbose       = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal.")
 	port          = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
-	serverLogPath = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server_log")
+	serverLogPath = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
 )
 
 func main() {
@@ -48,24 +48,24 @@ func main() {
 		MaxAge:     28, // days
 	})
 
-	// Send logs with level higher than error to stderr.
+	// Send logs with level higher than warning to stderr.
 	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,
 		LogLevels: []log.Level{
 			log.PanicLevel,
 			log.FatalLevel,
 			log.ErrorLevel,
+			log.WarnLevel,
 		},
 	})
 
 	if *verbose {
-		// If verbose, also send info, debug, warning logs to stdout.
+		// If verbose, also send info and debug logs to stdout.
 		log.AddHook(&writer.Hook{
 			Writer: os.Stdout,
 			LogLevels: []log.Level{
 				log.InfoLevel,
 				log.DebugLevel,
-				log.WarnLevel,
 			},
 		})
 	}

--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -31,6 +31,7 @@ func main() {
 	}
 
 	log.SetFormatter(&log.TextFormatter{DisableQuote: true})
+	log.SetLevel(log.ErrorLevel)
 
 	serverConfig := config.ParseServerConfiguration(*confPath)
 

--- a/src/golang/cmd/server/middleware/authentication/authentication.go
+++ b/src/golang/cmd/server/middleware/authentication/authentication.go
@@ -11,10 +11,10 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
-//	The `RequireApiKey` middleware expects a request whose header contains
-//	key `api-key` for authorization purposes. If the authorization is successful,
-//	it forwards the request to the controller. Otherwise, it sends an http response
-//	in JSON format with an `error` message.
+// The `RequireApiKey` middleware expects a request whose header contains
+// key `api-key` for authorization purposes. If the authorization is successful,
+// it forwards the request to the controller. Otherwise, it sends an http response
+// in JSON format with an `error` message.
 func RequireApiKey(userReader user.Reader, db database.Database) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/golang/cmd/server/request/payload.go
+++ b/src/golang/cmd/server/request/payload.go
@@ -10,12 +10,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//	Given an http request, this helper function extract its payload as a
-//	bytestring from its `Body` field. Currently, this function supports two
-//	`contentType`s: `application/octet-stream` and `multipart/form-data`.
-//	For `multipart/form-data`, since the request's `Body` comes from a file
-//	upload, the caller should specify the name of the file in `fileName`.
-//	This argument is ignored for `application/octet-stream`.
+// Given an http request, this helper function extract its payload as a
+// bytestring from its `Body` field. Currently, this function supports two
+// `contentType`s: `application/octet-stream` and `multipart/form-data`.
+// For `multipart/form-data`, since the request's `Body` comes from a file
+// upload, the caller should specify the name of the file in `fileName`.
+// This argument is ignored for `application/octet-stream`.
 func ExtractHttpPayload(contentType, fileName string, isFile bool, r *http.Request) ([]byte, error) {
 	payload := []byte{}
 	var err error

--- a/src/golang/cmd/server/response/response.go
+++ b/src/golang/cmd/server/response/response.go
@@ -21,10 +21,10 @@ func SendErrorResponse(w http.ResponseWriter, errorMsg string, errorCode int) {
 	SendJsonResponse(w, response, errorCode)
 }
 
-//	Internal utility function to send a JSON response by automatically
-//	serializing the provided response object and adding the provided statusCode
-//	as the response's status code. The response object is expected to be
-//	JSON-serializable.
+// Internal utility function to send a JSON response by automatically
+// serializing the provided response object and adding the provided statusCode
+// as the response's status code. The response object is expected to be
+// JSON-serializable.
 func SendJsonResponse(w http.ResponseWriter, response interface{}, statusCode int) {
 	jsonBlob, err := json.Marshal(response)
 	if err != nil {

--- a/src/golang/go.mod
+++ b/src/golang/go.mod
@@ -27,5 +27,6 @@ require (
 	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/src/golang/go.sum
+++ b/src/golang/go.sum
@@ -32,6 +32,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
@@ -564,6 +565,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/src/golang/lib/database/stmt_preparers/util.go
+++ b/src/golang/lib/database/stmt_preparers/util.go
@@ -12,10 +12,11 @@ import (
 //
 // Reference: https://stackoverflow.com/questions/45351644/golang-slice-in-mysql-query-with-where-in-clause
 // Example usage, fetching from a list of ids:
-//  query := "SELECT * FROM workflow WHERE id IN (" + GenerateArgsList(len(ids)) + ")"
-//  var workflows []Workflow
-//  args := CastIdsListToInterfaceList(ids)
-//  err := db.QueryToDest(ctx, &workflows, query, args...)
+//
+//	query := "SELECT * FROM workflow WHERE id IN (" + GenerateArgsList(len(ids)) + ")"
+//	var workflows []Workflow
+//	args := CastIdsListToInterfaceList(ids)
+//	err := db.QueryToDest(ctx, &workflows, query, args...)
 func GenerateArgsList(length int, startIdx int) string {
 	args := ""
 

--- a/src/golang/lib/logging/response.go
+++ b/src/golang/lib/logging/response.go
@@ -14,6 +14,7 @@ type Component string
 
 const (
 	ServerComponent Component = "Server"
+	errorStatus     string    = "ERROR"
 )
 
 // We register an obfuscation function to alter the header value before logging it
@@ -51,11 +52,11 @@ func LogRoute(
 	status := "SUCCEEDED"
 	var errMsg string
 	if err != nil {
-		status = "ERROR"
+		status = errorStatus
 		errMsg = err.Error()
 	}
 
-	if status == "ERROR" {
+	if status == errorStatus {
 		log.WithFields(log.Fields{
 			"ServiceName":   serviceName,
 			"URL":           r.URL,
@@ -93,11 +94,11 @@ func LogAsyncEvent(
 	status := "SUCCEEDED"
 	var errMsg string
 	if err != nil {
-		status = "ERROR"
+		status = errorStatus
 		errMsg = err.Error()
 	}
 
-	if status == "ERROR" {
+	if status == errorStatus {
 		log.WithFields(log.Fields{
 			"ServiceName":   serviceName,
 			"Status":        status,

--- a/src/golang/lib/logging/response.go
+++ b/src/golang/lib/logging/response.go
@@ -55,18 +55,33 @@ func LogRoute(
 		errMsg = err.Error()
 	}
 
-	log.WithFields(log.Fields{
-		"ServiceName":   serviceName,
-		"URL":           r.URL,
-		"Headers":       headers,
-		"Status":        status,
-		"Code":          statusCode,
-		"Component":     component,
-		"Route":         routeName,
-		"UserId":        ctx.Value(aq_context.UserIdKey),
-		"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
-		"Error":         errMsg,
-	}).Info()
+	if status == "ERROR" {
+		log.WithFields(log.Fields{
+			"ServiceName":   serviceName,
+			"URL":           r.URL,
+			"Headers":       headers,
+			"Status":        status,
+			"Code":          statusCode,
+			"Component":     component,
+			"Route":         routeName,
+			"UserId":        ctx.Value(aq_context.UserIdKey),
+			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
+			"Error":         errMsg,
+		}).Error()
+	} else {
+		log.WithFields(log.Fields{
+			"ServiceName":   serviceName,
+			"URL":           r.URL,
+			"Headers":       headers,
+			"Status":        status,
+			"Code":          statusCode,
+			"Component":     component,
+			"Route":         routeName,
+			"UserId":        ctx.Value(aq_context.UserIdKey),
+			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
+			"Error":         errMsg,
+		}).Info()
+	}
 }
 
 func LogAsyncEvent(
@@ -82,14 +97,25 @@ func LogAsyncEvent(
 		errMsg = err.Error()
 	}
 
-	log.WithFields(log.Fields{
-		"ServiceName":   serviceName,
-		"Status":        status,
-		"Component":     component,
-		"UserId":        ctx.Value(aq_context.UserIdKey),
-		"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
-		"Error":         errMsg,
-	}).Info()
+	if status == "ERROR" {
+		log.WithFields(log.Fields{
+			"ServiceName":   serviceName,
+			"Status":        status,
+			"Component":     component,
+			"UserId":        ctx.Value(aq_context.UserIdKey),
+			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
+			"Error":         errMsg,
+		}).Error()
+	} else {
+		log.WithFields(log.Fields{
+			"ServiceName":   serviceName,
+			"Status":        status,
+			"Component":     component,
+			"UserId":        ctx.Value(aq_context.UserIdKey),
+			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
+			"Error":         errMsg,
+		}).Info()
+	}
 }
 
 // Replaces the password in an integration config string into the equivalent * string.

--- a/src/golang/lib/logging/response.go
+++ b/src/golang/lib/logging/response.go
@@ -56,32 +56,23 @@ func LogRoute(
 		errMsg = err.Error()
 	}
 
+	logFields := log.Fields{
+		"ServiceName":   serviceName,
+		"URL":           r.URL,
+		"Headers":       headers,
+		"Status":        status,
+		"Code":          statusCode,
+		"Component":     component,
+		"Route":         routeName,
+		"UserId":        ctx.Value(aq_context.UserIdKey),
+		"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
+		"Error":         errMsg,
+	}
+
 	if status == errorStatus {
-		log.WithFields(log.Fields{
-			"ServiceName":   serviceName,
-			"URL":           r.URL,
-			"Headers":       headers,
-			"Status":        status,
-			"Code":          statusCode,
-			"Component":     component,
-			"Route":         routeName,
-			"UserId":        ctx.Value(aq_context.UserIdKey),
-			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
-			"Error":         errMsg,
-		}).Error()
+		log.WithFields(logFields).Error()
 	} else {
-		log.WithFields(log.Fields{
-			"ServiceName":   serviceName,
-			"URL":           r.URL,
-			"Headers":       headers,
-			"Status":        status,
-			"Code":          statusCode,
-			"Component":     component,
-			"Route":         routeName,
-			"UserId":        ctx.Value(aq_context.UserIdKey),
-			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
-			"Error":         errMsg,
-		}).Info()
+		log.WithFields(logFields).Info()
 	}
 }
 
@@ -98,24 +89,19 @@ func LogAsyncEvent(
 		errMsg = err.Error()
 	}
 
+	logFields := log.Fields{
+		"ServiceName":   serviceName,
+		"Status":        status,
+		"Component":     component,
+		"UserId":        ctx.Value(aq_context.UserIdKey),
+		"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
+		"Error":         errMsg,
+	}
+
 	if status == errorStatus {
-		log.WithFields(log.Fields{
-			"ServiceName":   serviceName,
-			"Status":        status,
-			"Component":     component,
-			"UserId":        ctx.Value(aq_context.UserIdKey),
-			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
-			"Error":         errMsg,
-		}).Error()
+		log.WithFields(logFields).Error()
 	} else {
-		log.WithFields(log.Fields{
-			"ServiceName":   serviceName,
-			"Status":        status,
-			"Component":     component,
-			"UserId":        ctx.Value(aq_context.UserIdKey),
-			"UserRequestId": ctx.Value(aq_context.UserRequestIdKey),
-			"Error":         errMsg,
-		}).Info()
+		log.WithFields(logFields).Info()
 	}
 }
 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -517,8 +517,9 @@ if __name__ == "__main__":
         "--verbose",
         default=False,
         action="store_true",
-        help="""Use this option to see all logs in the terminal. By default, only error logs are 
-                    shown and other logs are stored into a log file.""",
+        help="""If set to true, all log messages will be printed on stdout. By default, only error
+                and warning-level logs are routed to stdout. All log messages can be found at
+                $HOME/.aqueduct/server/logs/server""",
     )
     start_args.add_argument(
         "--port", dest="port", help="Specify the port on which the Aqueduct server runs."

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -296,7 +296,7 @@ def is_port_in_use(port: int) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
-def start(expose, port):
+def start(expose, port, verbose):
     update()
 
     if port is None:
@@ -312,27 +312,21 @@ def start(expose, port):
         server_port = int(port)
         print("Server will use the user-specified port %d" % server_port)
 
+    command = [
+        os.path.join(server_directory, "bin", "server"),
+        "--config",
+        os.path.join(server_directory, "config", "config.yml"),
+        "--port",
+        str(server_port),
+    ]
+
     if expose:
-        popen_handle = execute_command_nonblocking(
-            [
-                os.path.join(server_directory, "bin", "server"),
-                "--config",
-                os.path.join(server_directory, "config", "config.yml"),
-                "--expose",
-                "--port",
-                str(server_port),
-            ],
-        )
-    else:
-        popen_handle = execute_command_nonblocking(
-            [
-                os.path.join(server_directory, "bin", "server"),
-                "--config",
-                os.path.join(server_directory, "config", "config.yml"),
-                "--port",
-                str(server_port),
-            ],
-        )
+        command.append("--expose")
+    
+    if verbose:
+        command.append("--verbose")
+
+    popen_handle = execute_command_nonblocking(command)
     return popen_handle, server_port
 
 
@@ -520,6 +514,13 @@ if __name__ == "__main__":
         help="Use this option to expose the server to the public.",
     )
     start_args.add_argument(
+        "--verbose",
+        default=False,
+        action="store_true",
+        help="""Use this option to see all logs in the terminal. By default, only error logs are 
+                    shown and other logs are stored into a log file.""",
+    )
+    start_args.add_argument(
         "--port", dest="port", help="Specify the port on which the Aqueduct server runs."
     )
     server_args = subparsers.add_parser(
@@ -612,7 +613,7 @@ if __name__ == "__main__":
 
     if args.command == "start":
         try:
-            popen_handle, server_port = start(args.expose, args.port)
+            popen_handle, server_port = start(args.expose, args.port, args.verbose)
             time.sleep(1)
             terminated = popen_handle.poll()
             if terminated:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds `verbose` option to our CLI. By default, `verbose` is set to `False`, meaning that only error logs are shown in the terminal. If the user sets `verbose` to `True`, then all logs are shown in the terminal.

Regardless of `verbose`, all logs are always stored into a log file. The log file is managed by a library that performs log rotation to prevent the logs from growing infinitely.

The above only applies to logging done via `logrus`. Our route logger doesn't have this flexibility, so all REST events are still logged in the terminal regardless of `verbose`.

Without `verbose`:
![Screen Shot 2022-08-05 at 9 18 07 AM](https://user-images.githubusercontent.com/6820919/183119339-3b1ba5b9-e7f0-477e-8460-ac1ec9d5e401.png)

With `verbose`:
![Screen Shot 2022-08-05 at 9 18 31 AM](https://user-images.githubusercontent.com/6820919/183119391-59ecc255-0403-43e3-8d3e-92529476fec6.png)





## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


