### PR TITLE
[ENG-1504] Fixes bug where CSV upload modal errors were incorrectly displayed

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/addTableDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/addTableDialog.tsx
@@ -96,7 +96,7 @@ const AddTableDialog: React.FC<Props> = ({
         {errMsg && (
           <Alert severity="error">
             <AlertTitle>
-              Unable to upload CSV file to demo database..
+              Unable to upload CSV file to demo database.
             </AlertTitle>
             <pre>{errMsg}</pre>
           </Alert>

--- a/src/ui/common/src/components/integrations/dialogs/addTableDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/addTableDialog.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { LoadingButton } from '@mui/lab';
 import {
   Alert,
+  AlertTitle,
   Box,
   DialogActions,
   DialogContent,
@@ -71,6 +72,7 @@ const AddTableDialog: React.FC<Props> = ({
   const confirmConnect = () => {
     setIsConnecting(true);
     setErrMsg(null);
+
     addTable(user, integrationId, config)
       .then(() => {
         setShowSuccessToast(true);
@@ -81,8 +83,7 @@ const AddTableDialog: React.FC<Props> = ({
         setIsConnecting(false);
       })
       .catch((err) => {
-        const errorMessage = 'Unable to upload CSV file to the demo database: ';
-        setErrMsg(errorMessage + err.message);
+        setErrMsg(err.message);
         setIsConnecting(false);
       });
   };
@@ -92,7 +93,14 @@ const AddTableDialog: React.FC<Props> = ({
       <DialogTitle>{dialogHeader}</DialogTitle>
       <DialogContent>
         {serviceDialog}
-        {errMsg && <Alert severity="error">{errMsg}</Alert>}
+        {errMsg && (
+          <Alert severity="error">
+            <AlertTitle>
+              Unable to upload CSV file to demo database..
+            </AlertTitle>
+            <pre>{errMsg}</pre>
+          </Alert>
+        )}
         <Snackbar
           anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
           open={showSuccessToast}

--- a/src/ui/common/src/components/integrations/dialogs/addTableDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/addTableDialog.tsx
@@ -95,9 +95,7 @@ const AddTableDialog: React.FC<Props> = ({
         {serviceDialog}
         {errMsg && (
           <Alert severity="error">
-            <AlertTitle>
-              Unable to upload CSV file to demo database.
-            </AlertTitle>
+            <AlertTitle>Unable to upload CSV file to demo database.</AlertTitle>
             <pre>{errMsg}</pre>
           </Alert>
         )}

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -163,9 +163,10 @@ export async function addTable(
       body: config.csv.data,
     }
   );
+
   if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message);
+    const body = await res.json();
+    throw new Error(body.error);
   }
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Previously, when we got an error message from the backend, we were parsing it with `response.text()` rather than `response.json()`, so the error message body was wrapped in many `title: {some blob}` layers. Fixing that parsing allows us to return the actual error message from the backend and then display it in a `<pre>` block here: 

<img width="2672" alt="image" src="https://user-images.githubusercontent.com/867892/184252427-3d980488-e2a8-452e-be34-317cd20d08fb.png">

## Related issue number (if any)

ENG-1504

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


