### PR TITLE
Make k8s inactive on UI

### DIFF
--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -328,7 +328,7 @@ export const SupportedIntegrations: ServiceInfoMap = {
   },
   ['Kubernetes']: {
     logo: 'https://spiral-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/kubernetes.png',
-    activated: true,
+    activated: false,
     category: 'compute',
   },
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Make k8s inactive on UI
## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

![Screen Shot 2022-08-22 at 5 30 08 PM](https://user-images.githubusercontent.com/87333321/186042753-c1ad9761-4935-49cc-a04c-178f6b85e95a.png)

