### PR TITLE
Avoid spamming the server when reads when waiting for flows to complete in tests

### DIFF
--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -149,10 +149,10 @@ def wait_for_flow_runs(
     while True:
         assert time.time() - begin < timeout, "Timed out waiting for workflow run to complete."
 
+        time.sleep(poll_threshold)
+
         if all(str(flow_id) != flow_dict["flow_id"] for flow_dict in client.list_flows()):
             continue
-
-        time.sleep(poll_threshold)
 
         # A flow has been successfully published if it makes at least one workflow run, and
         # all its workflow runs have executed successfully.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We need to sleep every loop.

## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


