### PR TITLE
Fixes Airflow schedule string for manual workflows

### DIFF
--- a/src/python/aqueduct_executor/operators/airflow/dag.template
+++ b/src/python/aqueduct_executor/operators/airflow/dag.template
@@ -103,7 +103,11 @@ with DAG(
         'retries': 0,
     },
     start_date=datetime(2022, 1, 1, 1),
+    {% if schedule %}
     schedule_interval='{{ schedule }}',
+    {% else %}
+    schedule_interval={{ schedule }},
+    {% endif %}
     catchup=False,
     tags=['aqueduct'],
 ) as dag:

--- a/src/python/aqueduct_executor/operators/airflow/execute.py
+++ b/src/python/aqueduct_executor/operators/airflow/execute.py
@@ -54,6 +54,10 @@ def compile(spec: spec.CompileAirflowSpec) -> bytes:
     It returns the DAG file.
     """
 
+    schedule = None
+    if spec.cron_schedule:
+        schedule = spec.cron_schedule
+
     # Init Airflow tasks
     tasks = []
     task_to_alias = {}
@@ -75,7 +79,7 @@ def compile(spec: spec.CompileAirflowSpec) -> bytes:
     template = env.get_template("dag.template")
     r = template.render(
         dag_id=spec.dag_id,
-        schedule=spec.cron_schedule,
+        schedule=schedule,
         tasks=tasks,
         edges=edges,
         task_to_alias=task_to_alias,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the Airflow schedule set for workflows that are only invoked manually. Airflow requires the schedule to be `None` (without any quotes) if the schedule should be none. Otherwise, the schedule should be a cron string.

## Related issue number (if any)
ENG 1486

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


Confirmed that the Airflow DAG file has the correct schedule generated:
```
with DAG(
    dag_id='testingaflow2',
    default_args={
        'retries': 0,
    },
    start_date=datetime(2022, 1, 1, 1),
    
    schedule_interval=None,
    
    catchup=False,
    tags=['aqueduct'],
) as dag:
```