### PR TITLE
Eng 1438 backend support for connecting to s3 using credential file

### DIFF
--- a/src/golang/lib/engine/engine.go
+++ b/src/golang/lib/engine/engine.go
@@ -30,19 +30,16 @@ type Engine interface {
 		name string,
 		period string,
 	) error
-
 	ExecuteWorkflow(
 		ctx context.Context,
 		workflowId uuid.UUID,
 		timeConfig *AqueductTimeConfig,
 		parameters map[string]string,
 	) (shared.ExecutionStatus, error)
-
 	DeleteWorkflow(
 		ctx context.Context,
 		workflowId uuid.UUID,
 	) error
-
 	EditWorkflow(
 		ctx context.Context,
 		txn database.Database,

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -223,6 +223,10 @@ func (j *ProcessJobManager) mapJobTypeToCmd(jobName string, spec Spec) (*exec.Cm
 			"--spec",
 			specStr,
 		)
+
+		// This is required for credential related temp file creation.
+		// See S3 python executor for more details.
+		cmd.Dir = j.conf.OperatorStorageDir
 	} else if spec.Type() == SystemMetricJobType {
 		specStr, err := EncodeSpec(spec, JsonSerializationType)
 		if err != nil {

--- a/src/golang/lib/workflow/operator/connector/auth/static_config.go
+++ b/src/golang/lib/workflow/operator/connector/auth/static_config.go
@@ -27,8 +27,8 @@ func (sc *staticConfig) PublicConfig() map[string]string {
 	publicConf := make(map[string]string, len(sc.Conf))
 
 	// TODO: This is hacky for now. It assumes the only confidential information
-	// is "password" or "service_account_credentials".
-	sensitiveKeys := []string{"password", "service_account_credentials"}
+	// is "password" or "service_account_credentials" or "config_file_content".
+	sensitiveKeys := []string{"password", "service_account_credentials", "config_file_content"}
 
 	for key, val := range sc.Conf {
 		if !sliceContains(sensitiveKeys, key) {

--- a/src/python/aqueduct_executor/operators/connectors/tabular/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/config.py
@@ -29,7 +29,8 @@ class PostgresConfig(models.BaseConfig):
 
 class S3CredentialType(str, Enum, metaclass=MetaEnum):
     ACCESS_KEY = "access_key"
-    CONFIG_FILE = "config_file"
+    CONFIG_FILE_PATH = "config_file_path"
+    CONFIG_FILE_CONTENT = "config_file_content"
 
 
 class S3Config(models.BaseConfig):
@@ -40,8 +41,9 @@ class S3Config(models.BaseConfig):
     access_key_id: str = ""
     secret_access_key: str = ""
 
-    # Aws config file credentials
+    # Config credentials
     config_file_path: str = ""
+    config_file_content: str = ""
     config_file_profile: str = ""
 
     bucket: str = ""

--- a/src/python/aqueduct_executor/operators/connectors/tabular/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/config.py
@@ -1,6 +1,8 @@
+from enum import Enum
 from typing import Optional, Union
 
 from aqueduct_executor.operators.connectors.tabular import models
+from aqueduct_executor.operators.utils.enums import MetaEnum
 from pydantic import Field
 
 
@@ -25,10 +27,24 @@ class PostgresConfig(models.BaseConfig):
     port: Optional[str] = "5432"
 
 
+class S3CredentialType(str, Enum, metaclass=MetaEnum):
+    ACCESS_KEY = "access_key"
+    CONFIG_FILE = "config_file"
+
+
 class S3Config(models.BaseConfig):
-    access_key_id: str
-    secret_access_key: str
-    bucket: str
+    # default type to ACCESS_KEY mainly for backward compatibility
+    type: S3CredentialType = S3CredentialType.ACCESS_KEY
+
+    # Access key credentials
+    access_key_id: str = ""
+    secret_access_key: str = ""
+
+    # Aws config file credentials
+    config_file_path: str = ""
+    config_file_profile: str = ""
+
+    bucket: str = ""
 
 
 class SnowflakeConfig(models.BaseConfig):

--- a/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/tabular/s3.py
@@ -26,7 +26,7 @@ class S3Connector(connector.TabularConnector):
     def _handle_config_file_content(self, config: S3Config) -> None:
         """
         _handle_config_file_content updates config's access_key and secret_access_key
-        based on credentials in config_file_path and config_file_profile.
+        based on credentials in config_file_content and config_file_profile.
         """
         # write to temp file assuming the cwd is safe to create such file.
         temp_path = os.path.join(os.getcwd(), str(uuid.uuid4()))
@@ -36,11 +36,9 @@ class S3Connector(connector.TabularConnector):
 
         try:
             self._handle_config_file_path(config)
+        finally:
+            # always remove
             os.remove(temp_path)
-        except Exception as e:
-            # remove temp file before throwing original exception.
-            os.remove(temp_path)
-            raise e
 
     def __init__(self, config: S3Config):
         # Write a temp file

--- a/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
@@ -90,7 +90,7 @@ export const IntegrationFileUploadField: React.FC<
     header = (
       <Box>
         <Typography variant="body1" component="span" sx={{ mr: 4 }}>
-          <strong>{label}</strong>: {file.name}
+          <strong>{label}</strong>
         </Typography>
         <Button
           size="small"
@@ -106,7 +106,7 @@ export const IntegrationFileUploadField: React.FC<
 
     const styling = {
       margin: '16px',
-      height: '25vh',
+      maxHeight: '25vh',
       width: `max(100%-16px,${placeholder.length + 8}ch)`,
     };
 

--- a/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
@@ -79,7 +79,7 @@ export const BigQueryDialog: React.FC<Props> = ({ setDialogConfig }) => {
   );
 };
 
-function readCredentialsFile(
+export function readCredentialsFile(
   file: File,
   setFile: (credentials: FileData) => void
 ) {

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -24,6 +24,7 @@ import {
   CSVConfig,
   formatService,
   IntegrationConfig,
+  S3Config,
   Service,
   SupportedIntegrations,
 } from '../../../utils/integrations';
@@ -35,7 +36,7 @@ import { MariaDbDialog } from './mariadbDialog';
 import { MysqlDialog } from './mysqlDialog';
 import { PostgresDialog } from './postgresDialog';
 import { RedshiftDialog } from './redshiftDialog';
-import { S3Dialog } from './s3Dialog';
+import { isS3ConfigComplete, S3Dialog } from './s3Dialog';
 import { SnowflakeDialog } from './snowflakeDialog';
 
 type AddTableDialogProps = {
@@ -321,5 +322,9 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
 export function isConfigComplete(
   config: IntegrationConfig | CSVConfig
 ): boolean {
+  if (isS3ConfigComplete(config as S3Config)) {
+    return true;
+  }
+
   return Object.values(config).every((x) => x === undefined || (x && x !== ''));
 }

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -1,13 +1,26 @@
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
 
-import { IntegrationConfig, S3Config } from '../../../utils/integrations';
+import { Tab, Tabs } from '../../../components/primitives/Tabs.styles';
+import {
+  FileData,
+  IntegrationConfig,
+  S3Config,
+  S3CredentialType,
+} from '../../../utils/integrations';
+import { readCredentialsFile } from './bigqueryDialog';
+import { IntegrationFileUploadField } from './IntegrationFileUploadField';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: S3Config = {
+  type: S3CredentialType.AccessKey,
   bucket: 'aqueduct',
   access_key_id: '',
   secret_access_key: '',
+  config_file_path: '',
+  config_file_content: '',
+  config_file_profile: '',
 };
 
 type Props = {
@@ -18,28 +31,51 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [bucket, setBucket] = useState<string>(null);
   const [accessKeyId, setAccessKeyId] = useState<string>(null);
   const [secretAccessKey, setSecretAccessKey] = useState<string>(null);
+  const [configFilePath, setConfigFilePath] = useState<string>(null);
+  const [file, setFile] = useState<FileData>(null);
+  const [configFileProfile, setConfigFileProfile] = useState<string>(null);
+  const [s3Type, setS3Type] = useState<S3CredentialType>(
+    S3CredentialType.AccessKey
+  );
 
   useEffect(() => {
     const config: S3Config = {
+      type: s3Type,
       bucket: bucket,
       access_key_id: accessKeyId,
       secret_access_key: secretAccessKey,
+      config_file_path: configFilePath,
+      config_file_content: file?.data ?? '',
+      config_file_profile: configFileProfile,
     };
     setDialogConfig(config);
-  }, [bucket, accessKeyId, secretAccessKey]);
+  }, [
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    configFilePath,
+    file,
+    configFileProfile,
+    s3Type,
+  ]);
 
-  return (
-    <Box sx={{ mt: 2 }}>
-      <IntegrationTextInputField
-        spellCheck={false}
-        required={true}
-        label="Bucket*"
-        description="The name of the S3 bucket."
-        placeholder={Placeholders.bucket}
-        onChange={(event) => setBucket(event.target.value)}
-        value={bucket}
-      />
+  const configProfileInput = (
+    <IntegrationTextInputField
+      spellCheck={false}
+      required={true}
+      label="AWS Profile*"
+      description="The name of the profile specified in brackets in your credential file."
+      placeholder={Placeholders.secret_access_key}
+      onChange={(event) => setConfigFileProfile(event.target.value)}
+      value={secretAccessKey}
+    />
+  );
 
+  const accessKeyTab = (
+    <Box>
+      <Typography variant="body2" color="gray.700">
+        Manually enter your AWS credentials.
+      </Typography>
       <IntegrationTextInputField
         spellCheck={false}
         required={true}
@@ -61,4 +97,109 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       />
     </Box>
   );
+
+  const configPathTab = (
+    <Box>
+      <Typography variant="body2" color="gray.700">
+        Specify the path to your AWS credentials <strong>on the machine</strong>{' '}
+        where you are running the Aqueduct server. Typically, this is in{' '}
+        <code>~/.aws/credentials</code>. You also need to specify the profile
+        name you would like to use for the credentials file. Once connected, any
+        updates to the file content will automatically apply to this
+        integration.
+      </Typography>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="AWS Credentials File Path*"
+        description={'The absolute path to the credentials file'}
+        placeholder={Placeholders.access_key_id}
+        onChange={(event) => setConfigFilePath(event.target.value)}
+        value={accessKeyId}
+      />
+
+      {configProfileInput}
+    </Box>
+  );
+
+  const configUploadTab = (
+    <Box>
+      <Typography variant="body2" color="gray.700">
+        Upload your AWS credentials file. Typically, this is in{' '}
+        <code>~/.aws/credentials</code>. You also need to specify the profile
+        name you would like to use for the credentials file.
+      </Typography>
+      {/* add these message once integration edit is ready:
+        Once connected, you would need to re-upload the file to update the credentials.
+      */}
+      <IntegrationFileUploadField
+        label={'AWS Credentials File*'}
+        description={'Upload your credentials file here.'}
+        required={true}
+        file={file}
+        placeholder={''}
+        onFiles={(files) => {
+          const file = files[0];
+          readCredentialsFile(file, setFile);
+        }}
+        displayFile={null}
+        onReset={(_) => {
+          setFile(null);
+        }}
+      />
+
+      {configProfileInput}
+    </Box>
+  );
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Bucket*"
+        description="The name of the S3 bucket."
+        placeholder={Placeholders.bucket}
+        onChange={(event) => setBucket(event.target.value)}
+        value={bucket}
+      />
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+        <Tabs value={s3Type} onChange={(_, value) => setS3Type(value)}>
+          <Tab value={S3CredentialType.AccessKey} label="Enter Access Keys" />
+          <Tab
+            value={S3CredentialType.ConfigFilePath}
+            label="Specify Path to Credentials"
+          />
+          <Tab
+            value={S3CredentialType.ConfigFileContent}
+            label="Upload Credentials File"
+          />
+        </Tabs>
+      </Box>
+      {s3Type === S3CredentialType.AccessKey && accessKeyTab}
+      {s3Type === S3CredentialType.ConfigFilePath && configPathTab}
+      {s3Type === S3CredentialType.ConfigFileContent && configUploadTab}
+    </Box>
+  );
 };
+
+export function isS3ConfigComplete(config: S3Config): boolean {
+  if (!config.bucket) {
+    return false;
+  }
+
+  if (config.type === S3CredentialType.AccessKey) {
+    return !!config.access_key_id && !!config.secret_access_key;
+  }
+
+  if (config.type === S3CredentialType.ConfigFilePath) {
+    return !!config.config_file_profile && !!config.config_file_path;
+  }
+
+  if (config.type === S3CredentialType.ConfigFileContent) {
+    return !!config.config_file_profile && !!config.config_file_content;
+  }
+
+  return false;
+}

--- a/src/ui/common/src/components/integrations/integrationObjectList.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectList.tsx
@@ -53,7 +53,7 @@ const IntegrationObjectList: React.FC<Props> = ({ user, integration }) => {
 
   if (integration.service === 'S3') {
     return (
-      <Alert severity="warning" sx={{ width: '80%' }}>
+      <Alert severity="warning" sx={{ width: '80%', mt: 4 }}>
         <>
           We currently do not support listing data in an S3 bucket. But
           don&apos;t worry&mdash;we&apos;re working on adding this feature! If

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -85,10 +85,20 @@ export type SalesforceConfig = {
   code?: string;
 };
 
+export enum S3CredentialType {
+  AccessKey = 'access_key',
+  ConfigFilePath = 'config_file_path',
+  ConfigFileContent = 'config_file_content',
+}
+
 export type S3Config = {
+  type: S3CredentialType;
   bucket: string;
   access_key_id: string;
   secret_access_key: string;
+  config_file_path: string;
+  config_file_content: string;
+  config_file_profile: string;
 };
 
 export type AqueductDemoConfig = Record<string, never>;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds backend supports for using credentials file to connect S3 integrations, which should also enable SSO support. Specifically, we:
* Added a type for s3 config together with 3 types, to distinguish manual inputs, file path (read file content directly at runtime), and file uploads. Added additional config fields to specify file path, content, and aws profile to use.
* Updated python executor to use `boto3` API to read credential file together with the profile name. Per description in https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html , this exact API supports both regular access key credentials and SSO.
* Due to restrictions of boto3 API, in upload mode we would have to explicitly store uploaded credential content in a temp file. We updated working dir for all integration operators (auth, discover, extract, and load) to make sure this temp file is stored under `.aqueduct/server/storage/operators`.
## Related issue number (if any)
ENG-1436 ENG-1437 ENG-1438

## Checklist before requesting a review
Demo in #334 . Should be sufficient as long as in-PR integration tests passed.
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


