### PR TITLE
Reorder AWS credentials check for S3 storage

### DIFF
--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -13,19 +13,19 @@ class S3Storage(Storage):
 
     def __init__(self, config: S3StorageConfig):
 
-        if "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
-            # The AWS keys are passed in as environment variables for k8s engines
-            self._client = boto3.client(
-                "s3",
-                aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
-                aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
-            )
-        elif config.aws_access_key_id and config.aws_secret_access_key:
+        if config.aws_access_key_id and config.aws_secret_access_key:
             # The AWS keys are passed in as part of the storage spec for AWS Lambda engines
             self._client = boto3.client(
                 "s3",
                 aws_access_key_id=config.aws_access_key_id,
                 aws_secret_access_key=config.aws_secret_access_key,
+            )
+        elif "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
+            # The AWS keys are passed in as environment variables for k8s engines
+            self._client = boto3.client(
+                "s3",
+                aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+                aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
             )
         else:
             # Boto3 uses an environment variable to determine the credentials filepath and profile


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We want to check if the spec contains the AWS credentials first. In the lambda case they populate the AWS credentials with the lambda executor role's credentials, which may not have permissions to write to S3.
## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


