### PR TITLE
Add exception to traceback message

### DIFF
--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -156,4 +156,7 @@ def exception_traceback(exception: Exception) -> str:
 
     This is typically used for system error so that the full trace is captured.
     """
-    return "".join(traceback.format_tb(exception.__traceback__))  + f"{exception.__class__.__name__}: {str(exception)}"
+    return (
+        "".join(traceback.format_tb(exception.__traceback__))
+        + f"{exception.__class__.__name__}: {str(exception)}"
+    )

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -156,4 +156,4 @@ def exception_traceback(exception: Exception) -> str:
 
     This is typically used for system error so that the full trace is captured.
     """
-    return "".join(traceback.format_tb(exception.__traceback__))
+    return "".join(traceback.format_tb(exception.__traceback__))  + f"{exception.__class__.__name__}: {str(exception)}"


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The context currently only displays the trace but not the actual exception class & message which is not as helpful as it could be. Since the stack trace in Python shows both, this results in the trace looking cut-off. I believe this is the same issue encountered in https://github.com/aqueducthq/aqueduct/pull/248 being described in ENG-1445.

Before:
```
  File "/Users/eunice/Desktop/aqueduct/src/python/aqueduct_executor/operators/connectors/tabular/relational.py", line 47, in delete
    sql_table = metadata.tables[table]
```
After:
```
  File "/Users/eunice/Desktop/aqueduct/src/python/aqueduct_executor/operators/connectors/tabular/relational.py", line 47, in delete
    sql_table = metadata.tables[table]
KeyError: 'delete_table'
```

## Related issue number (if any)
ENG-1445

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


