### PR TITLE
[UI] Create mapping from untyped artifact to generic

### DIFF
--- a/src/ui/common/src/reducers/nodeSelection.ts
+++ b/src/ui/common/src/reducers/nodeSelection.ts
@@ -12,6 +12,7 @@ export enum NodeType {
   ImageArtifact = 'imageArtifact',
   DictArtifact = 'dictArtifact',
   GenericArtifact = 'genericArtifact',
+  UntypedArtifact = 'untypedArtifact',
   ExtractOp = 'extractOp',
   LoadOp = 'loadOp',
   FunctionOp = 'functionOp',
@@ -42,6 +43,7 @@ export const ArtifactTypeToNodeTypeMap: { [key in ArtifactType]: NodeType } = {
   [ArtifactType.Image]: NodeType.ImageArtifact,
   [ArtifactType.Bytes]: NodeType.GenericArtifact,
   [ArtifactType.Picklable]: NodeType.GenericArtifact,
+  [ArtifactType.Untyped]: NodeType.GenericArtifact,
 } as const;
 
 export type SelectedNode = {

--- a/src/ui/common/src/utils/artifacts.ts
+++ b/src/ui/common/src/utils/artifacts.ts
@@ -12,6 +12,7 @@ export enum ArtifactType {
   Bytes = 'bytes',
   Image = 'image',
   Picklable = 'picklable',
+  Untyped = 'untyped',
 }
 
 export enum SerializationType {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Running the following code and immediately looking at the UI:
```
@op
def basic_op(df):
    import time
    time.sleep(10)
    return df

sql = db.sql("SELECT * from hotel_reviews")
output = basic_op.lazy(sql)
```

The lazily executed one is no longer weird like in the current version

![image](https://user-images.githubusercontent.com/6466121/188956440-e2147a27-2d99-48dd-9f32-ca53ab3cc972.png)

## Related issue number (if any)
ENG-1631

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


