### PR TITLE
ENG-1399: Redesigns integration details page to explicitly show DB tables

### DIFF
--- a/src/ui/common/src/components/integrations/integrationObjectList.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectList.tsx
@@ -102,7 +102,7 @@ const IntegrationObjectList: React.FC<Props> = ({ user, integration }) => {
         key={i}
         onChange={() => handleChange(i)}
       >
-        <AccordionSummary sx={{ backgroundColor: theme.palette.gray[50] }}>
+        <AccordionSummary sx={{ backgroundColor: theme.palette.gray[25] }}>
           {' '}
           {listObjectNamesState.names[i]}{' '}
         </AccordionSummary>

--- a/src/ui/common/src/components/integrations/integrationObjectPreview.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectPreview.tsx
@@ -18,7 +18,7 @@ type Props = {
 };
 
 const IntegrationObjectPreview: React.FC<Props> = ({ objectName, object }) => {
-  if (isInitial(object.status)) {
+  if (!object || isInitial(object.status)) {
     return null;
   }
 
@@ -28,7 +28,7 @@ const IntegrationObjectPreview: React.FC<Props> = ({ objectName, object }) => {
       <Box sx={{ display: 'flex', flexDirection: 'row', mt: 3 }}>
         <CircularProgress size={30} />
         <Typography sx={{ ml: 2 }}>
-          Loading object <b>{objectName}</b>...
+          Loading <b>{objectName}</b>...
         </Typography>
       </Box>
     );

--- a/src/ui/common/src/components/integrations/operatorsOnIntegration.tsx
+++ b/src/ui/common/src/components/integrations/operatorsOnIntegration.tsx
@@ -91,7 +91,7 @@ const OperatorsOnIntegration: React.FC = () => {
       </Box>
     );
   } else {
-    return <Box>Integration is not used by any workflow.</Box>;
+    return <Box>This integration is not used by any workflows.</Box>;
   }
 };
 

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -173,12 +173,15 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
           </Alert>
         )}
 
-        {
-          selectedIntegration.name === 'aqueduct_demo' &&
-            <Typography variant="body1" sx={{ my: 1 }}>
-              You can see the documentation for the Aqueduct Demo database <Link href="https://docs.aqueducthq.com/integrations/aqueduct-demo-integration">here</Link>.
-            </Typography>
-        }
+        {selectedIntegration.name === 'aqueduct_demo' && (
+          <Typography variant="body1" sx={{ my: 1 }}>
+            You can see the documentation for the Aqueduct Demo database{' '}
+            <Link href="https://docs.aqueducthq.com/integrations/aqueduct-demo-integration">
+              here
+            </Link>
+            .
+          </Typography>
+        )}
 
         <IntegrationObjectList user={user} integration={selectedIntegration} />
 

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -171,7 +171,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
         )}
         <IntegrationObjectList user={user} integration={selectedIntegration} />
         <Typography
-          variant="h4"
+          variant="h5"
           gutterBottom
           component="div"
           sx={{ marginY: 4, mt: 4 }}
@@ -180,6 +180,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
         </Typography>
         <OperatorsOnIntegration />
       </Box>
+
       {showAddTableDialog && (
         <AddTableDialog
           user={user}
@@ -200,6 +201,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
           }}
         />
       )}
+
       {showEditDialog && (
         <IntegrationDialog
           user={user}
@@ -212,6 +214,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
           integrationToEdit={selectedIntegration}
         />
       )}
+
       <Snackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={showTestConnectToast}
@@ -227,6 +230,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
           {`Attempting to connect to ${selectedIntegration.name}`}
         </Alert>
       </Snackbar>
+
       <Snackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={showConnectSuccessToast}
@@ -242,6 +246,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
           {`Successfully connected to ${selectedIntegration.name}`}
         </Alert>
       </Snackbar>
+
       <Snackbar
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         open={showEditSuccessToast}

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -1,5 +1,6 @@
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
 import Snackbar from '@mui/material/Snackbar';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
@@ -154,6 +155,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             }}
           />
         </Box>
+
         {showDeleteTableDialog && (
           <DeleteIntegrationDialog
             user={user}
@@ -162,6 +164,7 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             onCloseDialog={() => setShowDeleteTableDialog(false)}
           />
         )}
+
         {testConnectStatus && isFailed(testConnectStatus) && (
           <Alert severity="error" sx={{ marginTop: 2 }}>
             Test-connect failed with error:
@@ -169,7 +172,16 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             <pre>{testConnectStatus.err}</pre>
           </Alert>
         )}
+
+        {
+          selectedIntegration.name === 'aqueduct_demo' &&
+            <Typography variant="body1" sx={{ my: 1 }}>
+              You can see the documentation for the Aqueduct Demo database <Link href="https://docs.aqueducthq.com/integrations/aqueduct-demo-integration">here</Link>.
+            </Typography>
+        }
+
         <IntegrationObjectList user={user} integration={selectedIntegration} />
+
         <Typography
           variant="h5"
           gutterBottom

--- a/src/ui/common/src/styles/theme/theme.tsx
+++ b/src/ui/common/src/styles/theme/theme.tsx
@@ -16,6 +16,7 @@ export const theme = {
       90: '#F4F6FA',
       75: '#F9FAFC',
       50: '#F2F2F2',
+      25: '#F9F9F9',
     },
     blue: {
       900: '#002F5E',


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Previously, we had a slightly opaque way of showing previews of the data tables on the integration details page behind a select menu. It was not clear to users what that menu was for or what would happen if you selected something. 

This PR slightly redesigns that interface to instead show an accordion, in which clicking on each item shows you a preview of the data. You can see a side-by-side comparison in the demo video below.

[Demo video](https://www.loom.com/share/b914d0f0507a457fbabb657b4ef13ccf)

## Related issue number (if any)

ENG-1399

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


