### PR TITLE
[SDK/3] ENG-1509 Add flag to Update Mode indicating which is currently used

### DIFF
--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -237,6 +237,7 @@ class SavedObjectUpdate(BaseModel):
     """This is an item in the list returned by ListWorkflowSavedObjectsResponse."""
 
     operator_name: str
+    created_at: int
     integration_name: str
     integration_id: uuid.UUID
     service: ServiceType


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Update the BE response class to add `created_at` as a field to the workflow objects list so we can signify to the user which update mode is the active one (since the active workflow is currently the latest workflow).

## Related issue number (if any)
ENG-1509
BE: https://github.com/aqueducthq/aqueduct/pull/410
SDK: https://github.com/aqueducthq/aqueduct/pull/411
UI: https://github.com/aqueducthq/aqueduct/pull/412

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


