### PR TITLE
Bump the timeout for periodic integration tests

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
       - name: Run the Integration Tests
-        timeout-minutes: 10
+        timeout-minutes: 15
         working-directory: integration_tests/sdk
         env:
           SERVER_ADDRESS: localhost:8080


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Looks like one of the recent tests timed out. Lets set it to the same timeout as our pre-merge integration tests.

## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


