### PR TITLE
Fix refresh on server start 

### DIFF
--- a/src/golang/cmd/server/server/cron.go
+++ b/src/golang/cmd/server/server/cron.go
@@ -28,9 +28,14 @@ func (s *AqServer) triggerMissedCronJobs(
 		// This means that the workflow should have been triggered, but it wasn't.
 		// So we manually trigger the workflow here.
 		_, _, err := (&handler.RefreshWorkflowHandler{
-			Database:       s.Database,
-			WorkflowReader: s.WorkflowReader,
-			Engine:         s.AqEngine,
+			Database:              s.Database,
+			WorkflowReader:        s.WorkflowReader,
+			Engine:                s.AqEngine,
+			Vault:                 s.Vault,
+			WorkflowDagReader:     s.WorkflowDagReader,
+			OperatorReader:        s.OperatorReader,
+			ArtifactReader:        s.ArtifactReader,
+			WorkflowDagEdgeReader: s.WorkflowDagEdgeReader,
 		}).Perform(
 			ctx,
 			&handler.RefreshWorkflowArgs{


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue that we couldn't trigger a missed workflow on server start. The issue is introduced as the handler init is out-of-date.

## Related issue number (if any)
We should follow up for testing in ENG-1689

## Checklist before requesting a review
Workflow trigger failed with nil pointer error on this fix, succeed with this fix.
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


