### PR TITLE
Changes Airflow DAG template to use Python virtual env

### DIFF
--- a/src/python/aqueduct_executor/operators/airflow/dag.template
+++ b/src/python/aqueduct_executor/operators/airflow/dag.template
@@ -1,36 +1,26 @@
 from datetime import datetime
+
 from airflow.models import DAG
-
 from airflow.operators.python import PythonVirtualenvOperator
-
-from aqueduct_executor.operators.function_executor import execute as func_execute
-from aqueduct_executor.operators.function_executor import spec as func_spec
-from aqueduct_executor.operators.param_executor import execute as param_execute
-from aqueduct_executor.operators.param_executor import spec as param_spec
-from aqueduct_executor.operators.system_metric_executor import execute as sys_metric_execute
-from aqueduct_executor.operators.system_metric_executor import spec as sys_metric_spec
-from aqueduct_executor.operators.connectors.data import execute as conn_execute
-from aqueduct_executor.operators.connectors.data import spec as conn_spec
-from aqueduct_executor.operators.utils import enums
 
 # Python requirements for each Airflow task
 VENV_REQUIREMENTS=[
-    aqueduct-ml,
-    awswrangler,
-    boto3,
-    cloudpickle,
-    distro,
-    google-cloud-bigquery,
-    mysqlclient,
-    pandas,
-    psycopg2-binary,
-    pyarrow,
-    pydantic,
-    pyodbc,
-    pyyaml,
-    snowflake-sqlalchemy,
-    SQLAlchemy,
-    typing_extensions,
+    "aqueduct-ml",
+    "awswrangler",
+    "boto3",
+    "cloudpickle",
+    "distro",
+    "google-cloud-bigquery",
+    "mysqlclient",
+    "pandas",
+    "psycopg2-binary",
+    "pyarrow",
+    "pydantic",
+    "pyodbc",
+    "pyyaml",
+    "snowflake-sqlalchemy",
+    "SQLAlchemy",
+    "typing_extensions",
 ]
 
 def invoke_task(spec, **kwargs):
@@ -38,83 +28,53 @@ def invoke_task(spec, **kwargs):
     Check the spec type and invoke the correct operator.
     First, append the dag_run_id to all of the storage paths in the spec.
     '''
+    from aqueduct_executor.operators.utils import enums
+    from aqueduct_executor.operators.function_executor import spec as func_spec
+    from aqueduct_executor.operators.param_executor import spec as param_spec
+    from aqueduct_executor.operators.system_metric_executor import spec as sys_metric_spec
+    from aqueduct_executor.operators.connectors.data import spec as conn_spec
+
+    from aqueduct_executor.operators.function_executor import execute as func_execute
+    from aqueduct_executor.operators.param_executor import execute as param_execute
+    from aqueduct_executor.operators.system_metric_executor import execute as sys_metric_execute
+    from aqueduct_executor.operators.connectors.data import execute as conn_execute
+
     dag_run_id = kwargs["run_id"]
 
     spec_type = enums.JobType(spec["type"])
     if spec_type == enums.JobType.FUNCTION:
         spec = func_spec.FunctionSpec(**spec)
-        handle_function(spec, dag_run_id)
+        spec.metadata_path = "{}_{}".format(spec.metadata_path, dag_run_id)
+        spec.input_content_paths = ["{}_{}".format(p, dag_run_id) for p in spec.input_content_paths]
+        spec.input_metadata_paths = ["{}_{}".format(p, dag_run_id) for p in spec.input_metadata_paths]
+        spec.output_content_paths = ["{}_{}".format(p, dag_run_id) for p in spec.output_content_paths]
+        spec.output_metadata_paths = ["{}_{}".format(p, dag_run_id) for p in spec.output_metadata_paths]
+        func_execute.run_with_setup(spec)
     elif spec_type == enums.JobType.EXTRACT:
         spec = conn_spec.ExtractSpec(**spec)
-        handle_extract(spec, dag_run_id)
+        spec.metadata_path = "{}_{}".format(spec.metadata_path, dag_run_id)
+        spec.output_content_path = "{}_{}".format(spec.output_content_path, dag_run_id)
+        spec.output_metadata_path = "{}_{}".format(spec.output_metadata_path, dag_run_id)
+        conn_execute.run(spec)
     elif spec_type == enums.JobType.LOAD:
         spec = conn_spec.LoadSpec(**spec)
-        handle_load(spec, dag_run_id)
+        spec.metadata_path = "{}_{}".format(spec.metadata_path, dag_run_id)
+        spec.input_content_path = "{}_{}".format(spec.input_content_path, dag_run_id)
+        spec.input_metadata_path = "{}_{}".format(spec.input_metadata_path, dag_run_id)
+        conn_execute.run(spec)
     elif spec_type == enums.JobType.PARAM:
         spec = param_spec.ParamSpec(**spec)
-        handle_param(spec, dag_run_id)
+        spec.metadata_path = "{}_{}".format(spec.metadata_path, dag_run_id)
+        spec.output_content_path = "{}_{}".format(spec.output_content_path, dag_run_id)
+        spec.output_metadata_path = "{}_{}".format(spec.output_metadata_path, dag_run_id)
+        param_execute.run(spec)
     elif spec_type == enums.JobType.SYSTEM_METRIC:
         spec = sys_metric_spec.SystemMetricSpec(**spec)
-        handle_system_metric(spec, dag_run_id)
-
-def handle_function(spec: func_spec.FunctionSpec, run_id: str):
-    """
-    Invokes a Function operator as an Airflow task.
-    It first ensures that all storage paths are unique by appending the run_id. 
-    """
-    spec.metadata_path = "{}_{}".format(spec.metadata_path, run_id)
-    spec.input_content_paths = ["{}_{}".format(p, run_id) for p in spec.input_content_paths]
-    spec.input_metadata_paths = ["{}_{}".format(p, run_id) for p in spec.input_metadata_paths]
-    spec.output_content_paths = ["{}_{}".format(p, run_id) for p in spec.output_content_paths]
-    spec.output_metadata_paths = ["{}_{}".format(p, run_id) for p in spec.output_metadata_paths]
-
-    func_execute.run_with_setup(spec)
-
-
-def handle_extract(spec: conn_spec.ExtractSpec, run_id: str):
-    """
-    Invokes an Extract operator as an Airflow task.
-    It first ensures that all storage paths are unique by appending the run_id. 
-    """
-    spec.metadata_path = "{}_{}".format(spec.metadata_path, run_id)
-    spec.output_content_path = "{}_{}".format(spec.output_content_path, run_id)
-    spec.output_metadata_path = "{}_{}".format(spec.output_metadata_path, run_id)
-
-    conn_execute.run(spec)
-
-def handle_load(spec: conn_spec.LoadSpec, run_id: str):
-    """
-    Invokes a Load operator as an Airflow task.
-    It first ensures that all storage paths are unique by appending the run_id. 
-    """
-    spec.metadata_path = "{}_{}".format(spec.metadata_path, run_id)
-    spec.input_content_path = "{}_{}".format(spec.input_content_path, run_id)
-    spec.input_metadata_path = "{}_{}".format(spec.input_metadata_path, run_id)
-
-    conn_execute.run(spec)
-
-def handle_param(spec: param_spec.ParamSpec, run_id: str):
-    """
-    Invokes a Parameter operator as an Airflow task.
-    It first ensures that all storage paths are unique by appending the run_id. 
-    """
-    spec.metadata_path = "{}_{}".format(spec.metadata_path, run_id)
-    spec.output_content_path = "{}_{}".format(spec.output_content_path, run_id)
-    spec.output_metadata_path = "{}_{}".format(spec.output_metadata_path, run_id)
-
-    param_execute.run(spec)
-
-def handle_system_metric(spec: sys_metric_spec.SystemMetricSpec, run_id: str):
-    """
-    Invokes a SystemMetric operator as an Airflow task.
-    It first ensures that all storage paths are unique by appending the run_id. 
-    """
-    spec.metadata_path = "{}_{}".format(spec.metadata_path, run_id)
-    spec.input_metadata_paths = ["{}_{}".format(p, run_id) for p in spec.input_metadata_paths]
-    spec.output_content_path = "{}_{}".format(spec.output_content_path, run_id)
-    spec.output_metadata_path = "{}_{}".format(spec.output_metadata_path, run_id)
-
-    sys_metric_execute.run(spec)
+        spec.metadata_path = "{}_{}".format(spec.metadata_path, dag_run_id)
+        spec.input_metadata_paths = ["{}_{}".format(p, dag_run_id) for p in spec.input_metadata_paths]
+        spec.output_content_path = "{}_{}".format(spec.output_content_path, dag_run_id)
+        spec.output_metadata_path = "{}_{}".format(spec.output_metadata_path, dag_run_id)
+        sys_metric_execute.run(spec)
 
 
 with DAG(

--- a/src/python/aqueduct_executor/operators/airflow/dag.template
+++ b/src/python/aqueduct_executor/operators/airflow/dag.template
@@ -1,7 +1,7 @@
 from datetime import datetime
 from airflow.models import DAG
 
-from airflow.operators.python import PythonOperator
+from airflow.operators.python import PythonVirtualenvOperator
 
 from aqueduct_executor.operators.function_executor import execute as func_execute
 from aqueduct_executor.operators.function_executor import spec as func_spec
@@ -12,6 +12,26 @@ from aqueduct_executor.operators.system_metric_executor import spec as sys_metri
 from aqueduct_executor.operators.connectors.data import execute as conn_execute
 from aqueduct_executor.operators.connectors.data import spec as conn_spec
 from aqueduct_executor.operators.utils import enums
+
+# Python requirements for each Airflow task
+VENV_REQUIREMENTS=[
+    aqueduct-ml,
+    awswrangler,
+    boto3,
+    cloudpickle,
+    distro,
+    google-cloud-bigquery,
+    mysqlclient,
+    pandas,
+    psycopg2-binary,
+    pyarrow,
+    pydantic,
+    pyodbc,
+    pyyaml,
+    snowflake-sqlalchemy,
+    SQLAlchemy,
+    typing_extensions,
+]
 
 def invoke_task(spec, **kwargs):
     '''
@@ -118,8 +138,10 @@ with DAG(
 
 
     {% for task in tasks %}
-    {{ task.alias }} = PythonOperator(
+    {{ task.alias }} = PythonVirtualenvOperator(
         task_id='{{ task.id }}',
+        requirements=VENV_REQUIREMENTS,
+        system_site_packages=False,
         python_callable=invoke_task,
         op_args=[
     {{ task.spec.json(indent=4, separators=(',', ': ')) }}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR changes the Airflow DAG template to use the PythonVirtualenv operator instead of the Python operator. This makes sure that the user does not need to install `aqueduct-ml` and other pkg dependencies on their Airflow server directly.

## Related issue number (if any)
ENG 1484

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)

## Tests
- Confirmed that the new Airflow DAG template successfully ran
