### PR TITLE
[ENG-1534] Adds status to WorkflowHeader

### DIFF
--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -173,7 +173,10 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', my: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
-          <Typography variant="h3" sx={{ fontFamily: 'Monospace', mr: 2, lineHeight: 1 }}>
+          <Typography
+            variant="h3"
+            sx={{ fontFamily: 'Monospace', mr: 2, lineHeight: 1 }}
+          >
             {name}
           </Typography>
 

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -171,9 +171,9 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', my: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
-          <Typography variant="h3" sx={{ fontFamily: 'Monospace', mr: 2 }}>
+          <Typography variant="h3" sx={{ fontFamily: 'Monospace', mr: 2, lineHeight: 1 }}>
             {name}
           </Typography>
 

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -20,6 +20,7 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import VersionSelector from './version_selector';
 import WorkflowSettings from './WorkflowSettings';
+import Status from './workflowStatus';
 
 type Props = {
   user: UserProfile;
@@ -171,10 +172,12 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center' }}>
-        <Box sx={{ flex: 1 }}>
-          <Typography variant="h3" sx={{ fontFamily: 'Monospace' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
+          <Typography variant="h3" sx={{ fontFamily: 'Monospace', mr: 2 }}>
             {name}
           </Typography>
+
+          <Status status={workflow.dagResults[0].status} />
         </Box>
 
         <Box sx={{ ml: 2 }}>
@@ -188,6 +191,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
               <FontAwesomeIcon icon={faGear} />
             </Box>
           </Button>
+
           <WorkflowSettings
             user={user}
             open={showSettings}


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Previously, the only indication we had that a workflow was running was if you looked at the version selector dropdown. This was pretty subtle for new users, so this PR brings back the `Status` component in the `WorkflowHeader` to show the status of the workflow clearly.

<img width="575" alt="Screen Shot 2022-08-11 at 4 32 26 PM" src="https://user-images.githubusercontent.com/867892/184259498-0cb2119a-7196-4672-b0bd-31ddf6218bee.png">
<img width="586" alt="image" src="https://user-images.githubusercontent.com/867892/184259510-0cda3e51-4587-4471-913c-a197d0dcd408.png">

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


