### PR TITLE
Lambda Workflows [builds lambda containers for operators] [4/5]

### DIFF
--- a/src/dockerfiles/Makefile
+++ b/src/dockerfiles/Makefile
@@ -44,31 +44,34 @@ build-sqlserver-connector:
 
 build-lambda-images: build-lambda-function build-lambda-param build-lambda-system-metric build-lambda-snowflake
 
+build-lambda-connectors: build-lambda-snowflake build-lambda-athena build-lambda-bigquery \
+	build-lambda-postgres build-lambda-s3
+
 build-lambda-function:
-	docker build . -t hsubbaraj/lambda-function -f lambda/function/function.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-function-38:0.0.14 -f lambda/function/function.dockerfile --no-cache
 
 build-lambda-param:
-	docker build . -t hsubbaraj/lambda-param -f lambda/param/param.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-param:0.0.14 -f lambda/param/param.dockerfile --no-cache
 
 build-lambda-system-metric:
-	docker build . -t hsubbaraj/lambda-system-metric -f lambda/system-metric/system-metric.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-system-metric:0.0.14 -f lambda/system-metric/system-metric.dockerfile --no-cache
 
 build-lambda-connectors: build-lambda-snowflake build-lambda-athena build-lambda-bigquery build-lambda-postgres build-lambda-s3
 
 build-lambda-snowflake:
-	docker build . -t hsubbaraj/lambda-snowflake -f lambda/connectors/snowflake.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-snowflake-connector:0.0.14 -f lambda/connectors/snowflake.dockerfile --no-cache
 
 build-lambda-athena:
-	docker build . -t aqueducthq/lambda-athena -f lambda/connectors/athena.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-athena-connector:0.0.14 -f lambda/connectors/athena.dockerfile --no-cache
 
 build-lambda-bigquery:
-	docker build . -t aqueducthq/lambda-bigquery -f lambda/connectors/bigquery.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-bigquery-connector:0.0.14 -f lambda/connectors/bigquery.dockerfile --no-cache
 
 build-lambda-postgres:
-	docker build . -t aqueducthq/lambda-postgres -f lambda/connectors/postgres.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-postgres-connector:0.0.14 -f lambda/connectors/postgres.dockerfile --no-cache
 
 build-lambda-s3:
-	docker build . -t aqueducthq/lambda-s3 -f lambda/connectors/s3.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-s3-connector:0.0.14 -f lambda/connectors/s3.dockerfile --no-cache
 
 
 publish-function:
@@ -90,10 +93,14 @@ publish-connectors:
 	docker push aqueducthq/sqlserver-connector:0.0.14
 
 publish-lambda:
-	docker push hsubbaraj/lambda-function
-	docker push hsubbaraj/lambda-snowflake
-	docker push hsubbaraj/lambda-param
-	docker push hsubbaraj/lambda-system-metric
+	docker push aqueducthq/lambda-function-38:0.0.14
+	docker push aqueducthq/lambda-param:0.0.14
+	docker push aqueducthq/lambda-system-metric:0.0.14
+	docker push aqueducthq/lambda-athena-connector:0.0.14
+	docker push aqueducthq/lambda-bigquery-connector:0.0.14
+	docker push aqueducthq/lambda-postgres-connector:0.0.14
+	docker push aqueducthq/lambda-s3-connector:0.0.14
+	docker push aqueducthq/lambda-snowflake-connector:0.0.14
 
 .PHONY:
 

--- a/src/dockerfiles/Makefile
+++ b/src/dockerfiles/Makefile
@@ -42,6 +42,35 @@ build-snowflake-connector:
 build-sqlserver-connector:
 	docker build . -t aqueducthq/sqlserver-connector:0.0.14 -f connectors/sqlserver.dockerfile --no-cache
 
+build-lambda-images: build-lambda-function build-lambda-param build-lambda-system-metric build-lambda-snowflake
+
+build-lambda-function:
+	docker build . -t hsubbaraj/lambda-function -f lambda/function/function.dockerfile --no-cache
+
+build-lambda-param:
+	docker build . -t hsubbaraj/lambda-param -f lambda/param/param.dockerfile --no-cache
+
+build-lambda-system-metric:
+	docker build . -t hsubbaraj/lambda-system-metric -f lambda/system-metric/system-metric.dockerfile --no-cache
+
+build-lambda-connectors: build-lambda-snowflake build-lambda-athena build-lambda-bigquery build-lambda-postgres build-lambda-s3
+
+build-lambda-snowflake:
+	docker build . -t hsubbaraj/lambda-snowflake -f lambda/connectors/snowflake.dockerfile --no-cache
+
+build-lambda-athena:
+	docker build . -t aqueducthq/lambda-athena -f lambda/connectors/athena.dockerfile --no-cache
+
+build-lambda-bigquery:
+	docker build . -t aqueducthq/lambda-bigquery -f lambda/connectors/bigquery.dockerfile --no-cache
+
+build-lambda-postgres:
+	docker build . -t aqueducthq/lambda-postgres -f lambda/connectors/postgres.dockerfile --no-cache
+
+build-lambda-s3:
+	docker build . -t aqueducthq/lambda-s3 -f lambda/connectors/s3.dockerfile --no-cache
+
+
 publish-function:
 	docker push aqueducthq/function:0.0.14
 
@@ -59,6 +88,12 @@ publish-connectors:
 	docker push aqueducthq/s3-connector:0.0.14
 	docker push aqueducthq/snowflake-connector:0.0.14
 	docker push aqueducthq/sqlserver-connector:0.0.14
+
+publish-lambda:
+	docker push hsubbaraj/lambda-function
+	docker push hsubbaraj/lambda-snowflake
+	docker push hsubbaraj/lambda-param
+	docker push hsubbaraj/lambda-system-metric
 
 .PHONY:
 

--- a/src/dockerfiles/lambda/app.py
+++ b/src/dockerfiles/lambda/app.py
@@ -1,0 +1,4 @@
+import sys
+import aqueduct_executor
+def handler(event, context):
+    return 'Hello from AWS Lambda using Python' + sys.version + '!'

--- a/src/dockerfiles/lambda/connectors/athena.dockerfile
+++ b/src/dockerfiles/lambda/connectors/athena.dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/connectors/data.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip3 install awswrangler --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "data.handler" ]

--- a/src/dockerfiles/lambda/connectors/bigquery.dockerfile
+++ b/src/dockerfiles/lambda/connectors/bigquery.dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/connectors/data.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip3 install google-cloud-bigquery --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "data.handler" ]

--- a/src/dockerfiles/lambda/connectors/data.py
+++ b/src/dockerfiles/lambda/connectors/data.py
@@ -1,0 +1,13 @@
+import base64
+
+from aqueduct_executor.operators.connectors.data import execute
+from aqueduct_executor.operators.connectors.data.spec import parse_spec
+
+def handler(event, context):
+    print(event)
+    input_spec = event["Spec"]
+
+    spec_json = base64.b64decode(input_spec)
+    spec = parse_spec(spec_json)
+
+    execute.run(spec)

--- a/src/dockerfiles/lambda/connectors/postgres.dockerfile
+++ b/src/dockerfiles/lambda/connectors/postgres.dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/connectors/data.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip3 install psycopg2-binary --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "data.handler" ]

--- a/src/dockerfiles/lambda/connectors/s3.dockerfile
+++ b/src/dockerfiles/lambda/connectors/s3.dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/connectors/data.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip3 install pyarrow --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "data.handler" ]

--- a/src/dockerfiles/lambda/connectors/snowflake.dockerfile
+++ b/src/dockerfiles/lambda/connectors/snowflake.dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/connectors/data.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip3 install snowflake-sqlalchemy
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "data.handler" ]

--- a/src/dockerfiles/lambda/function/function.dockerfile
+++ b/src/dockerfiles/lambda/function/function.dockerfile
@@ -1,0 +1,15 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/function/function.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "function.handler" ]

--- a/src/dockerfiles/lambda/function/function.py
+++ b/src/dockerfiles/lambda/function/function.py
@@ -1,0 +1,40 @@
+import base64
+import subprocess
+import sys
+import os
+
+from aqueduct_executor.operators.function_executor.spec import parse_spec
+from aqueduct_executor.operators.function_executor import extract_function
+from aqueduct_executor.operators.function_executor import prune_requirements
+from aqueduct_executor.operators.function_executor import execute
+
+def install_packages(requirements_path):
+    subprocess.run([sys.executable, "-m", "pip", "install", "-r", requirements_path, "--no-cache-dir"])
+
+def pip_freeze(local_deps_path):
+    subprocess.run([sys.executable, "-m", "pip", "freeze", ">>", local_deps_path])
+
+
+def handler(event, context):
+    """
+    1. extract function
+    2. download required packages
+    3. execute function.
+    """
+    input_spec = event["Spec"]
+
+    spec_json = base64.b64decode(input_spec)
+    spec = parse_spec(spec_json)
+
+    extract_function.run(spec)
+    open(spec.function_extract_path + "op/local_deps.txt", 'w')
+    open(spec.function_extract_path + "op/missing.txt", 'w')
+    pip_freeze(spec.function_extract_path + "op/local_deps.txt")
+    prune_requirements.run(
+        spec.function_extract_path + "op/local_deps.txt",
+        spec.function_extract_path + "op/requirements.txt",
+        spec.function_extract_path + "op/missing.txt",
+    )
+
+    install_packages(spec.function_extract_path + "op/requirements.txt")
+    execute.run(spec)

--- a/src/dockerfiles/lambda/lambda-test.dockerfile
+++ b/src/dockerfiles/lambda/lambda-test.dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/app.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "app.handler" ]

--- a/src/dockerfiles/lambda/param/param.dockerfile
+++ b/src/dockerfiles/lambda/param/param.dockerfile
@@ -1,0 +1,15 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/param/param.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "param.handler" ]

--- a/src/dockerfiles/lambda/param/param.py
+++ b/src/dockerfiles/lambda/param/param.py
@@ -1,0 +1,13 @@
+import base64
+
+from aqueduct_executor.operators.param_executor import execute
+from aqueduct_executor.operators.param_executor.spec import parse_spec
+
+def handler(event, context):
+    print(event)
+    input_spec = event["Spec"]
+
+    spec_json = base64.b64decode(input_spec)
+    spec = parse_spec(spec_json)
+
+    execute.run(spec)

--- a/src/dockerfiles/lambda/requirements.txt
+++ b/src/dockerfiles/lambda/requirements.txt
@@ -1,0 +1,8 @@
+boto3==1.18.0
+cloudpickle
+distro
+pandas==1.3.0
+pydantic==1.9.0
+pyyaml
+SQLAlchemy==1.4.30
+typing_extensions

--- a/src/dockerfiles/lambda/system-metric/system-metric.dockerfile
+++ b/src/dockerfiles/lambda/system-metric/system-metric.dockerfile
@@ -1,0 +1,15 @@
+FROM public.ecr.aws/lambda/python:3.8
+
+# Copy function code
+COPY lambda/system-metric/system_metric.py ${LAMBDA_TASK_ROOT}
+
+# Install the function's dependencies using file requirements.txt
+# from your project folder.
+
+COPY lambda/requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+RUN pip3 install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ aqueduct-ml-test-hari==0.0.1 --target "${LAMBDA_TASK_ROOT}"
+
+# Set the CMD to your handler (could also be done as a parameter override outside of the Dockerfile)
+CMD [ "system_metric.handler" ]

--- a/src/dockerfiles/lambda/system-metric/system_metric.py
+++ b/src/dockerfiles/lambda/system-metric/system_metric.py
@@ -1,0 +1,13 @@
+import base64
+
+from aqueduct_executor.operators.system_metric_executor import execute
+from aqueduct_executor.operators.system_metric_executor.spec import parse_spec
+
+def handler(event, context):
+    print(event)
+    input_spec = event["Spec"]
+
+    spec_json = base64.b64decode(input_spec)
+    spec = parse_spec(spec_json)
+
+    execute.run(spec)

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -238,6 +238,12 @@ func ValidateConfig(
 		return validateKubernetesConfig(ctx, config)
 	}
 
+	if service == integration.Lambda {
+		// Lambda authentication is performed by creating Lambda jobs
+		// instead of the Python client, so we don't launch a job for it.
+		return validateLambdaConfig(ctx, config)
+	}
+
 	// Schedule authenticate job
 	jobMetadataPath := fmt.Sprintf("authenticate-%s", requestId)
 
@@ -462,6 +468,17 @@ func validateKubernetesConfig(
 	config auth.Config,
 ) (int, error) {
 	if err := engine.AuthenticateK8sConfig(ctx, config); err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	return http.StatusOK, nil
+}
+
+func validateLambdaConfig(
+	ctx context.Context,
+	config auth.Config,
+) (int, error) {
+	if err := engine.AuthenticateLambdaConfig(ctx, config); err != nil {
 		return http.StatusBadRequest, err
 	}
 

--- a/src/golang/lib/job/lambda.go
+++ b/src/golang/lib/job/lambda.go
@@ -112,7 +112,7 @@ func (j *lambdaJobManager) DeleteCronJob(ctx context.Context, name string) error
 func mapJobTypeToLambdaFunction(spec Spec) (string, error) {
 	switch spec.Type() {
 	case FunctionJobType:
-		return lambda_utils.FunctionLambdaFunction, nil
+		return lambda_utils.FunctionLambdaFunction38, nil
 	case AuthenticateJobType:
 		authenticateSpec := spec.(*AuthenticateSpec)
 		return mapIntegrationServiceToLambdaFunction(authenticateSpec.ConnectorName)

--- a/src/golang/lib/lambda/constants.go
+++ b/src/golang/lib/lambda/constants.go
@@ -1,7 +1,7 @@
 package lambda
 
 const (
-	FunctionLambdaFunction     = "aqueduct-function"
+	FunctionLambdaFunction38   = "aqueduct-function-38"
 	ParameterLambdaFunction    = "aqueduct-parameter"
 	SystemMetricLambdaFunction = "aqueduct-systemmetric"
 
@@ -11,13 +11,13 @@ const (
 	S3LambdaFunction        = "aqueduct-s3"
 	SnowflakeLambdaFunction = "aqueduct-snowflake"
 
-	FunctionLambdaImage     = "aqueducthq/lambda-function:0.0.13"
-	ParameterLambdaImage    = "aqueducthq/lambda-param:0.0.13"
-	SystemMetricLambdaImage = "aqueducthq/lambda-system-metric:0.0.13"
+	FunctionLambdaImage38   = "aqueducthq/lambda-function-38"
+	ParameterLambdaImage    = "aqueducthq/lambda-param"
+	SystemMetricLambdaImage = "aqueducthq/lambda-system-metric"
 
-	AthenaConnectorLambdaImage    = "aqueducthq/lambda-athena-connector:0.0.13"
-	BigQueryConnectorLambdaImage  = "aqueducthq/lambda-bigquery-connector:0.0.13"
-	PostgresConnectorLambdaImage  = "aqueducthq/lambda-postgres-connector:0.0.13"
-	S3ConnectorLambdaImage        = "aqueducthq/lambda-s3-connector:0.0.13"
-	SnowflakeConnectorLambdaImage = "aqueducthq/lambda-snowflake-connector:0.0.13"
+	AthenaConnectorLambdaImage    = "aqueducthq/lambda-athena-connector"
+	BigQueryConnectorLambdaImage  = "aqueducthq/lambda-bigquery-connector"
+	PostgresConnectorLambdaImage  = "aqueducthq/lambda-postgres-connector"
+	S3ConnectorLambdaImage        = "aqueducthq/lambda-s3-connector"
+	SnowflakeConnectorLambdaImage = "aqueducthq/lambda-snowflake-connector"
 )

--- a/src/python/aqueduct_executor/operators/function_executor/extract_function.py
+++ b/src/python/aqueduct_executor/operators/function_executor/extract_function.py
@@ -52,7 +52,7 @@ def extract_function(storage: Storage, spec: FunctionSpec) -> None:
     """
     fn_path = spec.function_extract_path
     if not os.path.exists(fn_path):
-        os.mkdir(fn_path)
+        os.makedirs(fn_path)
 
     function_byte = storage.get(spec.function_path)
     _unzip_function_contents(

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -16,6 +16,7 @@ import { AqueductDemoCard } from './aqueductDemoCard';
 import { BigQueryCard } from './bigqueryCard';
 import { GCSCard } from './gcsCard';
 import { KubernetesCard } from './kubernetesCard';
+import { LambdaCard } from './lambdaCard';
 import { LoadSpecsCard } from './loadSpecCard';
 import { MariaDbCard } from './mariadbCard';
 import { MySqlCard } from './mysqlCard';
@@ -135,6 +136,9 @@ export const IntegrationCard: React.FC<IntegrationProps> = ({
       break;
     case 'Kubernetes':
       serviceCard = <KubernetesCard integration={integration} />;
+      break;
+    case 'Lambda':
+      serviceCard = <LambdaCard integration={integration} />;
       break;
     default:
       serviceCard = null;

--- a/src/ui/common/src/components/integrations/cards/detailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/detailCard.tsx
@@ -9,6 +9,8 @@ import {
 import { LoadingStatus } from '../../../utils/shared';
 import { AqueductDemoCard } from './aqueductDemoCard';
 import { BigQueryCard } from './bigqueryCard';
+import { KubernetesCard } from './kubernetesCard';
+import { LambdaCard } from './lambdaCard';
 import { MariaDbCard } from './mariadbCard';
 import { MySqlCard } from './mysqlCard';
 import { PostgresCard } from './postgresCard';
@@ -51,10 +53,28 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
     case 'S3':
       serviceCard = <S3Card integration={integration} />;
       break;
+    case 'Kubernetes':
+      serviceCard = <KubernetesCard integration={integration} />;
+      break;
+    case 'Lambda':
+      serviceCard = <LambdaCard integration={integration} />;
+      break;
     default:
       serviceCard = null;
   }
 
+  let createdOnText = null;
+  if (
+    integration.service !== 'Kubernetes' &&
+    integration.service !== 'Lambda'
+  ) {
+    createdOnText = (
+      <Typography variant="body1">
+        <strong>Created On: </strong>
+        {new Date(integration.createdAt * 1000).toLocaleString()}
+      </Typography>
+    );
+  }
   return (
     <Box
       sx={{
@@ -75,10 +95,7 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
             </Typography>
           </Box>
 
-          <Typography variant="body1">
-            <strong>Created On: </strong>
-            {new Date(integration.createdAt * 1000).toLocaleString()}
-          </Typography>
+          {createdOnText}
 
           {serviceCard}
         </Box>

--- a/src/ui/common/src/components/integrations/cards/lambdaCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/lambdaCard.tsx
@@ -1,0 +1,21 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { Integration, LambdaConfig } from '../../../utils/integrations';
+
+type Props = {
+  integration: Integration;
+};
+
+export const LambdaCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as LambdaConfig;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body1">
+        <strong>Lambda Role ARN: </strong>
+        {config.role_arn}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -30,6 +30,7 @@ import {
   Integration,
   IntegrationConfig,
   KubernetesConfig,
+  LambdaConfig,
   MySqlConfig,
   PostgresConfig,
   RedshiftConfig,
@@ -46,6 +47,7 @@ import { BigQueryDialog } from './bigqueryDialog';
 import { GCSDialog } from './gcsDialog';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 import { KubernetesDialog } from './kubernetesDialog';
+import { LambdaDialog } from './lambdaDialog';
 import { MariaDbDialog } from './mariadbDialog';
 import { MysqlDialog } from './mysqlDialog';
 import { PostgresDialog } from './postgresDialog';
@@ -236,6 +238,14 @@ const IntegrationDialog: React.FC<Props> = ({
         <KubernetesDialog
           onUpdateField={setConfigField}
           value={config as KubernetesConfig}
+        />
+      );
+      break;
+    case 'Lambda':
+      serviceDialog = (
+        <LambdaDialog
+          onUpdateField={setConfigField}
+          value={config as LambdaConfig}
         />
       );
       break;

--- a/src/ui/common/src/components/integrations/dialogs/lambdaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/lambdaDialog.tsx
@@ -1,0 +1,30 @@
+import Box from '@mui/material/Box';
+import React from 'react';
+
+import { LambdaConfig } from '../../../utils/integrations';
+import { IntegrationTextInputField } from './IntegrationTextInputField';
+
+const Placeholders: LambdaConfig = {
+  role_arn: '<my lambda role ARN>',
+};
+
+type Props = {
+  onUpdateField: (field: keyof LambdaConfig, value: string) => void;
+  value?: LambdaConfig;
+};
+
+export const LambdaDialog: React.FC<Props> = ({ onUpdateField, value }) => {
+  return (
+    <Box sx={{ mt: 2 }}>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Lambda Role ARN"
+        description="Region in which to run Lambda functions."
+        placeholder={Placeholders.role_arn}
+        onChange={(event) => onUpdateField('role_arn', event.target.value)}
+        value={value?.role_arn ?? null}
+      />
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/integrationObjectList.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectList.tsx
@@ -54,6 +54,13 @@ const IntegrationObjectList: React.FC<Props> = ({ user, integration }) => {
     );
   }, [selectedObject]);
 
+  if (
+    integration.service === 'Kubernetes' ||
+    integration.service === 'Lambda'
+  ) {
+    return null;
+  }
+
   if (integration.service === 'S3') {
     return (
       <Alert severity="warning" sx={{ width: '80%', mt: 4 }}>

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -140,6 +140,10 @@ export type KubernetesConfig = {
   cluster_name: string;
 };
 
+export type LambdaConfig = {
+  role_arn: string;
+};
+
 export type IntegrationConfig =
   | PostgresConfig
   | SnowflakeConfig
@@ -155,7 +159,8 @@ export type IntegrationConfig =
   | GCSConfig
   | AqueductDemoConfig
   | AirflowConfig
-  | KubernetesConfig;
+  | KubernetesConfig
+  | LambdaConfig;
 
 export type Service =
   | 'Postgres'
@@ -171,7 +176,8 @@ export type Service =
   | 'Aqueduct Demo'
   | 'Airflow'
   | 'Kubernetes'
-  | 'SQLite';
+  | 'SQLite'
+  | 'Lambda';
 
 type Info = {
   logo: string;
@@ -325,6 +331,11 @@ export const SupportedIntegrations: ServiceInfoMap = {
   },
   ['Kubernetes']: {
     logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/kubernetes.png',
+    activated: true,
+    category: 'compute',
+  },
+  ['Lambda']: {
+    logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/Lambda.png',
     activated: true,
     category: 'compute',
   },


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Builds the docker images that lambda uses to run Aqueduct operators. There are some changes included to aqueduct_executor to enable lambda to work as well.
## Related issue number (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


