### PR TITLE
[UI/3] ENG-1509 Add flag to Update Mode indicating which is currently used

### DIFF
--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -237,6 +237,7 @@ class SavedObjectUpdate(BaseModel):
     """This is an item in the list returned by ListWorkflowSavedObjectsResponse."""
 
     operator_name: str
+    created_at: int
     integration_name: str
     integration_id: uuid.UUID
     service: ServiceType

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -432,48 +432,54 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const listSavedObjects = (
     <FormGroup>
       {Object.entries(savedObjects).map(
-        ([integrationTableKey, savedObjectsList]) => (
-          <FormControlLabel
-            key={integrationTableKey}
-            control={
-              <Checkbox
-                id={integrationTableKey}
-                onChange={updateSelectedObjects}
-              />
-            }
-            label={
-              <Box>
-                {displayObject(
-                  savedObjectsList[0].integration_name,
-                  savedObjectsList[0].object_name
-                )}
+        ([integrationTableKey, savedObjectsList]) => {
+          const sortedObjects = [...savedObjectsList].sort(
+            (object) => object.created_at
+          );
+          return (
+            <FormControlLabel
+              key={integrationTableKey}
+              control={
+                <Checkbox
+                  id={integrationTableKey}
+                  onChange={updateSelectedObjects}
+                />
+              }
+              label={
+                <Box>
+                  {displayObject(
+                    savedObjectsList[0].integration_name,
+                    savedObjectsList[0].object_name
+                  )}
 
-                <Typography
-                  style={{
-                    color: theme.palette.gray[600],
-                    paddingRight: '8px',
-                  }}
-                  variant="body2"
-                  display="inline"
-                >
-                  Update Mode:{' '}
-                  {savedObjectsList
-                    .map((object) => object.update_mode)
-                    .join(', ')}
-                </Typography>
-
-                <Tooltip title="Multiple update modes have been associated with this object throughout workflow deployments.">
-                  <Typography display="inline">
-                    <FontAwesomeIcon
-                      icon={faCircleInfo}
-                      style={{ color: theme.palette.Info }}
-                    />
+                  <Typography
+                    style={{
+                      color: theme.palette.gray[600],
+                      paddingRight: '8px',
+                    }}
+                    variant="body2"
+                    display="inline"
+                  >
+                    Update Mode:{' '}
+                    {sortedObjects
+                      .map((object) => `${object.update_mode}`)
+                      .join(', ')}
+                    {sortedObjects.length > 1 ? ' (active)' : null}
                   </Typography>
-                </Tooltip>
-              </Box>
-            }
-          />
-        )
+
+                  <Tooltip title="Multiple update modes have been associated with this object throughout workflow deployments.">
+                    <Typography display="inline">
+                      <FontAwesomeIcon
+                        icon={faCircleInfo}
+                        style={{ color: theme.palette.Info }}
+                      />
+                    </Typography>
+                  </Tooltip>
+                </Box>
+              }
+            />
+          );
+        }
       )}
     </FormGroup>
   );

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -13,7 +13,6 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Tooltip,
 } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
@@ -424,10 +423,26 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     }
   };
 
-  const displayObject = (integration, name) => (
-    <Typography variant="body1">
-      [{integration}] <b>{name}</b>
-    </Typography>
+  const displayObject = (integration, name, sortedObjects) => (
+    <>
+      <Typography variant="body1">
+        [{integration}] <b>{name}</b>
+      </Typography>
+      {sortedObjects && <Typography
+        style={{
+          color: theme.palette.gray[600],
+          paddingRight: '8px',
+        }}
+        variant="body2"
+        display="inline"
+      >
+        Update Mode:{' '}
+        {sortedObjects
+          .map((object) => `${object.update_mode}`)
+          .join(', ')}
+        {sortedObjects.length > 1 && ' (active)'}
+      </Typography>}
+    </>
   );
   const listSavedObjects = (
     <FormGroup>
@@ -436,48 +451,27 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           const sortedObjects = [...savedObjectsList].sort(
             (object) => object.created_at
           );
+          // Cannot align the checkbox to the top of a multi-line label.
+          // Using a weird marginTop workaround.
           return (
             <FormControlLabel
+              style={{ marginTop: "-1.2em"}}
               key={integrationTableKey}
               control={
                 <Checkbox
                   id={integrationTableKey}
                   onChange={updateSelectedObjects}
                 />
-              }
-              label={
-                <Box>
-                  {displayObject(
-                    savedObjectsList[0].integration_name,
-                    savedObjectsList[0].object_name
-                  )}
-
-                  <Typography
-                    style={{
-                      color: theme.palette.gray[600],
-                      paddingRight: '8px',
-                    }}
-                    variant="body2"
-                    display="inline"
-                  >
-                    Update Mode:{' '}
-                    {sortedObjects
-                      .map((object) => `${object.update_mode}`)
-                      .join(', ')}
-                    {sortedObjects.length > 1 ? ' (active)' : null}
-                  </Typography>
-
-                  <Tooltip title="Multiple update modes have been associated with this object throughout workflow deployments.">
-                    <Typography display="inline">
-                      <FontAwesomeIcon
-                        icon={faCircleInfo}
-                        style={{ color: theme.palette.Info }}
-                      />
-                    </Typography>
-                  </Tooltip>
-                </Box>
-              }
-            />
+                }
+            label={
+            <div style={{ marginTop: "1.2em" }}> 
+              {displayObject(
+                savedObjectsList[0].integration_name,
+                savedObjectsList[0].object_name,
+                sortedObjects
+              )}
+            </div>
+            }/>
           );
         }
       )}
@@ -674,7 +668,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                     <ListItemText
                       primary={displayObject(
                         integrationName,
-                        objectResult.name
+                        objectResult.name,
+                        null
                       )}
                     />
                   </ListItem>

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -1,6 +1,5 @@
 import {
   faCircleCheck,
-  faCircleInfo,
   faCircleXmark,
   faXmark,
 } from '@fortawesome/free-solid-svg-icons';
@@ -428,20 +427,20 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
       <Typography variant="body1">
         [{integration}] <b>{name}</b>
       </Typography>
-      {sortedObjects && <Typography
-        style={{
-          color: theme.palette.gray[600],
-          paddingRight: '8px',
-        }}
-        variant="body2"
-        display="inline"
-      >
-        Update Mode:{' '}
-        {sortedObjects
-          .map((object) => `${object.update_mode}`)
-          .join(', ')}
-        {sortedObjects.length > 1 && ' (active)'}
-      </Typography>}
+      {sortedObjects && (
+        <Typography
+          style={{
+            color: theme.palette.gray[600],
+            paddingRight: '8px',
+          }}
+          variant="body2"
+          display="inline"
+        >
+          Update Mode:{' '}
+          {sortedObjects.map((object) => `${object.update_mode}`).join(', ')}
+          {sortedObjects.length > 1 && ' (active)'}
+        </Typography>
+      )}
     </>
   );
   const listSavedObjects = (
@@ -455,23 +454,24 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           // Using a weird marginTop workaround.
           return (
             <FormControlLabel
-              style={{ marginTop: "-1.2em"}}
+              style={{ marginTop: '-1.2em' }}
               key={integrationTableKey}
               control={
                 <Checkbox
                   id={integrationTableKey}
                   onChange={updateSelectedObjects}
                 />
-                }
-            label={
-            <div style={{ marginTop: "1.2em" }}> 
-              {displayObject(
-                savedObjectsList[0].integration_name,
-                savedObjectsList[0].object_name,
-                sortedObjects
-              )}
-            </div>
-            }/>
+              }
+              label={
+                <div style={{ marginTop: '1.2em' }}>
+                  {displayObject(
+                    savedObjectsList[0].integration_name,
+                    savedObjectsList[0].object_name,
+                    sortedObjects
+                  )}
+                </div>
+              }
+            />
           );
         }
       )}

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -454,7 +454,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           // Using a weird marginTop workaround.
           return (
             <FormControlLabel
-              style={{ marginTop: '-1.2em' }}
+              sx={{ marginTop: '-24px' }}
               key={integrationTableKey}
               control={
                 <Checkbox
@@ -463,13 +463,13 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                 />
               }
               label={
-                <div style={{ marginTop: '1.2em' }}>
+                <Box sx={{ paddingTop: '24px' }}>
                   {displayObject(
                     savedObjectsList[0].integration_name,
                     savedObjectsList[0].object_name,
                     sortedObjects
                   )}
-                </div>
+                </Box>
               }
             />
           );

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -83,6 +83,7 @@ export type GetWorkflowResponse = {
 
 export type SavedObject = {
   operator_name: string;
+  created_at: number;
   integration_name: string;
   integration_id: string;
   service: string;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Signify to the user which update mode is the active one (since the active workflow is currently the latest workflow).

<img width="1440" alt="update_mode_active" src="https://user-images.githubusercontent.com/30596854/187339489-4ed983c0-2677-423e-b0b9-2934d2c116a6.png">

## Related issue number (if any)
ENG-1509
BE: https://github.com/aqueducthq/aqueduct/pull/410
SDK: https://github.com/aqueducthq/aqueduct/pull/411
UI: https://github.com/aqueducthq/aqueduct/pull/412

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


