### PR TITLE
Fix bug with bad credentials errors message when connecting to Postgres

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -74,11 +74,14 @@ def _execute(spec: Spec, storage: Storage, exec_state: ExecutionState) -> None:
     if isinstance(spec.connector_name, dict):
         run_delete_saved_objects(spec, storage, exec_state)
     else:
-        op = setup_connector(spec.connector_name, spec.connector_config)
-
+        # Because constructing certain connectors (eg. Postgres) can also involve authentication,
+        # we do both in `run_authenticate()`, and give a more helpful error message on failure.
         if spec.type == enums.JobType.AUTHENTICATE:
-            run_authenticate(op, exec_state, is_demo=(spec.name == AQUEDUCT_DEMO_NAME))
-        elif spec.type == enums.JobType.EXTRACT:
+            run_authenticate(spec, exec_state, is_demo=(spec.name == AQUEDUCT_DEMO_NAME))
+            return
+
+        op = setup_connector(spec.connector_name, spec.connector_config)
+        if spec.type == enums.JobType.EXTRACT:
             run_extract(spec, op, storage, exec_state)
         elif spec.type == enums.JobType.LOADTABLE:
             run_load_table(spec, op, storage)
@@ -91,7 +94,7 @@ def _execute(spec: Spec, storage: Storage, exec_state: ExecutionState) -> None:
 
 
 def run_authenticate(
-    op: connector.DataConnector,
+    spec: Spec,
     exec_state: ExecutionState,
     is_demo: bool,
 ) -> None:
@@ -99,6 +102,7 @@ def run_authenticate(
         failure_tip=TIP_DEMO_CONNECTION if is_demo else TIP_INTEGRATION_CONNECTION
     )
     def _authenticate() -> None:
+        op = setup_connector(spec.connector_name, spec.connector_config)
         op.authenticate()
 
     _authenticate()

--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any
+from typing import Any, cast
 
 from aqueduct_executor.operators.connectors.data import common, config, connector, extract
 from aqueduct_executor.operators.connectors.data.spec import (
@@ -9,6 +9,7 @@ from aqueduct_executor.operators.connectors.data.spec import (
     LoadSpec,
     LoadTableSpec,
     Spec,
+    AuthenticateSpec,
 )
 from aqueduct_executor.operators.utils import enums, utils
 from aqueduct_executor.operators.utils.exceptions import MissingConnectorDependencyException
@@ -94,7 +95,7 @@ def _execute(spec: Spec, storage: Storage, exec_state: ExecutionState) -> None:
 
 
 def run_authenticate(
-    spec: Spec,
+    spec: AuthenticateSpec,
     exec_state: ExecutionState,
     is_demo: bool,
 ) -> None:

--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Any, cast
+from typing import Any
 
 from aqueduct_executor.operators.connectors.data import common, config, connector, extract
 from aqueduct_executor.operators.connectors.data.spec import (

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -17,7 +17,7 @@ _TIP_CREATE_BUG_REPORT = (
 TIP_UNKNOWN_ERROR = f"Sorry, we've run into an unexpected error! {_TIP_CREATE_BUG_REPORT}"
 TIP_INTEGRATION_CONNECTION = (
     "We were unable to connect to this integration. "
-    "Please check your credentials or contact your integraiton provider."
+    "Please check your credentials or contact your integration's provider."
 )
 TIP_DEMO_CONNECTION = f"We have trouble connecting to demo DB. {_TIP_CREATE_BUG_REPORT}"
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Task: https://linear.app/aqueducthq/issue/ENG-1480/fix-bug-where-we-spuriously-call-an-error-unexpected

Fixed:
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/6466121/191389469-13403142-97f0-477e-afcc-6f729a437ec9.png">

Authenticate is a little bit weird since for some integrations, it conflates with connector initialization, so I pulled it to the top and redirected all initialization and authentication errors to the same helpful error message.


## Related issue number (if any)
ENG-1480

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


