### PR TITLE
Eng 1507 add stack trace to failed object deletion in workflow deletion [UI/3]

### DIFF
--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -428,7 +428,6 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
       [{integration}] <b>{name}</b>
     </Typography>
   );
-  console.log(savedObjects);
   const listSavedObjects = (
     <FormGroup>
       {Object.entries(savedObjects).map(

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -6,6 +6,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
+  AlertTitle,
   Checkbox,
   FormGroup,
   List,
@@ -480,7 +481,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const hasSavedObjects = Object.keys(savedObjects).length > 0;
 
   const deleteDialog = (
-    <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)}>
+    <Dialog open={showDeleteDialog} onClose={() => setShowDeleteDialog(false)} fullWidth>
       <DialogTitle>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <Box sx={{ flex: 1 }}>
@@ -604,6 +605,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
       open={showSavedObjectDeletionResultsDialog}
       onClose={() => navigate('/workflows')}
       maxWidth={false}
+      fullWidth
     >
       <DialogTitle>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
@@ -626,7 +628,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
         </Box>
       </DialogTitle>
 
-      <DialogContent sx={{ width: '600px' }}>
+      <DialogContent>
         <Typography>
           <span style={{ fontFamily: 'Monospace' }}>
             {workflowDag.metadata?.name}
@@ -635,7 +637,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           object deletion.
         </Typography>
 
-        <List style={{ maxHeight: '200px', overflow: 'auto' }} dense={true}>
+        <List dense={true}>
           {Object.entries(deleteWorkflowResults)
             .map(([integrationName, objectResults]) =>
               objectResults.map((objectResult) => (
@@ -668,7 +670,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                   </ListItem>
                   {objectResult.exec_state.status ===
                     ExecutionStatus.Failed && (
-                    <Alert severity="error">
+                    <Alert icon={false} severity="error">
+                      <AlertTitle>Failed to delete {objectResult.name}.</AlertTitle>
                       <pre>{objectResult.exec_state.error.context}</pre>
                     </Alert>
                   )}

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -1,6 +1,6 @@
 import { Artifact } from './artifacts';
 import { normalizeOperator, Operator } from './operators';
-import ExecutionStatus from './shared';
+import ExecutionStatus, { ExecState } from './shared';
 
 export type S3Config = {
   region: string;
@@ -96,7 +96,7 @@ export type ListWorkflowSavedObjectsResponse = {
 
 export type SavedObjectDeletion = {
   name: string;
-  succeeded: boolean;
+  exec_state: ExecState;
 };
 
 export type DeleteWorkflowResponse = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Add stack traces / error messages to the failed object deletions as suggested in https://github.com/aqueducthq/aqueduct/pull/290.

BE Component https://github.com/aqueducthq/aqueduct/pull/340
UI Component https://github.com/aqueducthq/aqueduct/pull/341
SDK Component https://github.com/aqueducthq/aqueduct/pull/342


## Demo
Shows error with failed deletion:
<img width="593" alt="image" src="https://user-images.githubusercontent.com/30596854/184263370-a97418fe-32d4-4077-bb33-73d15ddb217c.png">

0:17 - Deletes 5 tables and shows the error along with failed deletion. Scrolls because there are too many results on the screen.

https://user-images.githubusercontent.com/30596854/184263334-07a1d32d-e9a9-489b-9b92-caba2044f804.mov


## Related issue number (if any)
ENG 1370
ENG 1507

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)