### PR TITLE
ENG-1644 Fix go lint errors related to using deprecated io/ioutil package.

### DIFF
--- a/src/golang/cmd/migrator/migrator/create.go
+++ b/src/golang/cmd/migrator/migrator/create.go
@@ -2,7 +2,6 @@ package migrator
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -78,7 +77,7 @@ func Create(name string, language ScriptLanguage) error {
 // nextVersion returns the next available schema version in the sequence.
 // It does this by checking the migration dirs that exist in internal/migration.
 func nextVersion() (int64, error) {
-	files, err := ioutil.ReadDir(migrationFilePath)
+	files, err := os.ReadDir(migrationFilePath)
 	if err != nil {
 		return -1, err
 	}

--- a/src/golang/cmd/server/handler/export_function.go
+++ b/src/golang/cmd/server/handler/export_function.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -225,7 +225,7 @@ func writeZipFile(w *zip.Writer, zf *zip.File, zfName string) error {
 	defer f.Close()
 
 	// Read content of `zf`
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/src/golang/config/config.go
+++ b/src/golang/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -69,7 +68,7 @@ func Init(path string) error {
 
 // loadConfig reads the file at `configPath` into `globalConfig`.
 func loadConfig() error {
-	bts, err := ioutil.ReadFile(globalConfigPath)
+	bts, err := os.ReadFile(globalConfigPath)
 	if err != nil {
 		return err
 	}
@@ -104,5 +103,5 @@ func dumpConfig() error {
 		return err
 	}
 
-	return ioutil.WriteFile(globalConfigPath, data, 0o664)
+	return os.WriteFile(globalConfigPath, data, 0o664)
 }

--- a/src/golang/lib/collections/operator/function/version.go
+++ b/src/golang/lib/collections/operator/function/version.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -62,7 +62,7 @@ func readPythonVersion(program []byte) (PythonVersion, error) {
 	}
 	defer f.Close()
 
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 	if err != nil {
 		return PythonVersionUnknown, err
 	}

--- a/src/golang/lib/storage/gcs.go
+++ b/src/golang/lib/storage/gcs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 
 	"cloud.google.com/go/storage"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -43,7 +42,7 @@ func (g *gcsStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 	defer rc.Close()
 
-	data, err := ioutil.ReadAll(rc)
+	data, err := io.ReadAll(rc)
 	if err != nil {
 		return nil, err
 	}

--- a/src/golang/lib/vault/file.go
+++ b/src/golang/lib/vault/file.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -59,11 +58,11 @@ func (f *fileVault) Put(ctx context.Context, name string, secrets map[string]str
 	}
 
 	// the WriteFile method returns an error if unsuccessful
-	return ioutil.WriteFile(f.getFullPath(name), gcm.Seal(nonce, nonce, serialized, nil), filePermissionCode)
+	return os.WriteFile(f.getFullPath(name), gcm.Seal(nonce, nonce, serialized, nil), filePermissionCode)
 }
 
 func (f *fileVault) Get(ctx context.Context, name string) (map[string]string, error) {
-	ciphertext, err := ioutil.ReadFile(f.getFullPath(name))
+	ciphertext, err := os.ReadFile(f.getFullPath(name))
 	if err != nil {
 		return nil, err
 	}

--- a/src/golang/lib/workflow/operator/connector/auth/oauth_config.go
+++ b/src/golang/lib/workflow/operator/connector/auth/oauth_config.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -122,7 +122,7 @@ func getGoogleSheetsPublicConfig(token *oauth2.Token) (map[string]string, error)
 	}
 
 	defer resp.Body.Close()
-	content, err := ioutil.ReadAll(resp.Body)
+	content, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes errors from running go linter related to using the deprecated io/ioutil package. Noticed these when running lint on my M1 mac.

Console output here:
```
(aqueduct-env) ➜  aqueduct git:(main) ✗ python3 scripts/run_linters.py --golang
Linting Go code...
lib/workflow/operator/connector/auth/oauth_config.go:7:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
	"io/ioutil"
	^
Traceback (most recent call last):
  File "/Users/andre/Documents/Code/aqueduct/scripts/run_linters.py", line 117, in <module>
    lint_golang(cwd)
  File "/Users/andre/Documents/Code/aqueduct/scripts/run_linters.py", line 60, in lint_golang
    execute_command(["golangci-lint", "run", "--concurrency=4", "--fix"], join(cwd, "src/golang"))
  File "/Users/andre/Documents/Code/aqueduct/scripts/run_linters.py", line 25, in execute_command
    raise Exception("Error executing command: %s" % args)
Exception: Error executing command: ['golangci-lint', 'run', '--concurrency=4', '--fix']
```

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1644/fix-golang-linter-warnings

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


