### PR TITLE
Makes exported function code more user-friendly to read

### DIFF
--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -248,7 +248,7 @@ class NumericArtifact(BaseArtifact):
         severity: CheckSeverity = CheckSeverity.WARNING,
         execution_mode: ExecutionMode = ExecutionMode.EAGER,
     ) -> bool_artifact.BoolArtifact:
-        zip_file = serialize_function(check_function)
+        zip_file = serialize_function(check_function, check_name)
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
             granularity=FunctionGranularity.TABLE,

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -305,15 +305,16 @@ class TableArtifact(BaseArtifact):
             # Run validation to return the result
             result = my_validator.validate()
             return bool(result.success)
+        
+        check_name = "ge_table_check: {%s}" % expectation_name
 
-        zip_file = serialize_function(great_expectations_check_method)
+        zip_file = serialize_function(great_expectations_check_method, check_name)
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
             granularity=FunctionGranularity.TABLE,
             file=zip_file,
         )
         check_spec = OperatorSpec(check=CheckSpec(level=severity, function=function_spec))
-        check_name = "ge_table_check: {%s}" % expectation_name
         check_description = "Check table with built in expectations from great expectations"
         new_artifact = self._apply_operator_to_table(
             check_spec,
@@ -380,7 +381,7 @@ class TableArtifact(BaseArtifact):
                 table_name,
             )
 
-        zip_file = serialize_function(metric_func)
+        zip_file = serialize_function(metric_func, metric_name)
 
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
@@ -417,7 +418,7 @@ class TableArtifact(BaseArtifact):
 
         metric_name = "num_rows"
         metric_description = "compute number of rows for %s" % table_name
-        zip_file = serialize_function(internal_num_rows_metric)
+        zip_file = serialize_function(internal_num_rows_metric, metric_name)
 
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
@@ -461,7 +462,7 @@ class TableArtifact(BaseArtifact):
             column_id,
             table_name,
         )
-        zip_file = serialize_function(internal_max_metric)
+        zip_file = serialize_function(internal_max_metric, metric_name)
 
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
@@ -505,7 +506,7 @@ class TableArtifact(BaseArtifact):
             column_id,
             table_name,
         )
-        zip_file = serialize_function(internal_min_metric)
+        zip_file = serialize_function(internal_min_metric, metric_name)
 
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
@@ -549,7 +550,7 @@ class TableArtifact(BaseArtifact):
             column_id,
             table_name,
         )
-        zip_file = serialize_function(internal_mean_metric)
+        zip_file = serialize_function(internal_mean_metric, metric_name)
 
         function_spec = FunctionSpec(
             type=FunctionType.FILE,
@@ -595,7 +596,7 @@ class TableArtifact(BaseArtifact):
             column_id,
             table_name,
         )
-        zip_file = serialize_function(internal_std_metric)
+        zip_file = serialize_function(internal_std_metric, metric_name)
 
         function_spec = FunctionSpec(
             type=FunctionType.FILE,

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -305,7 +305,7 @@ class TableArtifact(BaseArtifact):
             # Run validation to return the result
             result = my_validator.validate()
             return bool(result.success)
-        
+
         check_name = "ge_table_check: {%s}" % expectation_name
 
         zip_file = serialize_function(great_expectations_check_method, check_name)

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -271,7 +271,7 @@ def op(
 
             _type_check_decorated_function_arguments(OperatorType.FUNCTION, *input_artifacts)
 
-            zip_file = serialize_function(func, file_dependencies, requirements)
+            zip_file = serialize_function(func, name, file_dependencies, requirements)
             function_spec = FunctionSpec(
                 type=FunctionType.FILE,
                 granularity=FunctionGranularity.TABLE,
@@ -383,7 +383,7 @@ def metric(
 
             _type_check_decorated_function_arguments(OperatorType.METRIC, *input_artifacts)
 
-            zip_file = serialize_function(func, file_dependencies, requirements)
+            zip_file = serialize_function(func, name, file_dependencies, requirements)
 
             # TODO(ENG-735): Support granularity=FunctionGranularity.TABLE & granularity=FunctionGranularity.ROW
             function_spec = FunctionSpec(
@@ -518,7 +518,7 @@ def check(
 
             _type_check_decorated_function_arguments(OperatorType.CHECK, *input_artifacts)
 
-            zip_file = serialize_function(func, file_dependencies, requirements)
+            zip_file = serialize_function(func, name, file_dependencies, requirements)
             function_spec = FunctionSpec(
                 type=FunctionType.FILE,
                 granularity=FunctionGranularity.TABLE,

--- a/sdk/aqueduct/tests/decorator_test.py
+++ b/sdk/aqueduct/tests/decorator_test.py
@@ -58,8 +58,10 @@ def test_handle_reserved_file_dependencies():
 def test_serialize_function():
     initial_state = set(os.listdir())
     dependencies = ["./test_dependency_folder/helper_function.py"]
+    op_name = "helper_fn"
     zip_file = serialize_function(
         func=python_function,
+        op_name=op_name,
         file_dependencies=dependencies,
     )
     final_state = set(os.listdir())
@@ -73,7 +75,7 @@ def test_serialize_function():
         "model.py",
         "model.pkl",
         "requirements.txt",
-        "source.py",
+        "{}.py".format(op_name),
     ]
     zip_files = [name.split("/")[-1] for name in zip_file.namelist() if name.split("/")[-1]]
     assert set(zip_files) == set(files)

--- a/sdk/aqueduct/tests/decorator_test.py
+++ b/sdk/aqueduct/tests/decorator_test.py
@@ -73,6 +73,7 @@ def test_serialize_function():
         "model.py",
         "model.pkl",
         "requirements.txt",
+        "source.py",
     ]
     zip_files = [name.split("/")[-1] for name in zip_file.namelist() if name.split("/")[-1]]
     assert set(zip_files) == set(files)

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 import cloudpickle as pickle
 import multipart
 import numpy as np
-import pandas as pd
 import requests
 from aqueduct.config import AirflowEngineConfig, EngineConfig, FlowConfig, K8sEngineConfig
 from aqueduct.dag import DAG, RetentionPolicy, Schedule
@@ -110,11 +109,9 @@ def retention_policy_from_latest_runs(k_latest_runs: int) -> RetentionPolicy:
 
 MODEL_FILE_NAME = "model.py"
 MODEL_PICKLE_FILE_NAME = "model.pkl"
-FUNCTION_SOURCE_FILE_NAME = "source.py"
 PYTHON_VERSION_FILE_NAME = "python_version.txt"
 CONDA_VERSION_FILE_NAME = "conda_version.txt"
 RESERVED_FILE_NAMES = [
-    FUNCTION_SOURCE_FILE_NAME,
     MODEL_FILE_NAME,
     MODEL_PICKLE_FILE_NAME,
     PYTHON_VERSION_FILE_NAME,
@@ -160,6 +157,7 @@ def make_zip_dir() -> str:
 
 def serialize_function(
     func: Union[UserFunction, MetricFunction, CheckFunction],
+    op_name: str,
     file_dependencies: Optional[List[str]] = None,
     requirements: Optional[Union[str, List[str]]] = None,
 ) -> bytes:
@@ -169,6 +167,8 @@ def serialize_function(
     Arguments:
         func:
             The function to package
+        op_name:
+            The name of the function operator to package.    
         file_dependencies:
             A list of relative paths to files that the function needs to access.
         requirements:
@@ -200,7 +200,7 @@ def serialize_function(
             pickle.dump(func, f)
 
         # Write function source code to file
-        with open(os.path.join(dir_path, "source.py"), "w") as f:
+        with open(os.path.join(dir_path, op_name), "w") as f:
             source = inspect.getsource(func)
             print(source)
             f.write(source)

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -200,7 +200,8 @@ def serialize_function(
             pickle.dump(func, f)
 
         # Write function source code to file
-        with open(os.path.join(dir_path, op_name), "w") as f:
+        source_file = "{}.py".format(op_name)
+        with open(os.path.join(dir_path, source_file), "w") as f:
             source = inspect.getsource(func)
             print(source)
             f.write(source)

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -168,7 +168,7 @@ def serialize_function(
         func:
             The function to package
         op_name:
-            The name of the function operator to package.    
+            The name of the function operator to package.
         file_dependencies:
             A list of relative paths to files that the function needs to access.
         requirements:

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -198,7 +198,7 @@ def serialize_function(
             model_file.write(op_file_content())
         with open(os.path.join(dir_path, MODEL_PICKLE_FILE_NAME), "wb") as f:
             pickle.dump(func, f)
-        
+
         # Write function source code to file
         with open(os.path.join(dir_path, "source.py"), "w") as f:
             source = inspect.getsource(func)

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -203,7 +203,6 @@ def serialize_function(
         source_file = "{}.py".format(op_name)
         with open(os.path.join(dir_path, source_file), "w") as f:
             source = inspect.getsource(func)
-            print(source)
             f.write(source)
 
         zip_file_path = get_zip_file_path(dir_path)

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -110,9 +110,11 @@ def retention_policy_from_latest_runs(k_latest_runs: int) -> RetentionPolicy:
 
 MODEL_FILE_NAME = "model.py"
 MODEL_PICKLE_FILE_NAME = "model.pkl"
+FUNCTION_SOURCE_FILE_NAME = "source.py"
 PYTHON_VERSION_FILE_NAME = "python_version.txt"
 CONDA_VERSION_FILE_NAME = "conda_version.txt"
 RESERVED_FILE_NAMES = [
+    FUNCTION_SOURCE_FILE_NAME,
     MODEL_FILE_NAME,
     MODEL_PICKLE_FILE_NAME,
     PYTHON_VERSION_FILE_NAME,
@@ -196,6 +198,12 @@ def serialize_function(
             model_file.write(op_file_content())
         with open(os.path.join(dir_path, MODEL_PICKLE_FILE_NAME), "wb") as f:
             pickle.dump(func, f)
+        
+        # Write function source code to file
+        with open(os.path.join(dir_path, "source.py"), "w") as f:
+            source = inspect.getsource(func)
+            print(source)
+            f.write(source)
 
         zip_file_path = get_zip_file_path(dir_path)
         _make_archive(dir_path, zip_file_path)

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -153,7 +153,8 @@ func (*ExportFunctionHandler) SendResponse(w http.ResponseWriter, interfaceResp 
 
 // extractUserReadableCode takes the zipped function code and only returns a zipped file
 // containing the human-readable parts, i.e. source.py, requirements.txt, and python_version.txt
-// If no source code (i.e. source.py) is found, it simply returns the original zipped file.
+// If no source code (i.e. source.py) is found, it simply returns the original contents.
+// In all cases, it renames the top-level directory to `operatorName`.
 func extractUserReadableCode(data []byte, operatorName string) ([]byte, error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -126,7 +126,7 @@ func (h *ExportFunctionHandler) Perform(ctx context.Context, interfaceArgs inter
 	}
 
 	return &exportFunctionResponse{
-		fileName: args.operatorId.String(),
+		fileName: operatorObject.Name,
 		program:  bytes.NewBuffer(program),
 	}, http.StatusOK, nil
 }

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	// Names of the files inside a zipped Function
-	sourceFile      = "source.py"
 	modelFile       = "model.py"
 	modelPickleFile = "model.pkl"
 )
@@ -152,8 +151,8 @@ func (*ExportFunctionHandler) SendResponse(w http.ResponseWriter, interfaceResp 
 }
 
 // extractUserReadableCode takes the zipped function code and only returns a zipped file
-// containing the human-readable parts, i.e. source.py, requirements.txt, and python_version.txt
-// If no source code (i.e. source.py) is found, it simply returns the original contents.
+// containing the human-readable parts, i.e. source code, requirements.txt, and python_version.txt
+// If no source code is found, it simply returns the original contents.
 // In all cases, it renames the top-level directory to `operatorName`.
 func extractUserReadableCode(data []byte, operatorName string) ([]byte, error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
@@ -161,11 +160,11 @@ func extractUserReadableCode(data []byte, operatorName string) ([]byte, error) {
 		return nil, err
 	}
 
-	// Check if there is a source.py file, since older SDK clients did not generate this file
+	// Check if there is a source file, since older SDK clients did not generate this file
 	hasSourceFile := false
 	for _, zipFile := range zipReader.File {
 		parts := strings.Split(zipFile.Name, "/")
-		if len(parts) == 2 && parts[1] == sourceFile {
+		if len(parts) == 2 && parts[1] == operatorName {
 			hasSourceFile = true
 			break
 		}
@@ -179,7 +178,7 @@ func extractUserReadableCode(data []byte, operatorName string) ([]byte, error) {
 		if hasSourceFile &&
 			len(parts) == 2 &&
 			(parts[1] == modelFile || parts[1] == modelPickleFile) {
-			// There is a source.py so we can skip the files that are not user-friendly to read
+			// There is a source file so we can skip the files that are not user-friendly to read
 			continue
 		}
 

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -163,8 +164,9 @@ func extractUserReadableCode(data []byte, operatorName string) ([]byte, error) {
 	// Check if there is a source file, since older SDK clients did not generate this file
 	hasSourceFile := false
 	for _, zipFile := range zipReader.File {
+		sourceFileName := fmt.Sprintf("%s.py", operatorName)
 		parts := strings.Split(zipFile.Name, "/")
-		if len(parts) == 2 && parts[1] == operatorName {
+		if len(parts) == 2 && parts[1] == sourceFileName {
 			hasSourceFile = true
 			break
 		}

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -61,6 +61,12 @@ func (*ExportFunctionHandler) Name() string {
 	return "ExportFunction"
 }
 
+func (*ExportFunctionHandler) Headers() []string {
+	return []string{
+		routes.ExportFnUserFriendlyHeader,
+	}
+}
+
 func (h *ExportFunctionHandler) Prepare(r *http.Request) (interface{}, int, error) {
 	aqContext, statusCode, err := aq_context.ParseAqContext(r.Context())
 	if err != nil {

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -125,6 +125,11 @@ func (h *ExportFunctionHandler) Perform(ctx context.Context, interfaceArgs inter
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to get function from storage")
 	}
 
+	sourceCode, err := extractUserReadableCode(program)
+	if err != nil {
+		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to export function code")
+	}
+
 	return &exportFunctionResponse{
 		fileName: operatorObject.Name,
 		program:  bytes.NewBuffer(program),
@@ -134,4 +139,8 @@ func (h *ExportFunctionHandler) Perform(ctx context.Context, interfaceArgs inter
 func (*ExportFunctionHandler) SendResponse(w http.ResponseWriter, interfaceResp interface{}) {
 	resp := interfaceResp.(*exportFunctionResponse)
 	response.SendSmallFileResponse(w, resp.fileName, resp.program)
+}
+
+func extractUserReadableCode(data []byte) ([]byte, error) {
+
 }

--- a/src/golang/cmd/server/request/export.go
+++ b/src/golang/cmd/server/request/export.go
@@ -1,0 +1,14 @@
+package request
+
+import (
+	"net/http"
+
+	"github.com/aqueducthq/aqueduct/cmd/server/routes"
+)
+
+// ParseExportUserFriendlyFromRequest parses whether this export request is only for
+// user-friendly code.
+func ParseExportUserFriendlyFromRequest(r *http.Request) bool {
+	userFriendly := r.Header.Get(routes.ExportFnUserFriendlyHeader)
+	return userFriendly != ""
+}

--- a/src/golang/cmd/server/routes/headers.go
+++ b/src/golang/cmd/server/routes/headers.go
@@ -11,5 +11,8 @@ const (
 	IntegrationServiceHeader = "integration-service"
 	IntegrationConfigHeader  = "integration-config"
 
+	// Export Function headers
+	ExportFnUserFriendlyHeader = "user-friendly"
+
 	TableNameHeader = "table-name"
 )

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -152,6 +152,9 @@ export async function exportFunction(
     method: 'GET',
     headers: {
       'api-key': user.apiKey,
+      // We only want the user-friendly function code to be exported.
+      // The actual value does not matter, but the header has to be present and not an empty string.
+      'user-friendly': 'true',
     },
   });
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR refactors how we capture and return exported functions to the user.
The code is captured when a workflow is created by adding a special read-only file called `source.py`. This file isn't used as part of any operator execution, but it is just there as a user-friendly copy of the code that has been serialized into `model.pkl`.

## Related issue number (if any)
ENG 1190

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

UPDATE:
The files now look like
<img width="839" alt="Screen Shot 2022-08-29 at 4 48 40 PM" src="https://user-images.githubusercontent.com/10413474/187318228-16d86adf-9a66-4548-9ba0-13e596f3d182.png">

Demo: https://www.loom.com/share/a553c71f4d9b4216a7c2b22db30073ad


