### PR TITLE
Fixes linting script for UI

### DIFF
--- a/scripts/run_linters.py
+++ b/scripts/run_linters.py
@@ -61,7 +61,7 @@ def lint_golang(cwd):
 
 
 def lint_ui(cwd):
-    execute_command(["npm", "install"], join(cwd, "src/ui/common"))
+    execute_command(["npm", "install", "--force"], join(cwd, "src/ui/common"))
     execute_command(["npm", "run", "lint", "--", "--fix"], join(cwd, "src/ui/common"))
     execute_command(["npm", "link"], join(cwd, "src/ui/common"))
     execute_command(["npm", "link", "@aqueducthq/common"], join(cwd, "src/ui/app"))


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the linter script for the UI. It was failing previously during `npm install` without the `--force` option.

## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


