### PR TITLE
Fixes Airflow syncing bug with API response limit

### DIFF
--- a/src/golang/lib/airflow/client.go
+++ b/src/golang/lib/airflow/client.go
@@ -39,7 +39,7 @@ func newClient(ctx context.Context, authConf auth.Config) (*client, error) {
 
 // getDagRuns returns all of the Airflow DAGRuns for the Airflow DAG specified.
 func (c *client) getDagRuns(dagId string) ([]airflow.DAGRun, error) {
-	limit := 100 // This is the max number of DAG runs that can be returned in each response.
+	limitPerFetch := 100 // This is the max number of DAG runs that can be returned in each response.
 	offset := 0
 	var dagRuns []airflow.DAGRun
 
@@ -50,7 +50,7 @@ func (c *client) getDagRuns(dagId string) ([]airflow.DAGRun, error) {
 			dagId,
 		).
 			OrderBy("start_date").
-			Limit(int32(limit)).
+			Limit(int32(limitPerFetch)).
 			Offset(int32(offset)).
 			Execute()
 		if err != nil {
@@ -63,7 +63,7 @@ func (c *client) getDagRuns(dagId string) ([]airflow.DAGRun, error) {
 		}
 
 		dagRuns = append(dagRuns, *dagRunsResp.DagRuns...)
-		offset += limit
+		offset += limitPerFetch
 	}
 
 	return dagRuns, nil


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where if there were more runs than the default Airflow API limit, they would never be synced with Aqueduct. This PR ensures that all DAG runs get synced from Airflow into Aqueduct.

It doesn't do anything to improve the performance of syncing since that would be more involved and can be implemented for a later release.

## Related issue number (if any)
ENG 1531

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


