### PR TITLE
Give sane names to load operators

### DIFF
--- a/integration_tests/sdk/list_workflow_objects_test.py
+++ b/integration_tests/sdk/list_workflow_objects_test.py
@@ -68,6 +68,5 @@ def test_list_saved_objects(client):
         assert len(data[integration]) == 3
 
     finally:
-        pass
-        # for flow_id in flow_ids_to_delete:
-        # delete_flow(client, flow_id)
+        for flow_id in flow_ids_to_delete:
+            delete_flow(client, flow_id)

--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -3,7 +3,12 @@ import uuid
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
-from aqueduct.dag import DAG, AddOrReplaceOperatorDelta, apply_deltas_to_dag
+from aqueduct.dag import (
+    DAG,
+    AddOrReplaceOperatorDelta,
+    apply_deltas_to_dag,
+    find_duplicate_load_operator,
+)
 from aqueduct.enums import ArtifactType, OperatorType
 from aqueduct.error import (
     InvalidIntegrationException,
@@ -100,10 +105,11 @@ class BaseArtifact(ABC):
                     % integration_info.name
                 )
 
-        # We need to deduplicate the name of load operators based on the artifact it is loading,
-        # along with the name of the integration. This allows multiple artifacts to write to the
-        # same integration, as well as single artifacts to write to multiple integrations.
-        load_op_name = " %s %s loader" % (self.name(), integration_info.name)
+        # We deduplicate load operators based on name (and therefore integration) AND
+        # the input artifact. This allows multiple artifacts to write to the same integration,
+        # as well as single artifacts to write to multiple integrations, all while keeping
+        # the name of the load operator readable.
+        load_op_name = " %s loader" % integration_info.name
 
         # Add the load operator as a terminal node.
         apply_deltas_to_dag(
@@ -124,6 +130,7 @@ class BaseArtifact(ABC):
                         inputs=[self._artifact_id],
                     ),
                     output_artifacts=[],
-                )
+                    find_duplicate_fn=find_duplicate_load_operator,
+                ),
             ],
         )

--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -107,7 +107,7 @@ class BaseArtifact(ABC):
 
         # We deduplicate load operators based on name (and therefore integration) AND
         # the input artifact. This allows multiple artifacts to write to the same integration,
-        # as well as single artifacts to write to multiple integrations, all while keeping
+        # as well as a single artifact to write to multiple integrations, all while keeping
         # the name of the load operator readable.
         load_op_name = " %s loader" % integration_info.name
 

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -345,7 +345,7 @@ class AddOrReplaceOperatorDelta(DAGDelta):
         find_duplicate_fn:
             A caller-supplied function that defines when we want the new operator to replace
             and old one. Returns the operator to replace, or None if no collision is found.
-            Defaults to replacing any operator with the same name.
+            Defaults to replacing an operator with the same name.
     """
 
     def __init__(
@@ -388,14 +388,14 @@ class AddOrReplaceOperatorDelta(DAGDelta):
                     ),
                 )
 
-            # The colliding operator cannot be an dependency of the new operator. Otherwise, we would
+            # The colliding operator cannot be a dependency of the new operator. Otherwise, we would
             # not be able to remove the colliding operator.
             downstream_op_ids = dag.list_downstream_operators(colliding_op.id)
             for op_id in downstream_op_ids:
                 downstream_op = dag.must_get_operator(op_id)
                 if len(set(downstream_op.outputs).intersection(set(self.op.inputs))) > 0:
                     raise InvalidUserActionException(
-                        "Attempting to replace operator `%s`, but it cannot be overwritten since"
+                        "Attempting to replace operator `%s`, but it cannot be overwritten "
                         "because it is an upstream dependency of the new operator `%s`."
                         % (colliding_op.name, self.op.name)
                     )

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -1,7 +1,7 @@
 import copy
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.config import EngineConfig
@@ -308,6 +308,29 @@ class DAGDelta(ABC):
         pass
 
 
+# These helpers are meant to be fed into `AddOrReplaceOperatorDelta` as different ways
+# of resolving whether an operator already exists in the DAG or not.
+
+
+def find_duplicate_operator_by_name(dag: DAG, op: Operator) -> Optional[Operator]:
+    return dag.get_operator(with_name=op.name)
+
+
+def find_duplicate_load_operator(dag: DAG, op: Operator) -> Optional[Operator]:
+    """Load operators are only duplicates if they are loading the same artifact into the same integration."""
+    assert get_operator_type(op) == OperatorType.LOAD
+    assert len(op.inputs) == 1
+
+    artifact_to_load = dag.must_get_artifact(op.inputs[0])
+    existing_load_ops = dag.list_operators(
+        filter_to=[OperatorType.LOAD], on_artifact_id=artifact_to_load.id
+    )
+    for existing_load_op in existing_load_ops:
+        if existing_load_op.name == op.name:
+            return existing_load_op
+    return None
+
+
 class AddOrReplaceOperatorDelta(DAGDelta):
     """Adds an operator and its output artifacts to the DAG.
 
@@ -319,9 +342,20 @@ class AddOrReplaceOperatorDelta(DAGDelta):
             The new operator to add.
         output_artifacts:
             The output artifacts for this operation.
+        find_duplicate_fn:
+            A caller-supplied function that defines when we want the new operator to replace
+            and old one. Returns the operator to replace, or None if no collision is found.
+            Defaults to replacing any operator with the same name.
     """
 
-    def __init__(self, op: Operator, output_artifacts: List[ArtifactMetadata]):
+    def __init__(
+        self,
+        op: Operator,
+        output_artifacts: List[ArtifactMetadata],
+        find_duplicate_fn: Callable[
+            [DAG, Operator], Optional[Operator]
+        ] = find_duplicate_operator_by_name,
+    ):
         # Check that the operator's outputs correspond to the given output artifacts.
         if len(op.outputs) != len(output_artifacts):
             raise InternalAqueductError(
@@ -336,15 +370,22 @@ class AddOrReplaceOperatorDelta(DAGDelta):
 
         self.op = op
         self.output_artifacts = output_artifacts
+        self.find_duplicate_fn = find_duplicate_fn
 
     def apply(self, dag: DAG) -> None:
-        # If there exists an operator with the same name, remove it and its dependencies first!
-        colliding_op = dag.get_operator(with_name=self.op.name)
+        # Find any colliding operator, and remove it and its dependencies first!
+        colliding_op = self.find_duplicate_fn(dag, self.op)
         if colliding_op is not None:
             if get_operator_type(self.op) != get_operator_type(colliding_op):
                 raise InvalidUserActionException(
-                    "Another operator exists with the same name %s, but is of a different type %s."
-                    % (self.op.name, get_operator_type(self.op)),
+                    "Attempting to replace operator `%s` with a new operator `%s` of type %s, "
+                    "but the existing operator has type %s."
+                    % (
+                        colliding_op.name,
+                        self.op.name,
+                        get_operator_type(self.op),
+                        get_operator_type(colliding_op),
+                    ),
                 )
 
             # The colliding operator cannot be an dependency of the new operator. Otherwise, we would
@@ -354,8 +395,9 @@ class AddOrReplaceOperatorDelta(DAGDelta):
                 downstream_op = dag.must_get_operator(op_id)
                 if len(set(downstream_op.outputs).intersection(set(self.op.inputs))) > 0:
                     raise InvalidUserActionException(
-                        "Another operator exists with the same name %s, but cannot be overwritten "
-                        "because it is a dependency of the new operator." % self.op.name,
+                        "Attempting to replace operator `%s`, but it cannot be overwritten since"
+                        "because it is an upstream dependency of the new operator `%s`."
+                        % (colliding_op.name, self.op.name)
                     )
 
             logger().info(


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This looks a lot better. Different artifacts that write to the same integration will have the same loader name, and that's ok.
![image](https://user-images.githubusercontent.com/6466121/188753947-643bdf8e-e975-4825-a628-e906d242df0e.png)

Previously, it was:
![image](https://user-images.githubusercontent.com/6466121/188754020-956eb234-f09c-42ea-a77b-5a2c47e22b9c.png)


## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


