### PR TITLE
Fixes S3 path parsing bug

### DIFF
--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aws/aws-sdk-go/aws"
@@ -34,6 +35,8 @@ func (s *s3Storage) parseBucketAndKey(key string) (string, string, error) {
 	}
 
 	bucket := u.Host
+
+	u.Path = strings.TrimLeft(u.Path, "/")
 	key = path.Join(u.Path, key)
 
 	return bucket, key, nil

--- a/src/golang/lib/storage/s3_test.go
+++ b/src/golang/lib/storage/s3_test.go
@@ -8,18 +8,38 @@ import (
 )
 
 func TestParseBucketAndKey(t *testing.T) {
-	config := &shared.S3Config{
-		Region:             "us-east-2",
-		Bucket:             "s3://aqueduct/test/folder",
-		CredentialsPath:    "/home/users/aqueduct/.aws",
-		CredentialsProfile: "default",
-	}
-	storage := s3Storage{
-		s3Config: config,
+	type test struct {
+		inputBucket    string
+		inputKey       string
+		expectedBucket string
+		expectedKey    string
 	}
 
-	bucket, key, err := storage.parseBucketAndKey("key")
-	require.Nil(t, err)
-	require.Equal(t, "aqueduct", bucket)
-	require.Equal(t, "/test/folder/key", key)
+	tests := []test{
+		{
+			inputBucket:    "s3://aqueduct/test/folder",
+			inputKey:       "key",
+			expectedBucket: "aqueduct",
+			expectedKey:    "test/folder/key",
+		},
+		{
+			inputBucket:    "s3://aqueduct",
+			inputKey:       "key",
+			expectedBucket: "aqueduct",
+			expectedKey:    "key",
+		},
+	}
+
+	for _, tc := range tests {
+		storage := s3Storage{
+			s3Config: &shared.S3Config{
+				Bucket: tc.inputBucket,
+			},
+		}
+
+		bucket, key, err := storage.parseBucketAndKey(tc.inputKey)
+		require.Nil(t, err)
+		require.Equal(t, tc.expectedBucket, bucket)
+		require.Equal(t, tc.expectedKey, key)
+	}
 }

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -39,7 +39,7 @@ class S3Storage(Storage):
         key = self._prefix_key(key)
         print(f"reading from s3: {key}")
         return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()  # type: ignore
-    
+
     def _prefix_key(self, key: str) -> str:
         if not self._key_prefix:
             return key

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -31,14 +31,19 @@ class S3Storage(Storage):
         self._key_prefix = key_prefix
 
     def put(self, key: str, value: bytes) -> None:
-        key = self._key_prefix + "/" + key
+        key = self._prefix_key(key)
         print(f"writing to s3: {key}")
         self._client.put_object(Bucket=self._bucket, Key=key, Body=value)
 
     def get(self, key: str) -> bytes:
-        key = self._key_prefix + "/" + key
+        key = self._prefix_key(key)
         print(f"reading from s3: {key}")
         return self._client.get_object(Bucket=self._bucket, Key=key)["Body"].read()  # type: ignore
+    
+    def _prefix_key(self, key: str) -> str:
+        if not self._key_prefix:
+            return key
+        return self._key_prefix + "/" + key
 
 
 def parse_s3_path(s3_path: str) -> Tuple[str, str]:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug with how the S3 path is parsed in both the `Go` and `Python` execution. Since we allow users to provide a nested S3 path in the form of `s3://bucket/with/subdir`, we need to be able to deal with paths that look like the former and as well as something as simple as `s3://bucket`. There was currently a problem with parsing `s3://bucket`, where an extra `/` was being added to the key before any lookups were being performed.

## Related issue number (if any)
ENG 1554

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


