### PR TITLE
Fix bug where artifact from published flow uses latest data

### DIFF
--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 import pytest
-from aqueduct.artifacts.table_artifact import TableArtifact
 from aqueduct.enums import ExecutionStatus
 from aqueduct.error import IncompleteFlowException
 from constants import SENTIMENT_SQL_QUERY

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -16,9 +16,11 @@ from utils import (
     run_sentiment_model_multiple_input,
     wait_for_flow_runs,
 )
+import pandas as pd
+
 
 import aqueduct
-from aqueduct import LoadUpdateMode, check
+from aqueduct import LoadUpdateMode, check, op
 
 
 def test_basic_flow(client):
@@ -253,3 +255,53 @@ def test_multiple_flows_with_same_schedule(client):
     finally:
         delete_flow(client, flow_1.id())
         delete_flow(client, flow_2.id())
+
+
+@pytest.mark.publish
+def test_fetching_historical_flows_uses_old_data(client):
+    db = client.integration(name=get_integration_name())
+
+    # Write a new table into the demo db.
+    flows_to_delete = []
+    try:
+        initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
+
+        @op
+        def generate_initial_table():
+            return initial_table
+
+        setup_flow_name = generate_new_flow_name()
+        table = generate_initial_table()
+        table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
+        setup_flow = run_flow_test(client, name=setup_flow_name, artifacts=[table], delete_flow_after=False)
+        flows_to_delete.append(setup_flow.id())
+
+        @op
+        def noop(df):
+            return df
+
+        # Create a new flow that extracts this data.
+        output = db.sql("Select * from test_table", name="Test Table Query")
+        assert output.get().equals(initial_table)
+
+        flow = run_flow_test(client, artifacts=[output], delete_flow_after=False)
+        flows_to_delete.append(flow.id())
+
+        # Now, change the data that the new flow relies on (using the old flow).
+        @op
+        def generate_new_table():
+            return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
+
+        # TODO: refactor this.
+        table = generate_new_table()
+        table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
+        run_flow_test(client, name=setup_flow_name, artifacts=[table], num_runs=2, delete_flow_after=False)
+
+        # Fetching the historical flow and materializing the data will not use the new data
+        # that was just written. It will use a snapshot of the old data instead.
+        artifact = flow.latest().artifact(name="Test Table Query artifact")
+        assert artifact.get().equals(initial_table)
+
+    finally:
+        for flow_id in flows_to_delete:
+            delete_flow(client, flow_id)

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -288,12 +288,11 @@ def test_fetching_historical_flows_uses_old_data(client):
         flow = run_flow_test(client, artifacts=[output], delete_flow_after=False)
         flows_to_delete.append(flow.id())
 
-        # Now, change the data that the new flow relies on (using the old flow).
+        # Now, change the data that the new flow relies on, by populating data the same way as the setup flow.
         @op
         def generate_new_table():
             return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
-        # TODO: refactor this.
         table = generate_new_table()
         table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
         run_flow_test(

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import pandas as pd
 import pytest
 from aqueduct.enums import ExecutionStatus
 from aqueduct.error import IncompleteFlowException
@@ -16,8 +17,6 @@ from utils import (
     run_sentiment_model_multiple_input,
     wait_for_flow_runs,
 )
-import pandas as pd
-
 
 import aqueduct
 from aqueduct import LoadUpdateMode, check, op
@@ -273,7 +272,9 @@ def test_fetching_historical_flows_uses_old_data(client):
         setup_flow_name = generate_new_flow_name()
         table = generate_initial_table()
         table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
-        setup_flow = run_flow_test(client, name=setup_flow_name, artifacts=[table], delete_flow_after=False)
+        setup_flow = run_flow_test(
+            client, name=setup_flow_name, artifacts=[table], delete_flow_after=False
+        )
         flows_to_delete.append(setup_flow.id())
 
         @op
@@ -295,7 +296,9 @@ def test_fetching_historical_flows_uses_old_data(client):
         # TODO: refactor this.
         table = generate_new_table()
         table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
-        run_flow_test(client, name=setup_flow_name, artifacts=[table], num_runs=2, delete_flow_after=False)
+        run_flow_test(
+            client, name=setup_flow_name, artifacts=[table], num_runs=2, delete_flow_after=False
+        )
 
         # Fetching the historical flow and materializing the data will not use the new data
         # that was just written. It will use a snapshot of the old data instead.

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -4,8 +4,12 @@ from typing import Any, Dict, List
 import pandas as pd
 import pytest
 from aqueduct.enums import ArtifactType, ExecutionStatus
-from aqueduct.error import AqueductError, InvalidUserArgumentException, UnsupportedUserActionException, \
-    ArtifactNeverComputedException
+from aqueduct.error import (
+    AqueductError,
+    ArtifactNeverComputedException,
+    InvalidUserArgumentException,
+    UnsupportedUserActionException,
+)
 from constants import SENTIMENT_SQL_QUERY
 from pandas._testing import assert_frame_equal
 from utils import generate_new_flow_name, get_integration_name, run_flow_test, wait_for_flow_runs
@@ -209,7 +213,9 @@ def test_trigger_flow_with_different_sql_param(client):
 
     flow_id = None
     try:
-        flow = run_flow_test(client, artifacts=[sql_artifact], name=flow_name, delete_flow_after=False)
+        flow = run_flow_test(
+            client, artifacts=[sql_artifact], name=flow_name, delete_flow_after=False
+        )
         flow_id = flow.id()
 
         client.trigger(flow.id(), parameters={"table_name": "customer_activity"})
@@ -261,12 +267,14 @@ def test_parameterizing_published_artifact(client):
 def test_materializing_failed_artifact(client):
     @op
     def fail_fn():
-        5/0
+        5 / 0
 
     output = fail_fn.lazy()
     flow_id = None
     try:
-        flow = run_flow_test(client, artifacts=[output], expect_success=False, delete_flow_after=False)
+        flow = run_flow_test(
+            client, artifacts=[output], expect_success=False, delete_flow_after=False
+        )
         flow_id = flow.id()
 
         artifact = flow.latest().artifact(name="fail_fn artifact")

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -427,27 +427,6 @@ class APIClient:
 
         return [ListWorkflowResponseEntry(**workflow) for workflow in response.json()]
 
-    def get_artifact_result_data(self, dag_result_id: str, artifact_id: str) -> Any:
-        """Returns an empty string if the operator was not successfully executed."""
-        headers = self._generate_auth_headers()
-        url = self.construct_full_url(
-            self.GET_ARTIFACT_RESULT_TEMPLATE % (dag_result_id, artifact_id)
-        )
-        resp = requests.get(url, headers=headers)
-        utils.raise_errors(resp)
-
-        parsed_response = utils.parse_artifact_result_response(resp)
-
-        if parsed_response["metadata"]["exec_state"]["status"] != ExecutionStatus.SUCCEEDED:
-            print("Artifact result unavailable due to unsuccessful execution.")
-            return ""
-
-        serialization_type = parsed_response["metadata"]["serialization_type"]
-        if serialization_type not in deserialization_function_mapping:
-            raise Exception("Unsupported serialization type %s." % serialization_type)
-
-        return deserialization_function_mapping[serialization_type](parsed_response["data"])
-
     def get_node_positions(
         self, operator_mapping: Dict[str, Dict[str, Any]]
     ) -> Tuple[Dict[str, Dict[str, float]], Dict[str, Dict[str, float]]]:

--- a/sdk/aqueduct/artifacts/bool_artifact.py
+++ b/sdk/aqueduct/artifacts/bool_artifact.py
@@ -8,7 +8,7 @@ import numpy as np
 from aqueduct.artifacts import utils as artifact_utils
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
-from aqueduct.error import ArtifactNeverComputedException, UnsupportedUserActionException
+from aqueduct.error import ArtifactNeverComputedException
 from aqueduct.utils import format_header_for_print, get_description_for_check
 
 
@@ -68,7 +68,7 @@ class BoolArtifact(BaseArtifact):
                     "This artifact was part of an existing flow run but was never computed successfully!",
                 )
             elif parameters is not None:
-                raise UnsupportedUserActionException(
+                raise NotImplementedError(
                     "Parameterizing historical artifacts is not currently supported."
                 )
 

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -7,7 +7,7 @@ from aqueduct.artifacts import utils as artifact_utils
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
 from aqueduct.enums import ArtifactType
-from aqueduct.error import ArtifactNeverComputedException, UnsupportedUserActionException
+from aqueduct.error import ArtifactNeverComputedException
 
 
 class GenericArtifact(BaseArtifact):
@@ -56,7 +56,7 @@ class GenericArtifact(BaseArtifact):
                     "This artifact was part of an existing flow run but was never computed successfully!",
                 )
             elif parameters is not None:
-                raise UnsupportedUserActionException(
+                raise NotImplementedError(
                     "Parameterizing historical artifacts is not currently supported."
                 )
 

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -25,7 +25,6 @@ from aqueduct.enums import (
 from aqueduct.error import (
     AqueductError,
     ArtifactNeverComputedException,
-    UnsupportedUserActionException,
 )
 from aqueduct.operators import CheckSpec, FunctionSpec, Operator, OperatorSpec
 from aqueduct.utils import (
@@ -98,7 +97,7 @@ class NumericArtifact(BaseArtifact):
                     "This artifact was part of an existing flow run but was never computed successfully!",
                 )
             elif parameters is not None:
-                raise UnsupportedUserActionException(
+                raise NotImplementedError(
                     "Parameterizing historical artifacts is not currently supported."
                 )
 

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -22,10 +22,7 @@ from aqueduct.enums import (
     FunctionGranularity,
     FunctionType,
 )
-from aqueduct.error import (
-    AqueductError,
-    ArtifactNeverComputedException,
-)
+from aqueduct.error import AqueductError, ArtifactNeverComputedException
 from aqueduct.operators import CheckSpec, FunctionSpec, Operator, OperatorSpec
 from aqueduct.utils import (
     artifact_name_from_op_name,

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -22,7 +22,11 @@ from aqueduct.enums import (
     FunctionGranularity,
     FunctionType,
 )
-from aqueduct.error import AqueductError, ArtifactNeverComputedException, UnsupportedUserActionException
+from aqueduct.error import (
+    AqueductError,
+    ArtifactNeverComputedException,
+    UnsupportedUserActionException,
+)
 from aqueduct.operators import CheckSpec, FunctionSpec, Operator, OperatorSpec
 from aqueduct.utils import (
     artifact_name_from_op_name,
@@ -64,8 +68,8 @@ class NumericArtifact(BaseArtifact):
         self,
         dag: DAG,
         artifact_id: uuid.UUID,
-        from_flow_run: bool = False,
         content: Optional[Union[int, float, np.number]] = None,
+        from_flow_run: bool = False,
     ):
         self._dag = dag
         self._artifact_id = artifact_id

--- a/sdk/aqueduct/artifacts/param_artifact.py
+++ b/sdk/aqueduct/artifacts/param_artifact.py
@@ -5,29 +5,47 @@ from typing import Any, Dict, Optional
 
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
-from aqueduct.error import InvalidUserArgumentException
+from aqueduct.error import InvalidUserArgumentException, ArtifactNeverComputedException
 from aqueduct.utils import format_header_for_print
 
 
 class ParamArtifact(BaseArtifact):
-    def __init__(self, dag: DAG, artifact_id: uuid.UUID, from_flow_run: bool = False):
+    def __init__(
+        self,
+        dag: DAG,
+        artifact_id: uuid.UUID,
+        from_flow_run: bool = False,
+        content: Optional[Any] = None,
+    ):
         """The APIClient is only included because decorated functions operators acting on this parameter
         will need a handle to an API client."""
         self._dag = dag
         self._artifact_id = artifact_id
-        # This parameter indicates whether the artifact is fetched from flow-run or not.
+
+        # If the artifact was part of a published flow, fetch the data. This does not necessarily
+        # mean that the artifact was successfully computed.
         self._from_flow_run = from_flow_run
+        if self._from_flow_run:
+            self._set_content(content)
+        else:
+            # Set the content of this parameter from the SDK dag's operator spec.
+            param_op = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
+            assert param_op.spec.param is not None, "Artifact is not a parameter."
+            self._set_content(json.loads(param_op.spec.param.val))
 
     def get(self, parameters: Optional[Dict[str, Any]] = None) -> Any:
         if parameters is not None:
             raise InvalidUserArgumentException(
-                "Parameters cannot be supplied to parameter artifacts."
+                "Parameters cannot be supplied to parameter artifacts. They should only be provided"
+                "for artifact's that depend on parameters."
             )
 
-        _ = self._dag.must_get_artifact(self._artifact_id)
-        param_op = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
-        assert param_op.spec.param is not None, "Artifact is not a parameter."
-        return json.loads(param_op.spec.param.val)
+        if self._from_flow_run and self._get_content() is None:
+            raise ArtifactNeverComputedException(
+                "This artifact was part of an existing flow run but was never computed successfully!",
+            )
+
+        return self._get_content()
 
     def describe(self) -> None:
         print(

--- a/sdk/aqueduct/artifacts/param_artifact.py
+++ b/sdk/aqueduct/artifacts/param_artifact.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional
 
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
-from aqueduct.error import InvalidUserArgumentException, ArtifactNeverComputedException
+from aqueduct.error import ArtifactNeverComputedException, InvalidUserArgumentException
 from aqueduct.utils import format_header_for_print
 
 
@@ -14,8 +14,8 @@ class ParamArtifact(BaseArtifact):
         self,
         dag: DAG,
         artifact_id: uuid.UUID,
-        from_flow_run: bool = False,
         content: Optional[Any] = None,
+        from_flow_run: bool = False,
     ):
         """The APIClient is only included because decorated functions operators acting on this parameter
         will need a handle to an API client."""

--- a/sdk/aqueduct/artifacts/param_artifact.py
+++ b/sdk/aqueduct/artifacts/param_artifact.py
@@ -14,24 +14,18 @@ class ParamArtifact(BaseArtifact):
         self,
         dag: DAG,
         artifact_id: uuid.UUID,
-        content: Optional[Any] = None,
-        from_flow_run: bool = False,
     ):
         """The APIClient is only included because decorated functions operators acting on this parameter
         will need a handle to an API client."""
+
         self._dag = dag
         self._artifact_id = artifact_id
+        self._from_flow_run = False
 
-        # If the artifact was part of a published flow, fetch the data. This does not necessarily
-        # mean that the artifact was successfully computed.
-        self._from_flow_run = from_flow_run
-        if self._from_flow_run:
-            self._set_content(content)
-        else:
-            # Set the content of this parameter from the SDK dag's operator spec.
-            param_op = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
-            assert param_op.spec.param is not None, "Artifact is not a parameter."
-            self._set_content(json.loads(param_op.spec.param.val))
+        # Set the content of this parameter from the SDK dag's operator spec.
+        param_op = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
+        assert param_op.spec.param is not None, "Artifact is not a parameter."
+        self._set_content(json.loads(param_op.spec.param.val))
 
     def get(self, parameters: Optional[Dict[str, Any]] = None) -> Any:
         if parameters is not None:

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -24,7 +24,11 @@ from aqueduct.enums import (
     FunctionType,
     OperatorType,
 )
-from aqueduct.error import AqueductError, ArtifactNeverComputedException, UnsupportedUserActionException
+from aqueduct.error import (
+    AqueductError,
+    ArtifactNeverComputedException,
+    UnsupportedUserActionException,
+)
 from aqueduct.operators import (
     CheckSpec,
     FunctionSpec,
@@ -83,8 +87,8 @@ class TableArtifact(BaseArtifact):
         self,
         dag: DAG,
         artifact_id: uuid.UUID,
-        from_flow_run: bool = False,
         content: Optional[pd.DataFrame] = None,
+        from_flow_run: bool = False,
     ):
         self._dag = dag
         self._artifact_id = artifact_id

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -24,10 +24,7 @@ from aqueduct.enums import (
     FunctionType,
     OperatorType,
 )
-from aqueduct.error import (
-    AqueductError,
-    ArtifactNeverComputedException,
-)
+from aqueduct.error import AqueductError, ArtifactNeverComputedException
 from aqueduct.operators import (
     CheckSpec,
     FunctionSpec,

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -27,7 +27,6 @@ from aqueduct.enums import (
 from aqueduct.error import (
     AqueductError,
     ArtifactNeverComputedException,
-    UnsupportedUserActionException,
 )
 from aqueduct.operators import (
     CheckSpec,
@@ -122,7 +121,7 @@ class TableArtifact(BaseArtifact):
                     "This artifact was part of an existing flow run but was never computed successfully!",
                 )
             elif parameters is not None:
-                raise UnsupportedUserActionException(
+                raise NotImplementedError(
                     "Parameterizing historical artifacts is not currently supported."
                 )
 

--- a/sdk/aqueduct/artifacts/utils.py
+++ b/sdk/aqueduct/artifacts/utils.py
@@ -74,7 +74,11 @@ def preview_artifact(
         _update_artifact_type(dag, artifact_id, artifact_result.artifact_type)
 
     if target_artifact_type == ArtifactType.TABLE:
-        return table_artifact.TableArtifact(dag, target_artifact_id, target_artifact_content)
+        return table_artifact.TableArtifact(
+            dag,
+            target_artifact_id,
+            target_artifact_content,
+        )
     elif target_artifact_type == ArtifactType.NUMERIC:
         return numeric_artifact.NumericArtifact(dag, target_artifact_id, target_artifact_content)
     elif target_artifact_type == ArtifactType.BOOL:

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -83,7 +83,8 @@ def wrap_spec(
     for artifact in input_artifacts:
         if artifact._from_flow_run:
             raise InvalidUserActionException(
-                "Artifact fetched from flow run cannot be reused for computation."
+                "Artifact %s fetched from flow run cannot be reused for computation."
+                % artifact.name
             )
 
     dag = dag_module.__GLOBAL_DAG__

--- a/sdk/aqueduct/error.py
+++ b/sdk/aqueduct/error.py
@@ -104,12 +104,22 @@ class InvalidUserArgumentException(Error):
     pass
 
 
+# Exception raised when the user does something that makes sense, but is currently unsupported
+# by the system.
+class UnsupportedUserActionException(Error):
+    pass
+
+
 # Exception raised when user attempts to use an invalid file name as a file dependency.
 class ReservedFileNameException(Error):
     pass
 
 
 class ArtifactNotFoundException(Error):
+    pass
+
+
+class ArtifactNeverComputedException(Error):
     pass
 
 

--- a/sdk/aqueduct/error.py
+++ b/sdk/aqueduct/error.py
@@ -104,12 +104,6 @@ class InvalidUserArgumentException(Error):
     pass
 
 
-# Exception raised when the user does something that makes sense, but is currently unsupported
-# by the system.
-class UnsupportedUserActionException(Error):
-    pass
-
-
 # Exception raised when user attempts to use an invalid file name as a file dependency.
 class ReservedFileNameException(Error):
     pass

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -97,6 +97,9 @@ class FlowRun:
         if not isinstance(artifact_from_dag.type, ArtifactType):
             raise InternalAqueductError("The artifact's type can not be recognized.")
 
+        assert (
+            artifact_from_dag.type != ArtifactType.PARAM
+        ), "No such thing as a parameter type in a published flow."
         if artifact_from_dag.type is ArtifactType.TABLE:
             return table_artifact.TableArtifact(
                 self._dag,
@@ -113,13 +116,6 @@ class FlowRun:
             )
         elif artifact_from_dag.type is ArtifactType.BOOL:
             return bool_artifact.BoolArtifact(
-                self._dag,
-                artifact_from_dag.id,
-                content=content,
-                from_flow_run=True,
-            )
-        elif artifact_from_dag.type is ArtifactType.PARAM:
-            return param_artifact.ParamArtifact(
                 self._dag,
                 artifact_from_dag.id,
                 content=content,

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -66,7 +66,6 @@ class FlowRun:
             """
             )
         )
-
         param_artifacts = self._dag.list_artifacts(filter_to=[ArtifactType.PARAM])
         print(format_header_for_print("Parameters "))
         for param_artifact in param_artifacts:
@@ -91,20 +90,43 @@ class FlowRun:
         if artifact_from_dag is None:
             return None
 
+        content = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(self.id(), artifact_from_dag.id)
+
         if not isinstance(artifact_from_dag.type, ArtifactType):
             raise InternalAqueductError("The artifact's type can not be recognized.")
 
         if artifact_from_dag.type is ArtifactType.TABLE:
-            return table_artifact.TableArtifact(self._dag, artifact_from_dag.id, from_flow_run=True)
+            return table_artifact.TableArtifact(
+                self._dag,
+                artifact_from_dag.id,
+                from_flow_run=True,
+                content=content,
+            )
         elif artifact_from_dag.type is ArtifactType.NUMERIC:
             return numeric_artifact.NumericArtifact(
-                self._dag, artifact_from_dag.id, from_flow_run=True
+                self._dag,
+                artifact_from_dag.id,
+                from_flow_run=True,
+                content=content,
             )
         elif artifact_from_dag.type is ArtifactType.BOOL:
-            return bool_artifact.BoolArtifact(self._dag, artifact_from_dag.id, from_flow_run=True)
+            return bool_artifact.BoolArtifact(
+                self._dag,
+                artifact_from_dag.id,
+                from_flow_run=True,
+                content=content,
+            )
         elif artifact_from_dag.type is ArtifactType.PARAM:
-            return param_artifact.ParamArtifact(self._dag, artifact_from_dag.id, from_flow_run=True)
+            return param_artifact.ParamArtifact(
+                self._dag,
+                artifact_from_dag.id,
+                from_flow_run=True,
+                content=content,
+            )
         else:
             return generic_artifact.GenericArtifact(
-                self._dag, artifact_from_dag.id, from_flow_run=True
+                self._dag,
+                artifact_from_dag.id,
+                from_flow_run=True,
+                content=content,
             )

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -90,7 +90,9 @@ class FlowRun:
         if artifact_from_dag is None:
             return None
 
-        content = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(self.id(), artifact_from_dag.id)
+        content = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(
+            self._id, str(artifact_from_dag.id)
+        )
 
         if not isinstance(artifact_from_dag.type, ArtifactType):
             raise InternalAqueductError("The artifact's type can not be recognized.")
@@ -99,22 +101,22 @@ class FlowRun:
             return table_artifact.TableArtifact(
                 self._dag,
                 artifact_from_dag.id,
-                from_flow_run=True,
                 content=content,
+                from_flow_run=True,
             )
         elif artifact_from_dag.type is ArtifactType.NUMERIC:
             return numeric_artifact.NumericArtifact(
                 self._dag,
                 artifact_from_dag.id,
-                from_flow_run=True,
                 content=content,
+                from_flow_run=True,
             )
         elif artifact_from_dag.type is ArtifactType.BOOL:
             return bool_artifact.BoolArtifact(
                 self._dag,
                 artifact_from_dag.id,
-                from_flow_run=True,
                 content=content,
+                from_flow_run=True,
             )
         elif artifact_from_dag.type is ArtifactType.PARAM:
             return param_artifact.ParamArtifact(
@@ -127,6 +129,7 @@ class FlowRun:
             return generic_artifact.GenericArtifact(
                 self._dag,
                 artifact_from_dag.id,
-                from_flow_run=True,
+                artifact_from_dag.type,
                 content=content,
+                from_flow_run=True,
             )

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -122,8 +122,8 @@ class FlowRun:
             return param_artifact.ParamArtifact(
                 self._dag,
                 artifact_from_dag.id,
-                from_flow_run=True,
                 content=content,
+                from_flow_run=True,
             )
         else:
             return generic_artifact.GenericArtifact(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Loads the artifact contents into `flow_run.artifact(..)`, so that any .get() on a published artifact will not need to make any preview request. This preserves the old snapshotted data of the previous run.

Added some guardrails:
- If you attempt to materialize a published artifact who's operator has failed, you'll get an `ArtifactNeverComputedException` exception. You are still able to describe the artifact in most cases though.
- If you attempt to materialize a published artifact with parameters, you'll get a NotImplementedError. We may want to support this in the future.

## Related issue number (if any)
ENG-1638

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


