### PR TITLE
Deletes extracted function file for all engines and execution status

### DIFF
--- a/src/dockerfiles/function/start-function-executor.sh
+++ b/src/dockerfiles/function/start-function-executor.sh
@@ -27,11 +27,5 @@ fi
 conda run -n $PYTHON_VERSION python3 -m aqueduct_executor.operators.function_executor.main --spec "$JOB_SPEC"
 EXIT_CODE=$?
 
-# Double check to make sure the path doesn't contain something dangerous.
-if [ ! -z "$FUNCTION_EXTRACT_PATH" -a "$FUNCTION_EXTRACT_PATH" != *"*"* ]
-then
-      rm -rf $FUNCTION_EXTRACT_PATH
-fi
-
 # Exit after cleanup, regardless of execution success / failure.
 exit $(($EXIT_CODE))

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -181,13 +181,14 @@ def handle_type_error_and_exit(
     utils.write_exec_state(storage, spec.metadata_path, exec_state)
     sys.exit(1)
 
+
 def _cleanup(spec: FunctionSpec) -> None:
     """
     Cleans up any temporary files created during function execution.
     """
     # Delete the extracted fn file if it exists and the file path is not
     # something dangerous
-    if spec.function_extract_path and spec.function_extract_path[-1] != '*':
+    if spec.function_extract_path and spec.function_extract_path[-1] != "*":
         shutil.rmtree(spec.function_extract_path)
 
 

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -295,11 +295,10 @@ def run(spec: FunctionSpec) -> None:
         )
         print(f"Failed with system error. Full Logs:\n{exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, exec_state)
-
+        sys.exit(1)
+    finally:
         # Perform any cleanup
         _cleanup(spec)
-
-        sys.exit(1)
 
 
 def run_with_setup(spec: FunctionSpec) -> None:

--- a/src/python/aqueduct_executor/start-function-executor.sh
+++ b/src/python/aqueduct_executor/start-function-executor.sh
@@ -23,11 +23,5 @@ fi
 python3 -m aqueduct_executor.operators.function_executor.main --spec "$JOB_SPEC"
 EXIT_CODE=$?
 
-# Double check to make sure the path doesn't contain something dangerous.
-if [ ! -z "$FUNCTION_EXTRACT_PATH" -a "$FUNCTION_EXTRACT_PATH" != *"*"* ]
-then
-      rm -rf $FUNCTION_EXTRACT_PATH
-fi
-
 # Exit after cleanup, regardless of execution success / failure.
 exit $(($EXIT_CODE))


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR ensures that the extracted function file is deleted for all engine types regardless of the execution status.
Previously, the file would not be deleted for Airflow execution if there was some failure.

## Related issue number (if any)
ENG 1496

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


## Test
- Tested manually that the fn file was deleted for an Airflow workflow and an Aqueduct workflow