### PR TITLE
Adds AWS keys to S3 storage config

### DIFF
--- a/src/golang/lib/collections/shared/storage.go
+++ b/src/golang/lib/collections/shared/storage.go
@@ -26,6 +26,8 @@ type S3Config struct {
 	Bucket             string `yaml:"bucket" json:"bucket"`
 	CredentialsPath    string `yaml:"credentialsPath" json:"credentials_path"`
 	CredentialsProfile string `yaml:"credentialsProfile"  json:"credentials_profile"`
+	AWSAccessKeyID     string `yaml:"awsAccessKeyId"  json:"aws_access_key_id"`
+	AWSSecretAccessKey string `yaml:"awsSecretAccessKey"  json:"aws_secret_access_key"`
 }
 
 type FileConfig struct {

--- a/src/python/aqueduct_executor/operators/utils/storage/config.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/config.py
@@ -20,6 +20,8 @@ class S3StorageConfig(BaseModel):
     bucket: str
     credentials_path: str
     credentials_profile: str
+    aws_access_key_id: str = ""
+    aws_secret_access_key: str = ""
 
 
 class GCSStorageConfig(BaseModel):

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -14,10 +14,18 @@ class S3Storage(Storage):
     def __init__(self, config: S3StorageConfig):
 
         if "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
+            # The AWS keys are passed in as environment variables for k8s engines
             self._client = boto3.client(
                 "s3",
                 aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
                 aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+            )
+        elif config.aws_access_key_id and config.aws_secret_access_key:
+            # The AWS keys are passed in as part of the storage spec for AWS Lambda engines
+            self._client = boto3.client(
+                "s3",
+                aws_access_key_id=config.aws_access_key_id,
+                aws_secret_access_key=config.aws_secret_access_key,
             )
         else:
             # Boto3 uses an environment variable to determine the credentials filepath and profile


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds the AWS keys as fields for S3 StorageConfig. This is necessary for the AWS Lambda engine work, since we'll be passing in S3 credentials as part of the StorageConfig instead of passing them in as environment variables as we do in the k8s engine case.

NOTE: There will have to be a follow on PR once the Lambda jobManager has been implemented that actually sets the new AWS key fields before the StorageConfig is serialized as part of the JobSpec.

## Related issue number (if any)
ENG 1621

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


