### PR TITLE
Fix handling SSO credentials

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -127,7 +127,9 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       <Typography variant="body2" color="gray.700">
         Upload your AWS credentials file. Typically, this is in{' '}
         <code>~/.aws/credentials</code>. You also need to specify the profile
-        name you would like to use for the credentials file.
+        name you would like to use for the credentials file. If you are using an
+        SSO profile, you should <code>SPECIFY PATH TO CREDENTIALS</code>
+        instead.
       </Typography>
       {/* add these message once integration edit is ready:
         Once connected, you would need to re-upload the file to update the credentials.

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -128,7 +128,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
         Upload your AWS credentials file. Typically, this is in{' '}
         <code>~/.aws/credentials</code>. You also need to specify the profile
         name you would like to use for the credentials file. If you are using an
-        SSO profile, you should <code>SPECIFY PATH TO CREDENTIALS</code>
+        SSO profile, you should use <code>SPECIFY PATH TO CREDENTIALS</code>{' '}
         instead.
       </Typography>
       {/* add these message once integration edit is ready:

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -103,10 +103,10 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       <Typography variant="body2" color="gray.700">
         Specify the path to your AWS credentials <strong>on the machine</strong>{' '}
         where you are running the Aqueduct server. Typically, this is in{' '}
-        <code>~/.aws/credentials</code>. You also need to specify the profile
-        name you would like to use for the credentials file. Once connected, any
-        updates to the file content will automatically apply to this
-        integration.
+        <code>~/.aws/credentials</code>, or <code>~/.aws/config</code> for SSO.
+        You also need to specify the profile name you would like to use for the
+        credentials file. Once connected, any updates to the file content will
+        automatically apply to this integration.
       </Typography>
       <IntegrationTextInputField
         spellCheck={false}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR tries to fix SSO credentials handling. The python fix is regardless of product decision we land on, that we should use `session.resource()` from an authorized session since `credentials.access_key credentials.secret_key` cannot be explicitly used.

The product decision is an open question. It seems that SSO credentials are distributed in `config` file together with a file in `sso/cache`:
<img width="1121" alt="Screen Shot 2022-08-11 at 7 36 25 PM" src="https://user-images.githubusercontent.com/10411887/184274970-b0a9c79a-2632-434f-ab0f-e942db833393.png">

I've verified that auth doesn't work if only `config` file is provided. I haven't verified if we can just use either file in `sso/cache` and do some brittle auth process based on https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sso.html . Even if this approach work, the UI will look messy as we need to add additional switches to support file path / uploads for SSO which is not useful for most users.

In this way, the easiest solution is to only support SSO if the user specifies the path and in the case of SSO, we could assume proper process are done to generate `sso/cache` files. This PR adds an additional warning in UI mentioning SSO only works in path specification method.

## Related issue number (if any)
ENG-1437

## Checklist before requesting a review
Verified `SPECIFY PATH TO CREDENTIALS` works with an SSO config file and an SSO profile.
Description update:
<img width="1169" alt="Screen Shot 2022-08-11 at 7 50 25 PM" src="https://user-images.githubusercontent.com/10411887/184276019-3cc05b09-d5a1-4622-86a4-663a9deb5588.png">

- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


