### PR TITLE
ENG-1653 Disable strict mode on frontend

### DIFF
--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -31,12 +31,12 @@ const App = () => {
   let routesContent: React.ReactElement;
   routesContent = (
     <Routes>
-      <Route path={`${ pathPrefix ?? "/" }`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
+      <Route path={`${pathPrefix ?? "/"}`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/data`} element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/integrations`} element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/integration/:id`} element={<RequireAuth user={user}><IntegrationDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflows`} element={<RequireAuth user={user}><WorkflowsPage user={user} /> </RequireAuth>} />
-      <Route path={`/${pathPrefix}/login`} element={ user && user.apiKey ? <Navigate to="/" replace /> : <LoginPage />} />
+      <Route path={`/${pathPrefix}/login`} element={user && user.apiKey ? <Navigate to="/" replace /> : <LoginPage />} />
       <Route path={`/${pathPrefix}/account`} element={<RequireAuth user={user}><AccountPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:id`} element={<RequireAuth user={user}><WorkflowPage user={user} /> </RequireAuth>} />
     </Routes>
@@ -44,9 +44,9 @@ const App = () => {
 
   const muiTheme = createTheme(theme);
   return (
-      <ThemeProvider theme={muiTheme}>
-        <BrowserRouter>{routesContent}</BrowserRouter>
-      </ThemeProvider>
+    <ThemeProvider theme={muiTheme}>
+      <BrowserRouter>{routesContent}</BrowserRouter>
+    </ThemeProvider>
   );
 };
 
@@ -56,9 +56,7 @@ const root = ReactDOM.createRoot(
 );
 
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>
 )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR disables strict mode on the UI to get rid of some console errors that were appearing related to findDOMNode, a deprecated function that is used by react-virtualized.

## Loom Demo:
https://www.loom.com/share/88cccf7503644fc1834e90455576e21c

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1653/remove-strict-mode-on-react-to-get-rid-of-finddomnode-console-error

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


