### PR TITLE
Returns workflow dag result status for unavailable operator and artifact results

### DIFF
--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -199,12 +199,11 @@ func (h *GetArtifactResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
-		if err == database.ErrNoRows {
-			// ArtifactResult was never created
-			// Use the WorkflowDagResult's status as this ArtifactResult's status
-			execState.Status = dbWorkflowDagResult.Status
+		if err != database.ErrNoRows {
+			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
 		}
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
+		// ArtifactResult was never created, so we use the WorkflowDagResult's status as this ArtifactResult's status
+		execState.Status = dbWorkflowDagResult.Status
 	} else {
 		execState.Status = dbArtifactResult.Status
 	}

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow_dag_result"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/dropbox/godropbox/errors"
@@ -41,9 +42,10 @@ type getOperatorResultArgs struct {
 type GetOperatorResultHandler struct {
 	GetHandler
 
-	Database             database.Database
-	OperatorReader       operator.Reader
-	OperatorResultReader operator_result.Reader
+	Database                database.Database
+	OperatorReader          operator.Reader
+	OperatorResultReader    operator_result.Reader
+	WorkflowDagResultReader workflow_dag_result.Reader
 }
 
 func (*GetOperatorResultHandler) Name() string {
@@ -93,6 +95,16 @@ func (h *GetOperatorResultHandler) Perform(ctx context.Context, interfaceArgs in
 
 	emptyResp := shared.ExecutionState{}
 
+	dbWorkflowDagResult, err := h.WorkflowDagResultReader.GetWorkflowDagResult(
+		ctx,
+		args.workflowDagResultId,
+		h.Database,
+	)
+	if err != nil {
+		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving workflow result.")
+	}
+
+	response := shared.ExecutionState{}
 	dbOperatorResult, err := h.OperatorResultReader.GetOperatorResultByWorkflowDagResultIdAndOperatorId(
 		ctx,
 		args.workflowDagResultId,
@@ -100,14 +112,17 @@ func (h *GetOperatorResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
+		if err == database.ErrNoRows {
+			// OperatorResult was never created
+			// Use the WorkflowDagResult's status as this OperatorResult's status
+			response.Status = dbWorkflowDagResult.Status
+		}
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving operator result.")
+	} else {
+		response.Status = dbOperatorResult.Status
 	}
 
-	response := shared.ExecutionState{
-		Status: dbOperatorResult.Status,
-	}
-
-	if !dbOperatorResult.ExecState.IsNull {
+	if dbOperatorResult != nil && !dbOperatorResult.ExecState.IsNull {
 		response.FailureType = dbOperatorResult.ExecState.FailureType
 		response.Error = dbOperatorResult.ExecState.Error
 		response.UserLogs = dbOperatorResult.ExecState.UserLogs

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -112,12 +112,11 @@ func (h *GetOperatorResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
-		if err == database.ErrNoRows {
-			// OperatorResult was never created
-			// Use the WorkflowDagResult's status as this OperatorResult's status
-			response.Status = dbWorkflowDagResult.Status
+		if err != database.ErrNoRows {
+			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving operator result.")
 		}
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving operator result.")
+		// OperatorResult was never created, so we use the WorkflowDagResult's status as this OperatorResult's status
+		response.Status = dbWorkflowDagResult.Status
 	} else {
 		response.Status = dbOperatorResult.Status
 	}

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -53,10 +53,11 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			WorkflowDagReader: s.WorkflowDagReader,
 		},
 		routes.GetArtifactResultRoute: &handler.GetArtifactResultHandler{
-			Database:             s.Database,
-			ArtifactReader:       s.ArtifactReader,
-			ArtifactResultReader: s.ArtifactResultReader,
-			WorkflowDagReader:    s.WorkflowDagReader,
+			Database:                s.Database,
+			ArtifactReader:          s.ArtifactReader,
+			ArtifactResultReader:    s.ArtifactResultReader,
+			WorkflowDagReader:       s.WorkflowDagReader,
+			WorkflowDagResultReader: s.WorkflowDagResultReader,
 		},
 		routes.GetArtifactVersionsRoute: &handler.GetArtifactVersionsHandler{
 			Database:     s.Database,
@@ -64,9 +65,10 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 		},
 		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
 		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{
-			Database:             s.Database,
-			OperatorReader:       s.OperatorReader,
-			OperatorResultReader: s.OperatorResultReader,
+			Database:                s.Database,
+			OperatorReader:          s.OperatorReader,
+			OperatorResultReader:    s.OperatorResultReader,
+			WorkflowDagResultReader: s.WorkflowDagResultReader,
 		},
 		routes.GetUserProfileRoute: &handler.GetUserProfileHandler{},
 		routes.ListWorkflowObjectsRoute: &handler.ListWorkflowObjectsHandler{


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR refactors the get operator results and get artifact results routes to use the workflow dag result status when the operator or artifact result object does not exist. 

This issue also fixes the UI bug [here](https://linear.app/aqueducthq/issue/ENG-1611/fix-ui-bug-where-ui-crashes-if-user-clicks-into-an-artifact-or), since now the operator and artifact results will assume the status of the overall workflow dag result if no records are found in the database.

## Related issue number (if any)
ENG 1611

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

DEMO: https://www.loom.com/share/16ae1226c0604fbca7429bc9fe2f728c
