### PR TITLE
Adds test case for multiple workflows with same schedule

### DIFF
--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -217,28 +217,25 @@ def test_get_artifact_reuse_for_computation(client):
 
 @pytest.mark.publish
 def test_multiple_flows_with_same_schedule(client):
-    db = client.integration(name=get_integration_name())
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = run_sentiment_model(sql_artifact)
-    # output_artifact.save(
-    #     config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    # )
-
-    flow_1 = client.publish_flow(
-        name="same_schedule_1",
-        artifacts=[output_artifact],
-        schedule="* * * * *",
-    )
-    print("flow_1 id: ", str(flow_1.id()))
-
-    flow_2 = client.publish_flow(
-        name="same_schedule_2",
-        artifacts=[output_artifact],
-        schedule="* * * * *",
-    )
-    print("flow_2 id: ", str(flow_2.id()))
-
     try:
+        db = client.integration(name=get_integration_name())
+        sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+        output_artifact = run_sentiment_model(sql_artifact)
+
+        flow_1 = client.publish_flow(
+            name="same_schedule_1",
+            artifacts=[output_artifact],
+            schedule="* * * * *",
+        )
+        print("flow_1 id: ", str(flow_1.id()))
+
+        flow_2 = client.publish_flow(
+            name="same_schedule_2",
+            artifacts=[output_artifact],
+            schedule="* * * * *",
+        )
+        print("flow_2 id: ", str(flow_2.id()))
+
         wait_for_flow_runs(client, flow_1.id(), 2, True)
         wait_for_flow_runs(client, flow_2.id(), 2, True)
     finally:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a test case for multiple workflows with same schedule. It fails on the post-refactor engine PR, passes on current main.
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1526/add-test-case-for-multiple-workflows-with-same-schedule
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


