### PR TITLE
Update on Eng 1516 according to feedback

### DIFF
--- a/src/ui/common/src/components/integrations/cards/detailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/detailCard.tsx
@@ -62,35 +62,13 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
     default:
       serviceCard = null;
   }
-
-  if (
-    integration.service === 'Kubernetes' ||
-    integration.service === 'Lambda'
-  ) {
-    return (
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          width: '900px',
-        }}
-      >
-        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-          <img
-            height="45px"
-            src={SupportedIntegrations[integration.service].logo}
-          />
-          <Box sx={{ ml: 3 }}>
-            <Box display="flex" flexDirection="row">
-              <Typography sx={{ fontFamily: 'Monospace' }} variant="h4">
-                {integration.name}
-              </Typography>
-            </Box>
-            {serviceCard}
-          </Box>
-        </Box>
-      </Box>
-    );
+  let createdOnText = null;
+  if (integration.service !== 'Kubernetes' && integration.service !== 'Lambda') {
+    createdOnText = 
+      (<Typography variant="body1">
+        <strong>Created On: </strong>
+        {new Date(integration.createdAt * 1000).toLocaleString()}
+      </Typography>)
   }
 
   return (
@@ -113,11 +91,8 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
             </Typography>
           </Box>
 
-          <Typography variant="body1">
-            <strong>Created On: </strong>
-            {new Date(integration.createdAt * 1000).toLocaleString()}
-          </Typography>
-
+          {createdOnText}
+          
           {serviceCard}
         </Box>
       </Box>

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -249,14 +249,6 @@ const IntegrationDialog: React.FC<Props> = ({
         />
       );
       break;
-    case 'Lambda':
-      serviceDialog = (
-        <LambdaDialog
-          onUpdateField={setConfigField}
-          value={config as LambdaConfig}
-        />
-      );
-      break;
     case 'SQLite':
       serviceDialog = (
         <SQLiteDialog

--- a/src/ui/common/src/components/integrations/integrationObjectList.tsx
+++ b/src/ui/common/src/components/integrations/integrationObjectList.tsx
@@ -58,7 +58,26 @@ const IntegrationObjectList: React.FC<Props> = ({ user, integration }) => {
     integration.service === 'Kubernetes' ||
     integration.service === 'Lambda'
   ) {
-    return null;
+    return (
+      <Alert severity="warning" sx={{ width: '80%', mt: 4 }}>
+        <>
+          We currently do not support listing data in this integration. But
+          don&apos;t worry&mdash;we&apos;re working on adding this feature! If
+          you have questions, comments or would like to learn more about what
+          we&apos;re building, please{' '}
+        </>
+        <Link href="mailto:hello@aqueducthq.com">reach out</Link>
+        <>, </>
+        <Link href="https://join.slack.com/t/aqueductusers/shared_invite/zt-11hby91cx-cpmgfK0qfXqEYXv25hqD6A">
+          join our Slack channel
+        </Link>
+        <>, or </>
+        <Link href="https://github.com/aqueducthq/aqueduct/issues/new">
+          start a conversation on GitHub channel
+        </Link>
+        <>.</>
+      </Alert>
+    );
   }
 
   if (integration.service === 'S3') {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR addresses some feedback for the lambda configuration integration and updates the following:
1. delete duplicate dialog switch-case statement.
2. simplify the code for detail card when it comes to K8s and Lambda.
3. add alert statement according to feedback when navigating to k8s/lambda detail card instead of having null. The updated look is below, let me know if this is what you have in mind:
<img width="1135" alt="Screen Shot 2022-09-14 at 10 26 44 PM" src="https://user-images.githubusercontent.com/78303449/190321578-5fd9b118-bb64-4f38-a628-6880f54b0c3b.png">

## Related issue number (if any)
Eng 1516
## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


