### PR TITLE
Refactors execute workflow to improve persisting DAG status

### DIFF
--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/collections/workflow_dag"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow_dag_result"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/storage"
@@ -68,10 +69,11 @@ type getArtifactResultResponse struct {
 type GetArtifactResultHandler struct {
 	GetHandler
 
-	Database             database.Database
-	ArtifactReader       artifact.Reader
-	ArtifactResultReader artifact_result.Reader
-	WorkflowDagReader    workflow_dag.Reader
+	Database                database.Database
+	ArtifactReader          artifact.Reader
+	ArtifactResultReader    artifact_result.Reader
+	WorkflowDagReader       workflow_dag.Reader
+	WorkflowDagResultReader workflow_dag_result.Reader
 }
 
 func (*GetArtifactResultHandler) Name() string {
@@ -175,11 +177,21 @@ func (h *GetArtifactResultHandler) Perform(ctx context.Context, interfaceArgs in
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving workflow dag.")
 	}
 
+	dbWorkflowDagResult, err := h.WorkflowDagResultReader.GetWorkflowDagResult(
+		ctx,
+		args.workflowDagResultId,
+		h.Database,
+	)
+	if err != nil {
+		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving workflow result.")
+	}
+
 	dbArtifact, err := h.ArtifactReader.GetArtifact(ctx, args.artifactId, h.Database)
 	if err != nil {
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
 	}
 
+	execState := shared.ExecutionState{}
 	dbArtifactResult, err := h.ArtifactResultReader.GetArtifactResultByWorkflowDagResultIdAndArtifactId(
 		ctx,
 		args.workflowDagResultId,
@@ -187,12 +199,15 @@ func (h *GetArtifactResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
+		if err != database.ErrNoRows {
+			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
+		}
+		// ArtifactResult was never created, so we use the WorkflowDagResult's status as this ArtifactResult's status
+		execState.Status = dbWorkflowDagResult.Status
+	} else {
+		execState.Status = dbArtifactResult.Status
 	}
 
-	execState := shared.ExecutionState{
-		Status: dbArtifactResult.Status,
-	}
 	if !dbArtifactResult.ExecState.IsNull {
 		execState.FailureType = dbArtifactResult.ExecState.FailureType
 		execState.Error = dbArtifactResult.ExecState.Error

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow_dag_result"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/dropbox/godropbox/errors"
@@ -41,9 +42,10 @@ type getOperatorResultArgs struct {
 type GetOperatorResultHandler struct {
 	GetHandler
 
-	Database             database.Database
-	OperatorReader       operator.Reader
-	OperatorResultReader operator_result.Reader
+	Database                database.Database
+	OperatorReader          operator.Reader
+	OperatorResultReader    operator_result.Reader
+	WorkflowDagResultReader workflow_dag_result.Reader
 }
 
 func (*GetOperatorResultHandler) Name() string {
@@ -93,6 +95,16 @@ func (h *GetOperatorResultHandler) Perform(ctx context.Context, interfaceArgs in
 
 	emptyResp := shared.ExecutionState{}
 
+	dbWorkflowDagResult, err := h.WorkflowDagResultReader.GetWorkflowDagResult(
+		ctx,
+		args.workflowDagResultId,
+		h.Database,
+	)
+	if err != nil {
+		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving workflow result.")
+	}
+
+	response := shared.ExecutionState{}
 	dbOperatorResult, err := h.OperatorResultReader.GetOperatorResultByWorkflowDagResultIdAndOperatorId(
 		ctx,
 		args.workflowDagResultId,
@@ -100,14 +112,16 @@ func (h *GetOperatorResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving operator result.")
+		if err != database.ErrNoRows {
+			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving operator result.")
+		}
+		// OperatorResult was never created, so we use the WorkflowDagResult's status as this OperatorResult's status
+		response.Status = dbWorkflowDagResult.Status
+	} else {
+		response.Status = dbOperatorResult.Status
 	}
 
-	response := shared.ExecutionState{
-		Status: dbOperatorResult.Status,
-	}
-
-	if !dbOperatorResult.ExecState.IsNull {
+	if dbOperatorResult != nil && !dbOperatorResult.ExecState.IsNull {
 		response.FailureType = dbOperatorResult.ExecState.FailureType
 		response.Error = dbOperatorResult.ExecState.Error
 		response.UserLogs = dbOperatorResult.ExecState.UserLogs

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -53,10 +53,11 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			WorkflowDagReader: s.WorkflowDagReader,
 		},
 		routes.GetArtifactResultRoute: &handler.GetArtifactResultHandler{
-			Database:             s.Database,
-			ArtifactReader:       s.ArtifactReader,
-			ArtifactResultReader: s.ArtifactResultReader,
-			WorkflowDagReader:    s.WorkflowDagReader,
+			Database:                s.Database,
+			ArtifactReader:          s.ArtifactReader,
+			ArtifactResultReader:    s.ArtifactResultReader,
+			WorkflowDagReader:       s.WorkflowDagReader,
+			WorkflowDagResultReader: s.WorkflowDagResultReader,
 		},
 		routes.GetArtifactVersionsRoute: &handler.GetArtifactVersionsHandler{
 			Database:     s.Database,
@@ -64,9 +65,10 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 		},
 		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
 		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{
-			Database:             s.Database,
-			OperatorReader:       s.OperatorReader,
-			OperatorResultReader: s.OperatorResultReader,
+			Database:                s.Database,
+			OperatorReader:          s.OperatorReader,
+			OperatorResultReader:    s.OperatorResultReader,
+			WorkflowDagResultReader: s.WorkflowDagResultReader,
 		},
 		routes.GetUserProfileRoute: &handler.GetUserProfileHandler{},
 		routes.ListWorkflowObjectsRoute: &handler.ListWorkflowObjectsHandler{

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -200,6 +200,11 @@ func (eng *aqEngine) ExecuteWorkflow(
 
 	// Any errors after this point should be persisted to the WorkflowDagResult created above
 	defer func() {
+		if err != nil {
+			// Mark the workflow dag result as failed
+			status = shared.FailedExecutionStatus
+		}
+
 		workflow_utils.UpdateWorkflowDagResultMetadata(
 			ctx,
 			dbWorkflowDagResult.Id,

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -186,6 +186,32 @@ func (eng *aqEngine) ExecuteWorkflow(
 		return shared.FailedExecutionStatus, errors.Wrap(err, "Error reading latest workflowDag.")
 	}
 
+	dbWorkflowDagResult, err := workflow_utils.CreateWorkflowDagResult(
+		ctx,
+		dbWorkflowDag.Id,
+		eng.WorkflowDagResultWriter,
+		eng.Database,
+	)
+	if err != nil {
+		return shared.FailedExecutionStatus, errors.Wrap(err, "Error initializing workflowDagResult.")
+	}
+
+	status := shared.PendingExecutionStatus
+
+	// Any errors after this point should be persisted to the WorkflowDagResult created above
+	defer func() {
+		workflow_utils.UpdateWorkflowDagResultMetadata(
+			ctx,
+			dbWorkflowDagResult.Id,
+			status,
+			eng.WorkflowDagResultWriter,
+			eng.WorkflowReader,
+			eng.NotificationWriter,
+			eng.UserReader,
+			eng.Database,
+		)
+	}()
+
 	githubClient, err := eng.GithubManager.GetClient(ctx, dbWorkflowDag.Metadata.UserId)
 	if err != nil {
 		return shared.FailedExecutionStatus, errors.Wrap(err, "Error getting github client.")
@@ -234,6 +260,7 @@ func (eng *aqEngine) ExecuteWorkflow(
 
 	dag, err := dag_utils.NewWorkflowDag(
 		ctx,
+		dbWorkflowDagResult.Id,
 		dbWorkflowDag,
 		eng.WorkflowDagResultWriter,
 		eng.OperatorResultWriter,
@@ -264,26 +291,14 @@ func (eng *aqEngine) ExecuteWorkflow(
 		OpToDependencyCount: opToDependencyCount,
 		InProgressOps:       make(map[uuid.UUID]operator.Operator, len(dag.Operators())),
 		CompletedOps:        make(map[uuid.UUID]operator.Operator, len(dag.Operators())),
-		Status:              shared.PendingExecutionStatus,
 	}
 
-	// Make sure to persist the dag results on exit.
-	defer func() {
-		log.Info("workflowRunMetadata: ")
-		log.Info(wfRunMetadata)
-
-		err = dag.PersistResult(ctx, wfRunMetadata.Status)
-		if err != nil {
-			log.Errorf("Error when persisting dag results: %v", err)
-		}
-	}()
-
-	err = dag.InitializeResults(ctx)
+	err = dag.InitOpAndArtifactResults(ctx)
 	if err != nil {
 		return shared.FailedExecutionStatus, errors.Wrap(err, "Unable to initialize dag results.")
 	}
 
-	wfRunMetadata.Status = shared.RunningExecutionStatus
+	status = shared.RunningExecutionStatus
 	err = eng.execute(
 		ctx,
 		dag,
@@ -292,10 +307,10 @@ func (eng *aqEngine) ExecuteWorkflow(
 		operator.Publish,
 	)
 	if err != nil {
-		wfRunMetadata.Status = shared.FailedExecutionStatus
+		status = shared.FailedExecutionStatus
 		return shared.FailedExecutionStatus, errors.Wrapf(err, "Error executing workflow")
 	} else {
-		wfRunMetadata.Status = shared.SucceededExecutionStatus
+		status = shared.SucceededExecutionStatus
 	}
 
 	return shared.SucceededExecutionStatus, nil
@@ -319,6 +334,7 @@ func (eng *aqEngine) PreviewWorkflow(
 
 	dag, err := dag_utils.NewWorkflowDag(
 		ctx,
+		uuid.Nil, /* workflowDagResultID */
 		dbWorkflowDag,
 		eng.WorkflowDagResultWriter,
 		eng.OperatorResultWriter,

--- a/src/golang/lib/workflow/dag/workflow_dag.go
+++ b/src/golang/lib/workflow/dag/workflow_dag.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	db_operator "github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
-	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/collections/user"
 	"github.com/aqueducthq/aqueduct/lib/collections/workflow"
 	"github.com/aqueducthq/aqueduct/lib/collections/workflow_dag"
@@ -37,18 +36,14 @@ type WorkflowDag interface {
 	// OperatorInputs returns all the artifacts that are fed as input to the given operator.
 	OperatorInputs(operator.Operator) ([]artifact.Artifact, error)
 
-	// InitializeResult initializes the dag result in the database.
-	// Also initializes the operators and artifacts contained in this dag.
-	InitializeResults(ctx context.Context) error
-
-	// PersistResult updates the dag result in the database after execution.
-	// InitializeResult() must have already been called.
-	// *Does not* persist the operators or artifacts contained in this dag.
-	PersistResult(ctx context.Context, status shared.ExecutionStatus) error
+	// InitOpAndArtifactResults initializes the operators and artifact results for this dag.
+	InitOpAndArtifactResults(ctx context.Context) error
 }
 
 type workflowDagImpl struct {
 	dbWorkflowDag *workflow_dag.DBWorkflowDag
+	// resultID corresponds to the WorkflowDagResult created for the current run of this dag
+	resultID uuid.UUID
 
 	operators           map[uuid.UUID]operator.Operator
 	artifacts           map[uuid.UUID]artifact.Artifact
@@ -61,10 +56,6 @@ type workflowDagImpl struct {
 	notificationWriter notification.Writer
 	userReader         user.Reader
 	db                 database.Database
-
-	// Corresponds to the workflow dag result entry in the database.
-	// This is empty if InitializeResults() has not been called.
-	resultID uuid.UUID
 }
 
 // Assumption: all dag's start with operators.
@@ -155,6 +146,7 @@ func computeArtifactSignatures(
 
 func NewWorkflowDag(
 	ctx context.Context,
+	workflowDagResultID uuid.UUID,
 	dbWorkflowDag *workflow_dag.DBWorkflowDag,
 	dagResultWriter workflow_dag_result.Writer,
 	opResultWriter operator_result.Writer,
@@ -256,6 +248,7 @@ func NewWorkflowDag(
 
 	return &workflowDagImpl{
 		dbWorkflowDag:       dbWorkflowDag,
+		resultID:            workflowDagResultID,
 		operators:           operators,
 		artifacts:           artifacts,
 		opToOutputArtifacts: opToOutputArtifactIDs,
@@ -267,7 +260,6 @@ func NewWorkflowDag(
 		notificationWriter: notificationWriter,
 		userReader:         userReader,
 		db:                 db,
-		resultID:           uuid.Nil,
 	}, nil
 }
 
@@ -318,20 +310,9 @@ func (w *workflowDagImpl) OperatorInputs(op operator.Operator) ([]artifact.Artif
 	return artifacts, nil
 }
 
-func (w *workflowDagImpl) InitializeResults(ctx context.Context) error {
-	if w.resultWriter == nil {
-		return errors.New("Workflow dag's result writer cannot be nil.")
-	}
-
-	// Create a database record of workflow dag result and set its status to `pending`.
+func (w *workflowDagImpl) InitOpAndArtifactResults(ctx context.Context) error {
 	// TODO(ENG-599): wrap these writes into a transaction.
-	dagResult, err := w.resultWriter.CreateWorkflowDagResult(ctx, w.dbWorkflowDag.Id, w.db)
-	if err != nil {
-		return errors.Wrap(err, "Unable to create workflow dag result record.")
-	}
-	w.resultID = dagResult.Id
-
-	// Also initialize the operators and artifact results.
+	// Initialize the operators and artifact results.
 	for _, op := range w.Operators() {
 		err := op.InitializeResult(ctx, w.resultID)
 		if err != nil {
@@ -344,26 +325,6 @@ func (w *workflowDagImpl) InitializeResults(ctx context.Context) error {
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (w *workflowDagImpl) PersistResult(ctx context.Context, status shared.ExecutionStatus) error {
-	if w.resultID == uuid.Nil {
-		return errors.New("Workflow's dag result was not initialized before calling PersistResult.")
-	}
-
-	// We `defer` this call to ensure that the WorkflowDagResult metadata is always updated.
-	utils.UpdateWorkflowDagResultMetadata(
-		ctx,
-		w.resultID,
-		status,
-		w.resultWriter,
-		w.workflowReader,
-		w.notificationWriter,
-		w.userReader,
-		w.db,
-	)
 
 	return nil
 }

--- a/src/golang/lib/workflow/utils/utils.go
+++ b/src/golang/lib/workflow/utils/utils.go
@@ -384,6 +384,19 @@ func UpdateWorkflowDagToLatest(
 	)
 }
 
+func CreateWorkflowDagResult(
+	ctx context.Context,
+	workflowDagId uuid.UUID,
+	workflowDagResultWriter workflow_dag_result.Writer,
+	db database.Database,
+) (*workflow_dag_result.WorkflowDagResult, error) {
+	return workflowDagResultWriter.CreateWorkflowDagResult(
+		ctx,
+		workflowDagId,
+		db,
+	)
+}
+
 func UpdateWorkflowDagResultMetadata(
 	ctx context.Context,
 	workflowDagResultId uuid.UUID,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR refactors the `Engine.ExecuteWorkflow` implementation to capture as many errors as possible when persisting the DAG status to the WorkflowDagResult table.

Essentially, the more code we have BEFORE we initialize a new row in the WorkflowDagResult table, the more errors we will be unable to capture and update the WorkflowDagResult row accordingly. In order to do this, we want to minimize the code inside of `ExecuteWorkflow` BEFORE the WorkflowDagResult row is created, because as soon as this record is created, we can add a `deferred` function that captures the state of the DAG run and updates the WorkflowDagResult record accordingly.

This PR gets rid of the `PersistResults` method from the `WorkflowDag` interface, because this logic is now handled directly by the `ExecuteWorkflow` implementation. Similarly, `InitializeResults` has been refactored to only deal with initializing Artifact and Operator results.

## Related issue number (if any)
ENG 1608

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

Test:
I modified the `Execute` function to always throw an error when the JobManager is created [here](https://github.com/aqueducthq/aqueduct/blob/main/src/golang/lib/engine/aq_engine.go#L225). Before this change the new workflow dag result would not be created and the user wouldn't see any new runs on the UI.

AFTER these changes, the user will now see the following on the UI. The run is marked as failed. 
![Screen Shot 2022-08-26 at 1 49 47 PM](https://user-images.githubusercontent.com/10413474/186988662-dc24056c-ba25-4a4f-97f1-298c3dd26f4b.png)

__EDIT: These issues are solved by #404__
~~There are still some things that should be improved from an error handling standpoint:~~
1. We have no way of letting the user know why their workflow failed, because errors are tied only to operator results. We don't have any fields that track an error that occurred before any operators even ran. An example of this is a system internal error, such as an error when setting up the job manager. Kind of solved by #404 (We show this as a system internal error)
2. The UI shows all of the operators as in progress even though the workflow run has failed. SOLVED by #404 
3. The UI crashes if a user clicks into an artifact or operator result that does not exist. (This is very high priority and the relevant task has been created. SOLVED by https://github.com/aqueducthq/aqueduct/pull/404