### PR TITLE
Revert "ENG-1533 Frontend: Use default value for SERVER_ADDRESS"

### DIFF
--- a/src/ui/common/src/components/hooks/useAqueductConsts.ts
+++ b/src/ui/common/src/components/hooks/useAqueductConsts.ts
@@ -2,13 +2,8 @@ export type AqueductConsts = {
   apiAddress: string;
 };
 
-const DEFAULT_SERVER_ADDRESS = 'http://localhost:8080';
-
 export const useAqueductConsts = (): AqueductConsts => {
   return {
-    // Use default value for server address if there is not one set in the .env or env.local file.
-    apiAddress: process.env.SERVER_ADDRESS
-      ? process.env.SERVER_ADDRESS
-      : DEFAULT_SERVER_ADDRESS,
+    apiAddress: process.env.SERVER_ADDRESS,
   };
 };


### PR DESCRIPTION
Reverts aqueducthq/aqueduct#316

Defaulting to localhost won't work when the client and the server aren't running on the same machine, so we want to keep the behavior of when no server address is specified, we will use `/`.