### PR TITLE
Revert integration test concurrency back to 1

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           SERVER_ADDRESS: localhost:8080
           INTEGRATION: aqueduct_demo
-        run: pytest . -rP --publish -n 5
+        run: pytest . -rP --publish
 
       # These must be run with concurrency=1
       - name: Run the SDK Requirements Tests

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # These are all the Python versions that we support.
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        concurrency: [5]
+        concurrency: [2, 5]
 
     name: Run Integration Tests with Python Version ${{ matrix.python-version }} Concurrency ${{ matrix.concurrency }}
     steps:

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         # These are all the Python versions that we support.
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        concurrency: [2, 5]
+        concurrency: [ 2, 5 ]
 
     name: Run Integration Tests with Python Version ${{ matrix.python-version }} Concurrency ${{ matrix.concurrency }}
     steps:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Some new issues popped up with the `test_delete_workflow_saved_*` tests. Will revert concurrency in pre-merge integration tests until I can figure out why.

## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


