### PR TITLE
Log server filepaths and line numbers in verbose mode

### DIFF
--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -20,7 +20,7 @@ var (
 		"The path to .yml config file",
 	)
 	expose        = flag.Bool("expose", false, "Whether the server will be exposed to the public.")
-	verbose       = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal.")
+	verbose       = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal, with filepaths and line numbers.")
 	port          = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
 	serverLogPath = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
 )
@@ -68,6 +68,9 @@ func main() {
 				log.DebugLevel,
 			},
 		})
+
+		// Also print the filepath and line number.
+		log.SetReportCaller(true)
 	}
 
 	serverConfig := config.ParseServerConfiguration(*confPath)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
https://aqueducthq.slack.com/archives/C01KF131001/p1660603243468799

It's actually kinda useful, might take some getting used to tho. At least its gated behind `verbose`.
![image](https://user-images.githubusercontent.com/6466121/184786764-b5864aa5-430e-48f9-a810-a11a17663af6.png)


## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


