### PR TITLE
Changes operator name from load -> save to

### DIFF
--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -112,7 +112,7 @@ class BaseArtifact(ABC):
         # the input artifact. This allows multiple artifacts to write to the same integration,
         # as well as a single artifact to write to multiple integrations, all while keeping
         # the name of the load operator readable.
-        load_op_name = " %s loader" % integration_info.name
+        load_op_name = "save to %s" % integration_info.name
 
         # Add the load operator as a terminal node.
         apply_deltas_to_dag(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Change "Load" terminology to "Save to" on UI.

Before:
![Screen Shot 2022-09-13 at 2 21 08 PM](https://user-images.githubusercontent.com/87333321/189981984-d67d4c21-c2fc-4eaf-a289-967980f10479.png)

After:
![Screen Shot 2022-09-13 at 2 28 13 PM](https://user-images.githubusercontent.com/87333321/189981986-be24743e-74a8-4a16-99ec-e647770853d2.png)

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1442/rename-load-to-save-in-ui-and-sdk
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


