### PR TITLE
Sets default s3 credentials profile for Airflow integration

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -26,7 +26,7 @@ export const AirflowDialog: React.FC<Props> = ({
 }) => {
   const [host, setHost] = useState<string>(value?.host ?? null);
   const [s3CredsProfile, setS3CredsProfile] = useState<string>(
-    value?.s3_credentials_profile ?? null
+    value?.s3_credentials_profile ?? 'default'
   );
 
   useEffect(() => {
@@ -42,7 +42,7 @@ export const AirflowDialog: React.FC<Props> = ({
       }
     }
 
-    if (s3CredsProfile && s3CredsProfile !== 'default') {
+    if (s3CredsProfile) {
       onUpdateField('s3_credentials_profile', s3CredsProfile);
     }
   }, [host, s3CredsProfile]);

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -26,7 +26,7 @@ export const AirflowDialog: React.FC<Props> = ({
 }) => {
   const [host, setHost] = useState<string>(value?.host ?? null);
   const [s3CredsProfile, setS3CredsProfile] = useState<string>(
-    value?.s3_credentials_profile ?? 'default'
+    value?.s3_credentials_profile ?? Placeholders.s3_credentials_profile
   );
 
   useEffect(() => {
@@ -102,7 +102,7 @@ export const AirflowDialog: React.FC<Props> = ({
         description="The profile to use for the AWS credentials above. The default profile will be used if none is provided."
         placeholder={Placeholders.s3_credentials_profile}
         onChange={(event) => setS3CredsProfile(event.target.value)}
-        value={s3CredsProfile}
+        value={s3CredsProfile !== Placeholders.s3_credentials_profile ? s3CredsProfile : null}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/airflowDialog.tsx
@@ -102,7 +102,11 @@ export const AirflowDialog: React.FC<Props> = ({
         description="The profile to use for the AWS credentials above. The default profile will be used if none is provided."
         placeholder={Placeholders.s3_credentials_profile}
         onChange={(event) => setS3CredsProfile(event.target.value)}
-        value={s3CredsProfile !== Placeholders.s3_credentials_profile ? s3CredsProfile : null}
+        value={
+          s3CredsProfile !== Placeholders.s3_credentials_profile
+            ? s3CredsProfile
+            : null
+        }
       />
     </Box>
   );


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the default s3 credentials profile was not being sent as part of a connect integration request for Airflow.

## Related issue number (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


