### PR TITLE
ENG-1579: Fix bug where browser console throws error when there is no load operator

### DIFF
--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -454,14 +454,19 @@ export const workflowSlice = createSlice({
       (state, action) => {
         const response = action.payload;
         const savedObjects = {};
-        response.object_details.map((object) => {
-          const key = String([object.integration_name, object.object_name]);
-          if (savedObjects[key]) {
-            savedObjects[key].push(object);
-          } else {
-            savedObjects[key] = [object];
-          }
-        });
+
+        // Only run this code if there are saved objects. If there are none, then just skip
+        // this altogether.
+        if (!!response.object_details) {
+          response.object_details.map((object) => {
+            const key = String([object.integration_name, object.object_name]);
+            if (savedObjects[key]) {
+              savedObjects[key].push(object);
+            } else {
+              savedObjects[key] = [object];
+            }
+          });
+        }
 
         state.savedObjects.loadingStatus = {
           loading: LoadingStatusEnum.Succeeded,


### PR DESCRIPTION
## Describe your changes and why you are making these changes

We were just missing a simple guard to check if there were any saved objects. 🙂

## Related issue number (if any)

ENG-1579

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


