### PR TITLE
Simplifies release versions for docker images

### DIFF
--- a/src/dockerfiles/Makefile
+++ b/src/dockerfiles/Makefile
@@ -1,4 +1,5 @@
 .DEFAULT_GOAL = all
+VERSION = 0.0.14
 
 # By default, turn off the Makefile practice of printing each command before
 # you run it.
@@ -6,105 +7,112 @@ ifndef VERBOSE
 .SILENT:
 endif
 
+# Building K8s Images
+build-k8s-system-images: build-function build-param build-system-metric
+
 build-function:
-	docker build . -t aqueducthq/function:0.0.14 -f function/function.dockerfile --no-cache
+	docker build . -t aqueducthq/function:$(VERSION) -f function/function.dockerfile --no-cache
 
 build-param:
-	docker build . -t aqueducthq/param:0.0.14 -f param/param.dockerfile --no-cache
+	docker build . -t aqueducthq/param:$(VERSION) -f param/param.dockerfile --no-cache
 
 build-system-metric:
-	docker build . -t aqueducthq/system-metric:0.0.14 -f system-metric/system-metric.dockerfile --no-cache
+	docker build . -t aqueducthq/system-metric:$(VERSION) -f system-metric/system-metric.dockerfile --no-cache
 
 build-base-connector:
-	docker build . -t aqueducthq/base_connector:0.0.14 -f connectors/base.dockerfile --no-cache
+	docker build . -t aqueducthq/base_connector:$(VERSION) -f connectors/base.dockerfile --no-cache
 
 build-connectors: build-athena-connector build-bigquery-connector build-mysql-connector \
 	build-postgres-connector build-s3-connector build-snowflake-connector build-sqlserver-connector
 
 build-athena-connector:
-	docker build . -t aqueducthq/athena-connector:0.0.14 -f connectors/athena.dockerfile --no-cache
+	docker build . -t aqueducthq/athena-connector:$(VERSION) -f connectors/athena.dockerfile --no-cache
 
 build-bigquery-connector:
-	docker build . -t aqueducthq/bigquery-connector:0.0.14 -f connectors/bigquery.dockerfile --no-cache
+	docker build . -t aqueducthq/bigquery-connector:$(VERSION) -f connectors/bigquery.dockerfile --no-cache
 
 build-mysql-connector:
-	docker build . -t aqueducthq/mysql-connector:0.0.14 -f connectors/mysql.dockerfile --no-cache
+	docker build . -t aqueducthq/mysql-connector:$(VERSION) -f connectors/mysql.dockerfile --no-cache
 
 build-postgres-connector:
-	docker build . -t aqueducthq/postgres-connector:0.0.14 -f connectors/postgres.dockerfile --no-cache
+	docker build . -t aqueducthq/postgres-connector:$(VERSION) -f connectors/postgres.dockerfile --no-cache
 
 build-s3-connector:
-	docker build . -t aqueducthq/s3-connector:0.0.14 -f connectors/s3.dockerfile --no-cache
+	docker build . -t aqueducthq/s3-connector:$(VERSION) -f connectors/s3.dockerfile --no-cache
 
 build-snowflake-connector:
-	docker build . -t aqueducthq/snowflake-connector:0.0.14 -f connectors/snowflake.dockerfile --no-cache
+	docker build . -t aqueducthq/snowflake-connector:$(VERSION) -f connectors/snowflake.dockerfile --no-cache
 
 build-sqlserver-connector:
-	docker build . -t aqueducthq/sqlserver-connector:0.0.14 -f connectors/sqlserver.dockerfile --no-cache
+	docker build . -t aqueducthq/sqlserver-connector:$(VERSION) -f connectors/sqlserver.dockerfile --no-cache
 
-build-lambda-images: build-lambda-function build-lambda-param build-lambda-system-metric build-lambda-snowflake
+# Publishing K8s Images
+publish-k8s: publish-function publish-param publish-system-metric publish-connectors
+
+publish-function:
+	docker push aqueducthq/function:$(VERSION)
+
+publish-param:
+	docker push aqueducthq/param:$(VERSION)
+
+publish-system-metric:
+	docker push aqueducthq/system-metric:$(VERSION)
+
+publish-connectors:
+	docker push aqueducthq/athena-connector:$(VERSION)
+	docker push aqueducthq/bigquery-connector:$(VERSION)
+	docker push aqueducthq/mysql-connector:$(VERSION)
+	docker push aqueducthq/postgres-connector:$(VERSION)
+	docker push aqueducthq/s3-connector:$(VERSION)
+	docker push aqueducthq/snowflake-connector:$(VERSION)
+	docker push aqueducthq/sqlserver-connector:$(VERSION)
+
+# Building Lambda Images
+build-lambda-images: build-lambda-function build-lambda-param build-lambda-system-metric build-lambda-connectors
 
 build-lambda-connectors: build-lambda-snowflake build-lambda-athena build-lambda-bigquery \
 	build-lambda-postgres build-lambda-s3
 
 build-lambda-function:
-	docker build . -t aqueducthq/lambda-function-37:0.0.14 -f lambda/function/function37.dockerfile --no-cache
-	docker build . -t aqueducthq/lambda-function-38:0.0.14 -f lambda/function/function38.dockerfile --no-cache
-	docker build . -t aqueducthq/lambda-function-39:0.0.14 -f lambda/function/function39.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-function-37:$(VERSION) -f lambda/function/function37.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-function-38:$(VERSION) -f lambda/function/function38.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-function-39:$(VERSION) -f lambda/function/function39.dockerfile --no-cache
 
 build-lambda-param:
-	docker build . -t aqueducthq/lambda-param:0.0.14 -f lambda/param/param.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-param:$(VERSION) -f lambda/param/param.dockerfile --no-cache
 
 build-lambda-system-metric:
-	docker build . -t aqueducthq/lambda-system-metric:0.0.14 -f lambda/system-metric/system-metric.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-system-metric:$(VERSION) -f lambda/system-metric/system-metric.dockerfile --no-cache
 
 build-lambda-connectors: build-lambda-snowflake build-lambda-athena build-lambda-bigquery build-lambda-postgres build-lambda-s3
 
 build-lambda-snowflake:
-	docker build . -t aqueducthq/lambda-snowflake-connector:0.0.14 -f lambda/connectors/snowflake.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-snowflake-connector:$(VERSION) -f lambda/connectors/snowflake.dockerfile --no-cache
 
 build-lambda-athena:
-	docker build . -t aqueducthq/lambda-athena-connector:0.0.14 -f lambda/connectors/athena.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-athena-connector:$(VERSION) -f lambda/connectors/athena.dockerfile --no-cache
 
 build-lambda-bigquery:
-	docker build . -t aqueducthq/lambda-bigquery-connector:0.0.14 -f lambda/connectors/bigquery.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-bigquery-connector:$(VERSION) -f lambda/connectors/bigquery.dockerfile --no-cache
 
 build-lambda-postgres:
-	docker build . -t aqueducthq/lambda-postgres-connector:0.0.14 -f lambda/connectors/postgres.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-postgres-connector:$(VERSION) -f lambda/connectors/postgres.dockerfile --no-cache
 
 build-lambda-s3:
-	docker build . -t aqueducthq/lambda-s3-connector:0.0.14 -f lambda/connectors/s3.dockerfile --no-cache
+	docker build . -t aqueducthq/lambda-s3-connector:$(VERSION) -f lambda/connectors/s3.dockerfile --no-cache
 
-
-publish-function:
-	docker push aqueducthq/function:0.0.14
-
-publish-param:
-	docker push aqueducthq/param:0.0.14
-
-publish-system-metric:
-	docker push aqueducthq/system-metric:0.0.14
-
-publish-connectors:
-	docker push aqueducthq/athena-connector:0.0.14
-	docker push aqueducthq/bigquery-connector:0.0.14
-	docker push aqueducthq/mysql-connector:0.0.14
-	docker push aqueducthq/postgres-connector:0.0.14
-	docker push aqueducthq/s3-connector:0.0.14
-	docker push aqueducthq/snowflake-connector:0.0.14
-	docker push aqueducthq/sqlserver-connector:0.0.14
-
+# Publishing Lambda Images
 publish-lambda:
-	docker push aqueducthq/lambda-function-37:0.0.14
-	docker push aqueducthq/lambda-function-38:0.0.14
-	docker push aqueducthq/lambda-function-39:0.0.14
-	docker push aqueducthq/lambda-param:0.0.14
-	docker push aqueducthq/lambda-system-metric:0.0.14
-	docker push aqueducthq/lambda-athena-connector:0.0.14
-	docker push aqueducthq/lambda-bigquery-connector:0.0.14
-	docker push aqueducthq/lambda-postgres-connector:0.0.14
-	docker push aqueducthq/lambda-s3-connector:0.0.14
-	docker push aqueducthq/lambda-snowflake-connector:0.0.14
+	docker push aqueducthq/lambda-function-37:$(VERSION)
+	docker push aqueducthq/lambda-function-38:$(VERSION)
+	docker push aqueducthq/lambda-function-39:$(VERSION)
+	docker push aqueducthq/lambda-param:$(VERSION)
+	docker push aqueducthq/lambda-system-metric:$(VERSION)
+	docker push aqueducthq/lambda-athena-connector:$(VERSION)
+	docker push aqueducthq/lambda-bigquery-connector:$(VERSION)
+	docker push aqueducthq/lambda-postgres-connector:$(VERSION)
+	docker push aqueducthq/lambda-s3-connector:$(VERSION)
+	docker push aqueducthq/lambda-snowflake-connector:$(VERSION)
 
 .PHONY:
 

--- a/src/dockerfiles/Makefile
+++ b/src/dockerfiles/Makefile
@@ -8,7 +8,7 @@ ifndef VERBOSE
 endif
 
 # Building K8s Images
-build-k8s-system-images: build-function build-param build-system-metric
+build-k8s-system-images: build-function build-param build-system-metric build-base-connector
 
 build-function:
 	docker build . -t aqueducthq/function:$(VERSION) -f function/function.dockerfile --no-cache
@@ -69,9 +69,6 @@ publish-connectors:
 
 # Building Lambda Images
 build-lambda-images: build-lambda-function build-lambda-param build-lambda-system-metric build-lambda-connectors
-
-build-lambda-connectors: build-lambda-snowflake build-lambda-athena build-lambda-bigquery \
-	build-lambda-postgres build-lambda-s3
 
 build-lambda-function:
 	docker build . -t aqueducthq/lambda-function-37:$(VERSION) -f lambda/function/function37.dockerfile --no-cache

--- a/src/dockerfiles/function/py310_environment.yml
+++ b/src/dockerfiles/function/py310_environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - pydantic==1.9.0
   - pip:
     - scikit_learn==1.0.2
-    - aqueduct-ml
+    - aqueduct-ml==0.0.14

--- a/src/dockerfiles/function/py37_environment.yml
+++ b/src/dockerfiles/function/py37_environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - scikit_learn==1.0.2
     - typing_extensions==4.2.0
-    - aqueduct-ml
+    - aqueduct-ml==0.0.14

--- a/src/dockerfiles/function/py38_environment.yml
+++ b/src/dockerfiles/function/py38_environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - pydantic==1.9.0
   - pip:
     - scikit_learn==1.0.2
-    - aqueduct-ml
+    - aqueduct-ml==0.0.14

--- a/src/dockerfiles/function/py39_environment.yml
+++ b/src/dockerfiles/function/py39_environment.yml
@@ -13,4 +13,4 @@ dependencies:
   - pydantic==1.9.0
   - pip:
     - scikit_learn==1.0.2
-    - aqueduct-ml
+    - aqueduct-ml==0.0.14

--- a/src/dockerfiles/lambda/function/requirements-37.txt
+++ b/src/dockerfiles/lambda/function/requirements-37.txt
@@ -7,4 +7,4 @@ boto3==1.18.0
 pydantic==1.9.0
 scikit_learn==1.0.2
 typing_extensions==4.2.0
-aqueduct-ml
+aqueduct-ml==0.0.14

--- a/src/dockerfiles/lambda/requirements.txt
+++ b/src/dockerfiles/lambda/requirements.txt
@@ -6,4 +6,4 @@ pydantic==1.9.0
 pyyaml
 SQLAlchemy==1.4.30
 typing_extensions
-aqueduct-ml=0.0.14
+aqueduct-ml==0.0.14

--- a/src/golang/lib/job/constants.go
+++ b/src/golang/lib/job/constants.go
@@ -1,13 +1,14 @@
 package job
 
 const (
-	DefaultFunctionDockerImage           = "aqueducthq/function:0.0.14"
-	DefaultParameterDockerImage          = "aqueducthq/param:0.0.14"
-	DefaultSystemMetricDockerImage       = "aqueducthq/system-metric:0.0.14"
-	DefaultPostgresConnectorDockerImage  = "aqueducthq/postgres-connector:0.0.14"
-	DefaultSnowflakeConnectorDockerImage = "aqueducthq/snowflake-connector:0.0.14"
-	DefaultMySqlConnectorDockerImage     = "aqueducthq/mysql-connector:0.0.14"
-	DefaultSqlServerConnectorDockerImage = "aqueducthq/sqlserver-connector:0.0.14"
-	DefaultBigQueryConnectorDockerImage  = "aqueducthq/bigquery-connector:0.0.14"
-	DefaultS3ConnectorDockerImage        = "aqueducthq/s3-connector:0.0.14"
+	K8sImageVersionNumber                = "0.0.14"
+	DefaultFunctionDockerImage           = "aqueducthq/function"
+	DefaultParameterDockerImage          = "aqueducthq/param"
+	DefaultSystemMetricDockerImage       = "aqueducthq/system-metric"
+	DefaultPostgresConnectorDockerImage  = "aqueducthq/postgres-connector"
+	DefaultSnowflakeConnectorDockerImage = "aqueducthq/snowflake-connector"
+	DefaultMySqlConnectorDockerImage     = "aqueducthq/mysql-connector"
+	DefaultSqlServerConnectorDockerImage = "aqueducthq/sqlserver-connector"
+	DefaultBigQueryConnectorDockerImage  = "aqueducthq/bigquery-connector"
+	DefaultS3ConnectorDockerImage        = "aqueducthq/s3-connector"
 )

--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -90,10 +91,11 @@ func (j *k8sJobManager) Launch(ctx context.Context, name string, spec Spec) erro
 		}
 	}
 
-	containerImage, err := mapJobTypeToDockerImage(spec)
+	containerRepo, err := mapJobTypeToDockerImage(spec)
 	if err != nil {
 		return err
 	}
+	containerImage := fmt.Sprintf("%s:%s", containerRepo, K8sImageVersionNumber)
 
 	return k8s.LaunchJob(
 		name,

--- a/src/golang/lib/lambda/constants.go
+++ b/src/golang/lib/lambda/constants.go
@@ -1,7 +1,7 @@
 package lambda
 
 const (
-	ImageVersionNumber = "0.0.14"
+	LambdaImageVersionNumber = "0.0.14"
 
 	FunctionLambdaFunction37   = "aqueduct-function-37"
 	FunctionLambdaFunction38   = "aqueduct-function-38"

--- a/src/golang/lib/lambda/utils.go
+++ b/src/golang/lib/lambda/utils.go
@@ -34,7 +34,7 @@ func CreateLambdaFunction(functionType LambdaFunctionType, roleArn string) error
 	if err != nil {
 		return errors.Wrap(err, "Unable to map function type to image.")
 	}
-	versionedLambdaImageUri := fmt.Sprintf("%s:%s", lambdaImageUri, ImageVersionNumber)
+	versionedLambdaImageUri := fmt.Sprintf("%s:%s", lambdaImageUri, LambdaImageVersionNumber)
 
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -78,7 +78,7 @@ func CreateLambdaFunction(functionType LambdaFunctionType, roleArn string) error
 		}
 	}
 
-	repositoryUri := fmt.Sprintf("%s:%s", *result.Repository.RepositoryUri, ImageVersionNumber)
+	repositoryUri := fmt.Sprintf("%s:%s", *result.Repository.RepositoryUri, LambdaImageVersionNumber)
 
 	cmd = exec.Command("docker", "tag", versionedLambdaImageUri, repositoryUri)
 	err = cmd.Run()


### PR DESCRIPTION
## Describe your changes and why you are making these changes
1. Use constants for k8s/lambda image versions.
2. Restructure Makefile to use less commands
3. Use VERSION var to build images (should be modified in file during release but can also be set during invocation of Makefile a la `make build-lambda-images VERSION=0.0.15`)  
## Related issue number (if any)
[Eng-1709](https://linear.app/aqueducthq/issue/ENG-1709/refactor-makefile-to-use-version-number-variable)
## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


