### PR TITLE
Fix bug where the parameter value is too large to be passed to the python operators

### DIFF
--- a/sdk/aqueduct/serialization.py
+++ b/sdk/aqueduct/serialization.py
@@ -89,12 +89,10 @@ def serialize_val(val: Any, serialization_type: SerializationType) -> str:
 
 
 def _bytes_to_base64_string(content: bytes) -> str:
-    """Helper to convert any bytes-type to a string, by first encoding it with base64 it.
+    """Helper to convert bytes to a base64-string.
 
     For example, image-serialized bytes are not `utf8` encoded, so if we want to convert
     such bytes to string, we must use this function.
-
-    To convert this string back to bytes, use `base64_string_to_bytes()` in the aqueduct_executor.
     """
     return base64.b64encode(content).decode(_DEFAULT_ENCODING)
 

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	operator_db "github.com/aqueducthq/aqueduct/lib/collections/operator"
+	"github.com/aqueducthq/aqueduct/lib/collections/operator/param"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/collections/user"
@@ -169,7 +170,7 @@ func (eng *aqEngine) ExecuteWorkflow(
 	ctx context.Context,
 	workflowId uuid.UUID,
 	timeConfig *AqueductTimeConfig,
-	parameters map[string]string,
+	parameters map[string]param.Param,
 ) (shared.ExecutionStatus, error) {
 	dbWorkflowDag, err := workflow_utils.ReadLatestWorkflowDagFromDatabase(
 		ctx,
@@ -249,7 +250,8 @@ func (eng *aqEngine) ExecuteWorkflow(
 		return shared.FailedExecutionStatus, errors.Wrap(err, "Error updating workflowDag to latest.")
 	}
 
-	for name, newVal := range parameters {
+	// Overwrite the parameter specs for all custom parameters defined by the user.
+	for name, param := range parameters {
 		op := dbWorkflowDag.GetOperatorByName(name)
 		if op == nil {
 			continue
@@ -257,7 +259,8 @@ func (eng *aqEngine) ExecuteWorkflow(
 		if !op.Spec.IsParam() {
 			return shared.FailedExecutionStatus, errors.Wrap(err, "Cannot set parameters on a non-parameter operator.")
 		}
-		dbWorkflowDag.Operators[op.Id].Spec.Param().Val = newVal
+		dbWorkflowDag.Operators[op.Id].Spec.Param().Val = param.Val
+		dbWorkflowDag.Operators[op.Id].Spec.Param().SerializationType = param.SerializationType
 	}
 	engineConfig, err := generateJobManagerConfig(ctx, dbWorkflowDag, eng.AqPath, eng.Vault)
 	if err != nil {
@@ -666,7 +669,7 @@ func (eng *aqEngine) TriggerWorkflow(
 	workflowId uuid.UUID,
 	name string,
 	timeConfig *AqueductTimeConfig,
-	parameters map[string]string,
+	parameters map[string]param.Param,
 ) (shared.ExecutionStatus, error) {
 	jobManager, err := job.NewProcessJobManager(
 		&job.ProcessConfig{

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -749,8 +749,11 @@ func (eng *aqEngine) execute(
 		for _, op := range inProgressOps {
 			execState, err := op.Poll(ctx)
 			if err != nil {
+				log.Errorf("HELLO: error!!")
 				return err
 			}
+
+			log.Errorf("HELLO: status %s", execState.Status)
 
 			if execState.Status == shared.PendingExecutionStatus {
 				err = op.Launch(ctx)
@@ -773,7 +776,6 @@ func (eng *aqEngine) execute(
 					return errors.Wrapf(err, "Error when finishing execution of operator %s", op.Name())
 				}
 			}
-
 			// We can continue orchestration on non-fatal errors; currently, this only allows through succeeded operators
 			// and check operators with warning severity.
 			if shouldStopExecution(execState) {

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -149,7 +149,6 @@ type FunctionSpec struct {
 
 type ParamSpec struct {
 	BasePythonSpec
-	Val                string           `json:"val"  yaml:"val"`
 	ExpectedType       db_artifact.Type `json:"expected_type" yaml:"expected_type"`
 	SerializationType  string           `json:"serialization_type" yaml:"serialization_type"`
 	OutputContentPath  string           `json:"output_content_path"  yaml:"output_content_path"`

--- a/src/golang/lib/workflow/operator/param.go
+++ b/src/golang/lib/workflow/operator/param.go
@@ -2,9 +2,10 @@ package operator
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
-
 	"github.com/aqueducthq/aqueduct/lib/job"
+	"github.com/aqueducthq/aqueduct/lib/storage"
 	"github.com/google/uuid"
 )
 
@@ -30,6 +31,22 @@ func newParamOperator(
 		return nil, errWrongNumOutputs
 	}
 
+	// Write the parameter's value from the spec to the output content path.
+	// This is to avoid passing raw values in the spec, which can be of unbounded
+	// size (eg. images can be too large).
+	paramValBytes, err := base64.StdEncoding.DecodeString(base.dbOperator.Spec.Param().Val)
+	if err != nil {
+		return nil, err
+	}
+	err = storage.NewStorage(base.storageConfig).Put(
+		context.TODO(),
+		base.outputExecPaths[0].ArtifactContentPath,
+		paramValBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &paramOperatorImpl{
 		base,
 	}, nil
@@ -43,7 +60,6 @@ func (po *paramOperatorImpl) JobSpec() job.Spec {
 			*po.storageConfig,
 			po.metadataPath,
 		),
-		Val:               po.dbOperator.Spec.Param().Val,
 		ExpectedType:      po.outputs[0].Type(),
 		SerializationType: po.dbOperator.Spec.Param().SerializationType,
 

--- a/src/golang/lib/workflow/operator/param.go
+++ b/src/golang/lib/workflow/operator/param.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/aqueducthq/aqueduct/lib/storage"
 	"github.com/google/uuid"

--- a/src/python/aqueduct_executor/operators/param_executor/spec.py
+++ b/src/python/aqueduct_executor/operators/param_executor/spec.py
@@ -20,7 +20,6 @@ class ParamSpec(BaseModel):
     metadata_path: str
     expected_type: ArtifactType
     serialization_type: SerializationType
-    val: str
     output_content_path: str
     output_metadata_path: str
 

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -1,7 +1,7 @@
 import base64
 import io
 import json
-from typing import Any, Callable, Dict, List, Tuple, Union, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import cloudpickle as pickle
 import numpy as np
@@ -217,7 +217,6 @@ def write_artifact(
     output_metadata[_METADATA_SERIALIZATION_TYPE_KEY] = artifact_type_to_serialization_type(
         artifact_type, content
     ).value
-
 
     if output_path is not None:
         _serialization_function_mapping[output_metadata[_METADATA_SERIALIZATION_TYPE_KEY]](


### PR DESCRIPTION
## Describe your changes and why you are making these changes

During dag construction, we write the parameter value to a path and pass that path in through the spec. The parameter operator now expects that the output path has already been populated, and relegates itself to simply writing metadata and enforcing types.

This solution does not rely on any DB changes, but it does mean that for every run of a flow, we will write the parameter values to storage before calling orchestration.

@saurav-c to validate that this will work with airflow.

## Related issue number (if any)
ENG-1565

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


