### PR TITLE
Eng 1557 Fix bug where the required Python packages on the client machine aren't automatically installed on the server

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,7 +37,7 @@ jobs:
           go-version: 1.16.3
       
       - name: Install aqueduct-ml
-        run: pip3 install aqueduct-ml
+        run: python3 -m pip install aqueduct-ml
 
       - name: Start the server
         run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
@@ -58,7 +58,7 @@ jobs:
         run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install packages needed for testing
-        run: pip3 install nltk matplotlib pytest-xdist
+        run: python3 -m pip install nltk matplotlib pytest-xdist
 
       - name: Wait for server again
         timeout-minutes: 5

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install mypy pydantic
+          python3 -m pip install mypy pydantic
 
       - name: Install Type Stub Libraries
         run : |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pip install mypy pydantic
+          python3 -m pip install mypy pydantic
 
       - name: Install Type Stub Libraries
         run : |

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
           go-version: 1.16.3
       
       - name: Install aqueduct-ml
-        run: pip3 install aqueduct-ml
+        run: python3 -m pip install aqueduct-ml
 
       - name: Start the server
         run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
@@ -60,7 +60,7 @@ jobs:
         run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install packages needed for testing
-        run: pip3 install nltk matplotlib pytest-xdist
+        run: python3 -m pip install nltk matplotlib pytest-xdist
 
       - name: Wait for server again
         timeout-minutes: 1

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -39,7 +39,7 @@ jobs:
           go-version: 1.16.3
 
       - name: Install aqueduct-ml
-        run: pip3 install aqueduct-ml
+        run: python3 -m pip install aqueduct-ml
 
       - name: Start the server
         run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
@@ -60,7 +60,7 @@ jobs:
         run: (aqueduct start > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install Packages needed by the notebooks
-        run: pip3 install sklearn transformers torch
+        run: python3 -m pip install sklearn transformers torch
 
       - name: Wait for server again
         timeout-minutes: 1

--- a/.github/workflows/unit-tests-sdk.yml
+++ b/.github/workflows/unit-tests-sdk.yml
@@ -19,10 +19,10 @@ jobs:
 
       - name: Install Dependencies
         working-directory: ./sdk
-        run: pip3 install .
+        run: python3 -m pip install .
 
       - name: Install pytest
-        run: pip3 install pytest
+        run: python3 -m pip install pytest
 
       - name: Run Tests
         working-directory: ./sdk

--- a/examples/run_notebook.py
+++ b/examples/run_notebook.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import sys
 import subprocess
 import time
 from pathlib import Path
@@ -147,7 +148,7 @@ with open(notebook_script_path, "w") as f:
 
 start_time = time.time()
 process = subprocess.Popen(
-    "cd %s && python3 %s" % (notebook_dir, NOTEBOOK_SCRIPT_NAME),
+    "cd %s && %s %s" % (notebook_dir, sys.executable, NOTEBOOK_SCRIPT_NAME),
     shell=True,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,

--- a/integration_tests/sdk/requirements_tests/requirements_test.py
+++ b/integration_tests/sdk/requirements_tests/requirements_test.py
@@ -4,6 +4,7 @@ from aqueduct.error import AqueductError, InvalidUserArgumentException
 from constants import SENTIMENT_SQL_QUERY
 from transformers_model.model import sentiment_prediction_using_transformers
 from utils import get_integration_name
+import sys
 
 from aqueduct import infer_requirements, op
 
@@ -37,12 +38,12 @@ def _run_shell_command(cmd: str):
 
 def _uninstall_transformers_package():
     print("Uninstalling `transformers` package.")
-    _run_shell_command("pip3 uninstall -y transformers")
+    _run_shell_command(f"{sys.executable} -m pip uninstall -y transformers")
 
 
 def _install_transformers_package():
     print("Installing `transformers` package.")
-    _run_shell_command("pip3 install transformers")
+    _run_shell_command(f"{sys.executable} -m pip install transformers")
 
 
 def _check_infer_requirements(transformers_exists: bool):

--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -159,7 +159,7 @@ if __name__ == "__main__":
         print("Updating the Python SDK...")
         prev_pwd = os.environ["PWD"]
         os.environ["PWD"] = join(os.environ["PWD"], "sdk")
-        execute_command(["pip", "install", "."], cwd=join(cwd, "sdk"))
+        execute_command([sys.executable, "-m", "pip", "install", "."], cwd=join(cwd, "sdk"))
         os.environ["PWD"] = prev_pwd
 
     # Install the local python operators.
@@ -167,7 +167,7 @@ if __name__ == "__main__":
         print("Updating the Python executor...")
         prev_pwd = os.environ["PWD"]
         os.environ["PWD"] = join(os.environ["PWD"], "src/python")
-        execute_command(["pip", "install", "."], cwd=join(cwd, "src", "python"))
+        execute_command([sys.executable, "-m", "pip", "install", "."], cwd=join(cwd, "src", "python"))
         os.environ["PWD"] = prev_pwd
         
         execute_command([

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import uuid
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
 import __main__ as main
@@ -120,6 +121,14 @@ class Client:
         self._in_notebook_or_console_context = (not hasattr(main, "__file__")) and (
             not "PYTEST_CURRENT_TEST" in os.environ
         )
+
+        # Check if "@ file" in pip freeze requirements & warn user.
+        for requirement in infer_requirements():
+            if "@ file" in requirement:
+                warnings.warn(
+                    "You have installed at least one module from your local file system. These won't be installed in the server environment."
+                )
+                break
 
     def github(self, repo: str, branch: str = "") -> Github:
         """Retrieves a Github object connecting to specified repos and branch.

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -113,7 +113,7 @@ RESERVED_FILE_NAMES = [
     CONDA_VERSION_FILE_NAME,
 ]
 REQUIREMENTS_FILE = "requirements.txt"
-BLACKLISTED_REQUIREMENTS = ["aqueduct-ml", "aqueduct-sdk"]
+BLACKLISTED_REQUIREMENTS = ["aqueduct_ml", "aqueduct_sdk", "aqueduct-ml", "aqueduct-sdk"]
 
 UserFunction = Callable[..., pd.DataFrame]
 MetricFunction = Callable[..., float]
@@ -310,9 +310,7 @@ def _filter_out_blacklisted_requirements(packaged_requirements_path: str) -> Non
 
     with open(packaged_requirements_path, "w") as f:
         for line in req_lines:
-            if any(
-                line.startswith(blacklisted_req) for blacklisted_req in BLACKLISTED_REQUIREMENTS
-            ):
+            if any(blacklisted_req in line for blacklisted_req in BLACKLISTED_REQUIREMENTS):
                 continue
             f.write(line)
 

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -323,7 +323,7 @@ def _infer_requirements() -> List[str]:
     """
     try:
         process = subprocess.Popen(
-            "pip freeze",
+            f"{sys.executable} -m pip freeze",
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -218,7 +218,7 @@ def run_with_setup(spec: FunctionSpec) -> None:
 
     requirements_path = os.path.join(op_path, "requirements.txt")
     if os.path.exists(requirements_path):
-        os.system("pip3 install -r {}".format(requirements_path))
+        os.system("{} -m pip install -r {}".format(sys.executable, requirements_path))
 
     run(spec)
 

--- a/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
@@ -1,6 +1,5 @@
 import argparse
 
-
 def run(local_path: str, requirements_path: str, missing_path: str) -> None:
     with open(local_path, "r") as f:
         local_req = set(f.read().split("\n"))
@@ -10,9 +9,8 @@ def run(local_path: str, requirements_path: str, missing_path: str) -> None:
 
     missing = []
     for r in required:
-        if r not in local_req:
+        if r not in local_req and "@ file" not in r:
             missing.append(r)
-
     if len(missing) > 0:
         with open(missing_path, "w") as f:
             f.write("\n".join(missing))

--- a/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
@@ -12,7 +12,7 @@ def run(local_path: str, requirements_path: str, missing_path: str) -> None:
     for r in required:
         if r not in local_req and "@ file" not in r:
             missing.append(r)
-            
+
     if len(missing) > 0:
         with open(missing_path, "w") as f:
             f.write("\n".join(missing))

--- a/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
@@ -10,6 +10,7 @@ def run(local_path: str, requirements_path: str, missing_path: str) -> None:
 
     missing = []
     for r in required:
+        # Remove any @ file because we may not have those files local to the user's device in our file system.
         if r not in local_req and "@ file" not in r:
             missing.append(r)
 

--- a/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
@@ -1,5 +1,6 @@
 import argparse
 
+
 def run(local_path: str, requirements_path: str, missing_path: str) -> None:
     with open(local_path, "r") as f:
         local_req = set(f.read().split("\n"))

--- a/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/prune_requirements.py
@@ -12,6 +12,7 @@ def run(local_path: str, requirements_path: str, missing_path: str) -> None:
     for r in required:
         if r not in local_req and "@ file" not in r:
             missing.append(r)
+            
     if len(missing) > 0:
         with open(missing_path, "w") as f:
             f.write("\n".join(missing))

--- a/src/python/aqueduct_executor/start-function-executor.sh
+++ b/src/python/aqueduct_executor/start-function-executor.sh
@@ -10,7 +10,7 @@ if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
 
 if test -f "$FUNCTION_EXTRACT_PATH/op/requirements.txt"
 then
-      pip freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
+      pip3 freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
       python3 -m aqueduct_executor.operators.function_executor.prune_requirements --local_path="$FUNCTION_EXTRACT_PATH/op/local_deps.txt" --requirements_path="$FUNCTION_EXTRACT_PATH/op/requirements.txt" --missing_path="$FUNCTION_EXTRACT_PATH/op/missing.txt"
       EXIT_CODE=$?
       if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi

--- a/src/python/aqueduct_executor/start-function-executor.sh
+++ b/src/python/aqueduct_executor/start-function-executor.sh
@@ -10,13 +10,13 @@ if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
 
 if test -f "$FUNCTION_EXTRACT_PATH/op/requirements.txt"
 then
-      pip3 freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
+      python3 -m pip freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
       python3 -m aqueduct_executor.operators.function_executor.prune_requirements --local_path="$FUNCTION_EXTRACT_PATH/op/local_deps.txt" --requirements_path="$FUNCTION_EXTRACT_PATH/op/requirements.txt" --missing_path="$FUNCTION_EXTRACT_PATH/op/missing.txt"
       EXIT_CODE=$?
       if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
       if test -f "$FUNCTION_EXTRACT_PATH/op/missing.txt"
       then
-            pip3 install -r "$FUNCTION_EXTRACT_PATH/op/missing.txt" --no-cache-dir
+            python3 -m pip install -r "$FUNCTION_EXTRACT_PATH/op/missing.txt" --no-cache-dir
       fi
 fi
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
- The cause of the bug is that the server was unable to install the modules in requirement.txt because it is looking for local files that did not exist on that machine from in-place installs (`pip(3) install (-e) . `).
- Warn user if they have any local installs.
- Update blacklisted list to include aqueduct_sdk / aqueduct_ml (the format aqueduct_xyz would be in the case of installing with `pip3 install -e .`)

Checked with a requirements.txt that included modules in the following formats:
```
appnope==0.1.3
aqueduct-ml @ file:///Users/eunice/Desktop/aqueduct/src/python
-e git+ssh://git@github.com/aqueducthq/aqueduct.git@4990b42ed9fcc6758bc7b6fc2d7d475a5b1d7477#egg=aqueduct_sdk&subdirectory=sdk
```
## Related issue number (if any)
Eng 1557

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


