### PR TITLE
Fix a bug where non-preview operator zip files are mistakenly deleted

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       matrix:
         # These are all the Python versions that we support.
@@ -68,7 +68,7 @@ jobs:
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 15
+        timeout-minutes: 30
         working-directory: integration_tests/sdk
         env:
           SERVER_ADDRESS: localhost:8080

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,15 +1,13 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [ eng-1508-investigate-why-some-old-workflows ]
   workflow_call:
   workflow_dispatch:
 
 jobs:
   run-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 20
     strategy:
       matrix:
         # These are all the Python versions that we support.
@@ -70,7 +68,7 @@ jobs:
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 30
+        timeout-minutes: 15
         working-directory: integration_tests/sdk
         env:
           SERVER_ADDRESS: localhost:8080

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 
 on:
+  push:
+    branches: [ eng-1508-investigate-why-some-old-workflows ]
   workflow_call:
   workflow_dispatch:
 

--- a/src/golang/lib/airflow/schedule.go
+++ b/src/golang/lib/airflow/schedule.go
@@ -149,6 +149,7 @@ func ScheduleWorkflow(
 			jobManager,
 			vault,
 			&airflowStorageConfig,
+			false, // airflow operator will never run in preview mode
 			db,
 		)
 		if err != nil {

--- a/src/golang/lib/workflow/dag/workflow_dag.go
+++ b/src/golang/lib/workflow/dag/workflow_dag.go
@@ -76,6 +76,7 @@ func NewWorkflowDag(
 	jobManager job.JobManager,
 	vaultObject vault.Vault,
 	storageConfig *shared.StorageConfig,
+	isPreview bool,
 	db database.Database,
 ) (WorkflowDag, error) {
 	// First, allocate a content and metadata path for each artifact.
@@ -152,6 +153,7 @@ func NewWorkflowDag(
 			jobManager,
 			vaultObject,
 			storageConfig,
+			isPreview,
 			db,
 		)
 		if err != nil {

--- a/src/golang/lib/workflow/engine/aq_engine.go
+++ b/src/golang/lib/workflow/engine/aq_engine.go
@@ -289,10 +289,10 @@ func (eng *aqEngine) ExecuteWorkflow(
 	)
 	if err != nil {
 		workflowRunMetadata.Status = shared.FailedExecutionStatus
+		log.Errorf("Error when executing workflow: %v", err)
 	} else {
 		workflowRunMetadata.Status = shared.SucceededExecutionStatus
 	}
-	log.Errorf("Error when executing workflow: %v", err)
 }
 
 func (eng *aqEngine) PreviewWorkflow(

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -43,6 +43,7 @@ type baseOperator struct {
 	db            database.Database
 
 	resultsPersisted bool
+	isPreview        bool
 }
 
 func (bo *baseOperator) Type() operator.Type {
@@ -178,6 +179,11 @@ func (bo *baseOperator) InitializeResult(ctx context.Context, dagResultID uuid.U
 }
 
 func (bo *baseOperator) PersistResult(ctx context.Context) error {
+	if bo.isPreview {
+		// Don't persist any result for preview operators.
+		return nil
+	}
+
 	if bo.resultsPersisted {
 		return errors.Newf("Operator %s was already persisted!", bo.Name())
 	}
@@ -223,8 +229,8 @@ type baseFunctionOperator struct {
 }
 
 func (bfo *baseFunctionOperator) Finish(ctx context.Context) {
-	// If the operator was not persisted to the DB, cleanup the serialized function.
-	if !bfo.resultsPersisted {
+	// If the operator ran in preview mode, cleanup the serialized function.
+	if bfo.isPreview {
 		utils.CleanupStorageFile(ctx, bfo.storageConfig, bfo.dbOperator.Spec.Function().StoragePath)
 	}
 

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -51,6 +51,7 @@ func NewOperator(
 	jobManager job.JobManager,
 	vaultObject vault.Vault,
 	storageConfig *shared.StorageConfig,
+	isPreview bool,
 	db database.Database,
 ) (Operator, error) {
 	if len(inputs) != len(inputContentPaths) || len(inputs) != len(inputMetadataPaths) {
@@ -80,6 +81,7 @@ func NewOperator(
 		db:            db,
 
 		resultsPersisted: false,
+		isPreview:        isPreview,
 	}
 
 	if dbOperator.Spec.IsFunction() {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
If an operator failed during a regular workflow run, we had the logic where all of its downstream operators' zip files were deleted by mistake. This PR fixes the issue by passing a `isPreview` bool when constructing the operators, so that it relies on this value to determine whether the zip file should be GCed. We also deprecate the use of `shouldPersistResults `, as it's redundant.

I noticed that for some reason, integration tests for some Python versions are timing out, but I was able to successfully run all of them locally. Maybe there's something wrong with the GitHub worker or we should increase the timeout?

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


