### PR TITLE
[SDK] Print operator logs in a consistent fashion

### DIFF
--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -22,6 +22,7 @@ from aqueduct.responses import (
     GetWorkflowResponse,
     ListWorkflowResponseEntry,
     ListWorkflowSavedObjectsResponse,
+    Logs,
     OperatorResult,
     PreviewResponse,
     RegisterAirflowWorkflowResponse,
@@ -29,7 +30,7 @@ from aqueduct.responses import (
     SavedObjectUpdate,
 )
 from aqueduct.serialization import deserialization_function_mapping
-from aqueduct.utils import GITHUB_ISSUE_LINK
+from aqueduct.utils import GITHUB_ISSUE_LINK, indent_multiline_string
 from requests_toolbelt.multipart import decoder
 
 from aqueduct import utils
@@ -49,8 +50,8 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
     # There can be multiple operator failures, one for each entry.
     op_err_msgs: List[str] = []
 
-    # Creates the message to show the user in the error.
     def _construct_failure_error_msg(op_name: str, op_result: OperatorResult) -> str:
+        """This is the message is raised in the Exception message."""
         assert op_result.error is not None
         return (
             f"Operator `{op_name}` failed!\n"
@@ -60,6 +61,36 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
             f"\n"
         )
 
+    def _print_op_user_logs(op_name: str, logs: Logs) -> None:
+        """Prints out the logs for a single operator. The format is:
+
+        stdout:
+            {logs}
+            {logs}
+        ----------------------------------
+        stderr:
+            {logs}
+            {logs}
+
+        If either stdout or stderr is empty, we do not print anything for
+        the empty section, and do not draw the "--" delimiter line.
+        """
+        if logs.is_empty():
+            return
+
+        print(f"Operator {op_name} Logs:")
+        if len(logs.stdout) > 0:
+            print("stdout:")
+            print(indent_multiline_string(logs.stdout).rstrip("\n"))
+
+        if len(logs.stdout) > 0 and len(logs.stderr) > 0:
+            print("----------------------------------")
+
+        if len(logs.stderr) > 0:
+            print("stderr:")
+            print(indent_multiline_string(logs.stderr).rstrip("\n"))
+        print("")
+
     q: List[Operator] = dag.list_root_operators()
     seen_op_ids = set(op.id for op in q)
     while len(q) > 0:
@@ -68,14 +99,11 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
         if curr_op.id in preview_resp.operator_results:
             curr_op_result = preview_resp.operator_results[curr_op.id]
 
-            if curr_op_result.user_logs is not None and not curr_op_result.user_logs.is_empty():
-                print(f"Operator {curr_op.name} Logs:")
-                print(curr_op_result.user_logs)
-                print("")
+            if curr_op_result.user_logs is not None:
+                _print_op_user_logs(curr_op.name, curr_op_result.user_logs)
 
             if curr_op_result.error is not None:
                 op_err_msgs.append(_construct_failure_error_msg(curr_op.name, curr_op_result))
-
             else:
                 # Continue traversing, marking operators added to the queue as "seen"
                 for output_artifact_id in curr_op.outputs:

--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -1,4 +1,3 @@
-import textwrap
 import uuid
 from typing import Dict, List, Optional
 
@@ -22,15 +21,6 @@ class Logs(BaseModel):
 
     def is_empty(self) -> bool:
         return self.stdout == "" and self.stderr == ""
-
-    def __str__(self) -> str:
-        return textwrap.dedent(
-            f"""stdout:
-            {self.stdout}
-            --------------------------
-            stderr:
-            {self.stderr}""",
-        )
 
 
 class Error(BaseModel):

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -488,6 +488,11 @@ def human_readable_timestamp(ts: int) -> str:
     return datetime.utcfromtimestamp(ts).strftime(format)
 
 
+def indent_multiline_string(content: str) -> str:
+    """Indents every line of a multiline string block."""
+    return "\t" + "\t".join(content.splitlines(True))
+
+
 def parse_user_supplied_id(id: Union[str, uuid.UUID]) -> str:
     """Verifies that a user-defined id is of the expected types, returning the string version of the id."""
     if not isinstance(id, str) and not isinstance(id, uuid.UUID):

--- a/src/python/aqueduct_executor/operators/airflow/spec.py
+++ b/src/python/aqueduct_executor/operators/airflow/spec.py
@@ -1,6 +1,6 @@
 import json
-from typing import Dict, List, Literal, Union
 import uuid
+from typing import Dict, List, Literal, Union
 
 from aqueduct_executor.operators.connectors.data import spec as conn_spec
 from aqueduct_executor.operators.function_executor import spec as func_spec


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Moved all the high-level print logic into api_client.py, and added a helper method to help with indentation.

Looks like this now:
<img width="634" alt="image" src="https://user-images.githubusercontent.com/6466121/191583919-1df72c32-20f0-4c3e-a61d-29cc522553da.png">

If either stdout or stderr are not provided, they will be excluded from the printing. If neither exist, the op logs section won't be printed at all.

## Related issue number (if any)
ENG-1690

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


