### PR TITLE
Fix latency issue introduced by long requirement.txt

### DIFF
--- a/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
@@ -1,0 +1,28 @@
+import argparse
+
+
+def run(local_path: str, requirements_path: str, missing_path: str) -> None:
+    with open(local_path, "r") as f:
+        local_req = set(f.read().split("\n"))
+
+    with open(requirements_path, "r") as f:
+        required = f.read().split("\n")
+
+    missing = []
+    for r in required:
+        if r not in local_req:
+            missing.append(r)
+
+    if len(missing) > 0:
+        with open(missing_path, "w") as f:
+            f.write("\n".join(missing))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local_path", required=True)
+    parser.add_argument("--requirements_path", required=True)
+    parser.add_argument("--missing_path", required=True)
+    args = parser.parse_args()
+
+    run(args.local_path, args.requirements_path, args.missing_path)

--- a/src/python/aqueduct_executor/start-function-executor.sh
+++ b/src/python/aqueduct_executor/start-function-executor.sh
@@ -8,7 +8,17 @@ python3 -m aqueduct_executor.operators.function_executor.extract_function --spec
 EXIT_CODE=$?
 if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
 
-if test -f "$FUNCTION_EXTRACT_PATH/op/requirements.txt"; then pip3 install -r "$FUNCTION_EXTRACT_PATH/op/requirements.txt" --no-cache-dir; fi
+if test -f "$FUNCTION_EXTRACT_PATH/op/requirements.txt"
+then
+      pip freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
+      python3 -m aqueduct_executor.operators.function_executor.prune_requirements --local_path="$FUNCTION_EXTRACT_PATH/op/local_deps.txt" --requirements_path="$FUNCTION_EXTRACT_PATH/op/requirements.txt" --missing_path="$FUNCTION_EXTRACT_PATH/op/missing.txt"
+      EXIT_CODE=$?
+      if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
+      if test -f "$FUNCTION_EXTRACT_PATH/op/missing.txt"
+      then
+            pip3 install -r "$FUNCTION_EXTRACT_PATH/op/missing.txt" --no-cache-dir
+      fi
+fi
 
 python3 -m aqueduct_executor.operators.function_executor.main --spec "$JOB_SPEC"
 EXIT_CODE=$?


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Currently we infer requirements by running `pip freeze` locally  and install these requirements using `pip install -r`. This will make `pip install` to install the long `pip freeze` list which is very slow, introducing lots of latencies. This PR fixes this issue by manually compare the `requirement.txt` with a local `pip freeze` list, then we only install the mismatched packages.

## Related issue number (if any)
ENG-1528

## Checklist before requesting a review
Operator preview go down from 1min+ to ~6s. Also verified latency reduction for execution
```
2022/08/09 03:47:58 "POST http://localhost:8080/api/preview HTTP/1.1" from 127.0.0.1:34690 - 200 110119B in 1.099682551s
2022/08/09 03:48:01 "POST http://localhost:8080/api/preview HTTP/1.1" from 127.0.0.1:34692 - 200 345718B in 2.196247097s
2022/08/09 03:48:08 "POST http://localhost:8080/api/preview HTTP/1.1" from 127.0.0.1:34698 - 200 492610B in 5.211372649s
2022/08/09 03:48:18 "POST http://localhost:8080/api/preview HTTP/1.1" from 127.0.0.1:34704 - 200 492860B in 6.408507144s
```
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


