### PR TITLE
Fixes Airflow connect integration request

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -24,26 +24,28 @@ export const AirflowDialog: React.FC<Props> = ({
   value,
   editMode,
 }) => {
-  const [address, setAddress] = useState<string>(value?.host ?? null);
+  const [host, setHost] = useState<string>(value?.host ?? null);
   const [s3CredsProfile, setS3CredsProfile] = useState<string>(
     value?.s3_credentials_profile ?? null
   );
 
   useEffect(() => {
-    if (address && address.startsWith('http://')) {
-      // Backend requires the protocol to be stripped
-      onUpdateField('host', address.substring(7));
-    }
-
-    if (address && address.startsWith('https://')) {
-      // Backend requires the protocol to be stripped
-      onUpdateField('host', address.substring(8));
+    if (host) {
+      if (host.startsWith('http://')) {
+        // Backend requires the protocol to be stripped
+        onUpdateField('host', host.substring(7));
+      } else if (host.startsWith('https://')) {
+        // Backend requires the protocol to be stripped
+        onUpdateField('host', host.substring(8));
+      } else {
+        onUpdateField('host', host);
+      }
     }
 
     if (s3CredsProfile && s3CredsProfile !== 'default') {
       onUpdateField('s3_credentials_profile', s3CredsProfile);
     }
-  }, [address, s3CredsProfile]);
+  }, [host, s3CredsProfile]);
 
   return (
     <Box sx={{ mt: 2 }}>
@@ -53,8 +55,8 @@ export const AirflowDialog: React.FC<Props> = ({
         label="Host *"
         description="The hostname of the Airflow server."
         placeholder={Placeholders.host}
-        onChange={(event) => setAddress(event.target.value)}
-        value={address}
+        onChange={(event) => setHost(event.target.value)}
+        value={host}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the frontend was not sending the Airflow host as part of a connect integration request when the protocol (e.g. HTTP, HTTPS) is not provided by the user.

## Related issue number (if any)
ENG 1682

TEST: Tested this by successfully connecting an Airflow integration.

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


