### PR TITLE
Fixes noisy bug where database logs err after every txn

### DIFF
--- a/src/golang/lib/collections/tests/main_test.go
+++ b/src/golang/lib/collections/tests/main_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	schemaVersion = 15
+	schemaVersion = 16
 
 	// Postgres config
 	postgresHost     = "localhost"

--- a/src/golang/lib/database/standard.go
+++ b/src/golang/lib/database/standard.go
@@ -74,16 +74,13 @@ func (stx *standardTransaction) Rollback(ctx context.Context) error {
 		return nil
 	}
 
-	err := stx.tx.Rollback()
-	if err != sql.ErrTxDone {
-		// Transaction was not already committed or aborted
-		logQuery("Transaction ROLLBACK")
-	}
-	if err != nil {
-		log.Errorf("Rollback failed: %v.", err)
+	if err := stx.tx.Rollback(); err != nil {
+		return err
 	}
 
-	return err
+	// Transaction rollback actually happened
+	logQuery("Transaction ROLLBACK")
+	return nil
 }
 
 func (stx *standardTransaction) Commit(ctx context.Context) error {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Anytime a database txn is used, we used a `defer txn.Rollback` to perform a rollback in case there is an error. The rollback is a noop if the transaction was already committed or previously rolledback. Currently our logs were showing an error log at the end of every single transaction, because of how we were deciding if a rollback had "failed."

This PR fixes that by only logging if a rollback if it actually happened. It does not log in other cases.

It also bumps the version for the db tests.

## Related issue number (if any)
ENG 1586

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


