### PR TITLE
Implements option to publish a k8s workflow in SDK

### DIFF
--- a/sdk/aqueduct/__init__.py
+++ b/sdk/aqueduct/__init__.py
@@ -2,6 +2,7 @@ from typing import Any, List
 
 from aqueduct.aqueduct_client import Client, get_apikey, infer_requirements
 from aqueduct.constants import exports
+from aqueduct.dag import FlowConfig
 from aqueduct.decorator import check, metric, op, to_operator
 from aqueduct.enums import ArtifactType, CheckSeverity, LoadUpdateMode
 from aqueduct.flow import Flow

--- a/sdk/aqueduct/__init__.py
+++ b/sdk/aqueduct/__init__.py
@@ -1,8 +1,8 @@
 from typing import Any, List
 
 from aqueduct.aqueduct_client import Client, get_apikey, infer_requirements
+from aqueduct.config import FlowConfig
 from aqueduct.constants import exports
-from aqueduct.dag import FlowConfig
 from aqueduct.decorator import check, metric, op, to_operator
 from aqueduct.enums import ArtifactType, CheckSeverity, LoadUpdateMode
 from aqueduct.flow import Flow

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -11,16 +11,13 @@ import yaml
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.artifacts.param_artifact import ParamArtifact
+from aqueduct.config import AirflowEngineConfig, EngineConfig, FlowConfig, K8sEngineConfig
 
 from aqueduct import api_client, dag
 
 from .dag import (
     DAG,
     AddOrReplaceOperatorDelta,
-    AirflowEngineConfig,
-    EngineConfig,
-    FlowConfig,
-    K8sEngineConfig,
     Metadata,
     SubgraphDAGDelta,
     apply_deltas_to_dag,

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -19,6 +19,8 @@ from .dag import (
     AddOrReplaceOperatorDelta,
     AirflowEngineConfig,
     EngineConfig,
+    FlowConfig,
+    K8sEngineConfig,
     Metadata,
     SubgraphDAGDelta,
     apply_deltas_to_dag,
@@ -31,11 +33,12 @@ from .error import (
     InvalidUserActionException,
     InvalidUserArgumentException,
 )
-from .flow import Flow, FlowConfig
+from .flow import Flow
 from .github import Github
 from .integrations.airflow_integration import AirflowIntegration
 from .integrations.google_sheets_integration import GoogleSheetsIntegration
 from .integrations.integration import Integration, IntegrationInfo
+from .integrations.k8s_integration import K8sIntegration
 from .integrations.s3_integration import S3Integration
 from .integrations.salesforce_integration import SalesforceIntegration
 from .integrations.sql_integration import RelationalDBIntegration
@@ -44,6 +47,7 @@ from .operators import Operator, OperatorSpec, ParamSpec, serialize_parameter_va
 from .responses import Error, SavedObjectDelete, SavedObjectUpdate
 from .utils import (
     _infer_requirements,
+    generate_engine_config,
     generate_ui_url,
     generate_uuid,
     infer_artifact_type,
@@ -224,6 +228,7 @@ class Client:
         GoogleSheetsIntegration,
         RelationalDBIntegration,
         AirflowIntegration,
+        K8sIntegration,
     ]:
         """Retrieves a connected integration object.
 
@@ -268,6 +273,10 @@ class Client:
             )
         elif integration_info.service == ServiceType.AIRFLOW:
             return AirflowIntegration(
+                metadata=integration_info,
+            )
+        elif integration_info.service == ServiceType.K8S:
+            return K8sIntegration(
                 metadata=integration_info,
             )
         else:
@@ -384,15 +393,10 @@ class Client:
             schedule=cron_schedule,
             retention_policy=retention_policy,
         )
+        dag.engine_config = generate_engine_config(config)
 
-        if config and config.engine:
+        if dag.engine_config.type == RuntimeType.AIRFLOW:
             # This is an Airflow workflow
-            dag.engine_config = EngineConfig(
-                type=RuntimeType.AIRFLOW,
-                airflow_config=AirflowEngineConfig(
-                    integration_id=config.engine._metadata.id,
-                ),
-            )
             resp = api_client.__GLOBAL_API_CLIENT__.register_airflow_workflow(dag)
             flow_id, airflow_file = resp.id, resp.file
 

--- a/sdk/aqueduct/config.py
+++ b/sdk/aqueduct/config.py
@@ -1,0 +1,34 @@
+import uuid
+from typing import Optional, Union
+
+from aqueduct.enums import RuntimeType
+from aqueduct.integrations.airflow_integration import AirflowIntegration
+from aqueduct.integrations.k8s_integration import K8sIntegration
+from pydantic import BaseModel
+
+
+class AqueductEngineConfig(BaseModel):
+    pass
+
+
+class AirflowEngineConfig(BaseModel):
+    integration_id: uuid.UUID
+
+
+class K8sEngineConfig(BaseModel):
+    integration_id: uuid.UUID
+
+
+class EngineConfig(BaseModel):
+    type: RuntimeType = RuntimeType.AQUEDUCT
+    aqueduct_config: Optional[AqueductEngineConfig]
+    airflow_config: Optional[AirflowEngineConfig]
+    k8s_config: Optional[K8sEngineConfig]
+
+
+class FlowConfig(BaseModel):
+    engine: Optional[Union[AirflowIntegration, K8sIntegration]]
+
+    class Config:
+        # Necessary to allow an engine field
+        arbitrary_types_allowed = True

--- a/sdk/aqueduct/config.py
+++ b/sdk/aqueduct/config.py
@@ -20,6 +20,8 @@ class K8sEngineConfig(BaseModel):
 
 
 class EngineConfig(BaseModel):
+    # The runtime type dictates the engine config that is set.
+    # We default to the AqueductEngine.
     type: RuntimeType = RuntimeType.AQUEDUCT
     aqueduct_config: Optional[AqueductEngineConfig]
     airflow_config: Optional[AirflowEngineConfig]

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
 from aqueduct.artifacts.metadata import ArtifactMetadata
+from aqueduct.config import EngineConfig
 from aqueduct.enums import ArtifactType, OperatorType, RuntimeType, TriggerType
 from aqueduct.error import (
     ArtifactNotFoundException,
@@ -11,8 +12,6 @@ from aqueduct.error import (
     InvalidUserActionException,
     InvalidUserArgumentException,
 )
-from aqueduct.integrations.airflow_integration import AirflowIntegration
-from aqueduct.integrations.k8s_integration import K8sIntegration
 from aqueduct.logger import logger
 from aqueduct.operators import (
     Operator,
@@ -42,33 +41,6 @@ class Metadata(BaseModel):
     description: Optional[str]
     schedule: Optional[Schedule]
     retention_policy: Optional[RetentionPolicy]
-
-
-class AqueductEngineConfig(BaseModel):
-    pass
-
-
-class AirflowEngineConfig(BaseModel):
-    integration_id: uuid.UUID
-
-
-class K8sEngineConfig(BaseModel):
-    integration_id: uuid.UUID
-
-
-class EngineConfig(BaseModel):
-    type: RuntimeType = RuntimeType.AQUEDUCT
-    aqueduct_config: Optional[AqueductEngineConfig]
-    airflow_config: Optional[AirflowEngineConfig]
-    k8s_config: Optional[K8sEngineConfig]
-
-
-class FlowConfig(BaseModel):
-    engine: Optional[Union[AirflowIntegration, K8sIntegration]]
-
-    class Config:
-        # Necessary to allow an engine field
-        arbitrary_types_allowed = True
 
 
 class DAG(BaseModel):

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -1,7 +1,7 @@
 import copy
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.enums import ArtifactType, OperatorType, RuntimeType, TriggerType
@@ -11,6 +11,8 @@ from aqueduct.error import (
     InvalidUserActionException,
     InvalidUserArgumentException,
 )
+from aqueduct.integrations.airflow_integration import AirflowIntegration
+from aqueduct.integrations.k8s_integration import K8sIntegration
 from aqueduct.logger import logger
 from aqueduct.operators import (
     Operator,
@@ -50,10 +52,23 @@ class AirflowEngineConfig(BaseModel):
     integration_id: uuid.UUID
 
 
+class K8sEngineConfig(BaseModel):
+    integration_id: uuid.UUID
+
+
 class EngineConfig(BaseModel):
     type: RuntimeType = RuntimeType.AQUEDUCT
     aqueduct_config: Optional[AqueductEngineConfig]
     airflow_config: Optional[AirflowEngineConfig]
+    k8s_config: Optional[K8sEngineConfig]
+
+
+class FlowConfig(BaseModel):
+    engine: Optional[Union[AirflowIntegration, K8sIntegration]]
+
+    class Config:
+        # Necessary to allow an engine field
+        arbitrary_types_allowed = True
 
 
 class DAG(BaseModel):

--- a/sdk/aqueduct/enums.py
+++ b/sdk/aqueduct/enums.py
@@ -67,6 +67,7 @@ class ServiceType(str, Enum, metaclass=MetaEnum):
     S3 = "S3"
     SQLITE = "SQLite"
     AIRFLOW = "Airflow"
+    K8S = "Kubernetes"
 
 
 class RelationalDBServices(str, Enum, metaclass=MetaEnum):
@@ -159,3 +160,4 @@ class SerializationType(str, Enum, metaclass=MetaEnum):
 class RuntimeType(Enum, metaclass=MetaEnum):
     AQUEDUCT = "aqueduct"
     AIRFLOW = "airflow"
+    K8S = "k8s"

--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -6,7 +6,6 @@ from typing import DefaultDict, Dict, List, Optional, Union
 
 from aqueduct.dag import DAG
 from aqueduct.error import InvalidUserActionException, InvalidUserArgumentException
-from aqueduct.integrations.airflow_integration import AirflowIntegration
 from pydantic import BaseModel
 
 from aqueduct import api_client
@@ -187,11 +186,3 @@ class Flow:
             )
         )
         print(json.dumps(self.list_runs(), sort_keys=False, indent=4))
-
-
-class FlowConfig(BaseModel):
-    engine: Optional[AirflowIntegration]
-
-    class Config:
-        # Necessary to allow an engine field
-        arbitrary_types_allowed = True

--- a/sdk/aqueduct/integrations/k8s_integration.py
+++ b/sdk/aqueduct/integrations/k8s_integration.py
@@ -1,0 +1,15 @@
+from aqueduct.integrations.integration import Integration, IntegrationInfo
+
+
+class K8sIntegration(Integration):
+    """
+    Class for K8s integration.
+    """
+
+    def __init__(self, metadata: IntegrationInfo):
+        self._metadata = metadata
+
+    def describe(self) -> None:
+        """Prints out a human-readable description of the Airflow integration."""
+        print("==================== Airflow Integration  =============================")
+        self._metadata.describe()

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -15,21 +15,13 @@ import multipart
 import numpy as np
 import pandas as pd
 import requests
-from aqueduct.dag import (
-    DAG,
-    AirflowEngineConfig,
-    EngineConfig,
-    FlowConfig,
-    K8sEngineConfig,
-    RetentionPolicy,
-    Schedule,
-)
+from aqueduct.config import AirflowEngineConfig, EngineConfig, FlowConfig, K8sEngineConfig
+from aqueduct.dag import DAG, RetentionPolicy, Schedule
 from aqueduct.enums import ArtifactType, OperatorType, RuntimeType, TriggerType
 from aqueduct.error import *
-from aqueduct.logger import logger
-from aqueduct.enums import OperatorType
 from aqueduct.integrations.airflow_integration import AirflowIntegration
 from aqueduct.integrations.k8s_integration import K8sIntegration
+from aqueduct.logger import logger
 from aqueduct.operators import Operator
 from aqueduct.templates import op_file_content
 from croniter import croniter


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds option to publish a k8s workflow in SDK 

```
from aqueduct import FlowConfig
k8s_integration = client.integration("k8s_integration")
no_input_flow_k8s = client.publish_flow(
    name = "No input k8s", 
    artifacts = [output],
    config = FlowConfig(engine=k8s_integration),
)
```
## Related issue number (if any)
Eng-1555
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


