### PR TITLE
Fix bug where artifact with None value doesn't work with flow_run.artifact() api

### DIFF
--- a/integration_tests/sdk/no_return_test.py
+++ b/integration_tests/sdk/no_return_test.py
@@ -1,6 +1,7 @@
 import pytest
-from aqueduct import op
 from utils import run_flow_test
+
+from aqueduct import op
 
 
 @op
@@ -11,11 +12,11 @@ def no_return() -> None:
 @pytest.mark.publish
 def test_operator_with_no_return(client):
     result = no_return()
-    assert(result.get() is None)
+    assert result.get() is None
     flow = run_flow_test(client, artifacts=[result], delete_flow_after=False)
 
     try:
         artifact_return = flow.latest().artifact("no_return artifact")
-        assert(artifact_return.get() is None)
+        assert artifact_return.get() is None
     finally:
         client.delete_flow(flow.id())

--- a/integration_tests/sdk/no_return_test.py
+++ b/integration_tests/sdk/no_return_test.py
@@ -1,0 +1,21 @@
+import pytest
+from aqueduct import op
+from utils import run_flow_test
+
+
+@op
+def no_return() -> None:
+    return None
+
+
+@pytest.mark.publish
+def test_operator_with_no_return(client):
+    result = no_return()
+    assert(result.get() is None)
+    flow = run_flow_test(client, artifacts=[result], delete_flow_after=False)
+
+    try:
+        artifact_return = flow.latest().artifact("no_return artifact")
+        assert(artifact_return.get() is None)
+    finally:
+        client.delete_flow(flow.id())

--- a/integration_tests/sdk/no_return_test.py
+++ b/integration_tests/sdk/no_return_test.py
@@ -13,9 +13,8 @@ def no_return() -> None:
 def test_operator_with_no_return(client):
     result = no_return()
     assert result.get() is None
-    flow = run_flow_test(client, artifacts=[result], delete_flow_after=False)
-
     try:
+        flow = run_flow_test(client, artifacts=[result], delete_flow_after=False)
         artifact_return = flow.latest().artifact("no_return artifact")
         assert artifact_return.get() is None
     finally:

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -43,7 +43,7 @@ def test_flow_fails_on_unexpected_type_output_for_lazy(client):
     flow = run_flow_test(client, artifacts=[output], delete_flow_after=False)
 
     try:
-        # Because we not are violating our inferred types, this will fail!
+        # Because we are violating our inferred types, this will fail!
         client.trigger(flow.id(), parameters={"output_type_toggle": False})
         wait_for_flow_runs(
             client,

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -427,7 +427,9 @@ class APIClient:
 
         return [ListWorkflowResponseEntry(**workflow) for workflow in response.json()]
 
-    def get_artifact_result_data(self, dag_result_id: str, artifact_id: str) -> Optional[Any]:
+    def get_artifact_result_data(
+        self, dag_result_id: str, artifact_id: str
+    ) -> Tuple[Optional[Any], ExecutionStatus]:
         """Returns an empty string if the operator was not successfully executed."""
         headers = self._generate_auth_headers()
         url = self.construct_full_url(
@@ -437,16 +439,20 @@ class APIClient:
         utils.raise_errors(resp)
 
         parsed_response = utils.parse_artifact_result_response(resp)
+        execution_status = parsed_response["metadata"]["exec_state"]["status"]
 
-        if parsed_response["metadata"]["exec_state"]["status"] != ExecutionStatus.SUCCEEDED:
+        if execution_status != ExecutionStatus.SUCCEEDED:
             print("Artifact result unavailable due to unsuccessful execution.")
-            return None
+            return None, execution_status
 
         serialization_type = parsed_response["metadata"]["serialization_type"]
         if serialization_type not in deserialization_function_mapping:
             raise Exception("Unsupported serialization type %s." % serialization_type)
 
-        return deserialization_function_mapping[serialization_type](parsed_response["data"])
+        return (
+            deserialization_function_mapping[serialization_type](parsed_response["data"]),
+            execution_status,
+        )
 
     def get_node_positions(
         self, operator_mapping: Dict[str, Dict[str, Any]]

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -36,6 +36,9 @@ class GenericArtifact(BaseArtifact):
         # This parameter indicates whether the artifact is fetched from flow-run or not.
         self._from_flow_run = from_flow_run
         self._set_content(content)
+        # This is only relevant to generic artifact produced from flow_run.artifact().
+        # We need this to distinguish between when an artifact's content is None versus
+        # when it fails to compute successfully.
         self._execution_status = execution_status
 
     def get(self, parameters: Optional[Dict[str, Any]] = None) -> Any:

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 from aqueduct.artifacts import utils as artifact_utils
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
-from aqueduct.enums import ArtifactType
+from aqueduct.enums import ArtifactType, ExecutionStatus
 from aqueduct.error import ArtifactNeverComputedException
 
 
@@ -24,6 +24,7 @@ class GenericArtifact(BaseArtifact):
         artifact_type: ArtifactType = ArtifactType.UNTYPED,
         content: Optional[Any] = None,
         from_flow_run: bool = False,
+        execution_status: Optional[ExecutionStatus] = None,
     ):
         # Cannot initialize a generic artifact's content without also setting its type.
         if content is not None:
@@ -35,6 +36,7 @@ class GenericArtifact(BaseArtifact):
         # This parameter indicates whether the artifact is fetched from flow-run or not.
         self._from_flow_run = from_flow_run
         self._set_content(content)
+        self._execution_status = execution_status
 
     def get(self, parameters: Optional[Dict[str, Any]] = None) -> Any:
         """Materializes the artifact.
@@ -51,7 +53,7 @@ class GenericArtifact(BaseArtifact):
         self._dag.must_get_artifact(self._artifact_id)
 
         if self._from_flow_run:
-            if self._get_content() is None:
+            if self._execution_status != ExecutionStatus.SUCCEEDED:
                 raise ArtifactNeverComputedException(
                     "This artifact was part of an existing flow run but was never computed successfully!",
                 )
@@ -59,6 +61,7 @@ class GenericArtifact(BaseArtifact):
                 raise NotImplementedError(
                     "Parameterizing historical artifacts is not currently supported."
                 )
+            return self._get_content()
 
         if parameters is None and self._get_content() is not None:
             return self._get_content()

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -90,7 +90,7 @@ class FlowRun:
         if artifact_from_dag is None:
             return None
 
-        content = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(
+        content, execution_status = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(
             self._id, str(artifact_from_dag.id)
         )
 
@@ -128,4 +128,5 @@ class FlowRun:
                 artifact_from_dag.type,
                 content=content,
                 from_flow_run=True,
+                execution_status=execution_status,
             )

--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -1,6 +1,6 @@
 import textwrap
 import uuid
-from datetime import datetime, date
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
 from aqueduct.artifacts.metadata import ArtifactMetadata


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previously, if an artifact's content is `None`, when we retrieve it from `flow_run.artifact()` and call `get()`, it'll mistakenly complain the artifact wasn't computed successfully. This PR fixes this by distinguishing the two cases via an extra execution status argument passed into `GenericArtifact`.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


