### PR TITLE
Implicitly create parameter when passing non artifact to decorated functions

### DIFF
--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -95,17 +95,20 @@ def test_implicitly_created_parameter(client):
 
     result = func(2)
     assert result.get() == 2
-    client._dag.must_get_operator(with_name="foo")
+    assert result.get(parameters={"foo": 10}) == 10
 
-    client.create_param("bar", default="hello")
+    bar_param = client.create_param("bar", default="hello")
 
     @op
     def another_func(bar):
-        return foo
+        return bar
 
     with pytest.raises(InvalidUserArgumentException):
         # This should error because we try to implicitly create a parameter "bar" but it already exists.
         result = another_func(2)
+
+    result = another_func(bar_param)
+    assert result.get() == "hello"
 
 
 @op

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -88,6 +88,26 @@ def test_get_with_custom_parameter(client):
         param_doubled.get(parameters={"number": "NOT A NUMBER"})
 
 
+def test_implicitly_created_parameter(client):
+    @op
+    def func(foo):
+        return foo
+
+    result = func(2)
+    assert result.get() == 2
+    client._dag.must_get_operator(with_name="foo")
+
+    client.create_param("bar", default="hello")
+
+    @op
+    def another_func(bar):
+        return foo
+
+    with pytest.raises(InvalidUserArgumentException):
+        # This should error because we try to implicitly create a parameter "bar" but it already exists.
+        result = another_func(2)
+
+
 @op
 def append_row_to_df(df, row):
     """`row` is a list of values to append to the input dataframe."""

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -11,21 +11,14 @@ import yaml
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.bool_artifact import BoolArtifact
 from aqueduct.artifacts.generic_artifact import GenericArtifact
-from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.artifacts.table_artifact import TableArtifact
-from aqueduct.artifacts.utils import to_artifact_class
 from aqueduct.config import FlowConfig
+from aqueduct.parameter_utils import create_param
 
 from aqueduct import dag, globals
 
-from .dag import (
-    AddOrReplaceOperatorDelta,
-    Metadata,
-    SubgraphDAGDelta,
-    apply_deltas_to_dag,
-    validate_overwriting_parameters,
-)
+from .dag import Metadata, SubgraphDAGDelta, apply_deltas_to_dag, validate_overwriting_parameters
 from .enums import ExecutionStatus, OperatorType, RelationalDBServices, RuntimeType, ServiceType
 from .error import (
     IncompleteFlowException,
@@ -43,7 +36,7 @@ from .integrations.s3_integration import S3Integration
 from .integrations.salesforce_integration import SalesforceIntegration
 from .integrations.sql_integration import RelationalDBIntegration
 from .logger import logger
-from .operators import Operator, OperatorSpec, ParamSpec, serialize_parameter_value
+from .operators import serialize_parameter_value
 from .responses import SavedObjectUpdate
 from .utils import (
     _infer_requirements,
@@ -185,39 +178,7 @@ class Client:
         Returns:
             A parameter artifact.
         """
-        if default is None:
-            raise InvalidUserArgumentException("Parameter default value cannot be None.")
-
-        artifact_type = infer_artifact_type(default)
-
-        val = serialize_parameter_value(name, default)
-
-        operator_id = generate_uuid()
-        output_artifact_id = generate_uuid()
-        apply_deltas_to_dag(
-            self._dag,
-            deltas=[
-                AddOrReplaceOperatorDelta(
-                    op=Operator(
-                        id=operator_id,
-                        name=name,
-                        description=description,
-                        spec=OperatorSpec(param=ParamSpec(val=val)),
-                        inputs=[],
-                        outputs=[output_artifact_id],
-                    ),
-                    output_artifacts=[
-                        ArtifactMetadata(
-                            id=output_artifact_id,
-                            name=name,
-                            type=artifact_type,
-                        ),
-                    ],
-                )
-            ],
-        )
-
-        return to_artifact_class(self._dag, output_artifact_id, artifact_type, default)
+        return create_param(self._dag, name, default, description)
 
     def list_integrations(self) -> Dict[str, IntegrationInfo]:
         """Retrieves a dictionary of integrations the client can use.

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -199,7 +199,7 @@ def _convert_argument_to_parameter(
             if dag.get_operator(with_name=arg_name) is not None:
                 raise InvalidUserArgumentException(
                     """Input to function argument "%s" is not an artifact type. We tried implicitly \
-creating a parameter named "%s", but an existing operator or parameter with the same name already exist."""
+creating a parameter named "%s", but an existing operator or parameter with the same name already exists."""
                     % (arg_name, arg_name)
                 )
 

--- a/sdk/aqueduct/parameter_utils.py
+++ b/sdk/aqueduct/parameter_utils.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Union
+
+from aqueduct.artifacts.metadata import ArtifactMetadata
+from aqueduct.artifacts.utils import to_artifact_class
+from aqueduct.dag import DAG, AddOrReplaceOperatorDelta, apply_deltas_to_dag
+from aqueduct.error import InvalidUserArgumentException
+from aqueduct.operators import Operator, OperatorSpec, ParamSpec, serialize_parameter_value
+from aqueduct.utils import generate_uuid, infer_artifact_type
+
+if TYPE_CHECKING:
+    from aqueduct.artifacts.bool_artifact import BoolArtifact
+    from aqueduct.artifacts.generic_artifact import GenericArtifact
+    from aqueduct.artifacts.numeric_artifact import NumericArtifact
+    from aqueduct.artifacts.table_artifact import TableArtifact
+
+
+def create_param(
+    dag: DAG,
+    name: str,
+    default: Any,
+    description: str = "",
+) -> Union[TableArtifact, NumericArtifact, BoolArtifact, GenericArtifact]:
+    """Creates a parameter operator and return an artifact that can be fed into other operators."""
+    if default is None:
+        raise InvalidUserArgumentException("Parameter default value cannot be None.")
+
+    artifact_type = infer_artifact_type(default)
+
+    val = serialize_parameter_value(name, default)
+
+    operator_id = generate_uuid()
+    output_artifact_id = generate_uuid()
+    apply_deltas_to_dag(
+        dag,
+        deltas=[
+            AddOrReplaceOperatorDelta(
+                op=Operator(
+                    id=operator_id,
+                    name=name,
+                    description=description,
+                    spec=OperatorSpec(param=ParamSpec(val=val)),
+                    inputs=[],
+                    outputs=[output_artifact_id],
+                ),
+                output_artifacts=[
+                    ArtifactMetadata(
+                        id=output_artifact_id,
+                        name=name,
+                        type=artifact_type,
+                    ),
+                ],
+            )
+        ],
+    )
+
+    return to_artifact_class(dag, output_artifact_id, artifact_type, default)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When non-artifact types are passed to decorated functions, we attempt to implicitly create a parameter with name being the function argument's name and default value being the user-specified value. We print out a warning when this happens. If there is already an operator with the same name in the dag, we throw an error.

## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


