### PR TITLE
Remove system name prefix from newly connected integrations

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -176,8 +176,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
 
   useEffect(() => {
     setDisableConnect(
-      service !== 'Aqueduct Demo' &&
-        (!isConfigComplete(config) || name === '')
+      service !== 'Aqueduct Demo' && (!isConfigComplete(config) || name === '')
     );
   }, [config, name]);
 
@@ -260,7 +259,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
       required={true}
       label="Name*"
       description="Provide a unique name to refer to this integration."
-      placeholder={"my_"+formatService(service)+"_integration"}
+      placeholder={'my_' + formatService(service) + '_integration'}
       onChange={(event) => {
         setName(event.target.value);
       }}

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -168,8 +168,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
   const [successMessage, setSuccessMessage] = useState('');
   const [showSuccessToast, setShowSuccessToast] = useState(false);
 
-  const namePrefix = formatService(service) + '/';
-  const [name, setName] = useState(namePrefix);
+  const [name, setName] = useState('');
 
   const handleSuccessToastClose = () => {
     setShowSuccessToast(false);
@@ -178,7 +177,7 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
   useEffect(() => {
     setDisableConnect(
       service !== 'Aqueduct Demo' &&
-        (!isConfigComplete(config) || name === '' || name === namePrefix)
+        (!isConfigComplete(config) || name === '')
     );
   }, [config, name]);
 
@@ -261,10 +260,8 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
       required={true}
       label="Name*"
       description="Provide a unique name to refer to this integration."
-      placeholder={namePrefix}
+      placeholder={"my_"+formatService(service)+"_integration"}
       onChange={(event) => {
-        const input = event.target.value;
-        event.target.value = namePrefix + input.substr(namePrefix.length);
         setName(event.target.value);
       }}
       value={name}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Remove system prefixes from the integration name because it confuses users

This demo shows two integrations: Snowflake & Postgres. The integration name field has no prefix anymore and upon filling out all the required fields, the confirm button is enabled.

https://user-images.githubusercontent.com/30596854/183711139-926d0625-b098-421d-9ebb-fa21c29f42c7.mov

## Related issue number (if any)
ENG-1252

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


