### PR TITLE
Adds check for AWS env vars in aqueduct_executor

### DIFF
--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -12,11 +12,21 @@ class S3Storage(Storage):
     _config: S3StorageConfig
 
     def __init__(self, config: S3StorageConfig):
-        # Boto3 uses an environment variable to determine the credentials filepath and profile
-        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = config.credentials_path
-        os.environ["AWS_PROFILE"] = config.credentials_profile
 
-        self._client = boto3.client("s3", config=BotoConfig(region_name=config.region))
+        if (
+            "AWS_ACCESS_KEY_ID" in os.environ.keys()
+            and "AWS_SECRET_ACCESS_KEY" in os.environ.keys()
+        ):
+            self._client = boto3.client(
+                "s3",
+                aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+                aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+            )
+        else:
+            # Boto3 uses an environment variable to determine the credentials filepath and profile
+            os.environ["AWS_SHARED_CREDENTIALS_FILE"] = config.credentials_path
+            os.environ["AWS_PROFILE"] = config.credentials_profile
+            self._client = boto3.client("s3", config=BotoConfig(region_name=config.region))
         self._config = config
 
         bucket, key_prefix = parse_s3_path(self._config.bucket)

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -13,10 +13,7 @@ class S3Storage(Storage):
 
     def __init__(self, config: S3StorageConfig):
 
-        if (
-            "AWS_ACCESS_KEY_ID" in os.environ
-            and "AWS_SECRET_ACCESS_KEY" in os.environ
-        ):
+        if "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
             self._client = boto3.client(
                 "s3",
                 aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -14,8 +14,8 @@ class S3Storage(Storage):
     def __init__(self, config: S3StorageConfig):
 
         if (
-            "AWS_ACCESS_KEY_ID" in os.environ.keys()
-            and "AWS_SECRET_ACCESS_KEY" in os.environ.keys()
+            "AWS_ACCESS_KEY_ID" in os.environ
+            and "AWS_SECRET_ACCESS_KEY" in os.environ
         ):
             self._client = boto3.client(
                 "s3",


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds check for AWS env vars in aqueduct_executor. We will need these env vars when using the K8s integration.
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1567/add-env-variable-check-in-aqueduct-executor
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


