### PR TITLE
Fix periodic integration tests and add slack reporting on failure

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -88,3 +88,16 @@ jobs:
         with:
           name: Executor Logs
           path: ~/.aqueduct/server/logs/*
+
+      - name: Report to Slack on Failure
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notification_title: ''
+          message_format: '{emoji} *{workflow}* has {status_message}'
+          footer: '{run_url}'
+          notify_when: 'failure,warnings'
+          mention_users: 'U025MDH5KS6'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/integration_tests/sdk/local_test.py
+++ b/integration_tests/sdk/local_test.py
@@ -1,8 +1,7 @@
-from pandas._testing import assert_frame_equal
-
 from checks_test import success_on_single_table_input
 from constants import SENTIMENT_SQL_QUERY
 from pandas import DataFrame
+from pandas._testing import assert_frame_equal
 from test_metrics.constant.model import constant_metric
 from utils import (
     get_integration_name,

--- a/integration_tests/sdk/local_test.py
+++ b/integration_tests/sdk/local_test.py
@@ -1,3 +1,5 @@
+from pandas._testing import assert_frame_equal
+
 from checks_test import success_on_single_table_input
 from constants import SENTIMENT_SQL_QUERY
 from pandas import DataFrame
@@ -18,7 +20,7 @@ def test_local_operator(client):
     output_cloud = output_artifact.get()
     output_local = run_sentiment_model_local(sql_artifact)
     assert output_cloud.count()[0] == output_local.count()[0]
-    assert output_cloud.equals(output_local)
+    assert_frame_equal(output_cloud, output_local)
 
 
 def test_local_metric(client):
@@ -44,7 +46,7 @@ def test_local_dataframe_input(client):
     output_cloud = run_sentiment_model(sql_artifact).get()
     output_local = run_sentiment_model_local(sql_artifact.get())
     assert type(output_local) is DataFrame
-    assert output_cloud.equals(output_local)
+    assert_frame_equal(output_cloud, output_local)
 
 
 def test_local_on_multiple_inputs(client):
@@ -54,4 +56,4 @@ def test_local_on_multiple_inputs(client):
     output_cloud = run_sentiment_model_multiple_input(sql_artifact, sql_artifact2).get()
     output_local = run_sentiment_model_local_multiple_input(sql_artifact, sql_artifact2)
     assert type(output_local) is DataFrame
-    assert output_cloud.equals(output_local)
+    assert_frame_equal(output_cloud, output_local)

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -3,11 +3,10 @@ from typing import Any, Dict, List
 
 import pandas as pd
 import pytest
-from pandas._testing import assert_frame_equal
-
 from aqueduct.enums import ArtifactType
 from aqueduct.error import InvalidUserArgumentException
 from constants import SENTIMENT_SQL_QUERY
+from pandas._testing import assert_frame_equal
 from utils import generate_new_flow_name, get_integration_name, run_flow_test, wait_for_flow_runs
 
 from aqueduct import metric, op

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -3,10 +3,11 @@ from typing import Any, Dict, List
 
 import pandas as pd
 import pytest
+from pandas._testing import assert_frame_equal
+
 from aqueduct.enums import ArtifactType
 from aqueduct.error import InvalidUserArgumentException
 from constants import SENTIMENT_SQL_QUERY
-from pandas.util.testing import assert_frame_equal
 from utils import generate_new_flow_name, get_integration_name, run_flow_test, wait_for_flow_runs
 
 from aqueduct import metric, op

--- a/regression_tests/tests/workflow_comparer.py
+++ b/regression_tests/tests/workflow_comparer.py
@@ -2,8 +2,8 @@ import argparse
 import os
 import subprocess
 import sys
-from io import StringIO
 from contextlib import redirect_stdout
+from io import StringIO
 
 from aqueduct import Client, get_apikey
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
See title. The tests were failing consistently. Let's get alerted next time this happens. I believe this is only  an issue with the periodic tests because they use the `--complex_models` flag.

## Related issue number (if any)


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


