### PR TITLE
Introduce concurrency back into integration tests 

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           SERVER_ADDRESS: localhost:8080
           INTEGRATION: aqueduct_demo
-        run: pytest . -rP --publish -n 1
+        run: pytest . -rP --publish -n 5
 
       # These must be run with concurrency=1
       - name: Run the SDK Requirements Tests

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: python3 scripts/install_local.py --gobinary --sdk --executor
 
       - name: Start the server again
-        run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
+        run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install packages needed for testing
         run: pip3 install nltk matplotlib pytest-xdist

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # These are all the Python versions that we support.
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        concurrency: [1, 2, 5]
+        concurrency: [5]
 
     name: Run Integration Tests with Python Version ${{ matrix.python-version }} Concurrency ${{ matrix.concurrency }}
     steps:

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -36,11 +36,11 @@ def should_run_complex_models() -> bool:
 
 
 def generate_new_flow_name() -> str:
-    return "workflow_" + uuid.uuid4().hex[:8]
+    return "test_" + uuid.uuid4().hex
 
 
 def generate_table_name() -> str:
-    return "test_table_" + uuid.uuid4().hex[:8]
+    return "test_table_" + uuid.uuid4().hex[:24]
 
 
 def run_sentiment_model(artifact: TableArtifact) -> TableArtifact:

--- a/src/golang/lib/database/scanner.go
+++ b/src/golang/lib/database/scanner.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 
 	"github.com/dropbox/godropbox/errors"
@@ -33,6 +34,7 @@ func scanRows(rows *sql.Rows, dest interface{}) error {
 	case reflect.Struct:
 		// Scan a single row to a struct
 		if ok := rows.Next(); !ok {
+			log.Errorf("No more rows left to scan. Error: %s", rows.Err())
 			// No rows to scan
 			return ErrNoRows
 		}

--- a/src/golang/lib/database/scanner.go
+++ b/src/golang/lib/database/scanner.go
@@ -2,10 +2,10 @@ package database
 
 import (
 	"database/sql"
-	log "github.com/sirupsen/logrus"
 	"reflect"
 
 	"github.com/dropbox/godropbox/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR makes two tweaks that seem like they fix our concurrency issue. Both have to do with the sqlite configuration:
1) Uses write-ahead logging, so that writers and readers don't grab the same database locks.
2) Adds a busy-timeout of 3 seconds, meaning that we will wait up to 3 seconds for a lock before giving up. This should eliminate `database is locked` errors. If they come back, we should consider bumping this timeout.

This saves a couple minutes each run. Interestingly enough, it seems like concurrency at 5 with python 3.9 and 3.10 is significantly slower :/ Otherwise we would be halving our runtime.

I've run the tests 20 times with concurrency 5 on github actions, and all except 1 pass, which is much better than before. I will continue to see if I can repro that issue, but in the meantime this help us out.

## Related issue number (if any)
ENG-1468

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


