### PR TITLE
Eng 1359 fix a bug where tables with integer

### DIFF
--- a/integration_tests/sdk/preview_test.py
+++ b/integration_tests/sdk/preview_test.py
@@ -130,4 +130,5 @@ def test_table_with_non_string_column_name(client):
     def bad_return():
         return pd.DataFrame([0, 1, 2, 3], columns=[123])
 
-    bad_return()
+    with pytest.raises(AqueductError):
+        bad_return()

--- a/integration_tests/sdk/preview_test.py
+++ b/integration_tests/sdk/preview_test.py
@@ -1,5 +1,6 @@
 import time
 
+import pandas as pd
 import pytest
 from aqueduct.error import AqueductError, InvalidDependencyFilePath, InvalidFunctionException
 from constants import SENTIMENT_SQL_QUERY
@@ -122,3 +123,11 @@ def test_preview_artifact_caching(client):
     start = time.time()
     _ = noop(slow_output)
     assert time.time() - start < duration
+
+
+def test_table_with_non_string_column_name(client):
+    @op
+    def bad_return():
+        return pd.DataFrame([0, 1, 2, 3], columns=[123])
+
+    bad_return()

--- a/src/python/aqueduct_executor/operators/airflow/spec.py
+++ b/src/python/aqueduct_executor/operators/airflow/spec.py
@@ -1,6 +1,6 @@
 import json
-from typing import Dict, List, Literal, Union
 import uuid
+from typing import Dict, List, Literal, Union
 
 from aqueduct_executor.operators.connectors.data import spec as conn_spec
 from aqueduct_executor.operators.function_executor import spec as func_spec

--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -19,7 +19,6 @@ from aqueduct_executor.operators.utils.execution import (
     TIP_INTEGRATION_CONNECTION,
     TIP_LOAD,
     TIP_UNKNOWN_ERROR,
-    Error,
     ExecFailureException,
     ExecutionState,
     Logs,
@@ -60,8 +59,8 @@ def run(spec: Spec) -> None:
         exec_state.status = enums.ExecutionStatus.SUCCEEDED
         utils.write_exec_state(storage, spec.metadata_path, exec_state)
     except ExecFailureException as e:
-        from_exception_exec_state = ExecutionState.from_exception(e)
-        from_exception_exec_state.user_logs = exec_state.user_logs
+        # We must reconcile the user logs here, since those logs are not captured on the exception.
+        from_exception_exec_state = ExecutionState.from_exception(e, user_logs=exec_state.user_logs)
 
         print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)

--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -4,12 +4,12 @@ from typing import Any
 from aqueduct_executor.operators.connectors.data import common, config, connector, extract
 from aqueduct_executor.operators.connectors.data.spec import (
     AQUEDUCT_DEMO_NAME,
+    AuthenticateSpec,
     DiscoverSpec,
     ExtractSpec,
     LoadSpec,
     LoadTableSpec,
     Spec,
-    AuthenticateSpec,
 )
 from aqueduct_executor.operators.utils import enums, utils
 from aqueduct_executor.operators.utils.exceptions import MissingConnectorDependencyException
@@ -20,6 +20,7 @@ from aqueduct_executor.operators.utils.execution import (
     TIP_LOAD,
     TIP_UNKNOWN_ERROR,
     Error,
+    ExecFailureException,
     ExecutionState,
     Logs,
     exception_traceback,
@@ -52,20 +53,31 @@ def run(spec: Spec) -> None:
         # Each decorator may set exec_state.status to FAILED, but if none of them did, then we are
         # certain that the operator succeeded.
         if exec_state.status == enums.ExecutionStatus.FAILED:
+            print(f"Failed with error. Full Logs:\n{exec_state.json()}")
             utils.write_exec_state(storage, spec.metadata_path, exec_state)
             sys.exit(1)
-        else:
-            exec_state.status = enums.ExecutionStatus.SUCCEEDED
-            utils.write_exec_state(storage, spec.metadata_path, exec_state)
+
+        exec_state.status = enums.ExecutionStatus.SUCCEEDED
+        utils.write_exec_state(storage, spec.metadata_path, exec_state)
+    except ExecFailureException as e:
+        from_exception_exec_state = ExecutionState.from_exception(e)
+        from_exception_exec_state.user_logs = exec_state.user_logs
+
+        print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
+        utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
+        sys.exit(1)
+    except MissingConnectorDependencyException as e:
+        exec_state.mark_as_failure(
+            enums.FailureType.USER_FATAL, tip=str(e), context=exception_traceback(e)
+        )
+        utils.write_exec_state(storage, spec.metadata_path, exec_state)
+        sys.exit(1)
     except Exception as e:
-        exec_state.status = enums.ExecutionStatus.FAILED
-        if isinstance(e, MissingConnectorDependencyException):
-            exec_state.failure_type = enums.FailureType.USER_FATAL
-            exec_state.error = Error(context=exception_traceback(e), tip=str(e))
-        else:
-            exec_state.failure_type = enums.FailureType.SYSTEM
-            exec_state.error = Error(context=exception_traceback(e), tip=TIP_UNKNOWN_ERROR)
-            print(f"Failed with system error. Full Logs:\n{exec_state.json()}")
+        exec_state.mark_as_failure(
+            enums.FailureType.SYSTEM, tip=TIP_UNKNOWN_ERROR, context=exception_traceback(e)
+        )
+        print(f"Failed with system error. Full Logs:\n{exec_state.json()}")
+
         utils.write_exec_state(storage, spec.metadata_path, exec_state)
         sys.exit(1)
 

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -186,9 +186,7 @@ def run(spec: FunctionSpec) -> None:
     """
     print("Started %s job: %s" % (spec.type, spec.name))
 
-    # TODO:
     exec_state = ExecutionState(user_logs=Logs())
-
     storage = parse_storage(spec.storage_config)
     try:
         validate_spec(spec)
@@ -279,8 +277,8 @@ def run(spec: FunctionSpec) -> None:
             print(f"Succeeded! Full logs: {exec_state.json()}")
 
     except ExecFailureException as e:
-        from_exception_exec_state = ExecutionState.from_exception(e)
-        from_exception_exec_state.user_logs = exec_state.user_logs
+        # We must reconcile the user logs here, since those logs are not captured on the exception.
+        from_exception_exec_state = ExecutionState.from_exception(e, user_logs=exec_state.user_logs)
         print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
         sys.exit(1)

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -28,6 +28,7 @@ from aqueduct_executor.operators.utils.execution import (
     TIP_OP_EXECUTION,
     TIP_UNKNOWN_ERROR,
     Error,
+    ExecFailureException,
     ExecutionState,
     Logs,
     exception_traceback,
@@ -110,7 +111,7 @@ def _execute_function(
 ) -> Tuple[Any, ArtifactType, Dict[str, str]]:
     """
     Invokes the given function on the input data. Does not raise an exception on any
-    user function errors. Instead, returns the error message as a string.
+    user function errors, but instead annotates the given exec state with the error.
 
     :param inputs: the input data to feed into the user's function.
     """
@@ -169,19 +170,6 @@ def validate_spec(spec: FunctionSpec) -> None:
         )
 
 
-def handle_type_error_and_exit(
-    spec: FunctionSpec, storage: Storage, exec_state: ExecutionState, err_tip: str
-) -> None:
-    exec_state.status = ExecutionStatus.FAILED
-    exec_state.failure_type = FailureType.USER_FATAL
-    exec_state.error = Error(
-        context="",
-        tip=err_tip,
-    )
-    utils.write_exec_state(storage, spec.metadata_path, exec_state)
-    sys.exit(1)
-
-
 def _cleanup(spec: FunctionSpec) -> None:
     """
     Cleans up any temporary files created during function execution.
@@ -198,7 +186,9 @@ def run(spec: FunctionSpec) -> None:
     """
     print("Started %s job: %s" % (spec.type, spec.name))
 
+    # TODO:
     exec_state = ExecutionState(user_logs=Logs())
+
     storage = parse_storage(spec.storage_config)
     try:
         validate_spec(spec)
@@ -224,7 +214,10 @@ def run(spec: FunctionSpec) -> None:
                 or isinstance(result, float)
                 or isinstance(result, np.number)
             ):
-                handle_type_error_and_exit(spec, storage, exec_state, TIP_NOT_NUMERIC)
+                raise ExecFailureException(
+                    failure_type=FailureType.USER_FATAL,
+                    tip=TIP_NOT_NUMERIC,
+                )
 
         elif spec.operator_type == OperatorType.CHECK:
             if isinstance(result, pd.Series) and result.dtype == "bool":
@@ -237,18 +230,19 @@ def run(spec: FunctionSpec) -> None:
                 # Cast np.bool_ to a bool.
                 result = bool(result)
             else:
-                handle_type_error_and_exit(spec, storage, exec_state, TIP_NOT_BOOL)
+                raise ExecFailureException(
+                    failure_type=FailureType.USER_FATAL,
+                    tip=TIP_NOT_BOOL,
+                )
         else:
             for expected_output_type in spec.expected_output_artifact_types:
                 if (
                     expected_output_type != ArtifactType.UNTYPED
                     and expected_output_type != result_type
                 ):
-                    handle_type_error_and_exit(
-                        spec,
-                        storage,
-                        exec_state,
-                        "Expected %s type %s, but output is of type %s."
+                    raise ExecFailureException(
+                        failure_type=FailureType.USER_FATAL,
+                        tip="Expected %s type %s, but output is of type %s."
                         % (spec.name, expected_output_type, result_type),
                     )
 
@@ -264,6 +258,8 @@ def run(spec: FunctionSpec) -> None:
         # For check operators, we want to fail the operator based on the exact output of the user's function.
         # Assumption: the check operator only has a single output.
         if spec.operator_type == OperatorType.CHECK and not check_passed(result):
+            print(f"Check Operator did not pass.")
+
             check_severity = spec.check_severity
             if spec.check_severity is None:
                 print("Check operator has an unspecified severity on spec. Defaulting to ERROR.")
@@ -273,25 +269,25 @@ def run(spec: FunctionSpec) -> None:
             if check_severity == CheckSeverityLevel.WARNING:
                 failure_type = FailureType.USER_NON_FATAL
 
-            exec_state.status = ExecutionStatus.FAILED
-            exec_state.failure_type = failure_type
-            exec_state.error = Error(
-                context="",
+            raise ExecFailureException(
+                failure_type=failure_type,
                 tip=TIP_CHECK_DID_NOT_PASS,
             )
-            utils.write_exec_state(storage, spec.metadata_path, exec_state)
-            print(f"Check Operator did not pass. Full logs: {exec_state.json()}")
         else:
             exec_state.status = ExecutionStatus.SUCCEEDED
             utils.write_exec_state(storage, spec.metadata_path, exec_state)
             print(f"Succeeded! Full logs: {exec_state.json()}")
 
+    except ExecFailureException as e:
+        from_exception_exec_state = ExecutionState.from_exception(e)
+        from_exception_exec_state.user_logs = exec_state.user_logs
+        print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
+        utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
+        sys.exit(1)
+
     except Exception as e:
-        exec_state.status = ExecutionStatus.FAILED
-        exec_state.failure_type = FailureType.SYSTEM
-        exec_state.error = Error(
-            context=exception_traceback(e),
-            tip=TIP_UNKNOWN_ERROR,
+        exec_state.mark_as_failure(
+            FailureType.SYSTEM, TIP_UNKNOWN_ERROR, context=exception_traceback(e)
         )
         print(f"Failed with system error. Full Logs:\n{exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, exec_state)

--- a/src/python/aqueduct_executor/operators/param_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/param_executor/execute.py
@@ -5,6 +5,7 @@ from aqueduct_executor.operators.utils import enums, utils
 from aqueduct_executor.operators.utils.execution import (
     TIP_UNKNOWN_ERROR,
     Error,
+    ExecFailureException,
     ExecutionState,
     Logs,
     exception_traceback,
@@ -26,7 +27,6 @@ def run(spec: ParamSpec) -> None:
     print("Job Spec: \n{}".format(spec.json()))
 
     storage = parse_storage(spec.storage_config)
-    exec_state = ExecutionState(user_logs=Logs())
 
     try:
         val_bytes = storage.get(spec.output_content_path)
@@ -34,15 +34,11 @@ def run(spec: ParamSpec) -> None:
 
         inferred_type = infer_artifact_type(val)
         if inferred_type != spec.expected_type:
-            exec_state.status = enums.ExecutionStatus.FAILED
-            exec_state.failure_type = enums.FailureType.USER_FATAL
-            exec_state.error = Error(
-                context="",
+            raise ExecFailureException(
+                failure_type=enums.FailureType.USER_FATAL,
                 tip="Supplied parameter expects type `%s`, but got `%s` instead."
                 % (spec.expected_type, inferred_type),
             )
-            utils.write_exec_state(storage, spec.metadata_path, exec_state)
-            return
 
         utils.write_artifact(
             storage,
@@ -52,12 +48,25 @@ def run(spec: ParamSpec) -> None:
             val,
             system_metadata={},
         )
-        exec_state.status = enums.ExecutionStatus.SUCCEEDED
-        utils.write_exec_state(storage, spec.metadata_path, exec_state)
+
+        utils.write_exec_state(
+            storage,
+            spec.metadata_path,
+            ExecutionState(status=enums.ExecutionStatus.SUCCEEDED, user_logs=Logs()),
+        )
+
+    except ExecFailureException as e:
+        from_exception_exec_state = ExecutionState.from_exception(e)
+        print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
+        utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
+        sys.exit(1)
     except Exception as e:
-        exec_state.status = enums.ExecutionStatus.FAILED
-        exec_state.failure_type = enums.FailureType.SYSTEM
-        exec_state.error = Error(context=exception_traceback(e), tip=TIP_UNKNOWN_ERROR)
+        exec_state = ExecutionState(
+            status=enums.ExecutionStatus.FAILED,
+            failure_type=enums.FailureType.SYSTEM,
+            error=Error(context=exception_traceback(e), tip=TIP_UNKNOWN_ERROR),
+            user_logs=Logs(),
+        )
         print(f"Failed with system error. Full Logs:\n{exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, exec_state)
         sys.exit(1)

--- a/src/python/aqueduct_executor/operators/param_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/param_executor/execute.py
@@ -56,7 +56,7 @@ def run(spec: ParamSpec) -> None:
         )
 
     except ExecFailureException as e:
-        from_exception_exec_state = ExecutionState.from_exception(e)
+        from_exception_exec_state = ExecutionState.from_exception(e, user_logs=Logs())
         print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
         sys.exit(1)

--- a/src/python/aqueduct_executor/operators/system_metric_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/system_metric_executor/execute.py
@@ -37,7 +37,7 @@ def run(spec: SystemMetricSpec) -> None:
         exec_state.status = enums.ExecutionStatus.SUCCEEDED
         utils.write_exec_state(storage, spec.metadata_path, exec_state)
     except ExecFailureException as e:
-        from_exception_exec_state = ExecutionState.from_exception(e)
+        from_exception_exec_state = ExecutionState.from_exception(e, user_logs=Logs())
         print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
         utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
         sys.exit(1)

--- a/src/python/aqueduct_executor/operators/system_metric_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/system_metric_executor/execute.py
@@ -5,6 +5,7 @@ from aqueduct_executor.operators.utils import enums, utils
 from aqueduct_executor.operators.utils.execution import (
     TIP_UNKNOWN_ERROR,
     Error,
+    ExecFailureException,
     ExecutionState,
     Logs,
     exception_traceback,
@@ -35,6 +36,11 @@ def run(spec: SystemMetricSpec) -> None:
         )
         exec_state.status = enums.ExecutionStatus.SUCCEEDED
         utils.write_exec_state(storage, spec.metadata_path, exec_state)
+    except ExecFailureException as e:
+        from_exception_exec_state = ExecutionState.from_exception(e)
+        print(f"Failed with error. Full Logs:\n{from_exception_exec_state.json()}")
+        utils.write_exec_state(storage, spec.metadata_path, from_exception_exec_state)
+        sys.exit(1)
     except Exception as e:
         exec_state.status = enums.ExecutionStatus.FAILED
         exec_state.failure_type = enums.FailureType.SYSTEM

--- a/src/python/aqueduct_executor/operators/utils/exceptions.py
+++ b/src/python/aqueduct_executor/operators/utils/exceptions.py
@@ -1,3 +1,6 @@
+from aqueduct_executor.operators.utils.enums import FailureType
+
+
 class MissingConnectorDependencyException(Exception):
     """Exception raised due to the connector integration's dependencies aren't installed."""
 

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -4,8 +4,7 @@ import io
 import sys
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Any, Callable, Optional, TypeVar, Type
-
+from typing import Any, Callable, Optional, Type, TypeVar
 
 from aqueduct_executor.operators.utils.enums import ExecutionStatus, FailureType
 from pydantic import BaseModel

--- a/src/python/aqueduct_executor/operators/utils/execution.py
+++ b/src/python/aqueduct_executor/operators/utils/execution.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import io
 import sys
 import traceback
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, TypeVar, Type
+
 
 from aqueduct_executor.operators.utils.enums import ExecutionStatus, FailureType
 from pydantic import BaseModel


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We cannot support non-string column names for dataframes due to json-serialization (and also parquet if we chose to migrate), so if we detect such cases during serialization, we throw an error.

When you try to do something like this, you'll get:
<img width="531" alt="image" src="https://user-images.githubusercontent.com/6466121/191857410-91f41308-3798-4b15-9a3e-7646ea1f71b4.png">

In order to implement this nicely, we introduce the concept of an `ExecFailureException`, which can be translated to a failed `ExecutionState` at the top level. This allows us to not have to pass an exec_state around all the time to catch user errors. In this case, we had to throw an exception within the serialization helpers. It would have been somewhat to have to pass an exec_state all the way down.

In order to keep the two types of ExecutionState paths separate, we support the following pattern now, in addition to our `@user_fn_redirected` pattern:
```
raise ExecFailureException(...)
...
except ExecFailureException as e:
     write(ExecutionState.from_exception(e, user_logs=...))
```

@vsreekanti to inspect the error message.

## Related issue number (if any)
ENG-1359

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


