### PR TITLE
Fixes docker images to version 0.0.12 for k8s

### DIFF
--- a/src/golang/lib/job/constants.go
+++ b/src/golang/lib/job/constants.go
@@ -1,13 +1,13 @@
 package job
 
 const (
-	DefaultFunctionDockerImage           = "aqueducthq/function"
-	DefaultParameterDockerImage          = "aqueducthq/param"
-	DefaultSystemMetricDockerImage       = "aqueducthq/system-metric"
-	DefaultPostgresConnectorDockerImage  = "aqueducthq/postgres-connector"
-	DefaultSnowflakeConnectorDockerImage = "aqueducthq/snowflake-connector"
-	DefaultMySqlConnectorDockerImage     = "aqueducthq/mysql-connector"
-	DefaultSqlServerConnectorDockerImage = "aqueducthq/sqlserver-connector"
-	DefaultBigQueryConnectorDockerImage  = "aqueducthq/bigquery-connector"
-	DefaultS3ConnectorDockerImage        = "aqueducthq/s3-connector"
+	DefaultFunctionDockerImage           = "aqueducthq/function:0.0.12"
+	DefaultParameterDockerImage          = "aqueducthq/param:0.0.12"
+	DefaultSystemMetricDockerImage       = "aqueducthq/system-metric:0.0.12"
+	DefaultPostgresConnectorDockerImage  = "aqueducthq/postgres-connector:0.0.12"
+	DefaultSnowflakeConnectorDockerImage = "aqueducthq/snowflake-connector:0.0.12"
+	DefaultMySqlConnectorDockerImage     = "aqueducthq/mysql-connector:0.0.12"
+	DefaultSqlServerConnectorDockerImage = "aqueducthq/sqlserver-connector:0.0.12"
+	DefaultBigQueryConnectorDockerImage  = "aqueducthq/bigquery-connector:0.0.12"
+	DefaultS3ConnectorDockerImage        = "aqueducthq/s3-connector:0.0.12"
 )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the docker images to version 0.0.12.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


