### PR TITLE
width fix for operator accordion on integration details page.

### DIFF
--- a/src/ui/common/src/components/integrations/operatorsOnIntegration.tsx
+++ b/src/ui/common/src/components/integrations/operatorsOnIntegration.tsx
@@ -72,7 +72,7 @@ const OperatorsOnIntegration: React.FC = () => {
 
   if (Object.keys(operatorsByWorkflow).length > 0) {
     return (
-      <Box>
+      <Box maxWidth="900px">
         {Object.entries(operatorsByWorkflow).map(([wfId, item]) => (
           <WorkflowAccordion
             expanded={expandedWf === wfId}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fix width on workflows accordion on Integration Details Page

## Loom Demo:
https://www.loom.com/share/41383a939fd4462aad81131c0d873cdb

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1725/0015-fix-workflows-accordion-on-integration-details-page-is-too-wide

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


