### PR TITLE
Extracts Python version from serialized function

### DIFF
--- a/src/golang/lib/collections/operator/function/version.go
+++ b/src/golang/lib/collections/operator/function/version.go
@@ -33,7 +33,6 @@ func GetPythonVersion(ctx context.Context, path string, storageConfig *shared.St
 	}
 
 	return readPythonVersion(program)
-
 }
 
 // readPythonVersion looks for a file named `python_version.txt` in `program`, which

--- a/src/golang/lib/collections/operator/function/version.go
+++ b/src/golang/lib/collections/operator/function/version.go
@@ -1,0 +1,74 @@
+package function
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io/ioutil"
+	"strings"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/storage"
+	"github.com/dropbox/godropbox/errors"
+)
+
+type PythonVersion string
+
+const (
+	PythonVersionUnknown = "unknown"
+	PythonVersion37      = "3.7"
+	PythonVersion38      = "3.8"
+	PythonVersion39      = "3.9"
+	PythonVersion310     = "3.10"
+)
+
+const pythonVersionFile = "python_version.txt"
+
+// GetPythonVersion returns the Python version required by the function code stored
+// at `path`.
+func GetPythonVersion(ctx context.Context, path string, storageConfig *shared.StorageConfig) (PythonVersion, error) {
+	program, err := storage.NewStorage(storageConfig).Get(ctx, path)
+	if err != nil {
+		return PythonVersionUnknown, err
+	}
+
+	zipReader, err := zip.NewReader(bytes.NewReader(program), int64(len(program)))
+	if err != nil {
+		return PythonVersionUnknown, err
+	}
+
+	var versionFile *zip.File
+	for _, zipFile := range zipReader.File {
+		parts := strings.Split(zipFile.Name, "/")
+		if len(parts) == 2 && parts[1] == pythonVersionFile {
+			versionFile = zipFile
+			break
+		}
+	}
+
+	if versionFile == nil {
+		return PythonVersionUnknown, errors.New("Unable to find python_version.txt in serialized function.")
+	}
+
+	f, err := versionFile.Open()
+	if err != nil {
+		return PythonVersionUnknown, err
+	}
+	defer f.Close()
+
+	content, err := ioutil.ReadAll(f)
+	if err != nil {
+		return PythonVersionUnknown, err
+	}
+
+	version := string(content)
+	version = strings.TrimSpace(version)
+
+	pythonVersion := PythonVersion(version)
+	switch pythonVersion {
+	case PythonVersion37, PythonVersion38, PythonVersion39, PythonVersion310:
+		return pythonVersion, nil
+	default:
+		return PythonVersionUnknown, errors.Newf("Unknown Python version %v", pythonVersion)
+	}
+}

--- a/src/golang/lib/collections/operator/function/version.go
+++ b/src/golang/lib/collections/operator/function/version.go
@@ -15,11 +15,11 @@ import (
 type PythonVersion string
 
 const (
-	PythonVersionUnknown = "unknown"
-	PythonVersion37      = "3.7"
-	PythonVersion38      = "3.8"
-	PythonVersion39      = "3.9"
-	PythonVersion310     = "3.10"
+	PythonVersionUnknown PythonVersion = "unknown"
+	PythonVersion37      PythonVersion = "3.7"
+	PythonVersion38      PythonVersion = "3.8"
+	PythonVersion39      PythonVersion = "3.9"
+	PythonVersion310     PythonVersion = "3.10"
 )
 
 const pythonVersionFile = "python_version.txt"
@@ -32,6 +32,13 @@ func GetPythonVersion(ctx context.Context, path string, storageConfig *shared.St
 		return PythonVersionUnknown, err
 	}
 
+	return readPythonVersion(program)
+
+}
+
+// readPythonVersion looks for a file named `python_version.txt` in `program`, which
+// is zipped file. It returns the Python version found in the file.
+func readPythonVersion(program []byte) (PythonVersion, error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(program), int64(len(program)))
 	if err != nil {
 		return PythonVersionUnknown, err

--- a/src/golang/lib/collections/operator/function/version_test.go
+++ b/src/golang/lib/collections/operator/function/version_test.go
@@ -1,0 +1,56 @@
+package function
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadPythonVersion(t *testing.T) {
+	type test struct {
+		version PythonVersion
+	}
+
+	tests := []test{
+		{PythonVersion37},
+		{PythonVersion38},
+		{PythonVersion39},
+		{PythonVersion310},
+	}
+
+	for _, tc := range tests {
+		data := createZipWithVersion(t, tc.version)
+		version, err := readPythonVersion(data)
+		require.Nil(t, err)
+		require.Equal(t, version, tc.version)
+	}
+}
+
+func TestReadPythonVersionUnknown(t *testing.T) {
+	data := createZipWithVersion(t, PythonVersionUnknown)
+	version, err := readPythonVersion(data)
+	require.NotNil(t, err)
+	require.Equal(t, version, PythonVersionUnknown)
+}
+
+// createZipWithVersion creates a zipped file containing `python_version.txt`
+// with `version` written inside. It returns the zipped file.
+func createZipWithVersion(t *testing.T, version PythonVersion) []byte {
+	buf := new(bytes.Buffer)
+	zipWriter := zip.NewWriter(buf)
+
+	versionFile, err := zipWriter.Create(fmt.Sprintf("test/%s", pythonVersionFile))
+	require.Nil(t, err)
+
+	content := []byte(version)
+	_, err = versionFile.Write(content)
+	require.Nil(t, err)
+
+	err = zipWriter.Close()
+	require.Nil(t, err)
+
+	return buf.Bytes()
+}

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/aqueducthq/aqueduct/lib/collections/operator/function"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/go-co-op/gocron"
@@ -286,20 +285,6 @@ func (j *ProcessJobManager) Launch(
 	log.Infof("Running %s job %s.", spec.Type(), name)
 	if _, ok := j.getCmd(name); ok {
 		return ErrJobAlreadyExists
-	}
-
-	if spec.Type() == FunctionJobType {
-		fSpec, ok := spec.(*FunctionSpec)
-		if !ok {
-			return errors.New("Unable to cast to fn spec")
-		}
-
-		version, err := function.GetPythonVersion(ctx, fSpec.FunctionPath, &fSpec.StorageConfig)
-		if err != nil {
-			return err
-		}
-
-		log.Infof("Got Python Version: %v", version)
 	}
 
 	cmd, err := j.mapJobTypeToCmd(name, spec)

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aqueducthq/aqueduct/lib/collections/operator/function"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/go-co-op/gocron"
@@ -285,6 +286,20 @@ func (j *ProcessJobManager) Launch(
 	log.Infof("Running %s job %s.", spec.Type(), name)
 	if _, ok := j.getCmd(name); ok {
 		return ErrJobAlreadyExists
+	}
+
+	if spec.Type() == FunctionJobType {
+		fSpec, ok := spec.(*FunctionSpec)
+		if !ok {
+			return errors.New("Unable to cast to fn spec")
+		}
+
+		version, err := function.GetPythonVersion(ctx, fSpec.FunctionPath, &fSpec.StorageConfig)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Got Python Version: %v", version)
 	}
 
 	cmd, err := j.mapJobTypeToCmd(name, spec)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR extracts the Python version from a serialized function. This is necessary for Lambda support so the correct Lambda function can be invoked.

## Related issue number (if any)
ENG 1619

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


