### PR TITLE
Update integration detail UI for Kubernetes and Lambda

### DIFF
--- a/src/golang/lib/collections/integration/constants.go
+++ b/src/golang/lib/collections/integration/constants.go
@@ -69,11 +69,7 @@ const (
 func ParseService(s string) (Service, error) {
 	svc := Service(s)
 	switch svc {
-<<<<<<< HEAD
 	case Postgres, Snowflake, MySql, Redshift, MariaDb, SqlServer, BigQuery, GoogleSheets, Salesforce, S3, Athena, AqueductDemo, Github, Sqlite, Airflow, Kubernetes, GCS, Lambda:
-=======
-	case Postgres, Snowflake, MySql, Redshift, MariaDb, SqlServer, BigQuery, GoogleSheets, Salesforce, S3, Athena, AqueductDemo, Github, Sqlite, Airflow, Lambda, Kubernetes, GCS:
->>>>>>> c06ef6bbbfa12c445ad85f3d4e6c757ad3570e61
 		return svc, nil
 	default:
 		return "", errors.Newf("Unknown service: %s", s)

--- a/src/golang/lib/collections/integration/constants.go
+++ b/src/golang/lib/collections/integration/constants.go
@@ -57,6 +57,7 @@ const (
 	Sqlite       Service = "SQLite"
 	Airflow      Service = "Airflow"
 	Kubernetes   Service = "Kubernetes"
+	Lambda       Service = "Lambda"
 	GCS          Service = "GCS"
 	Athena       Service = "Athena"
 	Lambda       Service = "Lambda"
@@ -68,7 +69,11 @@ const (
 func ParseService(s string) (Service, error) {
 	svc := Service(s)
 	switch svc {
+<<<<<<< HEAD
 	case Postgres, Snowflake, MySql, Redshift, MariaDb, SqlServer, BigQuery, GoogleSheets, Salesforce, S3, Athena, AqueductDemo, Github, Sqlite, Airflow, Kubernetes, GCS, Lambda:
+=======
+	case Postgres, Snowflake, MySql, Redshift, MariaDb, SqlServer, BigQuery, GoogleSheets, Salesforce, S3, Athena, AqueductDemo, Github, Sqlite, Airflow, Lambda, Kubernetes, GCS:
+>>>>>>> c06ef6bbbfa12c445ad85f3d4e6c757ad3570e61
 		return svc, nil
 	default:
 		return "", errors.Newf("Unknown service: %s", s)

--- a/src/golang/lib/collections/integration/constants.go
+++ b/src/golang/lib/collections/integration/constants.go
@@ -60,7 +60,6 @@ const (
 	Lambda       Service = "Lambda"
 	GCS          Service = "GCS"
 	Athena       Service = "Athena"
-	Lambda       Service = "Lambda"
 
 	DemoDbIntegrationName = "aqueduct_demo"
 )

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -139,6 +139,7 @@ export const IntegrationCard: React.FC<IntegrationProps> = ({
       break;
     case 'Lambda':
       serviceCard = <LambdaCard integration={integration} />;
+      break;
     default:
       serviceCard = null;
   }

--- a/src/ui/common/src/components/integrations/cards/detailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/detailCard.tsx
@@ -9,6 +9,8 @@ import {
 import { LoadingStatus } from '../../../utils/shared';
 import { AqueductDemoCard } from './aqueductDemoCard';
 import { BigQueryCard } from './bigqueryCard';
+import { KubernetesDetailCard } from './kubernetesDetailCard';
+import { LambdaDetailCard } from './lambdaDetailCard';
 import { MariaDbCard } from './mariadbCard';
 import { MySqlCard } from './mysqlCard';
 import { PostgresCard } from './postgresCard';
@@ -51,8 +53,41 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
     case 'S3':
       serviceCard = <S3Card integration={integration} />;
       break;
+    case 'Kubernetes':
+      serviceCard = <KubernetesDetailCard integration={integration} />
+      break;
+    case 'Lambda':
+      serviceCard = <LambdaDetailCard integration={integration} />
+      break;
     default:
       serviceCard = null;
+  }
+
+  if (integration.service === 'Kubernetes' || integration.service === 'Lambda') {
+    return (
+      <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '900px',
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'row' }}>
+        <img
+          height="45px"
+          src={SupportedIntegrations[integration.service].logo}
+        />
+        <Box sx={{ ml: 3 }}>
+          <Box display="flex" flexDirection="row">
+            <Typography sx={{ fontFamily: 'Monospace' }} variant="h4">
+              {integration.name}
+            </Typography>
+          </Box>
+            {serviceCard}
+        </Box>
+      </Box>
+    </Box>
+    )
   }
 
   return (

--- a/src/ui/common/src/components/integrations/cards/kubernetesDetailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/kubernetesDetailCard.tsx
@@ -1,0 +1,29 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { Integration, KubernetesConfig } from '../../../utils/integrations';
+
+type Props = {
+  integration: Integration;
+};
+
+export const KubernetesDetailCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as KubernetesConfig;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body1">
+        <strong>Kubernetes Config Path: </strong>
+      </Typography>
+      <Typography variant="body1">
+        {config.kubeconfig_path}
+      </Typography>
+      <Typography variant="body1">
+        <strong>Cluster Name: </strong>
+      </Typography>
+      <Typography variant="body1">
+        {config.cluster_name}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/cards/lambdaDetailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/lambdaDetailCard.tsx
@@ -1,0 +1,23 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { Integration, LambdaConfig } from '../../../utils/integrations';
+
+type Props = {
+  integration: Integration;
+};
+
+export const LambdaDetailCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as LambdaConfig;
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body1">
+        <strong>Lambda Role ARN: </strong>
+      </Typography>
+      <Typography variant="body1">
+        {config.role_arn}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -240,6 +240,7 @@ const IntegrationDialog: React.FC<Props> = ({
           value={config as KubernetesConfig}
         />
       );
+      break;
     case 'Lambda':
       serviceDialog = (
         <LambdaDialog

--- a/src/ui/common/src/components/integrations/integrationObjectList.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectList.tsx
@@ -54,6 +54,12 @@ const IntegrationObjectList: React.FC<Props> = ({ user, integration }) => {
     );
   }, [selectedObject]);
 
+  if (integration.service === 'Kubernetes' || integration.service === 'Lambda') {
+    return (
+      <></>
+    )
+  }
+  
   if (integration.service === 'S3') {
     return (
       <Alert severity="warning" sx={{ width: '80%', mt: 4 }}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR is to update integration detail page for both k8s and lambda. With both k8s and lambda don't have data display feature, we will remove it in the detail integration page. Instead, we add more integration configuration information on the page.

**After:**
<img src ="https://user-images.githubusercontent.com/78303449/189711863-680e84c9-1f24-4798-82c5-849d67fcc9c0.png" width="1000" height="400" />
<img src ="https://user-images.githubusercontent.com/78303449/189711880-6ea77380-be76-404f-a473-869c8928677d.png" width="1000" height="400" />


This PR also fix a issue in branch eng-1516 where we need to have a "break" for each switch case.

## Related issue number (if any)
ENG-1642
https://linear.app/aqueducthq/issue/ENG-1642/update-integration-detail-ui-for-kubernetes-and-lambda

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


