### PR TITLE
ENG-1533 Frontend: Use default value for SERVER_ADDRESS

### DIFF
--- a/src/ui/common/src/components/hooks/useAqueductConsts.ts
+++ b/src/ui/common/src/components/hooks/useAqueductConsts.ts
@@ -2,8 +2,11 @@ export type AqueductConsts = {
   apiAddress: string;
 };
 
+const DEFAULT_SERVER_ADDRESS = 'http://localhost:8080';
+
 export const useAqueductConsts = (): AqueductConsts => {
   return {
-    apiAddress: process.env.SERVER_ADDRESS,
+    // Use default value for server address if there is not one set in the .env or env.local file.
+    apiAddress: process.env.SERVER_ADDRESS ? process.env.SERVER_ADDRESS : DEFAULT_SERVER_ADDRESS,
   };
 };

--- a/src/ui/common/src/components/hooks/useAqueductConsts.ts
+++ b/src/ui/common/src/components/hooks/useAqueductConsts.ts
@@ -7,6 +7,8 @@ const DEFAULT_SERVER_ADDRESS = 'http://localhost:8080';
 export const useAqueductConsts = (): AqueductConsts => {
   return {
     // Use default value for server address if there is not one set in the .env or env.local file.
-    apiAddress: process.env.SERVER_ADDRESS ? process.env.SERVER_ADDRESS : DEFAULT_SERVER_ADDRESS,
+    apiAddress: process.env.SERVER_ADDRESS
+      ? process.env.SERVER_ADDRESS
+      : DEFAULT_SERVER_ADDRESS,
   };
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR sets a default value to use for SERVER_ADDRESS if there is no environment variable present when running parcel builds.

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1533/set-default-value-for-server-address

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


