### PR TITLE
Removes deprecated commands from CLI

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -524,32 +524,6 @@ if __name__ == "__main__":
     start_args.add_argument(
         "--port", dest="port", help="Specify the port on which the Aqueduct server runs."
     )
-    server_args = subparsers.add_parser(
-        "server",
-        help="""[DEPRECATED] This starts the Aqueduct server in a
-                                   blocking fashion. To background the process,
-                                   run aqueduct server &.""",
-    )
-    server_args.add_argument(
-        "--expose",
-        default=False,
-        action="store_true",
-        help="Use this option to expose the server to the public.",
-    )
-    ui_args = subparsers.add_parser(
-        "ui",
-        help="""[DEPRECATED] This starts the Aqueduct UI in a blocking
-                               fashion. To background the process run aqueduct
-                               ui &.
-
-                               Add --expose <IP_ADDRESS> to access the UI from
-                               an external server, where <IP_ADDRESS> is the
-                               public IP of the server you are running on.
-                               """,
-    )
-    ui_args.add_argument(
-        "--expose", dest="expose", help="The IP address of the server running Aqueduct."
-    )
 
     install_args = subparsers.add_parser(
         "install",


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR just removes the `aqueduct server` and `aqueduct ui` that we introduced in v0.0.1 and deprecated in v0.0.2. afaik, no one is on those versions anymore, so I am removing them from the CLI.

## Related issue number (if any)

ENG-1524

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [N/A] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


