### PR TITLE
ENG-1566 Export CSV file name fix

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -267,7 +267,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
       return (
         <Button
           onClick={() =>
-            exportCsv(artifactResultData, getNodeLabel().replace(' ', '_'))
+            exportCsv(artifactResultData, getNodeLabel().replaceAll(' ', '_'))
           }
         >
           Export CSV


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fix bug where exported CSV files only have underscores on first occurrence of space character.

Before:
"My Multi Word Workflow" exports as "My_Multi Word Workflow.csv"

After:
"My Multi Word Workflow" exports as: "My_Multi_Word_Workflow.csv"

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1566/bug-filenames-only-have-underscores-on-first-occurrence-of-when

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


