### PR TITLE
Shows users workflows without any runs

### DIFF
--- a/sdk/aqueduct/enums.py
+++ b/sdk/aqueduct/enums.py
@@ -90,6 +90,7 @@ class ExecutionStatus(str, Enum, metaclass=MetaEnum):
     SUCCEEDED = "succeeded"
     FAILED = "failed"
     PENDING = "pending"
+    REGISTERED = "registered"
 
 
 class FailureType(Enum, metaclass=MetaEnum):

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -135,8 +135,9 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 			if !dbWorkflow.Status.IsNull {
 				response.Status = dbWorkflow.Status.ExecutionStatus
 			} else {
-				// There are no workflow runs yet for this workflow
-				response.Status = shared.PendingExecutionStatus
+				// There are no workflow runs yet for this workflow, so we simply return
+				// that the workflow has been registered
+				response.Status = shared.RegisteredExecutionStatus
 			}
 
 			workflows = append(workflows, response)

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 )
 
 // Route: /workflows
@@ -99,8 +98,6 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 	if err != nil {
 		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to list workflows.")
 	}
-
-	logrus.Warnf("Num flows: %v", len(dbWorkflows))
 
 	workflowIds := make([]uuid.UUID, 0, len(dbWorkflows))
 	for _, dbWorkflow := range dbWorkflows {

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -217,23 +217,23 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to create workflow.")
 	}
 
-	timeConfig := &engine.AqueductTimeConfig{
-		OperatorPollInterval: engine.DefaultPollIntervalMillisec,
-		ExecTimeout:          engine.DefaultExecutionTimeout,
-		CleanupTimeout:       engine.DefaultCleanupTimeout,
-	}
-	emptyParams := make(map[string]string)
+	// timeConfig := &engine.AqueductTimeConfig{
+	// 	OperatorPollInterval: engine.DefaultPollIntervalMillisec,
+	// 	ExecTimeout:          engine.DefaultExecutionTimeout,
+	// 	CleanupTimeout:       engine.DefaultCleanupTimeout,
+	// }
+	// emptyParams := make(map[string]string)
 
-	_, err = h.Engine.TriggerWorkflow(
-		ctx,
-		workflowId,
-		shared_utils.AppendPrefix(args.dbWorkflowDag.Metadata.Id.String()),
-		timeConfig,
-		emptyParams,
-	)
-	if err != nil {
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to trigger workflow.")
-	}
+	// _, err = h.Engine.TriggerWorkflow(
+	// 	ctx,
+	// 	workflowId,
+	// 	shared_utils.AppendPrefix(args.dbWorkflowDag.Metadata.Id.String()),
+	// 	timeConfig,
+	// 	emptyParams,
+	// )
+	// if err != nil {
+	// 	return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to trigger workflow.")
+	// }
 
 	if !args.isUpdate {
 		// If this workflow is newly created, automatically add the user to the workflow's

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -217,23 +217,23 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to create workflow.")
 	}
 
-	// timeConfig := &engine.AqueductTimeConfig{
-	// 	OperatorPollInterval: engine.DefaultPollIntervalMillisec,
-	// 	ExecTimeout:          engine.DefaultExecutionTimeout,
-	// 	CleanupTimeout:       engine.DefaultCleanupTimeout,
-	// }
-	// emptyParams := make(map[string]string)
+	timeConfig := &engine.AqueductTimeConfig{
+		OperatorPollInterval: engine.DefaultPollIntervalMillisec,
+		ExecTimeout:          engine.DefaultExecutionTimeout,
+		CleanupTimeout:       engine.DefaultCleanupTimeout,
+	}
+	emptyParams := make(map[string]string)
 
-	// _, err = h.Engine.TriggerWorkflow(
-	// 	ctx,
-	// 	workflowId,
-	// 	shared_utils.AppendPrefix(args.dbWorkflowDag.Metadata.Id.String()),
-	// 	timeConfig,
-	// 	emptyParams,
-	// )
-	// if err != nil {
-	// 	return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to trigger workflow.")
-	// }
+	_, err = h.Engine.TriggerWorkflow(
+		ctx,
+		workflowId,
+		shared_utils.AppendPrefix(args.dbWorkflowDag.Metadata.Id.String()),
+		timeConfig,
+		emptyParams,
+	)
+	if err != nil {
+		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to trigger workflow.")
+	}
 
 	if !args.isUpdate {
 		// If this workflow is newly created, automatically add the user to the workflow's

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -93,3 +93,24 @@ func (n *NullExecutionState) Scan(value interface{}) error {
 	n.ExecutionState, n.IsNull = *logs, false
 	return nil
 }
+
+type NullExecutionStatus struct {
+	ExecutionStatus
+	IsNull bool
+}
+
+func (n *NullExecutionStatus) Scan(value interface{}) error {
+	if value == nil {
+		n.IsNull = true
+		n.ExecutionStatus = UnknownExecutionStatus
+		return nil
+	}
+
+	s, ok := value.(string)
+	if !ok {
+		return errors.New("Type assertion to string failed")
+	}
+
+	n.ExecutionStatus, n.IsNull = ExecutionStatus(s), false
+	return nil
+}

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -102,7 +102,6 @@ type NullExecutionStatus struct {
 func (n *NullExecutionStatus) Scan(value interface{}) error {
 	if value == nil {
 		n.IsNull = true
-		n.ExecutionStatus = UnknownExecutionStatus
 		return nil
 	}
 

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -24,7 +24,10 @@ const (
 	FailedExecutionStatus    ExecutionStatus = "failed"
 	RunningExecutionStatus   ExecutionStatus = "running"
 	PendingExecutionStatus   ExecutionStatus = "pending"
-	UnknownExecutionStatus   ExecutionStatus = "unknown"
+	// Registered is a special state that indicates a workflow has been registered
+	// but has no workflow runs yet
+	RegisteredExecutionStatus ExecutionStatus = "registered"
+	UnknownExecutionStatus    ExecutionStatus = "unknown"
 )
 
 type FailureType int64

--- a/src/golang/lib/collections/workflow/noop.go
+++ b/src/golang/lib/collections/workflow/noop.go
@@ -126,7 +126,7 @@ func (r *noopReaderImpl) GetWorkflowsWithLatestRunResult(
 	ctx context.Context,
 	organizationId string,
 	db database.Database,
-) ([]latestWorkflowResponse, error) {
+) ([]LatestWorkflowResponse, error) {
 	return nil, utils.NoopInterfaceErrorHandling(r.throwError)
 }
 

--- a/src/golang/lib/collections/workflow/postgres.go
+++ b/src/golang/lib/collections/workflow/postgres.go
@@ -26,7 +26,7 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 	ctx context.Context,
 	organizationId string,
 	db database.Database,
-) ([]latestWorkflowResponse, error) {
+) ([]LatestWorkflowResponse, error) {
 	// Get workflow metadata (id, name, description, creation time, last run time, and last run status)
 	// for all workflows whose `organization_id` is `organizationId` ordered by when the workflow was created.
 	// Get the last run DAG by getting the max created_at timestamp for all workflow DAGs associated with each
@@ -47,7 +47,7 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 	) AS temp
 	ORDER BY created_at DESC;`
 
-	var latestWorkflowResponse []latestWorkflowResponse
+	var latestWorkflowResponse []LatestWorkflowResponse
 	err := db.Query(ctx, &latestWorkflowResponse, query, organizationId)
 	return latestWorkflowResponse, err
 }

--- a/src/golang/lib/collections/workflow/postgres.go
+++ b/src/golang/lib/collections/workflow/postgres.go
@@ -31,14 +31,21 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 	// for all workflows whose `organization_id` is `organizationId` ordered by when the workflow was created.
 	// Get the last run DAG by getting the max created_at timestamp for all workflow DAGs associated with each
 	// workflow in the organization.
-	query := `SELECT * FROM (SELECT DISTINCT ON (wf.id) wf.id AS id, wf.name AS name, 
-		 wf.description AS description, wf.created_at AS created_at, 
-		 wfdr.created_at AS last_run_at, wfdr.status as status 
-		 FROM workflow AS wf, app_user, workflow_dag AS wfd, workflow_dag_result AS wfdr 
-		 WHERE app_user.organization_id = $1 
-		 AND wf.user_id = app_user.id AND wfd.workflow_id = wf.id AND wfdr.workflow_dag_id = wfd.id 
-		 ORDER BY wf.id, wfdr.created_at DESC) AS temp
-		 ORDER BY created_at DESC;`
+	query := `
+	SELECT * FROM (
+		SELECT DISTINCT ON 
+			(wf.id) wf.id AS id, wf.name AS name, 
+		 	wf.description AS description, wf.created_at AS created_at, 
+		 	wfdr.created_at AS last_run_at, wfdr.status as status 
+		FROM 
+			workflow AS wf 
+			INNER JOIN app_user ON wf.user_id = app_user.id
+			LEFT JOIN workflow_dag AS wfd ON wf.id = wfd.workflow_id
+			LEFT JOIN workflow_dag_result AS wfdr ON wfd.id = wfdr.dag_id
+		WHERE app_user.organization_id = $1 
+		ORDER BY wf.id, wfdr.created_at DESC
+	) AS temp
+	ORDER BY created_at DESC;`
 
 	var latestWorkflowResponse []latestWorkflowResponse
 	err := db.Query(ctx, &latestWorkflowResponse, query, organizationId)

--- a/src/golang/lib/collections/workflow/postgres.go
+++ b/src/golang/lib/collections/workflow/postgres.go
@@ -40,8 +40,8 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 		FROM 
 			workflow AS wf 
 			INNER JOIN app_user ON wf.user_id = app_user.id
-			LEFT JOIN workflow_dag AS wfd ON wf.id = wfd.workflow_id
-			LEFT JOIN workflow_dag_result AS wfdr ON wfd.id = wfdr.dag_id
+			INNER JOIN workflow_dag AS wfd ON wf.id = wfd.workflow_id
+			LEFT JOIN workflow_dag_result AS wfdr ON wfd.id = wfdr.workflow_dag_id
 		WHERE app_user.organization_id = $1 
 		ORDER BY wf.id, wfdr.created_at DESC
 	) AS temp

--- a/src/golang/lib/collections/workflow/postgres.go
+++ b/src/golang/lib/collections/workflow/postgres.go
@@ -31,6 +31,12 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 	// for all workflows whose `organization_id` is `organizationId` ordered by when the workflow was created.
 	// Get the last run DAG by getting the max created_at timestamp for all workflow DAGs associated with each
 	// workflow in the organization.
+
+	// We want to return 1 row for each workflow, so we use a LEFT JOIN between the workflow_dag
+	// and workflow_dag_result tables. A LEFT JOIN outputs all rows in the left table even if there
+	// is no match with a row in the right table. If there is no match, the columns of the right table
+	// are NULL.
+	// This means that `last_run_at` and `status` in the query output can be NULL.
 	query := `
 	SELECT * FROM (
 		SELECT DISTINCT ON 

--- a/src/golang/lib/collections/workflow/sqlite.go
+++ b/src/golang/lib/collections/workflow/sqlite.go
@@ -53,7 +53,7 @@ func (r *sqliteReaderImpl) GetWorkflowsWithLatestRunResult(
 	ctx context.Context,
 	organizationId string,
 	db database.Database,
-) ([]latestWorkflowResponse, error) {
+) ([]LatestWorkflowResponse, error) {
 	// Get workflow metadata (id, name, description, creation time, last run time, and last run status)
 	// for all workflows whose `organization_id` is `organizationId` ordered by when the workflow was created.
 	// Get the last run DAG by getting the max created_at timestamp for all workflow DAGs associated with each
@@ -85,7 +85,7 @@ func (r *sqliteReaderImpl) GetWorkflowsWithLatestRunResult(
 		)
 		ORDER BY created_at DESC;`
 
-	var latestWorkflowResponse []latestWorkflowResponse
+	var latestWorkflowResponse []LatestWorkflowResponse
 	err := db.Query(ctx, &latestWorkflowResponse, query, organizationId)
 	return latestWorkflowResponse, err
 }

--- a/src/golang/lib/collections/workflow/sqlite.go
+++ b/src/golang/lib/collections/workflow/sqlite.go
@@ -58,6 +58,12 @@ func (r *sqliteReaderImpl) GetWorkflowsWithLatestRunResult(
 	// for all workflows whose `organization_id` is `organizationId` ordered by when the workflow was created.
 	// Get the last run DAG by getting the max created_at timestamp for all workflow DAGs associated with each
 	// workflow in the organization.
+
+	// We want to return 1 row for each workflow, so we use a LEFT JOIN between the workflow_dag
+	// and workflow_dag_result tables. A LEFT JOIN outputs all rows in the left table even if there
+	// is no match with a row in the right table. If there is no match, the columns of the right table
+	// are NULL.
+	// This means that `last_run_at` and `status` in the query output can be NULL.
 	query := `
 		WITH workflow_results AS
 		(

--- a/src/golang/lib/collections/workflow/sqlite.go
+++ b/src/golang/lib/collections/workflow/sqlite.go
@@ -58,19 +58,48 @@ func (r *sqliteReaderImpl) GetWorkflowsWithLatestRunResult(
 	// for all workflows whose `organization_id` is `organizationId` ordered by when the workflow was created.
 	// Get the last run DAG by getting the max created_at timestamp for all workflow DAGs associated with each
 	// workflow in the organization.
-	query := `SELECT wf.id AS id, wf.name AS name, 
-		 wf.description AS description, wf.created_at AS created_at, 
-		 wfdr.created_at AS last_run_at, wfdr.status as status 
-		 FROM workflow AS wf, app_user, workflow_dag AS wfd, workflow_dag_result AS wfdr, 
-		 (SELECT wf.id AS id, MAX(wfdr.created_at) AS last_run_at 
-		  FROM workflow AS wf, app_user, workflow_dag AS wfd, workflow_dag_result AS wfdr 
-		  WHERE app_user.organization_id = $1 
-		  AND wf.user_id = app_user.id AND wfd.workflow_id = wf.id AND wfdr.workflow_dag_id = wfd.id 
-		  GROUP BY wf.id) AS wflr 
-		 WHERE app_user.organization_id = $1 
-		 AND wf.user_id = app_user.id AND wfd.workflow_id = wf.id AND wfdr.workflow_dag_id = wfd.id AND 
-		 wf.id = wflr.id AND wfdr.created_at = wflr.last_run_at 
-		 ORDER BY created_at DESC;`
+	query := `
+		WITH workflow_results AS
+		(
+			SELECT
+				wf.id AS id, wf.name AS name, 
+		 		wf.description AS description, wf.created_at AS created_at, 
+		 		wfdr.created_at AS last_run_at, wfdr.status as status
+			FROM
+				workflow AS wf
+				INNER JOIN app_user ON wf.user_id = app_user.id
+				INNER JOIN workflow_dag AS wfd ON wf.id = wfd.workflow_id
+				LEFT JOIN workflow_dag_result AS wfdr ON wfd.id = wfdr.workflow_dag_id
+			WHERE app_user.organization_id = $1
+		),
+		latest_result AS
+		(
+			SELECT 
+				id, MAX(created_at) AS last_run_at 
+	  		FROM 
+				workflow_results
+	  		GROUP BY wf.id
+		),
+		SELECT
+			wf.id AS id, wf.name AS name, 
+		 	wf.description AS description, wf.created_at AS created_at, 
+		 	wfdr.created_at AS last_run_at, wfdr.status as status 
+		 	FROM workflow AS wf, app_user, workflow_dag AS wfd, workflow_dag_result AS wfdr, 
+		 		(
+					SELECT 
+						wf.id AS id, MAX(wfdr.created_at) AS last_run_at 
+		  			FROM workflow AS wf, app_user, workflow_dag AS wfd, workflow_dag_result AS wfdr 
+		  			WHERE app_user.organization_id = $1 
+		  			AND wf.user_id = app_user.id AND wfd.workflow_id = wf.id AND wfdr.workflow_dag_id = wfd.id 
+		  			GROUP BY wf.id
+				) AS wflr 
+		WHERE 
+			app_user.organization_id = $1 
+		 	AND wf.user_id = app_user.id 
+			AND wfd.workflow_id = wf.id 
+			AND wfdr.workflow_dag_id = wfd.id 
+			AND wf.id = wflr.id AND wfdr.created_at = wflr.last_run_at 
+		ORDER BY created_at DESC;`
 
 	var latestWorkflowResponse []latestWorkflowResponse
 	err := db.Query(ctx, &latestWorkflowResponse, query, organizationId)

--- a/src/golang/lib/collections/workflow/workflow.go
+++ b/src/golang/lib/collections/workflow/workflow.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/google/uuid"
 )
@@ -20,12 +21,12 @@ type Workflow struct {
 }
 
 type latestWorkflowResponse struct {
-	Id          uuid.UUID              `db:"id" json:"id"`
-	Name        string                 `db:"name" json:"name"`
-	Description string                 `db:"description" json:"description"`
-	CreatedAt   time.Time              `db:"created_at" json:"created_at"`
-	LastRunAt   time.Time              `db:"last_run_at" json:"last_run_at"`
-	Status      shared.ExecutionStatus `db:"status" json:"status"`
+	Id          uuid.UUID                  `db:"id" json:"id"`
+	Name        string                     `db:"name" json:"name"`
+	Description string                     `db:"description" json:"description"`
+	CreatedAt   time.Time                  `db:"created_at" json:"created_at"`
+	LastRunAt   utils.NullTime             `db:"last_run_at" json:"last_run_at"`
+	Status      shared.NullExecutionStatus `db:"status" json:"status"`
 }
 
 // Use to associate a workflow.name, workflow.id with workflow_dag_result.id (ENG-625)

--- a/src/golang/lib/collections/workflow/workflow.go
+++ b/src/golang/lib/collections/workflow/workflow.go
@@ -20,7 +20,7 @@ type Workflow struct {
 	RetentionPolicy RetentionPolicy `db:"retention_policy" json:"retention_policy"`
 }
 
-type latestWorkflowResponse struct {
+type LatestWorkflowResponse struct {
 	Id          uuid.UUID                  `db:"id" json:"id"`
 	Name        string                     `db:"name" json:"name"`
 	Description string                     `db:"description" json:"description"`
@@ -75,7 +75,7 @@ type Reader interface {
 		ctx context.Context,
 		organizationId string,
 		db database.Database,
-	) ([]latestWorkflowResponse, error)
+	) ([]LatestWorkflowResponse, error)
 	GetNotificationWorkflowMetadata(
 		ctx context.Context,
 		ids []uuid.UUID,

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -23,13 +23,13 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
 
   const lastUpdatedTime = new Date(workflow['last_run_at'] * 1000);
 
-  const lastRunComponent = (
+  const lastRunComponent = workflow['last_run_at'] ? (
     <Box sx={{ fontSize: 1, my: 1 }}>
       <Typography variant="subtitle1">
         <strong>Workflow Last Run:</strong> {lastUpdatedTime.toLocaleString()}
       </Typography>
     </Box>
-  );
+  ) : {};
 
   const cardContent = (
     <Card>

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -98,7 +98,7 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
         >
           <Alert
             onClose={handleInfoToastClose}
-            severity="success"
+            severity="info"
             sx={{ width: '100%' }}
           >
             {toastMessage}

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -29,7 +29,7 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
         <strong>Workflow Last Run:</strong> {lastUpdatedTime.toLocaleString()}
       </Typography>
     </Box>
-  ) : {};
+  ) : null;
 
   const cardContent = (
     <Card>

--- a/src/ui/common/src/components/workflows/workflowStatus.tsx
+++ b/src/ui/common/src/components/workflows/workflowStatus.tsx
@@ -18,6 +18,8 @@ export const Status: React.FC<Props> = ({ status }) => {
     statusIcons.push(<Chip label="Failed" color="error" size="small" />);
   } else if (runStatus === ExecutionStatus.Pending) {
     statusIcons.push(<Chip label="In Progress" color="default" size="small" />);
+  } else if (runStatus === ExecutionStatus.Registered) {
+    statusIcons.push(<Chip label="Pending" color="info" size="small" />);
   }
 
   return (

--- a/src/ui/common/src/utils/shared.ts
+++ b/src/ui/common/src/utils/shared.ts
@@ -33,6 +33,7 @@ export enum ExecutionStatus {
   Succeeded = 'succeeded',
   Failed = 'failed',
   Pending = 'pending',
+  Registered = 'registered',
 }
 
 export type ExecState = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds frontend and backend changes to show users workflows without any runs. This is important as it at least gives the user some confidence that Aqueduct registered their workflow.

## Related issue number (if any)
ENG 1485

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

DEMO: https://www.loom.com/share/bc3d00dfda7e43fe9609c07eaba4f632

