### PR TITLE
Eng 1507 add stack trace to failed object deletion in workflow deletion [SDK/3]

### DIFF
--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -155,9 +155,9 @@ def test_delete_workflow_saved_objects_twice(client):
         assert "delete_table" not in set(tables_response["object_names"])
 
         # Try to delete table deleted by other flow.
-        with pytest.raises(Exception) as e_info:
-            client.delete_flow(flow_2_id, saved_objects_to_delete=tables, force=True)
-        assert str(e_info).startswith("Failed to delete")
+        # with pytest.raises(Exception) as e_info:
+        client.delete_flow(flow_2_id, saved_objects_to_delete=tables, force=True)
+        # assert str(e_info).startswith("Failed to delete")
 
     finally:
         for flow_id in flow_ids_to_delete:

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -157,7 +157,7 @@ def test_delete_workflow_saved_objects_twice(client):
         # Try to delete table deleted by other flow.
         with pytest.raises(Exception) as e_info:
             client.delete_flow(flow_2_id, saved_objects_to_delete=tables, force=True)
-        assert str(e_info).startswith("Failed to delete")
+        assert str(e_info.value).startswith("Failed to delete")
 
     finally:
         for flow_id in flow_ids_to_delete:

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -155,9 +155,9 @@ def test_delete_workflow_saved_objects_twice(client):
         assert "delete_table" not in set(tables_response["object_names"])
 
         # Try to delete table deleted by other flow.
-        # with pytest.raises(Exception) as e_info:
-        client.delete_flow(flow_2_id, saved_objects_to_delete=tables, force=True)
-        # assert str(e_info).startswith("Failed to delete")
+        with pytest.raises(Exception) as e_info:
+            client.delete_flow(flow_2_id, saved_objects_to_delete=tables, force=True)
+        assert str(e_info).startswith("Failed to delete")
 
     finally:
         for flow_id in flow_ids_to_delete:

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -193,7 +193,7 @@ def delete_flow(client: aqueduct.Client, workflow_id: uuid.UUID) -> None:
     try:
         client.delete_flow(str(workflow_id))
     except Exception as e:
-        print("Error deleting workflow %s with exception %s" % (workflow_id, e))
+        print("Error deleting workflow %s with exception: %s" % (workflow_id, e))
     else:
         print("Successfully deleted workflow %s" % (workflow_id))
 

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -453,9 +453,10 @@ class Client:
         for integration in resp.saved_object_deletion_results:
             for obj in resp.saved_object_deletion_results[integration]:
                 if obj.exec_state.status == ExecutionStatus.FAILED:
-                    assert isinstance(obj.exec_state.error, Error)
-                    context = obj.exec_state.error.context.strip().replace("\n", "\n>\t")
-                    trace = f">\t{context}\n{obj.exec_state.error.tip}"
+                    trace = ""
+                    if obj.exec_state.error:
+                        context = obj.exec_state.error.context.strip().replace("\n", "\n>\t")
+                        trace = f">\t{context}\n{obj.exec_state.error.tip}"
                     failure_string = f"[{integration}] {obj.name}\n{trace}"
                     failures.append(failure_string)
         if len(failures) > 0:

--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -226,7 +226,7 @@ class SavedObjectDelete(BaseModel):
     """This is an item in the list returned by DeleteWorkflowResponse."""
 
     name: str
-    succeeded: bool
+    exec_state: OperatorResult
 
 
 class DeleteWorkflowResponse(BaseModel):

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -481,7 +481,11 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const hasSavedObjects = Object.keys(savedObjects).length > 0;
 
   const deleteDialog = (
-    <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)} fullWidth>
+    <Dialog
+      open={showDeleteDialog}
+      onClose={() => setShowDeleteDialog(false)}
+      fullWidth
+    >
       <DialogTitle>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <Box sx={{ flex: 1 }}>
@@ -671,7 +675,9 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                   {objectResult.exec_state.status ===
                     ExecutionStatus.Failed && (
                     <Alert icon={false} severity="error">
-                      <AlertTitle>Failed to delete {objectResult.name}.</AlertTitle>
+                      <AlertTitle>
+                        Failed to delete {objectResult.name}.
+                      </AlertTitle>
                       <pre>{objectResult.exec_state.error.context}</pre>
                     </Alert>
                   )}

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -478,6 +478,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     </FormGroup>
   );
 
+  const hasSavedObjects = Object.keys(savedObjects).length > 0;
+
   const deleteDialog = (
     <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
       <DialogTitle>
@@ -503,13 +505,13 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
       </DialogTitle>
 
       <DialogContent>
-        <Typography variant="body1">
+        {hasSavedObjects && <Typography variant="body1">
           The following objects had been saved by{' '}
           <span style={{ fontFamily: 'Monospace' }}>
             {workflowDag.metadata?.name}
           </span>{' '}
           and can be removed when deleting the workflow:
-        </Typography>
+        </Typography>}
 
         <Box sx={{ my: 2 }}>
           {savedObjectsStatus === LoadingStatusEnum.Succeeded &&
@@ -521,14 +523,18 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           )}
         </Box>
 
-        <Typography variant="body1">
+        {hasSavedObjects && <Typography variant="body1">
           Deleting workflow{' '}
           <span style={{ fontFamily: 'Monospace' }}>{name}</span> and the
           associated <b>{selectedObjects.size}</b> objects is not reversible.
           Please note that we cannot guarantee this will only delete data
           created by Aqueduct. The workflow will be deleted even if the
           underlying objects are not successfully deleted.
-        </Typography>
+        </Typography>}
+        {!hasSavedObjects && <Typography variant="body1">
+          Are you sure you want to delete{' '}
+          <span style={{ fontFamily: 'Monospace' }}>{name}</span>? This action is not reversible.
+        </Typography>}
 
         <Box sx={{ my: 2 }}>
           <Typography variant="body1">


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Add stack traces / error messages to the failed object deletions as suggested in https://github.com/aqueducthq/aqueduct/pull/290.

BE Component https://github.com/aqueducthq/aqueduct/pull/340
UI Component https://github.com/aqueducthq/aqueduct/pull/341
SDK Component https://github.com/aqueducthq/aqueduct/pull/342

If we fail to delete the objects, an exception is thrown with this message (taken from the integration pytest):
```
E           Exception: Failed to delete 1 saved objects.
E           Failures
E           [aqueduct_demo] delete_table
E           >   File "/Users/eunice/Desktop/aqueduct/src/python/aqueduct_executor/operators/connectors/tabular/relational.py", line 47, in delete
E           >       sql_table = metadata.tables[table]
E           Sorry, we've run into an unexpected error! Please create bug report in github: https://github.com/aqueducthq/aqueduct/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D . We will get back to you as soon as we can.
```

## Related issue number (if any)
ENG 1370
ENG 1507

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)