### PR TITLE
Enable different artifact type to produce meaningful outputs when calling describe()

### DIFF
--- a/sdk/aqueduct/artifacts/bool_artifact.py
+++ b/sdk/aqueduct/artifacts/bool_artifact.py
@@ -8,7 +8,9 @@ import numpy as np
 from aqueduct.artifacts import utils as artifact_utils
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
+from aqueduct.enums import OperatorType
 from aqueduct.error import ArtifactNeverComputedException
+from aqueduct.operators import get_operator_type
 from aqueduct.utils import format_header_for_print, get_description_for_check
 
 
@@ -93,7 +95,7 @@ class BoolArtifact(BaseArtifact):
 
         readable_dict = super()._describe()
         if get_operator_type(input_operator) is OperatorType.CHECK:
-            general_dict = get_description_for_check(input_operator, self._dag)
+            general_dict = get_description_for_check(input_operator)
             # Remove because values already in `readable_dict`
             general_dict.pop("Label")
             general_dict.pop("Granularity")

--- a/sdk/aqueduct/artifacts/bool_artifact.py
+++ b/sdk/aqueduct/artifacts/bool_artifact.py
@@ -91,14 +91,14 @@ class BoolArtifact(BaseArtifact):
         """Prints out a human-readable description of the bool artifact."""
         input_operator = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
 
-        general_dict = get_description_for_check(input_operator)
-
-        # Remove because values already in `readable_dict`
-        general_dict.pop("Label")
-        general_dict.pop("Level")
-
         readable_dict = super()._describe()
-        readable_dict.update(general_dict)
+        if get_operator_type(input_operator) is OperatorType.CHECK:
+            general_dict = get_description_for_check(input_operator, self._dag)
+            # Remove because values already in `readable_dict`
+            general_dict.pop("Label")
+            general_dict.pop("Granularity")
+            readable_dict.update(general_dict)
+
         readable_dict["Inputs"] = [
             self._dag.must_get_artifact(artf).name for artf in input_operator.inputs
         ]

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import uuid
 import json
+import uuid
 from typing import Any, Dict, Optional
 
 from aqueduct.artifacts import utils as artifact_utils

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+import json
 from typing import Any, Dict, Optional
 
 from aqueduct.artifacts import utils as artifact_utils
@@ -8,6 +9,7 @@ from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.dag import DAG
 from aqueduct.enums import ArtifactType, ExecutionStatus
 from aqueduct.error import ArtifactNeverComputedException
+from aqueduct.utils import format_header_for_print
 
 
 class GenericArtifact(BaseArtifact):
@@ -82,5 +84,10 @@ class GenericArtifact(BaseArtifact):
 
     def describe(self) -> None:
         """Prints out a human-readable description of the bool artifact."""
-        # TODO: make this more informative.
-        print("This is a %s artifact." % self._get_type())
+        input_operator = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
+        readable_dict = super()._describe()
+        readable_dict["Inputs"] = [
+            self._dag.must_get_artifact(artf).name for artf in input_operator.inputs
+        ]
+        print(format_header_for_print(f"'{input_operator.name}' {self._get_type()} Artifact"))
+        print(json.dumps(readable_dict, sort_keys=False, indent=4))

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -21,9 +21,10 @@ from aqueduct.enums import (
     ExecutionMode,
     FunctionGranularity,
     FunctionType,
+    OperatorType,
 )
 from aqueduct.error import AqueductError, ArtifactNeverComputedException
-from aqueduct.operators import CheckSpec, FunctionSpec, Operator, OperatorSpec
+from aqueduct.operators import CheckSpec, FunctionSpec, Operator, OperatorSpec, get_operator_type
 from aqueduct.utils import (
     artifact_name_from_op_name,
     format_header_for_print,
@@ -302,15 +303,14 @@ class NumericArtifact(BaseArtifact):
 
     def _describe(self) -> Dict[str, Any]:
         input_operator = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
-
-        general_dict = get_description_for_metric(input_operator, self._dag)
-
-        # Remove because values already in `readable_dict`
-        general_dict.pop("Label")
-        general_dict.pop("Granularity")
-
         readable_dict = super()._describe()
-        readable_dict.update(general_dict)
+        if get_operator_type(input_operator) is OperatorType.METRIC:
+            general_dict = get_description_for_metric(input_operator, self._dag)
+            # Remove because values already in `readable_dict`
+            general_dict.pop("Label")
+            general_dict.pop("Granularity")
+            readable_dict.update(general_dict)
+
         readable_dict["Inputs"] = [
             self._dag.must_get_artifact(artf).name for artf in input_operator.inputs
         ]


### PR DESCRIPTION
We add a missing describe for the generic artifact and fix some assumptions about the describe in previous numeric and boolean artifacts where they can be an output of an `@op` decorator as well as metrics/checks.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


