### PR TITLE
Adds notebook integration test for util.py file dependency

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -87,6 +87,10 @@ jobs:
       - name: Run Imported Function Notebook
         timeout-minutes: 10
         run: python3 examples/run_notebook.py --path "integration_tests/notebook/imported_function.ipynb" --server_address localhost:8080
+      
+      - name: Run Util File Dependency Notebook
+        timeout-minutes: 10
+        run: python3 examples/run_notebook.py --path "integration_tests/notebook/util_dependency.ipynb" --server_address localhost:8080
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/integration_tests/notebook/imported_function.ipynb
+++ b/integration_tests/notebook/imported_function.ipynb
@@ -1,6 +1,16 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "f05c74ac",
+   "metadata": {},
+   "source": [
+    "# Imported Function Test\n",
+    "\n",
+    "This notebook tests importing a function from a different file."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "e2ef5a7e",
@@ -34,7 +44,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'aqueduct.table_artifact.TableArtifact'>\n"
+      "<class 'aqueduct.artifacts.table_artifact.TableArtifact'>\n"
      ]
     }
    ],
@@ -213,7 +223,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<class 'aqueduct.table_artifact.TableArtifact'>\n"
+      "<class 'aqueduct.artifacts.table_artifact.TableArtifact'>\n"
      ]
     }
    ],
@@ -450,7 +460,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.9"
+   "version": "3.8.13"
   },
   "vscode": {
    "interpreter": {

--- a/integration_tests/notebook/util.py
+++ b/integration_tests/notebook/util.py
@@ -1,0 +1,3 @@
+
+def get_skip_cols():
+    return ["cust_id", "using_deep_learning", "using_dbt"]

--- a/integration_tests/notebook/util.py
+++ b/integration_tests/notebook/util.py
@@ -1,3 +1,2 @@
-
 def get_skip_cols():
     return ["cust_id", "using_deep_learning", "using_dbt"]

--- a/integration_tests/notebook/util_dependency.ipynb
+++ b/integration_tests/notebook/util_dependency.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "70416e3d",
+   "metadata": {},
+   "source": [
+    "# Util File Dependency Test\n",
+    "\n",
+    "This notebook tests having a file dependency for a file named `util.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2ef5a7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aqueduct \n",
+    "from aqueduct import op, check, metric\n",
+    "\n",
+    "import pandas as pd\n",
+    "import os\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef93cc74-49db-4ed7-a59a-c097125e3723",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# You can use `localhost` if you're running this notebook on the same machine as the server.\n",
+    "address = \"http://localhost:8080\"\n",
+    "api_key = aqueduct.get_apikey()\n",
+    "client = aqueduct.Client(api_key, address)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78909c5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "warehouse = client.integration(name=\"aqueduct_demo\")\n",
+    "customers_table = warehouse.sql(query=\"SELECT * FROM customers;\")\n",
+    "print(type(customers_table))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8693ae7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "customers_table.get().head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88add3e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@op(file_dependencies=[\"./util.py\"])\n",
+    "def log_featurize(cust: pd.DataFrame) -> pd.DataFrame:\n",
+    "    if not os.path.exists(\"util.py\"):\n",
+    "        raise Exception(\"util.py does not exist!\")\n",
+    "    \n",
+    "    import util\n",
+    "    \n",
+    "    features = cust.copy()\n",
+    "    skip_cols = util.get_skip_cols()\n",
+    "    for col in features.columns.difference(skip_cols):\n",
+    "        features[\"log_\" + col] = np.log(features[col] + 1.0)\n",
+    "    return features.drop(columns=\"cust_id\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac0ad103",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features_table = log_featurize(customers_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f1a9f68-b40c-4f2c-ab52-6f710f63024a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features_table.get().head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sdk/aqueduct/tests/decorator_test.py
+++ b/sdk/aqueduct/tests/decorator_test.py
@@ -51,7 +51,7 @@ def test_handle_reserved_file_dependencies():
         _package_files_and_requirements(
             python_function,
             dir_path=os.path.join(os.getcwd(), "test_function"),
-            file_dependencies=["aqueduct_utils.py", "file.py"],
+            file_dependencies=["conda_version.txt", "file.py"],
         )
 
 

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -105,13 +105,11 @@ def retention_policy_from_latest_runs(k_latest_runs: int) -> RetentionPolicy:
 
 MODEL_FILE_NAME = "model.py"
 MODEL_PICKLE_FILE_NAME = "model.pkl"
-AQUEDUCT_UTILS_FILE_NAME = "aqueduct_utils.py"
 PYTHON_VERSION_FILE_NAME = "python_version.txt"
 CONDA_VERSION_FILE_NAME = "conda_version.txt"
 RESERVED_FILE_NAMES = [
     MODEL_FILE_NAME,
     MODEL_PICKLE_FILE_NAME,
-    AQUEDUCT_UTILS_FILE_NAME,
     PYTHON_VERSION_FILE_NAME,
     CONDA_VERSION_FILE_NAME,
 ]


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds an integration test case for an operator with a file dependency named `util.py`. 
It also removes `aqueduct_utils.py` from the SDK reserved files list, since it is not used internally anymore.

## Related issue number (if any)
ENG 1103

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


