### PR TITLE
Eng 1438 UI support to connect to S3 using credential file.

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
@@ -90,7 +90,7 @@ export const IntegrationFileUploadField: React.FC<
     header = (
       <Box>
         <Typography variant="body1" component="span" sx={{ mr: 4 }}>
-          <strong>{label}</strong>: {file.name}
+          <strong>{label}</strong>
         </Typography>
         <Button
           size="small"

--- a/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
@@ -106,7 +106,7 @@ export const IntegrationFileUploadField: React.FC<
 
     const styling = {
       margin: '16px',
-      height: '25vh',
+      maxHeight: '25vh',
       width: `max(100%-16px,${placeholder.length + 8}ch)`,
     };
 

--- a/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
@@ -79,7 +79,7 @@ export const BigQueryDialog: React.FC<Props> = ({ setDialogConfig }) => {
   );
 };
 
-function readCredentialsFile(
+export function readCredentialsFile(
   file: File,
   setFile: (credentials: FileData) => void
 ) {

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -24,6 +24,7 @@ import {
   CSVConfig,
   formatService,
   IntegrationConfig,
+  S3Config,
   Service,
   SupportedIntegrations,
 } from '../../../utils/integrations';
@@ -35,7 +36,7 @@ import { MariaDbDialog } from './mariadbDialog';
 import { MysqlDialog } from './mysqlDialog';
 import { PostgresDialog } from './postgresDialog';
 import { RedshiftDialog } from './redshiftDialog';
-import { S3Dialog } from './s3Dialog';
+import { isS3ConfigComplete, S3Dialog } from './s3Dialog';
 import { SnowflakeDialog } from './snowflakeDialog';
 
 type AddTableDialogProps = {
@@ -321,5 +322,9 @@ export const IntegrationDialog: React.FC<IntegrationDialogProps> = ({
 export function isConfigComplete(
   config: IntegrationConfig | CSVConfig
 ): boolean {
+  if (isS3ConfigComplete(config as S3Config)) {
+    return true;
+  }
+
   return Object.values(config).every((x) => x === undefined || (x && x !== ''));
 }

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -1,13 +1,27 @@
 import Box from '@mui/material/Box';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
 
-import { IntegrationConfig, S3Config } from '../../../utils/integrations';
+import {
+  FileData,
+  IntegrationConfig,
+  S3Config,
+  S3CredentialType,
+} from '../../../utils/integrations';
+import { readCredentialsFile } from './bigqueryDialog';
+import { IntegrationFileUploadField } from './IntegrationFileUploadField';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: S3Config = {
+  type: S3CredentialType.AccessKey,
   bucket: 'aqueduct',
   access_key_id: '',
   secret_access_key: '',
+  config_file_path: '',
+  config_file_content: '',
+  config_file_profile: '',
 };
 
 type Props = {
@@ -18,28 +32,51 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [bucket, setBucket] = useState<string>(null);
   const [accessKeyId, setAccessKeyId] = useState<string>(null);
   const [secretAccessKey, setSecretAccessKey] = useState<string>(null);
+  const [configFilePath, setConfigFilePath] = useState<string>(null);
+  const [file, setFile] = useState<FileData>(null);
+  const [configFileProfile, setConfigFileProfile] = useState<string>(null);
+  const [s3Type, setS3Type] = useState<S3CredentialType>(
+    S3CredentialType.AccessKey
+  );
 
   useEffect(() => {
     const config: S3Config = {
+      type: s3Type,
       bucket: bucket,
       access_key_id: accessKeyId,
       secret_access_key: secretAccessKey,
+      config_file_path: configFilePath,
+      config_file_content: file?.data ?? '',
+      config_file_profile: configFileProfile,
     };
     setDialogConfig(config);
-  }, [bucket, accessKeyId, secretAccessKey]);
+  }, [
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    configFilePath,
+    file,
+    configFileProfile,
+    s3Type,
+  ]);
 
-  return (
-    <Box sx={{ mt: 2 }}>
-      <IntegrationTextInputField
-        spellCheck={false}
-        required={true}
-        label="Bucket*"
-        description="The name of the S3 bucket."
-        placeholder={Placeholders.bucket}
-        onChange={(event) => setBucket(event.target.value)}
-        value={bucket}
-      />
+  const configProfileInput = (
+    <IntegrationTextInputField
+      spellCheck={false}
+      required={true}
+      label="AWS Profile*"
+      description="The name of the profile specified in brackets in your credential file."
+      placeholder={Placeholders.secret_access_key}
+      onChange={(event) => setConfigFileProfile(event.target.value)}
+      value={secretAccessKey}
+    />
+  );
 
+  const accessKeyTab = (
+    <Box>
+      <Typography variant="body2" color="gray.700">
+        Manually enter your AWS credentials.
+      </Typography>
       <IntegrationTextInputField
         spellCheck={false}
         required={true}
@@ -61,4 +98,111 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       />
     </Box>
   );
+
+  const configPathTab = (
+    <Box>
+      <Typography variant="body2" color="gray.700">
+        Provide the credentials by specifying the path to your aws credentials,
+        together with the name of the profile you would like to use. <br />
+        The path has to be in the same machine as the one you run{' '}
+        <code> aqueduct start </code> . Typically, it&apos;s{' '}
+        <code>~/.aws/credentials</code>. <br />
+        Once connected, any updates to the file content will automatically apply
+        to this integration.
+      </Typography>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="AWS Credentials File Path*"
+        description={'The absolute path to the credentials file'}
+        placeholder={Placeholders.access_key_id}
+        onChange={(event) => setConfigFilePath(event.target.value)}
+        value={accessKeyId}
+      />
+
+      {configProfileInput}
+    </Box>
+  );
+
+  const configUploadTab = (
+    <Box>
+      <Typography variant="body2" color="gray.700">
+        Upload your aws credentials file and provide the name of the profile you
+        would like to use. Typically, it&apos;s <code>~/.aws/credentials</code>.
+        {/* uncomment once integration edit is ready:
+      <br/>
+      <br/>
+        Once connected, you would need to re-upload the file to update the credentials.
+      */}
+      </Typography>
+      <IntegrationFileUploadField
+        label={'AWS Credentials File*'}
+        description={'upload your credentials file here.'}
+        required={true}
+        file={file}
+        placeholder={''}
+        onFiles={(files) => {
+          const file = files[0];
+          readCredentialsFile(file, setFile);
+        }}
+        displayFile={null}
+        onReset={(_) => {
+          setFile(null);
+        }}
+      />
+
+      {configProfileInput}
+    </Box>
+  );
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Bucket*"
+        description="The name of the S3 bucket."
+        placeholder={Placeholders.bucket}
+        onChange={(event) => setBucket(event.target.value)}
+        value={bucket}
+      />
+
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+        <Tabs value={s3Type} onChange={(_, value) => setS3Type(value)}>
+          <Tab value={S3CredentialType.AccessKey} label="Access Keys" />
+          <Tab
+            value={S3CredentialType.ConfigFilePath}
+            label="Credentials Path"
+          />
+          <Tab
+            value={S3CredentialType.ConfigFileContent}
+            label="Upload Credentials File"
+          />
+        </Tabs>
+      </Box>
+      {s3Type === S3CredentialType.AccessKey && accessKeyTab}
+      {s3Type === S3CredentialType.ConfigFilePath && configPathTab}
+      {s3Type === S3CredentialType.ConfigFileContent && configUploadTab}
+    </Box>
+  );
 };
+
+export function isS3ConfigComplete(config: S3Config): boolean {
+  if (!config.bucket) {
+    return false;
+  }
+
+  if (config.type === S3CredentialType.AccessKey) {
+    return !!config.access_key_id && !!config.secret_access_key;
+  }
+
+  if (config.type === S3CredentialType.ConfigFilePath) {
+    return !!config.config_file_profile && !!config.config_file_path;
+  }
+
+  if (config.type === S3CredentialType.ConfigFileContent) {
+    return !!config.config_file_profile && !!config.config_file_content;
+  }
+
+  return false;
+}

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -102,15 +102,11 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
     <Box>
       <Typography variant="body2" color="gray.700">
         Specify the path to your AWS credentials <strong>on the machine</strong>{' '}
-        where you are running the Aqueduct server.
-      </Typography>
-      <Typography variant="body2" color="gray.700">
-        Typically, this is in <code>~/.aws/credentials</code>. You also need to
-        specify the profile name you would like to use for the credentials file.
-      </Typography>
-      <Typography variant="body2" color="gray.700">
-        Once connected, any updates to the file content will automatically apply
-        to this integration.
+        where you are running the Aqueduct server. Typically, this is in{' '}
+        <code>~/.aws/credentials</code>. You also need to specify the profile
+        name you would like to use for the credentials file. Once connected, any
+        updates to the file content will automatically apply to this
+        integration.
       </Typography>
       <IntegrationTextInputField
         spellCheck={false}
@@ -129,11 +125,9 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const configUploadTab = (
     <Box>
       <Typography variant="body2" color="gray.700">
-        Upload your AWS credentials file.
-      </Typography>
-      <Typography variant="body2" color="gray.700">
-        Typically, this is in <code>~/.aws/credentials</code>. You also need to
-        specify the profile name you would like to use for the credentials file.
+        Upload your AWS credentials file. Typically, this is in{' '}
+        <code>~/.aws/credentials</code>. You also need to specify the profile
+        name you would like to use for the credentials file.
       </Typography>
       {/* add these message once integration edit is ready:
         Once connected, you would need to re-upload the file to update the credentials.

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -1,9 +1,8 @@
 import Box from '@mui/material/Box';
-import Tab from '@mui/material/Tab';
-import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
 
+import { Tab, Tabs } from '../../../components/primitives/Tabs.styles';
 import {
   FileData,
   IntegrationConfig,
@@ -102,11 +101,14 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const configPathTab = (
     <Box>
       <Typography variant="body2" color="gray.700">
-        Provide the credentials by specifying the path to your aws credentials,
-        together with the name of the profile you would like to use. <br />
-        The path has to be in the same machine as the one you run{' '}
-        <code> aqueduct start </code> . Typically, it&apos;s{' '}
-        <code>~/.aws/credentials</code>. <br />
+        Specify the path to your AWS credentials <strong>on the machine</strong>{' '}
+        where you are running the Aqueduct server.
+      </Typography>
+      <Typography variant="body2" color="gray.700">
+        Typically, this is in <code>~/.aws/credentials</code>. You also need to
+        specify the profile name you would like to use for the credentials file.
+      </Typography>
+      <Typography variant="body2" color="gray.700">
         Once connected, any updates to the file content will automatically apply
         to this integration.
       </Typography>
@@ -127,17 +129,18 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const configUploadTab = (
     <Box>
       <Typography variant="body2" color="gray.700">
-        Upload your aws credentials file and provide the name of the profile you
-        would like to use. Typically, it&apos;s <code>~/.aws/credentials</code>.
-        {/* uncomment once integration edit is ready:
-      <br/>
-      <br/>
+        Upload your AWS credentials file.
+      </Typography>
+      <Typography variant="body2" color="gray.700">
+        Typically, this is in <code>~/.aws/credentials</code>. You also need to
+        specify the profile name you would like to use for the credentials file.
+      </Typography>
+      {/* add these message once integration edit is ready:
         Once connected, you would need to re-upload the file to update the credentials.
       */}
-      </Typography>
       <IntegrationFileUploadField
         label={'AWS Credentials File*'}
-        description={'upload your credentials file here.'}
+        description={'Upload your credentials file here.'}
         required={true}
         file={file}
         placeholder={''}
@@ -169,10 +172,10 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
         <Tabs value={s3Type} onChange={(_, value) => setS3Type(value)}>
-          <Tab value={S3CredentialType.AccessKey} label="Access Keys" />
+          <Tab value={S3CredentialType.AccessKey} label="Enter Access Keys" />
           <Tab
             value={S3CredentialType.ConfigFilePath}
-            label="Credentials Path"
+            label="Specify Path to Credentials"
           />
           <Tab
             value={S3CredentialType.ConfigFileContent}

--- a/src/ui/common/src/components/integrations/integrationObjectList.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectList.tsx
@@ -53,7 +53,7 @@ const IntegrationObjectList: React.FC<Props> = ({ user, integration }) => {
 
   if (integration.service === 'S3') {
     return (
-      <Alert severity="warning" sx={{ width: '80%' }}>
+      <Alert severity="warning" sx={{ width: '80%', mt: 4 }}>
         <>
           We currently do not support listing data in an S3 bucket. But
           don&apos;t worry&mdash;we&apos;re working on adding this feature! If

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -85,10 +85,20 @@ export type SalesforceConfig = {
   code?: string;
 };
 
+export enum S3CredentialType {
+  AccessKey = 'access_key',
+  ConfigFilePath = 'config_file_path',
+  ConfigFileContent = 'config_file_content',
+}
+
 export type S3Config = {
+  type: S3CredentialType;
   bucket: string;
   access_key_id: string;
   secret_access_key: string;
+  config_file_path: string;
+  config_file_content: string;
+  config_file_profile: string;
 };
 
 export type AqueductDemoConfig = Record<string, never>;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds UI support for connecting to S3 using credential files. We support both specifying a path and read in live, and uploading the content of the file. The main changes involves adding UI components so that the users could select how to auth, and fill those new fields properly.

## Related issue number (if any)
ENG-1436 ENG-1437 ENG-1438

## Checklist before requesting a review
Demo: https://www.loom.com/share/259db52d71074a0fad74603996fae7cb

The alert box is too close to detail card. Also fixed:
<img width="1107" alt="Screen Shot 2022-08-11 at 10 54 44 AM" src="https://user-images.githubusercontent.com/10411887/184209144-3b24afb5-707a-47a8-8bfe-7feba801e35b.png">

- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


