### PR TITLE
ENG-1607 add integration unable to delete popup

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/deleteIntegrationDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/deleteIntegrationDialog.tsx
@@ -13,6 +13,7 @@ import {
 import { AppDispatch, RootState } from '../../../stores/store';
 import UserProfile from '../../../utils/auth';
 import { isFailed, isLoading, isSucceeded } from '../../../utils/shared';
+
 type Props = {
   user: UserProfile;
   integrationId: string;
@@ -59,52 +60,76 @@ const DeleteIntegrationDialog: React.FC<Props> = ({
     );
   };
 
-  return (
-    <>
+  const operatorsState = useSelector((state: RootState) => {
+    return state.integrationReducer.operators;
+  });
+  
+  if (
+    isSucceeded(operatorsState.status) &&
+    operatorsState.operators.length === 0
+  ) {
+    return (
+      <>
+        <Dialog
+          open={!deleteIntegrationStatus || !isFailed(deleteIntegrationStatus)}
+          onClose={onCloseDialog}
+          maxWidth="lg"
+        >
+          <DialogContent>
+            Are you sure you want to delete the integration?
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={onCloseDialog}>Cancel</Button>
+            <LoadingButton
+              autoFocus
+              onClick={confirmConnect}
+              loading={isConnecting}
+            >
+              Confirm
+            </LoadingButton>
+          </DialogActions>
+        </Dialog>
+        <Dialog
+          open={isFailed(deleteIntegrationStatus)}
+          onClose={onCloseDialog}
+          maxWidth="lg"
+        >
+          {deleteIntegrationStatus && isFailed(deleteIntegrationStatus) && (
+            <Alert severity="error" sx={{ margin: 2 }}>
+              Integration deletion failed with error:
+              <br></br>
+              <pre>{deleteIntegrationStatus.err}</pre>
+            </Alert>
+          )}
+          <DialogActions>
+            <Button
+              onClick={() => {
+                onCloseDialog();
+                dispatch(resetDeletionStatus());
+              }}
+            >
+              Dismiss
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  } else {
+    return (
       <Dialog
         open={!deleteIntegrationStatus || !isFailed(deleteIntegrationStatus)}
         onClose={onCloseDialog}
         maxWidth="lg"
       >
         <DialogContent>
-          Are you sure you want to delete the integration?
+          We cannot delete this integration because it is currently being used.
         </DialogContent>
         <DialogActions>
-          <Button onClick={onCloseDialog}>Cancel</Button>
-          <LoadingButton
-            autoFocus
-            onClick={confirmConnect}
-            loading={isConnecting}
-          >
-            Confirm
-          </LoadingButton>
+          <Button onClick={onCloseDialog}>Dismiss</Button>
         </DialogActions>
       </Dialog>
-      <Dialog
-        open={isFailed(deleteIntegrationStatus)}
-        onClose={onCloseDialog}
-        maxWidth="lg"
-      >
-        {deleteIntegrationStatus && isFailed(deleteIntegrationStatus) && (
-          <Alert severity="error" sx={{ margin: 2 }}>
-            Integration deletion failed with error:
-            <br></br>
-            <pre>{deleteIntegrationStatus.err}</pre>
-          </Alert>
-        )}
-        <DialogActions>
-          <Button
-            onClick={() => {
-              onCloseDialog();
-              dispatch(resetDeletionStatus());
-            }}
-          >
-            Dismiss
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
-  );
+      );
+  }
 };
 
 export default DeleteIntegrationDialog;

--- a/src/ui/common/src/components/integrations/dialogs/deleteIntegrationDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/deleteIntegrationDialog.tsx
@@ -63,7 +63,7 @@ const DeleteIntegrationDialog: React.FC<Props> = ({
   const operatorsState = useSelector((state: RootState) => {
     return state.integrationReducer.operators;
   });
-  
+
   if (
     isSucceeded(operatorsState.status) &&
     operatorsState.operators.length === 0
@@ -128,7 +128,7 @@ const DeleteIntegrationDialog: React.FC<Props> = ({
           <Button onClick={onCloseDialog}>Dismiss</Button>
         </DialogActions>
       </Dialog>
-      );
+    );
   }
 };
 

--- a/src/ui/common/src/components/integrations/options.tsx
+++ b/src/ui/common/src/components/integrations/options.tsx
@@ -10,6 +10,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import React, { useState } from 'react';
+
 import { Integration, isDemo } from '../../utils/integrations';
 import { Button } from '../primitives/Button.styles';
 

--- a/src/ui/common/src/components/integrations/options.tsx
+++ b/src/ui/common/src/components/integrations/options.tsx
@@ -10,11 +10,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
-
-import { RootState } from '../../stores/store';
 import { Integration, isDemo } from '../../utils/integrations';
-import { LoadingStatusEnum } from '../../utils/shared';
 import { Button } from '../primitives/Button.styles';
 
 type Props = {
@@ -37,16 +33,6 @@ const IntegrationOptions: React.FC<Props> = ({
   const onMenuClose = () => {
     setAnchorEl(null);
   };
-  const operatorsState = useSelector((state: RootState) => {
-    return state.integrationReducer.operators;
-  });
-  let inUse = true;
-  if (
-    operatorsState.status.loading === LoadingStatusEnum.Succeeded &&
-    operatorsState.operators.length === 0
-  ) {
-    inUse = false;
-  }
   return (
     <Box display="flex" flexDirection="row" sx={{ height: 'fit-content' }}>
       {isDemo(integration) && (
@@ -117,7 +103,6 @@ const IntegrationOptions: React.FC<Props> = ({
               setAnchorEl(null);
               onDeleteIntegration();
             }}
-            disabled={inUse}
           >
             <FontAwesomeIcon color="gray.800" icon={faTrash} />
             <Typography color="gray.800" variant="body2" sx={{ marginLeft: 1 }}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes

If the user cannot delete a workflow, bring up a popup with an explanation rather than disable the button.

https://user-images.githubusercontent.com/30596854/187237386-ca5ebb5f-66c3-46f2-94a0-c7bedad4ef7f.mov

## Related issue number (if any)
ENG-1607

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


