### PR TITLE
[ENG-1328] Cleans up welcome page

### DIFF
--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -10,25 +10,20 @@ import Link from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
-import { theme } from '../../styles/theme/theme';
 
+import { theme } from '../../styles/theme/theme';
 import UserProfile from '../../utils/auth';
 import { getPathPrefix } from '../../utils/getPathPrefix';
 
-const sharedCardStyling = {
-  display: 'flex',
-  borderWidth: '2px',
-  borderColor: '#002F5E',
-  borderRadius: '5px',
-  borderStyle: 'solid',
-  width: '100%',
-};
-
 const InfoCard = styled(Box)({
   ['&.MuiBox-root']: {
-    ...sharedCardStyling,
-    marginTop: '8px',
     display: 'flex',
+    borderWidth: '2px',
+    borderColor: '#002F5E',
+    borderRadius: '5px',
+    borderStyle: 'solid',
+    width: '100%',
+    marginTop: '8px',
     alignItems: 'center',
     padding: '16px 8px 16px 8px',
     '&:hover': {
@@ -50,23 +45,29 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
   }
 
   const waveEmoji = () => {
-    const emojiElement = document.getElementById("greet-emoji");
+    const emojiElement = document.getElementById('greet-emoji');
     emojiElement.style.transitionDuration = '.4s';
     emojiElement.style.transformOrigin = 'right bottom';
- 
+
     const delayIncrement = 400;
     let delay = 100;
-    for(let i = 0; i < 8; i++) {
+    for (let i = 0; i < 8; i++) {
       if (i % 2 === 0) {
-        setTimeout(() => emojiElement.style.transform = 'rotate(30deg)', delay)
+        setTimeout(
+          () => (emojiElement.style.transform = 'rotate(30deg)'),
+          delay
+        );
       } else {
-        setTimeout(() => emojiElement.style.transform = 'rotate(-30deg)', delay)
+        setTimeout(
+          () => (emojiElement.style.transform = 'rotate(-30deg)'),
+          delay
+        );
       }
 
       delay += delayIncrement;
     }
 
-    setTimeout(() => emojiElement.style.transform = 'rotate(0deg)', delay)
+    setTimeout(() => (emojiElement.style.transform = 'rotate(0deg)'), delay);
   };
 
   useEffect(waveEmoji, []);
@@ -84,7 +85,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
     >
       <img
         src="https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct-logo-two-tone/1x/aqueduct-logo-two-tone-1x.png"
-        width='300px'
+        width="300px"
       />
 
       <Box
@@ -100,7 +101,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
         }}
       >
         {user && (
-          <InfoCard sx={{ mb: '32px' }} onMouseOver={() => waveEmoji()}>
+          <InfoCard sx={{ mb: '32px' }} onMouseEnter={() => waveEmoji()}>
             <Box
               sx={{
                 display: 'flex',
@@ -109,7 +110,13 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
                 alignItems: 'center',
               }}
             >
-              <Typography sx={{ width: 'min-content'}} variant="h4" id="greet-emoji">👋</Typography>
+              <Typography
+                sx={{ width: 'min-content' }}
+                variant="h4"
+                id="greet-emoji"
+              >
+                👋
+              </Typography>
               <Typography variant="h4">{greeting}</Typography>
 
               <Typography variant="h6">
@@ -148,7 +155,9 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
                   <li>
                     <Typography variant="body1">
                       Go to the{' '}
-                      <Link href={`${getPathPrefix()}/workflows`}>workflows</Link>{' '}
+                      <Link href={`${getPathPrefix()}/workflows`}>
+                        workflows
+                      </Link>{' '}
                       page to see a visualization of the workflow you just
                       created.
                     </Typography>

--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -9,29 +9,31 @@ import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
-import React from 'react';
+import React, { useEffect } from 'react';
+import { theme } from '../../styles/theme/theme';
 
 import UserProfile from '../../utils/auth';
 import { getPathPrefix } from '../../utils/getPathPrefix';
 
 const sharedCardStyling = {
   display: 'flex',
-  backgroundColor: 'gray.50',
-  borderRadius: 3,
-  paddingX: 1,
-  paddingY: 2,
+  borderWidth: '2px',
+  borderColor: '#002F5E',
+  borderRadius: '5px',
+  borderStyle: 'solid',
+  width: '100%',
 };
 
 const InfoCard = styled(Box)({
   ['&.MuiBox-root']: {
     ...sharedCardStyling,
     marginTop: '8px',
-    height: '125px',
-    width: '50%',
     display: 'flex',
     alignItems: 'center',
-    minWidth: '450px',
-    maxWidth: '750px',
+    padding: '16px 8px 16px 8px',
+    '&:hover': {
+      backgroundColor: theme.palette.blue[50],
+    },
   },
 });
 
@@ -47,6 +49,28 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
     greeting = 'Welcome to Aqueduct!';
   }
 
+  const waveEmoji = () => {
+    const emojiElement = document.getElementById("greet-emoji");
+    emojiElement.style.transitionDuration = '.4s';
+    emojiElement.style.transformOrigin = 'right bottom';
+ 
+    const delayIncrement = 400;
+    let delay = 100;
+    for(let i = 0; i < 8; i++) {
+      if (i % 2 === 0) {
+        setTimeout(() => emojiElement.style.transform = 'rotate(30deg)', delay)
+      } else {
+        setTimeout(() => emojiElement.style.transform = 'rotate(-30deg)', delay)
+      }
+
+      delay += delayIncrement;
+    }
+
+    setTimeout(() => emojiElement.style.transform = 'rotate(0deg)', delay)
+  };
+
+  useEffect(waveEmoji, []);
+
   return (
     <Box
       sx={{
@@ -58,6 +82,11 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
         flexDirection: 'column',
       }}
     >
+      <img
+        src="https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct-logo-two-tone/1x/aqueduct-logo-two-tone-1x.png"
+        width='300px'
+      />
+
       <Box
         sx={{
           display: 'flex',
@@ -66,123 +95,116 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
           width: '50%',
           backgroundColor: 'white',
           minWidth: '500px',
+          maxWidth: '750px',
+          mt: '32px',
         }}
       >
         {user && (
-          <Box
-            sx={{
-              ...sharedCardStyling,
-              flexDirection: 'column',
-              textAlign: 'center',
-              maxWidth: '750px',
-              marginY: '32px',
-            }}
-          >
-            <Typography variant="h4">👋 {greeting}</Typography>
+          <InfoCard sx={{ mb: '32px' }} onMouseOver={() => waveEmoji()}>
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                textAlign: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <Typography sx={{ width: 'min-content'}} variant="h4" id="greet-emoji">👋</Typography>
+              <Typography variant="h4">{greeting}</Typography>
 
-            <Typography variant="h6">
-              Here&apos;s how you can get started with Aqueduct.
-            </Typography>
+              <Typography variant="h6">
+                Here&apos;s how you can get started.
+              </Typography>
 
-            <Box sx={{ textAlign: 'left', mr: '16px' }}>
-              <ol>
-                <li>
-                  <Typography variant="body1">
-                    First go to the{' '}
-                    <Link href={`${getPathPrefix()}/integrations`}>
-                      integrations
-                    </Link>{' '}
-                    page and connect a database. (If you don&apos;t have a
-                    database handy, you can use the <code>aqueduct_demo</code>{' '}
-                    database -- see the documentation{' '}
-                    <Link href="https://docs.aqueducthq.com/example-workflows/demo-data-warehouse">
-                      here
-                    </Link>
-                    .)
-                  </Typography>
-                </li>
+              <Box sx={{ textAlign: 'left', mr: '16px' }}>
+                <ol>
+                  <li>
+                    <Typography variant="body1">
+                      First go to the{' '}
+                      <Link href={`${getPathPrefix()}/integrations`}>
+                        integrations
+                      </Link>{' '}
+                      page and connect a database. If you don&apos;t have a
+                      database handy, you can use the <code>aqueduct_demo</code>{' '}
+                      database -- see the documentation{' '}
+                      <Link href="https://docs.aqueducthq.com/example-workflows/demo-data-warehouse">
+                        here
+                      </Link>
+                      .
+                    </Typography>
+                  </li>
 
-                <li>
-                  <Typography variant="body1">
-                    Install our{' '}
-                    <Link href="https://github.com/aqueducthq/aqueduct/blob/main/sdk">
-                      Python SDK
-                    </Link>
-                    .
-                  </Typography>
-                </li>
+                  <li>
+                    <Typography variant="body1">
+                      Create your first workflow -- see our{' '}
+                      <Link href="https://docs.aqueducthq.com/quickstart-guide">
+                        {' '}
+                        Quickstart Guide{' '}
+                      </Link>{' '}
+                      for an example.
+                    </Typography>
+                  </li>
 
-                <li>
-                  <Typography variant="body1">
-                    Create your first workflow from the Python SDK -- see our{' '}
-                    <Link href="https://github.com/aqueducthq/aqueduct/blob/main/sdk/examples/churn_prediction/Build%20and%20Deploy%20Churn%20Ensemble.ipynb">
-                      {' '}
-                      churn example{' '}
-                    </Link>{' '}
-                    for some inspiration.
-                  </Typography>
-                </li>
-
-                <li>
-                  <Typography variant="body1">
-                    Go to the{' '}
-                    <Link href={`${getPathPrefix()}/workflows`}>workflows</Link>{' '}
-                    page to see a visualization of the workflow you just
-                    created.
-                  </Typography>
-                </li>
-              </ol>
+                  <li>
+                    <Typography variant="body1">
+                      Go to the{' '}
+                      <Link href={`${getPathPrefix()}/workflows`}>workflows</Link>{' '}
+                      page to see a visualization of the workflow you just
+                      created.
+                    </Typography>
+                  </li>
+                </ol>
+              </Box>
             </Box>
-          </Box>
+          </InfoCard>
         )}
+
+        <InfoCard>
+          <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
+            <FontAwesomeIcon icon={faBook} color="#002F5E" />
+          </Box>
+          <Typography variant="body1" sx={{ fontSize: '20px' }}>
+            {`If you still have questions, you can find our documentation `}
+            <Link href="https://docs.aqueducthq.com">here</Link>.
+          </Typography>
+        </InfoCard>
+
+        <InfoCard>
+          <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
+            <FontAwesomeIcon icon={faEnvelope} color="#002F5E" />
+          </Box>
+          <Typography variant="body1" sx={{ fontSize: '20px' }}>
+            {`Have any other questions? You can reach our team via email at `}
+            <Link href="mailto:support@aqueducthq.com">
+              support@aqueducthq.com
+            </Link>
+            .
+          </Typography>
+        </InfoCard>
+
+        <InfoCard>
+          <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
+            <FontAwesomeIcon icon={faSlack} color="#002F5E" />
+          </Box>
+          <Typography variant="body1" sx={{ fontSize: '20px' }}>
+            {`You can also join our Slack community `}
+            <Link href="https://join.slack.com/t/aqueductusers/shared_invite/zt-11hby91cx-cpmgfK0qfXqEYXv25hqD6A">
+              here
+            </Link>
+            .
+          </Typography>
+        </InfoCard>
+
+        <InfoCard>
+          <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
+            <FontAwesomeIcon icon={faThumbsUp} color="#002F5E" />
+          </Box>
+          <Typography variant="body1" sx={{ fontSize: '20px' }}>
+            {`Have feedback? Let us know how we're doing `}
+            <Link href="https://forms.gle/Ef5hvT35d7j27YqV6">here</Link>.
+          </Typography>
+        </InfoCard>
       </Box>
-
-      {/* `styled` currently doesn't respect `backgroundColor` for some reason, so we have to set it explicitly here.. */}
-      <InfoCard sx={{ backgroundColor: 'gray.50' }}>
-        <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
-          <FontAwesomeIcon icon={faBook} />
-        </Box>
-        <Typography variant="h6">
-          {`If you still have questions, you can find our documentation `}
-          <Link href="https://docs.aqueducthq.com">here</Link>.
-        </Typography>
-      </InfoCard>
-
-      <InfoCard sx={{ backgroundColor: 'gray.50' }}>
-        <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
-          <FontAwesomeIcon icon={faEnvelope} />
-        </Box>
-        <Typography variant="h6">
-          {`Have any other questions? You can reach our team via email at `}
-          <Link href="mailto:support@aqueducthq.com">
-            support@aqueducthq.com
-          </Link>
-          .
-        </Typography>
-      </InfoCard>
-
-      <InfoCard sx={{ backgroundColor: 'gray.50' }}>
-        <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
-          <FontAwesomeIcon icon={faSlack} />
-        </Box>
-        <Typography variant="h6">
-          {`You can also join our Slack community `}
-          <Link href="https://join.slack.com/t/aqueductusers/shared_invite/zt-11hby91cx-cpmgfK0qfXqEYXv25hqD6A">
-            here
-          </Link>
-          .
-        </Typography>
-      </InfoCard>
-
-      <InfoCard sx={{ backgroundColor: 'gray.50' }}>
-        <Box sx={{ width: '80px', px: 2, fontSize: '48px' }}>
-          <FontAwesomeIcon icon={faThumbsUp} />
-        </Box>
-        <Typography variant="h6">
-          {`Have feedback? Let us know how we're doing `}
-          <Link href="https://forms.gle/Ef5hvT35d7j27YqV6">here</Link>.
-        </Typography>
-      </InfoCard>
     </Box>
   );
 };

--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -35,7 +35,7 @@ export const DefaultLayout: React.FC<Props> = ({
         <Box
           sx={{
             marginLeft: MenuSidebarOffset,
-            marginRight: layoutType === 'page' ? MenuSidebarOffset : '0px',
+            marginRight: 0,
             width: '100%',
             marginTop: 3,
           }}


### PR DESCRIPTION
## Describe your changes and why you are making these changes

As discussed on Linear, this PR makes a number of small fixes to the welcome page:
* Makes all the blocks even width. 
* Removes the light grey background adds dark blue borders to each block, combined with a light blue hover background.
* Adds Aqueduct logo to the top of the page.
* Cleans up getting started instructions to match the latest information.
* Animates wave emoji on page load and when hovering over the welcome block.

https://user-images.githubusercontent.com/867892/184013864-69cd5881-51b0-4361-ba63-4f191d42b150.mov

## Related issue number (if any)

ENG-1328

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


