### PR TITLE
Allows users to set S3 as storage layer when connecting integration

### DIFF
--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -45,12 +45,6 @@ class S3Storage(Storage):
             return key
         return self._key_prefix + "/" + key
 
-    def _prefix_key(self, key: str) -> str:
-        if not self._key_prefix:
-            return key
-        return self._key_prefix + "/" + key
-
-
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:
     path_parts = s3_path.replace("s3://", "").split("/")
     bucket = path_parts.pop(0)

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -45,6 +45,7 @@ class S3Storage(Storage):
             return key
         return self._key_prefix + "/" + key
 
+
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:
     path_parts = s3_path.replace("s3://", "").split("/")
     bucket = path_parts.pop(0)

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -39,7 +39,7 @@ class S3Storage(Storage):
         key = self._prefix_key(key)
         print(f"reading from s3: {key}")
         return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()  # type: ignore
-    
+
     def _prefix_key(self, key: str) -> str:
         if not self._key_prefix:
             return key

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -39,6 +39,11 @@ class S3Storage(Storage):
         key = self._prefix_key(key)
         print(f"reading from s3: {key}")
         return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()  # type: ignore
+    
+    def _prefix_key(self, key: str) -> str:
+        if not self._key_prefix:
+            return key
+        return self._key_prefix + "/" + key
 
     def _prefix_key(self, key: str) -> str:
         if not self._key_prefix:

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -22,7 +22,7 @@ const Placeholders: S3Config = {
   config_file_path: '',
   config_file_content: '',
   config_file_profile: '',
-  use_as_storage: false,
+  use_as_storage: '',
 };
 
 type Props = {
@@ -39,7 +39,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [s3Type, setS3Type] = useState<S3CredentialType>(
     S3CredentialType.AccessKey
   );
-  const [useAsStorage, setUseAsStorage] = useState<boolean>(false);
+  const [useAsStorage, setUseAsStorage] = useState<string>('false');
 
   useEffect(() => {
     const config: S3Config = {
@@ -190,10 +190,9 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
 
       <FormControlLabel
         label="Use this integration for Aqueduct storage."
-        control={<Checkbox checked={useAsStorage} onChange={(event) => setUseAsStorage(event.target.checked)} />}
+        control={<Checkbox checked={useAsStorage === 'true'} onChange={(event) => setUseAsStorage(event.target.checked ? 'true' : 'false')} />}
       />
     </Box>
-
   );
 };
 

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -17,6 +17,7 @@ import { IntegrationTextInputField } from './IntegrationTextInputField';
 const Placeholders: S3Config = {
   type: S3CredentialType.AccessKey,
   bucket: 'aqueduct',
+  region: '',
   access_key_id: '',
   secret_access_key: '',
   config_file_path: '',
@@ -31,6 +32,7 @@ type Props = {
 
 export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [bucket, setBucket] = useState<string>(null);
+  const [region, setRegion] = useState<string>(null);
   const [accessKeyId, setAccessKeyId] = useState<string>(null);
   const [secretAccessKey, setSecretAccessKey] = useState<string>(null);
   const [configFilePath, setConfigFilePath] = useState<string>(null);
@@ -45,6 +47,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
     const config: S3Config = {
       type: s3Type,
       bucket: bucket,
+      region: region,
       access_key_id: accessKeyId,
       secret_access_key: secretAccessKey,
       config_file_path: configFilePath,
@@ -55,6 +58,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
     setDialogConfig(config);
   }, [
     bucket,
+    region,
     accessKeyId,
     secretAccessKey,
     configFilePath,
@@ -169,6 +173,16 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
         placeholder={Placeholders.bucket}
         onChange={(event) => setBucket(event.target.value)}
         value={bucket}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Region*"
+        description="The region the S3 bucket belongs to."
+        placeholder={Placeholders.region}
+        onChange={(event) => setRegion(event.target.value)}
+        value={region}
       />
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -1,3 +1,4 @@
+import { Checkbox, FormControlLabel } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
@@ -21,6 +22,7 @@ const Placeholders: S3Config = {
   config_file_path: '',
   config_file_content: '',
   config_file_profile: '',
+  use_as_storage: false,
 };
 
 type Props = {
@@ -37,6 +39,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
   const [s3Type, setS3Type] = useState<S3CredentialType>(
     S3CredentialType.AccessKey
   );
+  const [useAsStorage, setUseAsStorage] = useState<boolean>(false);
 
   useEffect(() => {
     const config: S3Config = {
@@ -47,6 +50,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       config_file_path: configFilePath,
       config_file_content: file?.data ?? '',
       config_file_profile: configFileProfile,
+      use_as_storage: useAsStorage,
     };
     setDialogConfig(config);
   }, [
@@ -57,6 +61,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
     file,
     configFileProfile,
     s3Type,
+    useAsStorage,
   ]);
 
   const configProfileInput = (
@@ -182,7 +187,13 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       {s3Type === S3CredentialType.AccessKey && accessKeyTab}
       {s3Type === S3CredentialType.ConfigFilePath && configPathTab}
       {s3Type === S3CredentialType.ConfigFileContent && configUploadTab}
+
+      <FormControlLabel
+        label="Use this integration for Aqueduct storage."
+        control={<Checkbox checked={useAsStorage} onChange={(event) => setUseAsStorage(event.target.checked)} />}
+      />
     </Box>
+
   );
 };
 

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -17,7 +17,7 @@ import { IntegrationTextInputField } from './IntegrationTextInputField';
 const Placeholders: S3Config = {
   type: S3CredentialType.AccessKey,
   bucket: 'aqueduct',
-  region: '',
+  region: 'us-east-1',
   access_key_id: '',
   secret_access_key: '',
   config_file_path: '',
@@ -203,7 +203,7 @@ export const S3Dialog: React.FC<Props> = ({ setDialogConfig }) => {
       {s3Type === S3CredentialType.ConfigFileContent && configUploadTab}
 
       <FormControlLabel
-        label="Use this integration for Aqueduct storage."
+        label="Use this integration for Aqueduct metadata storage."
         control={<Checkbox checked={useAsStorage === 'true'} onChange={(event) => setUseAsStorage(event.target.checked ? 'true' : 'false')} />}
       />
     </Box>

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -94,6 +94,7 @@ export enum S3CredentialType {
 export type S3Config = {
   type: S3CredentialType;
   bucket: string;
+  region: string;
   access_key_id: string;
   secret_access_key: string;
   config_file_path: string;

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -99,6 +99,7 @@ export type S3Config = {
   config_file_path: string;
   config_file_content: string;
   config_file_profile: string;
+  use_as_storage: boolean;
 };
 
 export type AqueductDemoConfig = Record<string, never>;

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -99,7 +99,7 @@ export type S3Config = {
   config_file_path: string;
   config_file_content: string;
   config_file_profile: string;
-  use_as_storage: boolean;
+  use_as_storage: string;
 };
 
 export type AqueductDemoConfig = Record<string, never>;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR allows a user to set the S3 integration they are adding to be the new Aqueduct storage layer. This is only allowed for S3 at the moment. This is to make it easier for users to avoid having to provide the same AWS credentials in multiple places.

DEMO: https://www.loom.com/share/d3ec5d47a8994b71a68c04fed81fa6f5

## Related issue number (if any)
ENG 1552

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


