### PR TITLE
Adds documentation link for connecting Google Cloud Storage integration

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -199,6 +199,8 @@ const IntegrationDialog: React.FC<Props> = ({
       );
       break;
     case 'GCS':
+      const gcsConfig = config as GCSConfig;
+      gcsConfig.use_as_storage = 'true';
       serviceDialog = (
         <GCSDialog
           onUpdateField={setConfigField}

--- a/src/ui/common/src/components/integrations/dialogs/gcsDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/gcsDialog.tsx
@@ -1,4 +1,5 @@
 import { Checkbox, FormControlLabel } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
 import React, { useState } from 'react';
@@ -44,11 +45,11 @@ export const GCSDialog: React.FC<Props> = ({
       <Link
         sx={{ fontSize: 'inherit' }}
         target="_blank"
-        href="https://cloud.google.com/docs/authentication/getting-started#creating_a_service_account"
+        href="https://docs.aqueducthq.com/integrations/adding-an-integration/connecting-to-google-cloud-storage"
       >
         here
       </Link>
-      <> to get your service account key file.</>
+      <> to create a service account and get the service account key file.</>
     </>
   );
 
@@ -94,10 +95,14 @@ export const GCSDialog: React.FC<Props> = ({
                 event.target.checked ? 'true' : 'false'
               )
             }
-            disabled={editMode}
+            disabled={true}
           />
         }
       />
+
+      <Typography>We currently only support using Google Cloud Storage as the Aqueduct metadata storage.
+        Support for using it as a data integration will be added soon.
+      </Typography>
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/dialogs/gcsDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/gcsDialog.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, FormControlLabel } from '@mui/material';
-import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
 import React, { useState } from 'react';
 
 import { FileData, GCSConfig } from '../../../utils/integrations';
@@ -100,8 +100,10 @@ export const GCSDialog: React.FC<Props> = ({
         }
       />
 
-      <Typography>We currently only support using Google Cloud Storage as the Aqueduct metadata storage.
-        Support for using it as a data integration will be added soon.
+      <Typography>
+        We currently only support using Google Cloud Storage as the Aqueduct
+        metadata storage. Support for using it as a data integration will be
+        added soon.
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR links documentation for connecting to Google Cloud Storage. It also sets the GCS integration to be the metadata store by default, since that is the only use case for now. 

## Related issue number (if any)
ENG 1605

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


