### PR TITLE
Launches versioned docker image for function operator

### DIFF
--- a/src/golang/lib/job/constants.go
+++ b/src/golang/lib/job/constants.go
@@ -1,14 +1,17 @@
 package job
 
 const (
-	K8sImageVersionNumber                = "0.0.15"
-	DefaultFunctionDockerImage           = "aqueducthq/function"
-	DefaultParameterDockerImage          = "aqueducthq/param"
-	DefaultSystemMetricDockerImage       = "aqueducthq/system-metric"
-	DefaultPostgresConnectorDockerImage  = "aqueducthq/postgres-connector"
-	DefaultSnowflakeConnectorDockerImage = "aqueducthq/snowflake-connector"
-	DefaultMySqlConnectorDockerImage     = "aqueducthq/mysql-connector"
-	DefaultSqlServerConnectorDockerImage = "aqueducthq/sqlserver-connector"
-	DefaultBigQueryConnectorDockerImage  = "aqueducthq/bigquery-connector"
-	DefaultS3ConnectorDockerImage        = "aqueducthq/s3-connector"
+	K8sImageVersionNumber         = "0.0.15"
+	Function37DockerImage         = "aqueducthq/function37"
+	Function38DockerImage         = "aqueducthq/function38"
+	Function39DockerImage         = "aqueducthq/function39"
+	Function310DockerImage        = "aqueducthq/function310"
+	ParameterDockerImage          = "aqueducthq/param"
+	SystemMetricDockerImage       = "aqueducthq/system-metric"
+	PostgresConnectorDockerImage  = "aqueducthq/postgres-connector"
+	SnowflakeConnectorDockerImage = "aqueducthq/snowflake-connector"
+	MySqlConnectorDockerImage     = "aqueducthq/mysql-connector"
+	SqlServerConnectorDockerImage = "aqueducthq/sqlserver-connector"
+	BigQueryConnectorDockerImage  = "aqueducthq/bigquery-connector"
+	S3ConnectorDockerImage        = "aqueducthq/s3-connector"
 )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The K8sJobManager now gets the python version server side and launches the correct docker image as a job.
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1728/select-docker-image-based-on-python-version-in-k8sjobmanager
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


