### PR TITLE
ENG-1013 and ENG-1494 NEW metric and check nodes

### DIFF
--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -74,7 +74,8 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
       //sort checkOpNodes and boolArtifactNodes by value of label
       //operator nodes have just a name
       //artifact nodes have same name + ' artifact' at the end.
-      const alphabeticallySortNodes = (a, b) => a.data.label.localeCompare(b.data.label);
+      const alphabeticallySortNodes = (a, b) =>
+        a.data.label.localeCompare(b.data.label);
       checkOpNodes.sort(alphabeticallySortNodes);
       boolArtifactNodes.sort(alphabeticallySortNodes);
 
@@ -188,9 +189,9 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
 
     return {
       edges: filteredEdges,
-      nodes: filteredNodes
-    }
-  }
+      nodes: filteredNodes,
+    };
+  };
 
   const { edges, nodes } = collapseNodes();
 

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -44,10 +44,54 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     setTimeout(fitView, 200);
   }, [openSideSheetState]);
 
+  //console.log('nodes: ', dagPositionState.result.nodes);
+  console.log('dagPositionState: ', dagPositionState);
+
+  const checkOpNodes = [];
+  const boolArtifactNodes = [];
+  // first find all check operators.
+  if (dagPositionState.result) {
+
+
+    const nodes = dagPositionState.result.nodes;
+    nodes.forEach(node => {
+      if (node.type === 'checkOp') {
+        checkOpNodes.push(node);
+      } else if (node.type === 'boolArtifact') {
+        boolArtifactNodes.push(node);
+      }
+    });
+
+    //sort checkOpNodes and boolArtifactNodes by value of label
+    //operator nodes have just a name
+    //artifact nodes have same name + ' artifact' at the end.
+    checkOpNodes.sort((a, b) => a.data.label.localeCompare(b.data.label));
+    boolArtifactNodes.sort((a, b) => a.data.label.localeCompare(b.data.label));
+
+    console.log('checkOpNodes', checkOpNodes);
+    console.log('boolArtifactNodes: ', boolArtifactNodes);
+  }
+
+  // Remove artifactNodes from the DAG
+  let nodes = dagPositionState.result?.nodes;
+  if (nodes) {
+    nodes = nodes.filter((node) => {
+      for (let i = 0; i < boolArtifactNodes.length; i++) {
+        if (node.id === boolArtifactNodes[i].id) {
+          return false
+        }
+      }
+
+      return true;
+    })
+  }
+
+  // Remove edges that went into each boolArtifactNode
+
   return (
     <ReactFlow
       onPaneClick={onPaneClicked}
-      nodes={dagPositionState.result?.nodes}
+      nodes={nodes}
       edges={dagPositionState.result?.edges}
       onNodeClick={switchSideSheet}
       nodeTypes={nodeTypes}

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -32,14 +32,11 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     (state: RootState) => state.workflowReducer.selectedDagPosition
   );
 
-  const operatorResults = useSelector(
-    (state: RootState) => state.workflowReducer.operatorResults
-  );
   const artifactResults = useSelector(
     (state: RootState) => state.workflowReducer.artifactResults
   );
 
-  const { fitView, viewportInitialized } = useReactFlow();
+  const { fitView } = useReactFlow();
   useEffect(() => {
     fitView();
   }, [dagPositionState]);
@@ -52,148 +49,156 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     setTimeout(fitView, 200);
   }, [openSideSheetState]);
 
-  const checkOpNodes = [];
-  const boolArtifactNodes = [];
+  const collapseNodes = () => {
+    const checkOpNodes = [];
+    const boolArtifactNodes = [];
 
-  const metricOpNodes = [];
-  const metricArtifactNodes = [];
+    const metricOpNodes = [];
+    const metricArtifactNodes = [];
 
-  // first find all check operators.
-  if (dagPositionState.result) {
-    const nodes = dagPositionState.result.nodes;
-    nodes.forEach((node) => {
-      if (node.type === 'checkOp') {
-        checkOpNodes.push(node);
-      } else if (node.type === 'boolArtifact') {
-        boolArtifactNodes.push(node);
-      } else if (node.type === 'metricOp') {
-        metricOpNodes.push(node);
-      } else if (node.type === 'numericArtifact') {
-        metricArtifactNodes.push(node);
+    // first find all check operators.
+    if (dagPositionState.result) {
+      const nodes = dagPositionState.result.nodes;
+      nodes.forEach((node) => {
+        if (node.type === 'checkOp') {
+          checkOpNodes.push(node);
+        } else if (node.type === 'boolArtifact') {
+          boolArtifactNodes.push(node);
+        } else if (node.type === 'metricOp') {
+          metricOpNodes.push(node);
+        } else if (node.type === 'numericArtifact') {
+          metricArtifactNodes.push(node);
+        }
+      });
+
+      //sort checkOpNodes and boolArtifactNodes by value of label
+      //operator nodes have just a name
+      //artifact nodes have same name + ' artifact' at the end.
+      const alphabeticallySortNodes = (a, b) => a.data.label.localeCompare(b.data.label);
+      checkOpNodes.sort(alphabeticallySortNodes);
+      boolArtifactNodes.sort(alphabeticallySortNodes);
+
+      // Do the same sorting for metric and metric artifact nodes.
+      metricOpNodes.sort(alphabeticallySortNodes);
+      metricArtifactNodes.sort(alphabeticallySortNodes);
+    }
+
+    // Remove artifactNodes from the DAG
+    // Take artifact result and set inside operator's data.result field.
+    const nodes = dagPositionState.result?.nodes;
+    const enrichedNodes = produce(nodes, (draftState) => {
+      // NOTE: only mutate the draftState variable here.
+      // See docs here for more information: https://redux-toolkit.js.org/usage/immer-reducers#immutable-updates-with-immer
+      if (nodes) {
+        // loop through and find checkOpNodes, doing fancy logic stuffs.
+        for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
+          // boolArtifactNodes and checkOps are sorted and now have the same index as one another.
+          // Let's take the operators and set their data.result fields accordingly.
+          for (let i = 0; i < checkOpNodes.length; i++) {
+            if (nodes[nodeIndex].id === checkOpNodes[i].id) {
+              // Let's find the artifact result of the corresponding booleanArtifactNode.
+              const boolArtifactResult =
+                artifactResults[boolArtifactNodes[i].id].result?.data;
+              if (boolArtifactResult) {
+                draftState[nodeIndex].data.result = boolArtifactResult;
+              }
+            }
+          }
+
+          // find metric nodes and put the result into the operator's data field
+          for (let i = 0; i < metricOpNodes.length; i++) {
+            if (nodes[nodeIndex].id === metricOpNodes[i].id) {
+              const metricArtifactResult =
+                artifactResults[metricArtifactNodes[i].id].result?.data;
+              if (metricArtifactResult) {
+                draftState[nodeIndex].data.result = metricArtifactResult;
+              }
+            }
+          }
+        }
       }
     });
 
-    //sort checkOpNodes and boolArtifactNodes by value of label
-    //operator nodes have just a name
-    //artifact nodes have same name + ' artifact' at the end.
-    checkOpNodes.sort((a, b) => a.data.label.localeCompare(b.data.label));
-    boolArtifactNodes.sort((a, b) => a.data.label.localeCompare(b.data.label));
+    //Finally, let's remove any boolean artifacts from the list
+    // This has to be two separate steps or Immer will complain that we are producing a new value and modifying it's draft.
+    // i.e. Error: [Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft.
+    const filteredNodes = produce(enrichedNodes, (draftState) => {
+      if (!enrichedNodes) {
+        return [];
+      }
 
-    // Do the same sorting for metric and metric artifact nodes.
-    metricOpNodes.sort((a, b) => a.data.label.localeCompare(b.data.label));
-    metricArtifactNodes.sort((a, b) =>
-      a.data.label.localeCompare(b.data.label)
-    );
+      return draftState.filter((node) => {
+        for (let i = 0; i < boolArtifactNodes.length; i++) {
+          if (node.id === boolArtifactNodes[i].id) {
+            return false;
+          }
+        }
+
+        for (let i = 0; i < metricArtifactNodes.length; i++) {
+          if (node.id === metricArtifactNodes[i].id) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    });
+
+    const edges = dagPositionState.result?.edges;
+    const updatedEdges = produce(edges, (edgeDraftState) => {
+      if (!edges) {
+        return [];
+      }
+
+      // we have two sorted arrays of metric and metric artifact nodes.
+      // each array entry corresponds to an entry at the same index in the other array.
+      // metricOpNode                         metricArtifactNode
+      for (let i = 0; i < metricOpNodes.length; i++) {
+        const metricOpNode = metricOpNodes[i];
+        const metricArtifactNode = metricArtifactNodes[i];
+
+        // find all edges with the metricArtifactNode as a source.
+        for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
+          if (edges[edgeIndex].source === metricArtifactNode.id) {
+            edgeDraftState[edgeIndex].source = metricOpNode.id;
+          }
+        }
+      }
+    });
+
+    // remove any edge who's target is a metric artifact.
+    const filteredEdges = produce(updatedEdges, (draftState) => {
+      if (!updatedEdges) {
+        return [];
+      }
+
+      return draftState.filter((edge) => {
+        for (let i = 0; i < metricArtifactNodes.length; i++) {
+          if (
+            edge.target === metricArtifactNodes[i].id ||
+            edge.source === metricArtifactNodes[i].id
+          ) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+    });
+
+    return {
+      edges: filteredEdges,
+      nodes: filteredNodes
+    }
   }
 
-  // Remove artifactNodes from the DAG
-  // Take artifact result and set inside operator's data.result field.
-  const nodes = dagPositionState.result?.nodes;
-  const enrichedNodes = produce(nodes, (draftState) => {
-    // NOTE: only mutate the draftState variable here.
-    // See docs here for more information: https://redux-toolkit.js.org/usage/immer-reducers#immutable-updates-with-immer
-    if (nodes) {
-      // loop through and find checkOpNodes, doing fancy logic stuffs.
-      for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
-        // boolArtifactNodes and checkOps are sorted and now have the same index as one another.
-        // Let's take the operators and set their data.result fields accordingly.
-        for (let i = 0; i < checkOpNodes.length; i++) {
-          if (nodes[nodeIndex].id === checkOpNodes[i].id) {
-            // Let's find the artifact result of the corresponding booleanArtifactNode.
-            const boolArtifactResult =
-              artifactResults[boolArtifactNodes[i].id].result?.data;
-            if (boolArtifactResult) {
-              draftState[nodeIndex].data.result = boolArtifactResult;
-            }
-          }
-        }
-
-        // find metric nodes and put the result into the operator's data field
-        for (let i = 0; i < metricOpNodes.length; i++) {
-          if (nodes[nodeIndex].id === metricOpNodes[i].id) {
-            const metricArtifactResult =
-              artifactResults[metricArtifactNodes[i].id].result?.data;
-            if (metricArtifactResult) {
-              draftState[nodeIndex].data.result = metricArtifactResult;
-            }
-          }
-        }
-      }
-    }
-  });
-
-  //Finally, let's remove any boolean artifacts from the list
-  // This has to be two separate steps or Immer will complain that we are producing a new value and modifying it's draft.
-  // i.e. Error: [Immer] An immer producer returned a new value *and* modified its draft. Either return a new value *or* modify the draft.
-  const filteredNodes = produce(enrichedNodes, (draftState) => {
-    if (!enrichedNodes) {
-      return [];
-    }
-
-    return draftState.filter((node) => {
-      for (let i = 0; i < boolArtifactNodes.length; i++) {
-        if (node.id === boolArtifactNodes[i].id) {
-          return false;
-        }
-      }
-
-      for (let i = 0; i < metricArtifactNodes.length; i++) {
-        if (node.id === metricArtifactNodes[i].id) {
-          return false;
-        }
-      }
-
-      return true;
-    });
-  });
-
-  const edges = dagPositionState.result?.edges;
-  const updatedEdges = produce(edges, (edgeDraftState) => {
-    if (!edges) {
-      return [];
-    }
-
-    // we have two sorted arrays of metric and metric artifact nodes.
-    // each array entry corresponds to an entry at the same index in the other array.
-    // metricOpNode                         metricArtifactNode
-    for (let i = 0; i < metricOpNodes.length; i++) {
-      const metricOpNode = metricOpNodes[i];
-      const metricArtifactNode = metricArtifactNodes[i];
-
-      // find all edges with the metricArtifactNode as a source.
-      for (let edgeIndex = 0; edgeIndex < edges.length; edgeIndex++) {
-        if (edges[edgeIndex].source === metricArtifactNode.id) {
-          edgeDraftState[edgeIndex].source = metricOpNode.id;
-        }
-      }
-    }
-  });
-
-  // remove any edge who's target is a metric artifact.
-  const filteredEdges = produce(updatedEdges, (draftState) => {
-    if (!updatedEdges) {
-      return [];
-    }
-
-    return draftState.filter((edge) => {
-      for (let i = 0; i < metricArtifactNodes.length; i++) {
-        if (
-          edge.target === metricArtifactNodes[i].id ||
-          edge.source === metricArtifactNodes[i].id
-        ) {
-          return false;
-        }
-      }
-
-      return true;
-    });
-  });
+  const { edges, nodes } = collapseNodes();
 
   return (
     <ReactFlow
       onPaneClick={onPaneClicked}
-      nodes={filteredNodes}
-      edges={filteredEdges}
+      nodes={nodes}
+      edges={edges}
       onNodeClick={switchSideSheet}
       nodeTypes={nodeTypes}
       connectionLineStyle={connectionLineStyle}

--- a/src/ui/common/src/components/workflows/nodes/BoolArtifactNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/BoolArtifactNode.tsx
@@ -1,7 +1,5 @@
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import React, { memo } from 'react';
-import { useSelector } from 'react-redux';
-import { RootState } from '../../../stores/store';
 
 import { ReactFlowNodeData } from '../../../utils/reactflow';
 import Node from './Node';

--- a/src/ui/common/src/components/workflows/nodes/BoolArtifactNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/BoolArtifactNode.tsx
@@ -1,5 +1,7 @@
 import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
 import React, { memo } from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../stores/store';
 
 import { ReactFlowNodeData } from '../../../utils/reactflow';
 import Node from './Node';
@@ -12,6 +14,11 @@ type Props = {
 export const boolArtifactNodeIcon = faCircleCheck;
 
 const BoolArtifactNode: React.FC<Props> = ({ data, isConnectable }) => {
+  //console.log('boolArtifactNode data: ', data);
+  // TODO: Log the result of the artifact here.
+  //const artifactResults = useSelector((state: RootState) => state.workflowReducer.artifactResults);
+  //console.log('boolData from artfResults: ', artifactResults[data.nodeId])
+
   return (
     <Node
       icon={boolArtifactNodeIcon}

--- a/src/ui/common/src/components/workflows/nodes/BoolArtifactNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/BoolArtifactNode.tsx
@@ -14,11 +14,6 @@ type Props = {
 export const boolArtifactNodeIcon = faCircleCheck;
 
 const BoolArtifactNode: React.FC<Props> = ({ data, isConnectable }) => {
-  //console.log('boolArtifactNode data: ', data);
-  // TODO: Log the result of the artifact here.
-  //const artifactResults = useSelector((state: RootState) => state.workflowReducer.artifactResults);
-  //console.log('boolData from artfResults: ', artifactResults[data.nodeId])
-
   return (
     <Node
       icon={boolArtifactNodeIcon}

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -1,16 +1,21 @@
-import { faCheck, faCircleCheck, faExclamation, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCheck,
+  faCircleCheck,
+  faExclamation,
+  faMagnifyingGlass,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import React, { memo } from 'react';
-import { RootState } from '../../../stores/store';
+import { Handle, Position } from 'react-flow-renderer';
 import { useSelector } from 'react-redux';
 
-import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
+import { RootState } from '../../../stores/store';
 import { theme } from '../../../styles/theme/theme';
+import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
 import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
 import { BaseNode } from './BaseNode.styles';
-import Box from '@mui/material/Box';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Typography from '@mui/material/Typography';
-import { Handle, Position } from 'react-flow-renderer';
 
 type Props = {
   data: ReactFlowNodeData;
@@ -20,7 +25,7 @@ type Props = {
 export const checkOperatorNodeIcon = faMagnifyingGlass;
 
 const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
-  const defaultLabel = "Check";
+  const defaultLabel = 'Check';
   const label = data.label ? data.label : defaultLabel;
   const result = data.result;
   const currentNode = useSelector(
@@ -71,7 +76,7 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     hoverColor = 'blue.200';
   }
 
-  let icon = result === 'true' ? faCheck : faExclamation;
+  const icon = result === 'true' ? faCheck : faExclamation;
 
   return (
     <BaseNode
@@ -85,31 +90,44 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
         padding: '0px',
       }}
     >
-      <Box sx={{ height: '32px', width: '100%', borderBottom: `1px solid ${borderColor}` }}>
-        <Box width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+      <Box
+        sx={{
+          height: '32px',
+          width: '100%',
+          borderBottom: `1px solid ${borderColor}`,
+        }}
+      >
+        <Box
+          width="100%"
+          height="100%"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+        >
           <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
             <FontAwesomeIcon icon={faCircleCheck} />
           </Box>
-          <Typography
-            variant="body1"
-          >
-            {label}
-          </Typography>
+          <Typography variant="body1">{label}</Typography>
         </Box>
       </Box>
 
-      {data.result &&
-        <Box width="100%" height="100%" minHeight="80px" display="flex" justifyContent="center" alignItems="center">
+      {data.result && (
+        <Box
+          width="100%"
+          height="100%"
+          minHeight="80px"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+        >
           <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
             <FontAwesomeIcon icon={icon} />
           </Box>
-          <Typography
-            variant="body1"
-          >
+          <Typography variant="body1">
             {data.result === 'true' ? 'passed' : 'failed'}
           </Typography>
         </Box>
-      }
+      )}
 
       <Handle
         type="source"

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -1,10 +1,9 @@
-import { faCheck, faCircleCheck, faCircleExclamation, faExclamation, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faCircleCheck, faExclamation, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import React, { memo } from 'react';
 import { RootState } from '../../../stores/store';
 import { useSelector } from 'react-redux';
 
 import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
-// import Node from './Node';
 import { theme } from '../../../styles/theme/theme';
 import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
 import { BaseNode } from './BaseNode.styles';
@@ -72,7 +71,6 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     hoverColor = 'blue.200';
   }
 
-  //let icon = result === 'true' ? faCircleCheck : faCircleExclamation;
   let icon = result === 'true' ? faCheck : faExclamation;
 
   return (

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -35,12 +35,7 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     (state: RootState) => state.workflowReducer
   );
   const selected = currentNode.id === data.nodeId;
-  let execState: ExecState;
-  if (data.nodeType === ReactflowNodeType.Operator) {
-    execState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
-  } else {
-    execState = workflowState.artifactResults[data.nodeId]?.result?.exec_state;
-  }
+  const execState: ExecState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
 
   const textColor = selected
     ? theme.palette.DarkContrast50
@@ -57,7 +52,7 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     // Warning color for non-fatal errors.
   } else if (
     execState?.status === ExecutionStatus.Failed &&
-    execState.failure_type == FailureType.UserNonFatal
+    execState.failure_type === FailureType.UserNonFatal
   ) {
     backgroundColor = selected
       ? theme.palette.DarkWarningMain50

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -13,7 +13,7 @@ import { useSelector } from 'react-redux';
 
 import { RootState } from '../../../stores/store';
 import { theme } from '../../../styles/theme/theme';
-import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
+import { ReactFlowNodeData } from '../../../utils/reactflow';
 import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
 import { BaseNode } from './BaseNode.styles';
 
@@ -35,7 +35,8 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     (state: RootState) => state.workflowReducer
   );
   const selected = currentNode.id === data.nodeId;
-  const execState: ExecState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
+  const execState: ExecState =
+    workflowState.operatorResults[data.nodeId]?.result?.exec_state;
 
   const textColor = selected
     ? theme.palette.DarkContrast50

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -1,10 +1,17 @@
-import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faCircleCheck, faCircleExclamation, faExclamation, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import React, { memo } from 'react';
 import { RootState } from '../../../stores/store';
 import { useSelector } from 'react-redux';
 
-import { ReactFlowNodeData } from '../../../utils/reactflow';
-import Node from './Node';
+import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
+// import Node from './Node';
+import { theme } from '../../../styles/theme/theme';
+import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
+import { BaseNode } from './BaseNode.styles';
+import Box from '@mui/material/Box';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Typography from '@mui/material/Typography';
+import { Handle, Position } from 'react-flow-renderer';
 
 type Props = {
   data: ReactFlowNodeData;
@@ -14,25 +21,119 @@ type Props = {
 export const checkOperatorNodeIcon = faMagnifyingGlass;
 
 const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
-  // return (
-  //   <Node
-  //     icon={checkOperatorNodeIcon}
-  //     data={data}
-  //     isConnectable={isConnectable}
-  //     defaultLabel="Check"
-  //   />
-  // );
+  const defaultLabel = "Check";
+  const label = data.label ? data.label : defaultLabel;
+  const result = data.result;
+  const currentNode = useSelector(
+    (state: RootState) => state.nodeSelectionReducer.selected
+  );
+  const workflowState = useSelector(
+    (state: RootState) => state.workflowReducer
+  );
+  const selected = currentNode.id === data.nodeId;
+  let execState: ExecState;
+  if (data.nodeType === ReactflowNodeType.Operator) {
+    execState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
+  } else {
+    execState = workflowState.artifactResults[data.nodeId]?.result?.exec_state;
+  }
 
-  const operatorResults = useSelector((state: RootState) => state.workflowReducer.operatorResults);
-  console.log('operatorResultData: ', operatorResults[data.nodeId]);
-  const artifactResults = useSelector((state: RootState) => state.workflowReducer.artifactResults);
-  console.log('artifactResultData', artifactResults[data.nodeId]);
+  const textColor = selected
+    ? theme.palette.DarkContrast50
+    : theme.palette.DarkContrast;
+  const borderColor = textColor;
+
+  let backgroundColor, hoverColor;
+  if (execState?.status === ExecutionStatus.Succeeded) {
+    backgroundColor = selected
+      ? theme.palette.DarkSuccessMain50
+      : theme.palette.DarkSuccessMain;
+    hoverColor = theme.palette.DarkSuccessMain75;
+
+    // Warning color for non-fatal errors.
+  } else if (
+    execState?.status === ExecutionStatus.Failed &&
+    execState.failure_type == FailureType.UserNonFatal
+  ) {
+    backgroundColor = selected
+      ? theme.palette.DarkWarningMain50
+      : theme.palette.DarkWarningMain;
+    hoverColor = theme.palette.DarkWarningMain75;
+  } else if (execState?.status === ExecutionStatus.Failed) {
+    backgroundColor = selected
+      ? theme.palette.DarkErrorMain50
+      : theme.palette.DarkErrorMain;
+    hoverColor = theme.palette.DarkErrorMain75;
+  } else if (execState?.status === ExecutionStatus.Canceled) {
+    backgroundColor = selected ? 'gray.700' : 'gray.500';
+    hoverColor = 'gray.600';
+  } else if (execState?.status === ExecutionStatus.Pending) {
+    backgroundColor = selected ? 'blue.300' : 'blue.100';
+    hoverColor = 'blue.200';
+  }
+
+  //let icon = result === 'true' ? faCircleCheck : faCircleExclamation;
+  let icon = result === 'true' ? faCheck : faExclamation;
+
   return (
-    <Node
-      data={data}
-      isConnectable={isConnectable}
-      defaultLabel="Check"
-    />
+    <BaseNode
+      sx={{
+        backgroundColor,
+        color: textColor,
+        borderColor: borderColor,
+        '&:hover': { backgroundColor: hoverColor },
+        minHeight: 'unset',
+        minWidth: '240px',
+        padding: '0px',
+      }}
+    >
+      <Box sx={{ height: '32px', width: '100%', borderBottom: `1px solid ${borderColor}` }}>
+        <Box width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+          <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
+            <FontAwesomeIcon icon={faCircleCheck} />
+          </Box>
+          <Typography
+            variant="body1"
+          >
+            {label}
+          </Typography>
+        </Box>
+      </Box>
+
+      {data.result &&
+        <Box width="100%" height="100%" minHeight="80px" display="flex" justifyContent="center" alignItems="center">
+          <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
+            <FontAwesomeIcon icon={icon} />
+          </Box>
+          <Typography
+            variant="body1"
+          >
+            {data.result === 'true' ? 'passed' : 'failed'}
+          </Typography>
+        </Box>
+      }
+
+      <Handle
+        type="source"
+        id="db-source-id"
+        style={{
+          background: theme.palette.darkGray as string,
+          border: theme.palette.darkGray as string,
+        }}
+        isConnectable={isConnectable}
+        position={Position.Right}
+      />
+      <Handle
+        type="target"
+        id="db-target-id"
+        style={{
+          background: theme.palette.darkGray as string,
+          border: theme.palette.darkGray as string,
+        }}
+        isConnectable={isConnectable}
+        position={Position.Left}
+      />
+    </BaseNode>
   );
 };
 

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -1,5 +1,7 @@
 import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import React, { memo } from 'react';
+import { RootState } from '../../../stores/store';
+import { useSelector } from 'react-redux';
 
 import { ReactFlowNodeData } from '../../../utils/reactflow';
 import Node from './Node';
@@ -12,9 +14,21 @@ type Props = {
 export const checkOperatorNodeIcon = faMagnifyingGlass;
 
 const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
+  // return (
+  //   <Node
+  //     icon={checkOperatorNodeIcon}
+  //     data={data}
+  //     isConnectable={isConnectable}
+  //     defaultLabel="Check"
+  //   />
+  // );
+
+  const operatorResults = useSelector((state: RootState) => state.workflowReducer.operatorResults);
+  console.log('operatorResultData: ', operatorResults[data.nodeId]);
+  const artifactResults = useSelector((state: RootState) => state.workflowReducer.artifactResults);
+  console.log('artifactResultData', artifactResults[data.nodeId]);
   return (
     <Node
-      icon={checkOperatorNodeIcon}
       data={data}
       isConnectable={isConnectable}
       defaultLabel="Check"

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -11,7 +11,7 @@ import { useSelector } from 'react-redux';
 
 import { RootState } from '../../../stores/store';
 import { theme } from '../../../styles/theme/theme';
-import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
+import { ReactFlowNodeData } from '../../../utils/reactflow';
 import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
 import { BaseNode } from './BaseNode.styles';
 
@@ -32,7 +32,8 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     (state: RootState) => state.workflowReducer
   );
   const selected = currentNode.id === data.nodeId;
-  const execState: ExecState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
+  const execState: ExecState =
+    workflowState.operatorResults[data.nodeId]?.result?.exec_state;
 
   const textColor = selected
     ? theme.palette.DarkContrast50
@@ -110,7 +111,9 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
           justifyContent="center"
           alignItems="center"
         >
-          <Typography variant="h5">{parseFloat(data.result).toFixed(3)}</Typography>
+          <Typography variant="h5">
+            {parseFloat(data.result).toFixed(3)}
+          </Typography>
         </Box>
       )}
 

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -1,16 +1,19 @@
-import { faHashtag, faTemperatureHalf } from '@fortawesome/free-solid-svg-icons';
+import {
+  faHashtag,
+  faTemperatureHalf,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import React, { memo } from 'react';
-import { RootState } from '../../../stores/store';
+import { Handle, Position } from 'react-flow-renderer';
 import { useSelector } from 'react-redux';
 
-import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
+import { RootState } from '../../../stores/store';
 import { theme } from '../../../styles/theme/theme';
+import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
 import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
 import { BaseNode } from './BaseNode.styles';
-import Box from '@mui/material/Box';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Typography from '@mui/material/Typography';
-import { Handle, Position } from 'react-flow-renderer';
 
 type Props = {
   data: ReactFlowNodeData;
@@ -20,7 +23,7 @@ type Props = {
 export const metricOperatorNodeIcon = faTemperatureHalf;
 
 const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
-  const defaultLabel = "Metric";
+  const defaultLabel = 'Metric';
   const label = data.label ? data.label : defaultLabel;
   const currentNode = useSelector(
     (state: RootState) => state.nodeSelectionReducer.selected
@@ -82,28 +85,39 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
         padding: '0px',
       }}
     >
-      <Box sx={{ height: '32px', width: '100%', borderBottom: `1px solid ${borderColor}` }}>
-        <Box width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+      <Box
+        sx={{
+          height: '32px',
+          width: '100%',
+          borderBottom: `1px solid ${borderColor}`,
+        }}
+      >
+        <Box
+          width="100%"
+          height="100%"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+        >
           <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
             <FontAwesomeIcon icon={faHashtag} />
           </Box>
-          <Typography
-            variant="body1"
-          >
-            {label}
-          </Typography>
+          <Typography variant="body1">{label}</Typography>
         </Box>
       </Box>
 
-      {data.result &&
-        <Box width="100%" height="100%" minHeight="80px" display="flex" justifyContent="center" alignItems="center">
-          <Typography
-            variant="h5"
-          >
-            {data.result}
-          </Typography>
+      {data.result && (
+        <Box
+          width="100%"
+          height="100%"
+          minHeight="80px"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+        >
+          <Typography variant="h5">{data.result}</Typography>
         </Box>
-      }
+      )}
 
       <Handle
         type="source"

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -32,12 +32,7 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     (state: RootState) => state.workflowReducer
   );
   const selected = currentNode.id === data.nodeId;
-  let execState: ExecState;
-  if (data.nodeType === ReactflowNodeType.Operator) {
-    execState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
-  } else {
-    execState = workflowState.artifactResults[data.nodeId]?.result?.exec_state;
-  }
+  const execState: ExecState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
 
   const textColor = selected
     ? theme.palette.DarkContrast50
@@ -54,7 +49,7 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     // Warning color for non-fatal errors.
   } else if (
     execState?.status === ExecutionStatus.Failed &&
-    execState.failure_type == FailureType.UserNonFatal
+    execState.failure_type === FailureType.UserNonFatal
   ) {
     backgroundColor = selected
       ? theme.palette.DarkWarningMain50
@@ -115,7 +110,7 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
           justifyContent="center"
           alignItems="center"
         >
-          <Typography variant="h5">{data.result}</Typography>
+          <Typography variant="h5">{parseFloat(data.result).toFixed(3)}</Typography>
         </Box>
       )}
 

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -1,8 +1,16 @@
-import { faTemperatureHalf } from '@fortawesome/free-solid-svg-icons';
+import { faHashtag, faTemperatureHalf } from '@fortawesome/free-solid-svg-icons';
 import React, { memo } from 'react';
+import { RootState } from '../../../stores/store';
+import { useSelector } from 'react-redux';
 
-import { ReactFlowNodeData } from '../../../utils/reactflow';
-import Node from './Node';
+import { ReactFlowNodeData, ReactflowNodeType } from '../../../utils/reactflow';
+import { theme } from '../../../styles/theme/theme';
+import ExecutionStatus, { ExecState, FailureType } from '../../../utils/shared';
+import { BaseNode } from './BaseNode.styles';
+import Box from '@mui/material/Box';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Typography from '@mui/material/Typography';
+import { Handle, Position } from 'react-flow-renderer';
 
 type Props = {
   data: ReactFlowNodeData;
@@ -12,13 +20,112 @@ type Props = {
 export const metricOperatorNodeIcon = faTemperatureHalf;
 
 const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
+  const defaultLabel = "Metric";
+  const label = data.label ? data.label : defaultLabel;
+  const currentNode = useSelector(
+    (state: RootState) => state.nodeSelectionReducer.selected
+  );
+  const workflowState = useSelector(
+    (state: RootState) => state.workflowReducer
+  );
+  const selected = currentNode.id === data.nodeId;
+  let execState: ExecState;
+  if (data.nodeType === ReactflowNodeType.Operator) {
+    execState = workflowState.operatorResults[data.nodeId]?.result?.exec_state;
+  } else {
+    execState = workflowState.artifactResults[data.nodeId]?.result?.exec_state;
+  }
+
+  const textColor = selected
+    ? theme.palette.DarkContrast50
+    : theme.palette.DarkContrast;
+  const borderColor = textColor;
+
+  let backgroundColor, hoverColor;
+  if (execState?.status === ExecutionStatus.Succeeded) {
+    backgroundColor = selected
+      ? theme.palette.DarkSuccessMain50
+      : theme.palette.DarkSuccessMain;
+    hoverColor = theme.palette.DarkSuccessMain75;
+
+    // Warning color for non-fatal errors.
+  } else if (
+    execState?.status === ExecutionStatus.Failed &&
+    execState.failure_type == FailureType.UserNonFatal
+  ) {
+    backgroundColor = selected
+      ? theme.palette.DarkWarningMain50
+      : theme.palette.DarkWarningMain;
+    hoverColor = theme.palette.DarkWarningMain75;
+  } else if (execState?.status === ExecutionStatus.Failed) {
+    backgroundColor = selected
+      ? theme.palette.DarkErrorMain50
+      : theme.palette.DarkErrorMain;
+    hoverColor = theme.palette.DarkErrorMain75;
+  } else if (execState?.status === ExecutionStatus.Canceled) {
+    backgroundColor = selected ? 'gray.700' : 'gray.500';
+    hoverColor = 'gray.600';
+  } else if (execState?.status === ExecutionStatus.Pending) {
+    backgroundColor = selected ? 'blue.300' : 'blue.100';
+    hoverColor = 'blue.200';
+  }
+
   return (
-    <Node
-      icon={metricOperatorNodeIcon}
-      data={data}
-      isConnectable={isConnectable}
-      defaultLabel="Metric"
-    />
+    <BaseNode
+      sx={{
+        backgroundColor,
+        color: textColor,
+        borderColor: borderColor,
+        '&:hover': { backgroundColor: hoverColor },
+        minHeight: 'unset',
+        minWidth: '240px',
+        padding: '0px',
+      }}
+    >
+      <Box sx={{ height: '32px', width: '100%', borderBottom: `1px solid ${borderColor}` }}>
+        <Box width="100%" height="100%" display="flex" justifyContent="center" alignItems="center">
+          <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
+            <FontAwesomeIcon icon={faHashtag} />
+          </Box>
+          <Typography
+            variant="body1"
+          >
+            {label}
+          </Typography>
+        </Box>
+      </Box>
+
+      {data.result &&
+        <Box width="100%" height="100%" minHeight="80px" display="flex" justifyContent="center" alignItems="center">
+          <Typography
+            variant="h5"
+          >
+            {data.result}
+          </Typography>
+        </Box>
+      }
+
+      <Handle
+        type="source"
+        id="db-source-id"
+        style={{
+          background: theme.palette.darkGray as string,
+          border: theme.palette.darkGray as string,
+        }}
+        isConnectable={isConnectable}
+        position={Position.Right}
+      />
+      <Handle
+        type="target"
+        id="db-target-id"
+        style={{
+          background: theme.palette.darkGray as string,
+          border: theme.palette.darkGray as string,
+        }}
+        isConnectable={isConnectable}
+        position={Position.Left}
+      />
+    </BaseNode>
   );
 };
 

--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -84,12 +84,11 @@ export const Node: React.FC<Props> = ({
         '&:hover': { backgroundColor: hoverColor },
       }}
     >
-      {
-        icon &&
+      {icon && (
         <Box sx={{ fontSize: '50px', mb: '2px' }}>
           <FontAwesomeIcon icon={icon} />
         </Box>
-      }
+      )}
 
       <Typography
         sx={{

--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -16,7 +16,7 @@ type Props = {
   data: ReactFlowNodeData;
   defaultLabel: string;
   isConnectable: boolean;
-  icon: IconDefinition;
+  icon?: IconDefinition;
 };
 
 export const Node: React.FC<Props> = ({
@@ -84,9 +84,13 @@ export const Node: React.FC<Props> = ({
         '&:hover': { backgroundColor: hoverColor },
       }}
     >
-      <Box sx={{ fontSize: '50px', mb: '2px' }}>
-        <FontAwesomeIcon icon={icon} />
-      </Box>
+      {
+        icon &&
+        <Box sx={{ fontSize: '50px', mb: '2px' }}>
+          <FontAwesomeIcon icon={icon} />
+        </Box>
+      }
+
       <Typography
         sx={{
           fontSize: '18px',

--- a/src/ui/common/src/utils/reactflow.ts
+++ b/src/ui/common/src/utils/reactflow.ts
@@ -1,5 +1,6 @@
 import { Edge, Node } from 'react-flow-renderer';
 import { Position } from 'react-flow-renderer';
+
 import AqueductBezier from '../components/workflows/edges/AqueductBezier';
 import AqueductQuadratic from '../components/workflows/edges/AqueductQuadratic';
 import AqueductStraight from '../components/workflows/edges/AqueductStraight';

--- a/src/ui/common/src/utils/reactflow.ts
+++ b/src/ui/common/src/utils/reactflow.ts
@@ -29,7 +29,7 @@ export type ReactFlowNodeData = {
   nodeType: ReactflowNodeType;
   nodeId: string;
   label?: string;
-  // Used to metric or check results inside the node
+  // Used to present metric or check results inside the node
   result?: string;
 };
 

--- a/src/ui/common/src/utils/reactflow.ts
+++ b/src/ui/common/src/utils/reactflow.ts
@@ -1,6 +1,5 @@
 import { Edge, Node } from 'react-flow-renderer';
 import { Position } from 'react-flow-renderer';
-
 import AqueductBezier from '../components/workflows/edges/AqueductBezier';
 import AqueductQuadratic from '../components/workflows/edges/AqueductQuadratic';
 import AqueductStraight from '../components/workflows/edges/AqueductStraight';
@@ -29,6 +28,8 @@ export type ReactFlowNodeData = {
   nodeType: ReactflowNodeType;
   nodeId: string;
   label?: string;
+  // Used to metric or check results inside the node
+  result?: string;
 };
 
 export type GetPositionResponse = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR consolidates metric and check artifact/operator pairs into one node.

Users are now able to see the results of a metric or check from right within the metric or check's operator node.

## Loom Demo:
https://www.loom.com/share/5ede8201f2804fc18c342875dd83ead5

## Related issue number (if any)
ENG-1013 (https://linear.app/aqueducthq/issue/ENG-1013/designimplement-metric-artifact-dag-node)
ENG-1494 (https://linear.app/aqueducthq/issue/ENG-1494/designimplement-check-artifact-dag-node)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


