### PR TITLE
Removes team pane from notifications

### DIFF
--- a/src/ui/common/src/components/notifications/NotificationsPopover.tsx
+++ b/src/ui/common/src/components/notifications/NotificationsPopover.tsx
@@ -27,7 +27,6 @@ interface NotificationsPopoverProps {
 enum NotificationsTabs {
   All = 'All',
   Workflow = 'Workflow',
-  Team = 'Team',
 }
 
 export const NotificationsPopover: React.FC<NotificationsPopoverProps> = ({
@@ -67,8 +66,6 @@ export const NotificationsPopover: React.FC<NotificationsPopoverProps> = ({
           association === NotificationAssociation.Workflow ||
           association === NotificationAssociation.WorkflowDagResult
         );
-      } else if (activeTab === NotificationsTabs.Team) {
-        return association === NotificationAssociation.Organization;
       }
 
       return true;
@@ -100,12 +97,6 @@ export const NotificationsPopover: React.FC<NotificationsPopoverProps> = ({
           key={NotificationsTabs.Workflow}
           label={NotificationsTabs.Workflow}
           value={NotificationsTabs.Workflow}
-          sx={{ '&:hover': { color: 'gray900' } }}
-        />
-        <Tab
-          key={NotificationsTabs.Team}
-          label={NotificationsTabs.Team}
-          value={NotificationsTabs.Team}
           sx={{ '&:hover': { color: 'gray900' } }}
         />
       </Tabs>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR removes the team pane from notifications, since the community edition does not have a concept of teams.

## Related issue number (if any)
ENG 1574

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

![Screen Shot 2022-08-25 at 3 46 45 PM](https://user-images.githubusercontent.com/10413474/186782244-a1105a72-fddd-443a-b6be-2ea723fb30a2.png)

