### PR TITLE
Adds support for k8s engines to access gcs credentials

### DIFF
--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -80,9 +80,16 @@ func generateJobManagerConfig(
 		if dbWorkflowDag.StorageConfig.Type != shared.S3StorageType && dbWorkflowDag.StorageConfig.Type != shared.GCSStorageType {
 			return nil, errors.New("Must use S3 or GCS storage config for K8s engine.")
 		}
-		awsAccessKeyId, awsSecretAccessKey, err := extractAwsCredentials(dbWorkflowDag.StorageConfig.S3Config)
-		if err != nil {
-			return nil, errors.Wrap(err, "Unable to extract AWS credentials from file.")
+
+		var awsAccessKeyId, awsSecretAccessKey string
+		if dbWorkflowDag.StorageConfig.Type == shared.S3StorageType {
+			keyId, secretKey, err := extractAwsCredentials(dbWorkflowDag.StorageConfig.S3Config)
+			if err != nil {
+				return nil, errors.Wrap(err, "Unable to extract AWS credentials from file.")
+			}
+
+			awsAccessKeyId = keyId
+			awsSecretAccessKey = secretKey
 		}
 
 		k8sIntegrationId := dbWorkflowDag.EngineConfig.K8sConfig.IntegrationId

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -77,8 +77,8 @@ func generateJobManagerConfig(
 			OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
 		}, nil
 	case shared.K8sEngineType:
-		if dbWorkflowDag.StorageConfig.Type != shared.S3StorageType {
-			return nil, errors.New("Must use S3 storage config for K8s engine.")
+		if dbWorkflowDag.StorageConfig.Type != shared.S3StorageType && dbWorkflowDag.StorageConfig.Type != shared.GCSStorageType {
+			return nil, errors.New("Must use S3 or GCS storage config for K8s engine.")
 		}
 		awsAccessKeyId, awsSecretAccessKey, err := extractAwsCredentials(dbWorkflowDag.StorageConfig.S3Config)
 		if err != nil {

--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -2,7 +2,6 @@ package job
 
 import (
 	"context"
-	"io/ioutil"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -14,7 +13,6 @@ import (
 const (
 	defaultFunctionExtractPath = "/app/function/"
 	jobSpecEnvVarKey           = "JOB_SPEC"
-	gcsCredentialsEnvVarKey    = "GCS_CREDENTIALS"
 )
 
 type k8sJobManager struct {
@@ -79,24 +77,15 @@ func (j *k8sJobManager) Launch(ctx context.Context, name string, spec Spec) erro
 	secretEnvVars := []string{}
 
 	if spec.HasStorageConfig() {
+		// This job spec has a storage config that k8s needs access to
 		storageConfig, err := spec.GetStorageConfig()
 		if err != nil {
 			return err
 		}
 
-		switch storageConfig.Type {
-		case shared.S3StorageType:
+		if storageConfig.Type == shared.S3StorageType {
 			// k8s clusters access S3 via credentials passed as a secret
 			secretEnvVars = append(secretEnvVars, k8s.AwsCredentialsSecretName)
-		case shared.GCSStorageType:
-			// For GCS the credentials must be provided as an environment variable
-			data, err := ioutil.ReadFile(storageConfig.GCSConfig.CredentialsPath)
-			if err != nil {
-				return err
-			}
-			environmentVariables[gcsCredentialsEnvVarKey] = string(data)
-		default:
-			return errors.Newf("Storage type %v is not supported for k8s job managers", storageConfig.Type)
 		}
 	}
 

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -63,6 +63,10 @@ type ExecutorConfiguration struct {
 type Spec interface {
 	Type() JobType
 	JobName() string
+	// HasStorageConfig returns whether this job spec has a storage config.
+	HasStorageConfig() bool
+	// GetStorageConfig returns the storage config if the job spec has one, otherwise it returns an error.
+	GetStorageConfig() (*shared.StorageConfig, error)
 }
 
 // BaseSpec defines fields shared by all job specs.
@@ -80,6 +84,14 @@ type WorkflowRetentionSpec struct {
 	ExecutorConfig *ExecutorConfiguration
 }
 
+func (wrs *WorkflowRetentionSpec) HasStorageConfig() bool {
+	return false
+}
+
+func (wrs *WorkflowRetentionSpec) GetStorageConfig() (*shared.StorageConfig, error) {
+	return nil, errors.New("WorkflowRetention job specs don't have a storage config.")
+}
+
 type WorkflowSpec struct {
 	BaseSpec
 	WorkflowId     string               `json:"workflow_id" yaml:"workflowId"`
@@ -89,6 +101,14 @@ type WorkflowSpec struct {
 	ExecutorConfig *ExecutorConfiguration
 }
 
+func (ws *WorkflowSpec) HasStorageConfig() bool {
+	return false
+}
+
+func (ws *WorkflowSpec) GetStorageConfig() (*shared.StorageConfig, error) {
+	return nil, errors.New("Workflow job specs don't have a storage config.")
+}
+
 // BasePythonSpec defines fields shared by all Python job specs.
 // These Python jobs can be one-off jobs (e.g. Authenticate, Discover)
 // or Workflow operators (e.g. Function, Extract, Load).
@@ -96,6 +116,14 @@ type BasePythonSpec struct {
 	BaseSpec
 	StorageConfig shared.StorageConfig `json:"storage_config"  yaml:"storage_config"`
 	MetadataPath  string               `json:"metadata_path"  yaml:"metadata_path"`
+}
+
+func (bs *BasePythonSpec) HasStorageConfig() bool {
+	return true
+}
+
+func (bs *BasePythonSpec) GetStorageConfig() (*shared.StorageConfig, error) {
+	return &bs.StorageConfig, nil
 }
 
 type FunctionSpec struct {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds support for a k8s engine to access GCS credentials. We pass in the credentials as an environment variable. We wait until the job is launched to set this env var, because storage configs can be modified by users now.

## Related issue number (if any)
ENG 1600

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


