### PR TITLE
Fix sqlite transactional concurrency issue around SQLITE_BUSY and SQLITE_LOCKED

### DIFF
--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -120,7 +120,7 @@ def run_flow_test(
         artifacts=artifacts,
         schedule=schedule,
     )
-    print("Workflow registration succeeded. Workflow ID: %s" % flow.id())
+    print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
 
     try:
         wait_for_flow_runs(client, flow.id(), num_runs, expect_success)

--- a/src/golang/lib/database/scanner.go
+++ b/src/golang/lib/database/scanner.go
@@ -34,7 +34,10 @@ func scanRows(rows *sql.Rows, dest interface{}) error {
 	case reflect.Struct:
 		// Scan a single row to a struct
 		if ok := rows.Next(); !ok {
-			log.Errorf("No more rows left to scan. Error: %s", rows.Err())
+			if rows.Err() != nil {
+				log.Errorf("Error when calling rows.Next(): %s", rows.Err())
+			}
+
 			// No rows to scan
 			return ErrNoRows
 		}

--- a/src/golang/lib/database/sqlite.go
+++ b/src/golang/lib/database/sqlite.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	stmt "github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
-	_ "github.com/mattn/go-sqlite3"
 	"os"
 	"path"
+
+	stmt "github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
 )
 
 const (
@@ -132,10 +132,6 @@ func (sdb *sqliteDatabase) BeginTx(ctx context.Context) (Transaction, error) {
 			nested: false,
 		},
 	}, nil
-}
-
-func (sdb *sqliteDatabase) Close() {
-	sdb.standardDatabase.Close()
 }
 
 func (*sqliteTransaction) Type() Type {

--- a/src/golang/lib/database/sqlite.go
+++ b/src/golang/lib/database/sqlite.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	stmt "github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 const (

--- a/src/golang/lib/database/sqlite.go
+++ b/src/golang/lib/database/sqlite.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
-	"path"
-
 	stmt "github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
 	_ "github.com/mattn/go-sqlite3"
+	"os"
+	"path"
 )
 
 const (
@@ -21,10 +20,32 @@ const (
 var DefaultSqliteFile = path.Join(os.Getenv("HOME"), ".aqueduct", "server", SqliteDatabasePath)
 
 var defaultSqliteOptions = map[string]string{
-	"mode":          "rwc",
-	"cache":         "shared",
-	"_journal_mode": "WAL",  // Enable Write-Ahead logging.
-	"_busy_timeout": "3000", // Wait for a bit on database locks before giving up.
+	"mode": "rwc",
+
+	// Write-Ahead Logging allows readers to continue to read even when a write transaction
+	// in progress. This does not resolve write-write conflicts.
+	"_journal_mode": "WAL",
+
+	// If the database is locked by another in-progress write, the current write
+	// will block for this amount of time before giving up with a SQLITE_BUSY error.
+	// Units are milliseconds. Default value is 5 seconds.
+	//
+	// Set this value > the expected time for the longest transaction in our system to complete.
+	"_busy_timeout": "10000",
+
+	// Transactions will always start as write transactions, instead of deferring
+	// the decision for later. This prevents the following edge case, where there are two
+	// concurrent transactions:
+	// 1) Begin Transaction
+	// 2) Select statement
+	// 3) Insert statement
+	// 4) Commit
+	// Because we perform a read first at step 2, the transaction will start as a read
+	// transaction and then get upgraded afterwards to a write at step 3. This will lead
+	// to an immediate SQLITE_BUSY error that our `_busy_timeout` above cannot protect against.
+	// By forcing all transactions to first grab write locks, we force any conflicting writes
+	// to wait on each other, respecting our `_busy_timeout` value.
+	"_txlock": "IMMEDIATE",
 }
 
 type sqliteDatabase struct {
@@ -111,6 +132,10 @@ func (sdb *sqliteDatabase) BeginTx(ctx context.Context) (Transaction, error) {
 			nested: false,
 		},
 	}, nil
+}
+
+func (sdb *sqliteDatabase) Close() {
+	sdb.standardDatabase.Close()
 }
 
 func (*sqliteTransaction) Type() Type {

--- a/src/golang/lib/database/standard.go
+++ b/src/golang/lib/database/standard.go
@@ -32,7 +32,12 @@ func (sdb *standardDatabase) Query(ctx context.Context, dest interface{}, query 
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() {
+		err = rows.Close()
+		if err != nil {
+			log.Errorf("Error when closing rows: %s", err)
+		}
+	}()
 
 	return scanRows(rows, dest)
 }
@@ -53,7 +58,12 @@ func (stx *standardTransaction) Query(ctx context.Context, dest interface{}, que
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer func() {
+		err = rows.Close()
+		if err != nil {
+			log.Errorf("Error when closing rows: %s", err)
+		}
+	}()
 
 	return scanRows(rows, dest)
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
It turns out the culprit to these "Unable to create workflow" transient errors boils down to the fact that we had concurrent write transactions that started with DEFERRED locking. With DEFERRED locking, the transaction only grabs locks when it has to, so when you have two concurrent transactions that both first grab read locks, and then upgrade to write locks, this upgrade fails with a SQLITE_BUSY error, and completely bypasses our `_busy_timeout` value.

The solution in the PR is to start everything as a write transaction, so any conflicting writes will wait for a `_busy_timeout` time before giving up. As long as `_busy_timeout` is set high enough, and our transactions are fast enough, this particular issue should no longer be a problem.

## Related issue number (if any)
ENG-1468

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


