### PR TITLE
Eng 1599 workflow status bar popover

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -41,7 +41,6 @@ import {
 import DefaultLayout from '../../../layouts/default';
 import { Button } from '../../../primitives/Button.styles';
 import ReactFlowCanvas from '../../../workflows/ReactFlowCanvas';
-import WorkflowStatusBar from '../../../workflows/StatusBar';
 import WorkflowHeader from '../../../workflows/workflowHeader';
 import { LayoutProps } from '../../types';
 
@@ -264,7 +263,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -288,7 +288,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -370,8 +370,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           </Box>
         </Drawer>
       )}
-
-      {/* <WorkflowStatusBar user={user} /> */}
     </Layout>
   );
 };

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -264,8 +264,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -289,8 +288,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -372,7 +370,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         </Drawer>
       )}
 
-      <WorkflowStatusBar user={user} />
+      {/* <WorkflowStatusBar user={user} /> */}
     </Layout>
   );
 };

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -62,7 +62,7 @@ interface ActiveWorkflowStatusTabProps {
 export const StatusBarHeaderHeightInPx = 41;
 export const CollapsedStatusBarWidthInPx = 75;
 export const StatusBarWidthInPx = 432;
-export const StatusBarListHeightInPx = 800;
+export const MaxStatusBarListHeightInPx = 800;
 
 const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
   activeWorkflowStatusTab,
@@ -120,9 +120,11 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
     <Box
       sx={{
         width: `${StatusBarWidthInPx}px`,
-        height: `${StatusBarListHeightInPx - StatusBarHeaderHeightInPx}px`,
-        overflowY: 'scroll',
+        maxHeight: `${MaxStatusBarListHeightInPx}px`,
+        display: 'block',
+        overflow: 'auto',
         backgroundColor: 'white',
+        borderRadius: '8px',
       }}
     >
       {listItems.map((listItem, index) => {
@@ -203,7 +205,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
     workflow.selectedDag?.operators ?? {};
 
   const [activeWorkflowStatusTab, setActiveWorkflowStatusTab] = useState(
-    WorkflowStatusTabs.Errors
+    WorkflowStatusTabs.Collapsed
   );
 
   const [numErrors, setNumErrors] = useState(0);
@@ -335,14 +337,14 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   };
 
   const collapseWorkflowStatusBar = (event: React.MouseEvent) => {
-    event.preventDefault();
+    event.stopPropagation();
     dispatch(setWorkflowStatusBarOpenState(false));
     setActiveWorkflowStatusTab(WorkflowStatusTabs.Collapsed);
   };
 
   // Chevron up is clicked. Errors tab is left most tab, so we select that one.
   const expandWorkflowStatusbar = (event: React.MouseEvent) => {
-    event.preventDefault();
+    event.stopPropagation();
     selectTab(WorkflowStatusTabs.Errors);
   };
 
@@ -527,15 +529,21 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   return (
     <Box
       sx={{
+        cursor: 'pointer',
         position: 'absolute',
         left: '700px',
         top: '123px',
-        height: collapsed
-          ? `${StatusBarHeaderHeightInPx}px`
-          : `${StatusBarListHeightInPx}px`,
         zIndex: 10,
-        border: `1px solid ${theme.palette.gray['500']}`,
+        borderLeft: `1px solid ${theme.palette.gray['500']}`,
+        borderTop: `1px solid ${theme.palette.gray['500']}`,
+        borderRight: `1px solid ${theme.palette.gray['500']}`,
+        borderBottom: collapsed
+          ? `1px solid ${theme.palette.gray['500']}`
+          : null,
         borderRadius: '8px',
+      }}
+      onClick={() => {
+        selectTab(WorkflowStatusTabs.Errors);
       }}
     >
       <Box
@@ -550,10 +558,15 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           borderBottom: collapsed
             ? null
             : `1px solid ${theme.palette.gray['500']}`,
+          overflowY: 'none',
         }}
       >
         <Box
-          onClick={() => selectTab(WorkflowStatusTabs.Errors)}
+          onClick={(event: React.MouseEvent) => {
+            // handle event here and keep from being handled by root onClick listener of parent div.
+            event.stopPropagation();
+            selectTab(WorkflowStatusTabs.Errors);
+          }}
           sx={{
             ...statusBarIconStyles,
             color:
@@ -575,7 +588,10 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         </Box>
 
         <Box
-          onClick={() => selectTab(WorkflowStatusTabs.Warnings)}
+          onClick={(event: React.MouseEvent) => {
+            event.stopPropagation();
+            selectTab(WorkflowStatusTabs.Warnings);
+          }}
           sx={{
             ...statusBarIconStyles,
             color:
@@ -596,7 +612,10 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         </Box>
 
         <Box
-          onClick={() => selectTab(WorkflowStatusTabs.Logs)}
+          onClick={(event: React.MouseEvent) => {
+            event.stopPropagation();
+            selectTab(WorkflowStatusTabs.Logs);
+          }}
           sx={{
             ...statusBarIconStyles,
             color:
@@ -616,27 +635,28 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           <Typography sx={{ ml: 1 }}>{numWorkflowLogs}</Typography>
         </Box>
 
-        <Box>
-          <Box
-            onClick={() => selectTab(WorkflowStatusTabs.Checks)}
-            sx={{
-              ...statusBarIconStyles,
-              color:
-                activeWorkflowStatusTab === WorkflowStatusTabs.Checks
-                  ? theme.palette.green['500']
-                  : theme.palette.green['400'],
-              borderBottom:
-                activeWorkflowStatusTab === WorkflowStatusTabs.Checks
-                  ? `2px solid ${theme.palette.green['500']}`
-                  : '', // green500
-              '&:hover': { color: theme.palette.green['500'] },
-              fontSize: '20px',
-              marginRight: 4,
-            }}
-          >
-            <FontAwesomeIcon icon={faCircleCheck} />
-            <Typography sx={{ ml: 1 }}>{numWorkflowChecksPassed}</Typography>
-          </Box>
+        <Box
+          onClick={(event: React.MouseEvent) => {
+            event.stopPropagation();
+            selectTab(WorkflowStatusTabs.Checks);
+          }}
+          sx={{
+            ...statusBarIconStyles,
+            color:
+              activeWorkflowStatusTab === WorkflowStatusTabs.Checks
+                ? theme.palette.green['500']
+                : theme.palette.green['400'],
+            borderBottom:
+              activeWorkflowStatusTab === WorkflowStatusTabs.Checks
+                ? `2px solid ${theme.palette.green['500']}`
+                : '', // green500
+            '&:hover': { color: theme.palette.green['500'] },
+            fontSize: '20px',
+            marginRight: 4,
+          }}
+        >
+          <FontAwesomeIcon icon={faCircleCheck} />
+          <Typography sx={{ ml: 1 }}>{numWorkflowChecksPassed}</Typography>
         </Box>
 
         <Box

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -1,6 +1,8 @@
 import {
+  faChevronDown,
   faChevronLeft,
   faChevronRight,
+  faChevronUp,
   faCircleCheck,
   faCircleExclamation,
   faCircleInfo,
@@ -450,9 +452,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;
@@ -509,11 +510,14 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   };
 
   const collapsed = activeWorkflowStatusTab === WorkflowStatusTabs.Collapsed;
+  console.log('collapsed: ', collapsed);
 
   const statusBarIconStyles = {
     mx: collapsed ? 0 : 1,
+    //mx: 1,
     py: 1,
-    width: collapsed ? '100%' : '40px',
+    //width: collapsed ? '100%' : '40px',
+    width: '40px',
     cursor: 'pointer',
     alignItems: 'start',
     display: 'flex',
@@ -524,9 +528,10 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
       sx={{
         position: 'absolute',
         bottom: 0,
-        right: 0,
+        top: '110px',
+        right: '40%',
+        height: collapsed ? `${StatusBarHeaderHeightInPx}px` : '100%',
         zIndex: 10,
-        height: '100%',
         borderTop: '0px',
         borderLeft: '1px',
         borderRight: '0px',
@@ -539,24 +544,31 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
       <Box
         sx={{
           display: 'flex',
-          flexDirection: collapsed ? 'column' : 'row',
-          alignItems: collapsed ? 'start' : 'center',
-          px: collapsed ? 1 : 0,
-          ml: collapsed ? 1 : 0,
-          py: collapsed ? 0 : 1,
+          //flexDirection: collapsed ? 'column' : 'row',
+          flexDirection: 'row',
+          //alignItems: collapsed ? 'start' : 'center',
+          alignItems: 'center',
+          //px: collapsed ? 1 : 0,
+          px: 0,
+          //ml: collapsed ? 1 : 0,
+          ml: 0,
+          //py: collapsed ? 0 : 1,
+          py: 1,
           height: collapsed ? undefined : `${StatusBarHeaderHeightInPx}px`,
-          width: collapsed ? CollapsedStatusBarWidthInPx : StatusBarWidthInPx,
+          //height: `${StatusBarHeaderHeightInPx}px`,
+          //width: collapsed ? CollapsedStatusBarWidthInPx : StatusBarWidthInPx,
+          width: StatusBarWidthInPx,
         }}
       >
         <Box sx={{ cursor: 'pointer', my: 2, mx: collapsed ? 0 : 1 }}>
           {collapsed ? (
             <FontAwesomeIcon
-              icon={faChevronLeft}
+              icon={faChevronDown}
               onClick={expandWorkflowStatusbar}
             />
           ) : (
             <FontAwesomeIcon
-              icon={faChevronRight}
+              icon={faChevronUp}
               onClick={collapseWorkflowStatusBar}
             />
           )}

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -56,17 +56,21 @@ type WorkflowStatusItem = {
 };
 
 interface ActiveWorkflowStatusTabProps {
+  setActiveWorkflowStatusTab: (tab: WorkflowStatusTabs) => void;
   activeWorkflowStatusTab: string;
   listItems: WorkflowStatusItem[];
 }
 
 export const StatusBarHeaderHeightInPx = 50;
+//export const StatusBarHeaderHeightInPx = 82;
 export const CollapsedStatusBarWidthInPx = 75;
-export const StatusBarWidthInPx = 400;
+export const StatusBarWidthInPx = 432;
+export const StatusBarListHeightInPx = 800;
 
 const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
   activeWorkflowStatusTab,
   listItems,
+  setActiveWorkflowStatusTab,
 }) => {
   const openSideSheetState = useSelector(
     (state: RootState) => state.openSideSheetReducer
@@ -120,7 +124,9 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
       sx={{
         width: `${StatusBarWidthInPx}px`,
         maxWidth: `${StatusBarWidthInPx}px`,
-        height: `calc(100% - ${StatusBarHeaderHeightInPx}px)`,
+        //height: `calc(100% - ${StatusBarHeaderHeightInPx}px)`,
+        height: `${StatusBarListHeightInPx}px`,
+        //overflowY: 'none',
         overflowX: 'auto',
         backgroundColor: 'white',
       }}
@@ -160,6 +166,11 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
                 onClick={() => {
                   if (listItem.nodeId && listItem.type) {
                     switchSideSheet(listItem.nodeId, listItem.type);
+                    //const collapseWorkflowStatusBar = (event: React.MouseEvent) => {
+                    //  event.preventDefault();
+                    dispatch(setWorkflowStatusBarOpenState(false));
+                    setActiveWorkflowStatusTab(WorkflowStatusTabs.Collapsed);
+                    //};
                   }
                 }}
               >
@@ -513,8 +524,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   console.log('collapsed: ', collapsed);
 
   const statusBarIconStyles = {
-    mx: collapsed ? 0 : 1,
-    //mx: 1,
+    //mx: collapsed ? 0 : 1,
+    mx: 1,
     py: 1,
     //width: collapsed ? '100%' : '40px',
     width: '40px',
@@ -527,18 +538,19 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
     <Box
       sx={{
         position: 'absolute',
-        bottom: 0,
+        left: '700px',
+        //bottom: 0,
         top: '110px',
-        right: '40%',
-        height: collapsed ? `${StatusBarHeaderHeightInPx}px` : '100%',
+        //right: '40%',
+        height: collapsed ? `${StatusBarHeaderHeightInPx}px` : `${StatusBarListHeightInPx}px`,
+        //zIndex: collapsed ? null : 10,
         zIndex: 10,
         borderTop: '0px',
-        borderLeft: '1px',
+        //borderLeft: '1px',
         borderRight: '0px',
         borderBottom: '0px',
-        borderColor: theme.palette.gray['500'],
-        borderStyle: 'solid',
-        backgroundColor: theme.palette.gray['100'],
+        //borderColor: theme.palette.gray['500'],
+        //borderStyle: 'solid',
       }}
     >
       <Box
@@ -554,13 +566,14 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           ml: 0,
           //py: collapsed ? 0 : 1,
           py: 1,
-          height: collapsed ? undefined : `${StatusBarHeaderHeightInPx}px`,
+          height: `${StatusBarHeaderHeightInPx}px`,
           //height: `${StatusBarHeaderHeightInPx}px`,
           //width: collapsed ? CollapsedStatusBarWidthInPx : StatusBarWidthInPx,
           width: StatusBarWidthInPx,
+          backgroundColor: theme.palette.gray['100'],
         }}
       >
-        <Box sx={{ cursor: 'pointer', my: 2, mx: collapsed ? 0 : 1 }}>
+        <Box sx={{ cursor: 'pointer', my: 2, mx: 1 }}>
           {collapsed ? (
             <FontAwesomeIcon
               icon={faChevronDown}
@@ -658,6 +671,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
       <ActiveWorkflowStatusTab
         activeWorkflowStatusTab={activeWorkflowStatusTab}
         listItems={listItems}
+        setActiveWorkflowStatusTab={setActiveWorkflowStatusTab}
       />
     </Box>
   );

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -60,7 +60,6 @@ interface ActiveWorkflowStatusTabProps {
 }
 
 export const StatusBarHeaderHeightInPx = 41;
-//export const StatusBarHeaderHeightInPx = 82;
 export const CollapsedStatusBarWidthInPx = 75;
 export const StatusBarWidthInPx = 432;
 export const StatusBarListHeightInPx = 800;
@@ -121,10 +120,8 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
     <Box
       sx={{
         width: `${StatusBarWidthInPx}px`,
-        //height: `calc(100% - ${StatusBarHeaderHeightInPx}px)`,
         height: `${StatusBarListHeightInPx - StatusBarHeaderHeightInPx}px`,
         overflowY: 'scroll',
-        //overflowX: 'auto',
         backgroundColor: 'white',
       }}
     >
@@ -137,7 +134,6 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
               flexDirection: 'row',
               width: '100%',
               backgroundColor: 'white',
-              //p: 2,
               borderBottom: `1px solid`,
               borderColor: 'gray.500',
               alignItems: 'start',
@@ -148,7 +144,6 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
             </Box>
             <Box
               sx={{
-                //marginLeft: 2,
                 display: 'flex',
                 flexDirection: 'column',
                 verticalAlign: 'middle',
@@ -166,11 +161,8 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
                 onClick={() => {
                   if (listItem.nodeId && listItem.type) {
                     switchSideSheet(listItem.nodeId, listItem.type);
-                    //const collapseWorkflowStatusBar = (event: React.MouseEvent) => {
-                    //  event.preventDefault();
                     dispatch(setWorkflowStatusBarOpenState(false));
                     setActiveWorkflowStatusTab(WorkflowStatusTabs.Collapsed);
-                    //};
                   }
                 }}
               >
@@ -525,10 +517,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   console.log('collapsed: ', collapsed);
 
   const statusBarIconStyles = {
-    //mx: collapsed ? 0 : 1,
     mx: 1,
     py: 1,
-    //width: collapsed ? '100%' : '40px',
     width: '40px',
     cursor: 'pointer',
     alignItems: 'start',
@@ -540,42 +530,25 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
       sx={{
         position: 'absolute',
         left: '700px',
-        //bottom: 0,
         top: '123px',
-        //right: '40%',
         height: collapsed
           ? `${StatusBarHeaderHeightInPx}px`
           : `${StatusBarListHeightInPx}px`,
-        //zIndex: collapsed ? null : 10,
         zIndex: 10,
         border: `1px solid ${theme.palette.gray['500']}`,
-        //borderColor: theme.palette.gray['500'],
-        //borderStyle: 'solid',
         borderRadius: '8px',
-        //borderStyle: 'solid',
-        //borderColor: theme.palette.gray['700'],
       }}
     >
       <Box
         sx={{
           display: 'flex',
-          //flexDirection: collapsed ? 'column' : 'row',
           flexDirection: 'row',
-          //alignItems: collapsed ? 'start' : 'center',
           alignItems: 'center',
           justifyContent: 'space-evenly',
-          //px: collapsed ? 1 : 0,
           px: 0,
-          //ml: collapsed ? 1 : 0,
           ml: 0,
-          //py: collapsed ? 0 : 1,
-          //py: 1,
           height: `${StatusBarHeaderHeightInPx}px`,
-          //height: `${StatusBarHeaderHeightInPx}px`,
-          //width: collapsed ? CollapsedStatusBarWidthInPx : StatusBarWidthInPx,
           width: StatusBarWidthInPx,
-          //backgroundColor: theme.palette.gray['100'],
-          //backgroundColor: 'white'
           borderBottom: collapsed
             ? null
             : `1px solid ${theme.palette.gray['500']}`,

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -61,7 +61,7 @@ interface ActiveWorkflowStatusTabProps {
   listItems: WorkflowStatusItem[];
 }
 
-export const StatusBarHeaderHeightInPx = 50;
+export const StatusBarHeaderHeightInPx = 41;
 //export const StatusBarHeaderHeightInPx = 82;
 export const CollapsedStatusBarWidthInPx = 75;
 export const StatusBarWidthInPx = 432;
@@ -123,11 +123,10 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
     <Box
       sx={{
         width: `${StatusBarWidthInPx}px`,
-        maxWidth: `${StatusBarWidthInPx}px`,
         //height: `calc(100% - ${StatusBarHeaderHeightInPx}px)`,
-        height: `${StatusBarListHeightInPx}px`,
-        //overflowY: 'none',
-        overflowX: 'auto',
+        height: `${StatusBarListHeightInPx - StatusBarHeaderHeightInPx}px`,
+        overflowY: 'scroll',
+        //overflowX: 'auto',
         backgroundColor: 'white',
       }}
     >
@@ -140,19 +139,22 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
               flexDirection: 'row',
               width: '100%',
               backgroundColor: 'white',
-              p: 2,
+              //p: 2,
               borderBottom: `1px solid`,
               borderColor: 'gray.500',
               alignItems: 'start',
             }}
           >
-            {listItem ? workflowStatusIcons[listItem.level] : null}
+            <Box sx={{ marginLeft: '8px', marginTop: '16px' }}>
+              {listItem ? workflowStatusIcons[listItem.level] : null}
+            </Box>
             <Box
               sx={{
-                mx: 2,
+                //marginLeft: 2,
                 display: 'flex',
                 flexDirection: 'column',
                 verticalAlign: 'middle',
+                padding: 2,
               }}
             >
               <Typography
@@ -540,17 +542,17 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         position: 'absolute',
         left: '700px',
         //bottom: 0,
-        top: '110px',
+        top: '123px',
         //right: '40%',
         height: collapsed ? `${StatusBarHeaderHeightInPx}px` : `${StatusBarListHeightInPx}px`,
         //zIndex: collapsed ? null : 10,
         zIndex: 10,
-        borderTop: '0px',
-        //borderLeft: '1px',
-        borderRight: '0px',
-        borderBottom: '0px',
+        border: `1px solid ${theme.palette.gray['500']}`,
         //borderColor: theme.palette.gray['500'],
         //borderStyle: 'solid',
+        borderRadius: '8px',
+        //borderStyle: 'solid',
+        //borderColor: theme.palette.gray['700'],
       }}
     >
       <Box
@@ -560,33 +562,22 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           flexDirection: 'row',
           //alignItems: collapsed ? 'start' : 'center',
           alignItems: 'center',
+          justifyContent: 'space-evenly',
           //px: collapsed ? 1 : 0,
           px: 0,
           //ml: collapsed ? 1 : 0,
           ml: 0,
           //py: collapsed ? 0 : 1,
-          py: 1,
+          //py: 1,
           height: `${StatusBarHeaderHeightInPx}px`,
           //height: `${StatusBarHeaderHeightInPx}px`,
           //width: collapsed ? CollapsedStatusBarWidthInPx : StatusBarWidthInPx,
           width: StatusBarWidthInPx,
-          backgroundColor: theme.palette.gray['100'],
+          //backgroundColor: theme.palette.gray['100'],
+          //backgroundColor: 'white'
+          borderBottom: collapsed ? null : `1px solid ${theme.palette.gray['500']}`,
         }}
       >
-        <Box sx={{ cursor: 'pointer', my: 2, mx: 1 }}>
-          {collapsed ? (
-            <FontAwesomeIcon
-              icon={faChevronDown}
-              onClick={expandWorkflowStatusbar}
-            />
-          ) : (
-            <FontAwesomeIcon
-              icon={faChevronUp}
-              onClick={collapseWorkflowStatusBar}
-            />
-          )}
-        </Box>
-
         <Box
           onClick={() => selectTab(WorkflowStatusTabs.Errors)}
           sx={{
@@ -647,24 +638,40 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           <Typography sx={{ ml: 1 }}>{numWorkflowLogs}</Typography>
         </Box>
 
-        <Box
-          onClick={() => selectTab(WorkflowStatusTabs.Checks)}
-          sx={{
-            ...statusBarIconStyles,
-            color:
-              activeWorkflowStatusTab === WorkflowStatusTabs.Checks
-                ? theme.palette.green['500']
-                : theme.palette.green['400'],
-            borderBottom:
-              activeWorkflowStatusTab === WorkflowStatusTabs.Checks
-                ? `2px solid ${theme.palette.green['500']}`
-                : '', // green500
-            '&:hover': { color: theme.palette.green['500'] },
-            fontSize: '20px',
-          }}
-        >
-          <FontAwesomeIcon icon={faCircleCheck} />
-          <Typography sx={{ ml: 1 }}>{numWorkflowChecksPassed}</Typography>
+        <Box>
+          <Box
+            onClick={() => selectTab(WorkflowStatusTabs.Checks)}
+            sx={{
+              ...statusBarIconStyles,
+              color:
+                activeWorkflowStatusTab === WorkflowStatusTabs.Checks
+                  ? theme.palette.green['500']
+                  : theme.palette.green['400'],
+              borderBottom:
+                activeWorkflowStatusTab === WorkflowStatusTabs.Checks
+                  ? `2px solid ${theme.palette.green['500']}`
+                  : '', // green500
+              '&:hover': { color: theme.palette.green['500'] },
+              fontSize: '20px',
+            }}
+          >
+            <FontAwesomeIcon icon={faCircleCheck} />
+            <Typography sx={{ ml: 1 }}>{numWorkflowChecksPassed}</Typography>
+          </Box>
+        </Box>
+
+        <Box sx={{ cursor: 'pointer', my: 2, mx: 1 }}>
+          {collapsed ? (
+            <FontAwesomeIcon
+              icon={faChevronDown}
+              onClick={expandWorkflowStatusbar}
+            />
+          ) : (
+            <FontAwesomeIcon
+              icon={faChevronUp}
+              onClick={collapseWorkflowStatusBar}
+            />
+          )}
         </Box>
       </Box>
 

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -1,7 +1,5 @@
 import {
   faChevronDown,
-  faChevronLeft,
-  faChevronRight,
   faChevronUp,
   faCircleCheck,
   faCircleExclamation,
@@ -465,8 +463,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;
@@ -544,7 +543,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         //bottom: 0,
         top: '123px',
         //right: '40%',
-        height: collapsed ? `${StatusBarHeaderHeightInPx}px` : `${StatusBarListHeightInPx}px`,
+        height: collapsed
+          ? `${StatusBarHeaderHeightInPx}px`
+          : `${StatusBarListHeightInPx}px`,
         //zIndex: collapsed ? null : 10,
         zIndex: 10,
         border: `1px solid ${theme.palette.gray['500']}`,
@@ -575,7 +576,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           width: StatusBarWidthInPx,
           //backgroundColor: theme.palette.gray['100'],
           //backgroundColor: 'white'
-          borderBottom: collapsed ? null : `1px solid ${theme.palette.gray['500']}`,
+          borderBottom: collapsed
+            ? null
+            : `1px solid ${theme.palette.gray['500']}`,
         }}
       >
         <Box

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -455,9 +455,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;
@@ -514,7 +513,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   };
 
   const collapsed = activeWorkflowStatusTab === WorkflowStatusTabs.Collapsed;
-  console.log('collapsed: ', collapsed);
 
   const statusBarIconStyles = {
     mx: 1,
@@ -544,7 +542,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',
-          justifyContent: 'space-evenly',
           px: 0,
           ml: 0,
           height: `${StatusBarHeaderHeightInPx}px`,
@@ -568,6 +565,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
                 : '', // red600
             '&:hover': { color: theme.palette.red['600'] },
             fontSize: '20px',
+            marginRight: 4,
+            marginLeft: 2,
           }}
         >
           <FontAwesomeIcon icon={faCircleExclamation} />
@@ -588,6 +587,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
                 : '', // orange600
             '&:hover': { color: theme.palette.orange['600'] },
             fontSize: '20px',
+            marginRight: 4,
           }}
         >
           <FontAwesomeIcon icon={faTriangleExclamation} />
@@ -608,6 +608,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
                 : '', // blue500
             '&:hover': { color: theme.palette.blue['500'] },
             fontSize: '20px',
+            marginRight: 4,
           }}
         >
           <FontAwesomeIcon icon={faCircleInfo} />
@@ -629,6 +630,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
                   : '', // green500
               '&:hover': { color: theme.palette.green['500'] },
               fontSize: '20px',
+              marginRight: 4,
             }}
           >
             <FontAwesomeIcon icon={faCircleCheck} />
@@ -636,7 +638,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           </Box>
         </Box>
 
-        <Box sx={{ cursor: 'pointer', my: 2, mx: 1 }}>
+        <Box sx={{ cursor: 'pointer', my: 2, marginLeft: 'auto', marginRight: 2 }}>
           {collapsed ? (
             <FontAwesomeIcon
               icon={faChevronDown}

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -455,8 +455,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;
@@ -638,7 +639,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
           </Box>
         </Box>
 
-        <Box sx={{ cursor: 'pointer', my: 2, marginLeft: 'auto', marginRight: 2 }}>
+        <Box
+          sx={{ cursor: 'pointer', my: 2, marginLeft: 'auto', marginRight: 2 }}
+        >
           {collapsed ? (
             <FontAwesomeIcon
               icon={faChevronDown}

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -10,7 +10,6 @@ import TextField from '@mui/material/TextField';
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSelector } from 'react-redux';
-import { WorkflowStatusBar } from './StatusBar';
 
 import { RootState } from '../../stores/store';
 import style from '../../styles/markdown.module.css';
@@ -19,6 +18,7 @@ import { getNextUpdateTime } from '../../utils/cron';
 import { WorkflowDag, WorkflowUpdateTrigger } from '../../utils/workflows';
 import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
+import { WorkflowStatusBar } from './StatusBar';
 import VersionSelector from './version_selector';
 import WorkflowSettings from './WorkflowSettings';
 import Status from './workflowStatus';
@@ -58,7 +58,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-    WorkflowUpdateTrigger.Periodic &&
+      WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -10,6 +10,7 @@ import TextField from '@mui/material/TextField';
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSelector } from 'react-redux';
+import { WorkflowStatusBar } from './StatusBar';
 
 import { RootState } from '../../stores/store';
 import style from '../../styles/markdown.module.css';
@@ -57,7 +58,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-      WorkflowUpdateTrigger.Periodic &&
+    WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(
@@ -218,10 +219,6 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
         {workflow.dagResults && workflow.dagResults.length > 0 && (
           <VersionSelector />
         )}
-
-        {/* NOTE: Funnyily enough, `size=large` on a button is what
-                    makes it match the size of the `FormControl` when set to
-                    small. Go figure. */}
         <Button
           color="primary"
           sx={{ height: '100%' }}
@@ -231,6 +228,9 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
           <FontAwesomeIcon icon={faPlay} />
           <Typography sx={{ ml: 1 }}>Run Workflow</Typography>
         </Button>
+
+        <WorkflowStatusBar user={user} />
+
         {runWorkflowDialog}
       </Box>
 

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -184,7 +184,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag }) => {
           <Status status={workflow.dagResults[0].status} />
         </Box>
 
-        <Box sx={{ ml: 2 }}>
+        <Box sx={{ mr: 4 }}>
           <Button
             variant="outlined"
             color="primary"

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -1,6 +1,6 @@
 import { useAqueductConsts } from '../components/hooks/useAqueductConsts';
 import UserProfile from './auth';
-import { Error, ExecState, ExecutionStatus } from './shared';
+import { ExecState, ExecutionStatus } from './shared';
 
 export enum OperatorType {
   Function = 'function',


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR takes the workflow status bar that was on the right side of the workflow details screen and turns it into a popover which is now located in the workflow header.

## Related issue number (if any)
ENG-1599

## Loom Demo:
https://www.loom.com/share/b0407dcc1195480f834204b41705c35a

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


