### PR TITLE
Clean up metrics artf detail pages

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -10,10 +10,7 @@ import { handleGetArtifactResultContent } from '../../../../handlers/getArtifact
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { getMetricsAndChecksOnArtifact } from '../../../../handlers/responses/dag';
 import { AppDispatch, RootState } from '../../../../stores/store';
-import { ArtifactType } from '../../../../utils/artifacts';
 import UserProfile from '../../../../utils/auth';
-import { DataSchema } from '../../../../utils/data';
-import { exportCsv } from '../../../../utils/preview';
 import {
   isFailed,
   isInitial,
@@ -21,11 +18,12 @@ import {
   isSucceeded,
 } from '../../../../utils/shared';
 import DefaultLayout from '../../../layouts/default';
-import { Button } from '../../../primitives/Button.styles';
-import OperatorExecStateTable, {
-  OperatorExecStateTableType,
-} from '../../../tables/OperatorExecStateTable';
-import PaginatedTable from '../../../tables/PaginatedTable';
+import ArtifactContent from '../../../workflows/artifact/content';
+import CsvExporter from '../../../workflows/artifact/csvExporter';
+import {
+  ChecksOverview,
+  MetricsOverview,
+} from '../../../workflows/artifact/metricsAndChecksOverview';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
 
@@ -50,7 +48,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const artifact = (workflowDagResultWithLoadingStatus?.result?.artifacts ??
     {})[artifactId];
   const artifactResultId = artifact?.result?.id;
-  const contentsWithLoadingStatus = artifactResultId
+  const contentWithLoadingStatus = artifactResultId
     ? artifactContents[artifactResultId]
     : undefined;
   const { metrics, checks } =
@@ -88,7 +86,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
         !!artifact.result &&
         // intentional '==' to check undefined or null.
         artifact.result.content_serialized == null &&
-        !contentsWithLoadingStatus
+        !contentWithLoadingStatus
       ) {
         dispatch(
           handleGetArtifactResultContent({
@@ -134,197 +132,30 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
     );
   }
 
-  const metricsChecksSchema: DataSchema = {
-    fields: [
-      { name: 'Title', type: 'varchar' },
-      { name: 'Value', type: 'varchar' },
-    ],
-    pandas_version: '0.0.1', // TODO: Figure out what to set this value to.
-  };
-
-  const metricTableEntries = {
-    schema: metricsChecksSchema,
-    data: metrics
-      .map((metricArtf) => {
-        let name = metricArtf.name;
-        if (name.endsWith('artifact') || name.endsWith('Aritfact')) {
-          name = name.slice(0, 0 - 'artifact'.length);
-        }
-        return {
-          title: name,
-          value: metricArtf.result?.content_serialized,
-        };
-      })
-      .filter((x) => !!x.value),
-  };
-
-  const metricsSection = (
-    <Box width="100%">
-      <Typography variant="h5" component="div" marginBottom="8px">
-        Metrics
-      </Typography>
-      {metricTableEntries.data.length > 0 ? (
-        <OperatorExecStateTable
-          schema={metricTableEntries.schema}
-          rows={metricTableEntries}
-          tableType={OperatorExecStateTableType.Metric}
-        />
-      ) : (
-        <Typography variant="body2">
-          This artifact has no associated downstream Metrics.
-        </Typography>
-      )}
-    </Box>
-  );
-
-  const checkTableEntries = {
-    schema: metricsChecksSchema,
-    data: checks
-      .map((checkArtf) => {
-        let name = checkArtf.name;
-        if (name.endsWith('artifact') || name.endsWith('Aritfact')) {
-          name = name.slice(0, 0 - 'artifact'.length);
-        }
-        return {
-          title: name,
-          value: checkArtf.result?.content_serialized,
-        };
-      })
-      .filter((x) => !!x.value),
-  };
-
-  const checksSection = (
-    <Box width="100%">
-      <Typography variant="h5" component="div" marginBottom="8px">
-        Checks
-      </Typography>
-      {checkTableEntries.data.length > 0 ? (
-        <OperatorExecStateTable
-          schema={checkTableEntries.schema}
-          rows={checkTableEntries}
-          tableType={OperatorExecStateTableType.Check}
-        />
-      ) : (
-        <Typography variant="body2">
-          This artifact has no associated downstream Checks.
-        </Typography>
-      )}
-    </Box>
-  );
-
-  let csvExporter = null;
-  let contentSection = null;
-  if (!artifact.result) {
-    contentSection = (
-      <Typography variant="h5" component="div" marginBottom="8px">
-        No result to show for this artifact.
-      </Typography>
-    );
-  } else if (artifact.result.content_serialized != null) {
-    contentSection = (
-      <Typography variant="body1" component="div" marginBottom="8px">
-        <code>{artifact.result.content_serialized}</code>
-      </Typography>
-    );
-  } else if (!!contentsWithLoadingStatus) {
-    if (
-      isInitial(contentsWithLoadingStatus.status) ||
-      isLoading(contentsWithLoadingStatus.status)
-    ) {
-      contentSection = <CircularProgress />;
-    } else if (isFailed(contentsWithLoadingStatus.status)) {
-      contentSection = (
-        <Alert title="Failed to load artifact contents.">
-          {contentsWithLoadingStatus.status.err}
-        </Alert>
-      );
-    } else if (!contentsWithLoadingStatus.data) {
-      contentSection = (
-        <Typography variant="h5" component="div" marginBottom="8px">
-          No result to show for this artifact.
-        </Typography>
-      );
-    } else {
-      if (
-        artifact.type === ArtifactType.Bytes ||
-        artifact.type === ArtifactType.Picklable
-      ) {
-        contentSection = (
-          <Button
-            variant="contained"
-            sx={{ maxHeight: '32px' }}
-            onClick={() => {
-              const content = contentsWithLoadingStatus.data;
-              const blob = new Blob([content], { type: 'text' });
-              const url = window.URL.createObjectURL(blob);
-              const a = document.createElement('a');
-              a.href = url;
-              a.download = artifact.name;
-              a.click();
-
-              return true;
-            }}
-          >
-            Download
-          </Button>
-        );
-      } else if (artifact.type === ArtifactType.Table) {
-        try {
-          const data = JSON.parse(contentsWithLoadingStatus.data);
-          csvExporter = (
-            <Button
-              variant="contained"
-              sx={{ maxHeight: '32px' }}
-              onClick={() => {
-                exportCsv(
-                  data,
-                  artifact.name ? artifact.name.replaceAll(' ', '_') : 'data'
-                );
-              }}
-            >
-              Export
-            </Button>
-          );
-          contentSection = <PaginatedTable data={data} />;
-        } catch (err) {
-          contentSection = (
-            <Alert title="Cannot parse table data.">
-              {err}
-              {contentsWithLoadingStatus.data}
-            </Alert>
-          );
-        }
-      } else {
-        // TODO: handle images here
-        contentSection = (
-          <Typography variant="body1" component="div" marginBottom="8px">
-            <code>{contentsWithLoadingStatus.data}</code>
-          </Typography>
-        );
-      }
-    }
-  } else {
-    contentSection = <CircularProgress />;
-  }
-
   return (
     <Layout user={user}>
       <Box width={'800px'}>
         <Box width="100%">
           <Box width="100%" display="flex" alignItems="center">
             <DetailsPageHeader name={artifact.name} />
-            {csvExporter}
+            <CsvExporter
+              artifact={artifact}
+              contentWithLoadingStatus={contentWithLoadingStatus}
+            />
           </Box>
           <Box width="100%" marginTop="12px">
             <Typography variant="h5" component="div" marginBottom="8px">
               Preview
             </Typography>
-            {contentSection}
+            <ArtifactContent
+              artifact={artifact}
+              contentWithLoadingStatus={contentWithLoadingStatus}
+            />
           </Box>
           <Box display="flex" width="100%" paddingTop="40px">
-            {metricsSection}
+            <MetricsOverview metrics={metrics} />
             <Box width="96px" />
-            {checksSection}
+            <ChecksOverview checks={checks} />
           </Box>
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -2,7 +2,7 @@ import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
@@ -28,9 +28,6 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 }) => {
   const dispatch: AppDispatch = useDispatch();
   const { workflowId, workflowDagResultId, metricOperatorId } = useParams();
-
-  const [inputsExpanded, setInputsExpanded] = useState<boolean>(true);
-  const [outputsExpanded, setOutputsExpanded] = useState<boolean>(true);
 
   const workflowDagResultWithLoadingStatus = useSelector(
     (state: RootState) =>
@@ -89,12 +86,6 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     }
   }, [operator]);
 
-  const listStyle = {
-    width: '100%',
-    maxWidth: 360,
-    bgcolor: 'background.paper',
-  };
-
   if (
     !workflowDagResultWithLoadingStatus ||
     isInitial(workflowDagResultWithLoadingStatus.status) ||
@@ -117,18 +108,17 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     );
   }
 
-  const inputs = operator.inputs
-    .map(
-      (artifactId) =>
-        (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[artifactId]
-    )
-    .filter((artf) => !!artf);
-  const outputs = operator.outputs
-    .map(
-      (artifactId) =>
-        (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[artifactId]
-    )
-    .filter((artf) => !!artf);
+  const mapArtifacts = (artfIds: string[]) =>
+    artfIds
+      .map(
+        (artifactId) =>
+          (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
+            artifactId
+          ]
+      )
+      .filter((artf) => !!artf);
+  const inputs = mapArtifacts(operator.inputs);
+  const outputs = mapArtifacts(operator.outputs);
 
   return (
     <Layout user={user}>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -1,27 +1,19 @@
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { CircularProgress, Link, List, ListItem } from '@mui/material';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import AccordionSummary from '@mui/material/AccordionSummary';
+import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
-import Plot from 'react-plotly.js';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link as RouterLink, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import PaginatedTable from '../../../../components/tables/PaginatedTable';
-import { artifactTypeToIconMapping } from '../../../../components/workflows/nodes/nodeTypes';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
-import { Data } from '../../../../utils/data';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import DefaultLayout from '../../../layouts/default';
+import MetricsHistory from '../../../workflows/artifact/metric/history';
+import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
 
@@ -125,134 +117,18 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     );
   }
 
-  // Function to get the numerical value of the metric output
-  const operatorOutputsList = operator.outputs.map((artifactId) => {
-    const artifactResult = (workflowDagResultWithLoadingStatus.result
-      ?.artifacts ?? {})[artifactId];
-    if (!artifactResult) {
-      return null;
-    }
-
-    if (
-      !artifactResult.result ||
-      artifactResult.result.content_serialized === undefined
-    ) {
-      // Link to appropriate artifact details page
-      // Show tableIcon here as part of the link.
-      return (
-        <Box key={artifactId}>
-          <Link
-            to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
-            component={RouterLink as any}
-            sx={{ marginLeft: '16px' }}
-            underline="none"
-          >
-            {artifactResult.name}
-          </Link>
-        </Box>
-      );
-    }
-
-    return (
-      <Box key={artifactId}>
-        <Typography variant="body1">
-          {artifactResult.result.content_serialized}
-        </Typography>
-      </Box>
-    );
-  });
-
-  const operatorInputsList = operator.inputs.map((artifactId, index) => {
-    const artifactResult = (workflowDagResultWithLoadingStatus.result
-      ?.artifacts ?? {})[artifactId];
-    if (!artifactResult) {
-      return null;
-    }
-
-    return (
-      <ListItem divider key={`metric-input-${index}`}>
-        <Box display="flex">
-          <Box
-            sx={{
-              width: '16px',
-              height: '16px',
-              color: 'rgba(0,0,0,0.54)',
-            }}
-          >
-            <FontAwesomeIcon
-              icon={artifactTypeToIconMapping[artifactResult.type]}
-            />
-          </Box>
-          <Link
-            to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
-            component={RouterLink as any}
-            sx={{ marginLeft: '16px' }}
-            underline="none"
-          >
-            {artifactResult.name}
-          </Link>
-        </Box>
-      </ListItem>
-    );
-  });
-
-  let historicalOutputsSection = null;
-  if (
-    !artifactHistoryWithLoadingStatus ||
-    isInitial(artifactHistoryWithLoadingStatus.status) ||
-    isLoading(artifactHistoryWithLoadingStatus.status)
-  ) {
-    historicalOutputsSection = <CircularProgress />;
-  } else if (isFailed(artifactHistoryWithLoadingStatus.status)) {
-    historicalOutputsSection = (
-      <Alert title="Failed to load historical data.">
-        {artifactHistoryWithLoadingStatus.status.err}
-      </Alert>
-    );
-  } else {
-    const historicalData: Data = {
-      schema: {
-        fields: [
-          { name: 'status', type: 'varchar' },
-          { name: 'timestamp', type: 'varchar' },
-          { name: 'value', type: 'float' },
-        ],
-        pandas_version: '0.0.1',
-      },
-      data: (artifactHistoryWithLoadingStatus.results?.results ?? []).map(
-        (artifactStatusResult) => {
-          return {
-            status: artifactStatusResult.exec_state?.status ?? 'Unknown',
-            timestamp: artifactStatusResult.exec_state?.timestamps?.finished_at,
-            value: artifactStatusResult.content_serialized,
-          };
-        }
-      ),
-    };
-
-    const dataToPlot = historicalData.data.filter(
-      (x) => !!x['timestamp'] && !!x['value']
-    );
-    const timestamps = dataToPlot.map((x) => x['timestamp']);
-    const values = dataToPlot.map((x) => x['value']);
-    historicalOutputsSection = (
-      <Box display="flex" justifyContent="center" flexDirection="column">
-        <Plot
-          data={[
-            {
-              x: timestamps,
-              y: values,
-              type: 'scatter',
-              mode: 'lines+markers',
-              marker: { color: 'red' },
-            },
-          ]}
-          layout={{ width: '100%', height: '100%' }}
-        />
-        <PaginatedTable data={historicalData} />
-      </Box>
-    );
-  }
+  const inputs = operator.inputs
+    .map(
+      (artifactId) =>
+        (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[artifactId]
+    )
+    .filter((artf) => !!artf);
+  const outputs = operator.outputs
+    .map(
+      (artifactId) =>
+        (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[artifactId]
+    )
+    .filter((artf) => !!artf);
 
   return (
     <Layout user={user}>
@@ -267,67 +143,21 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
           <Box display="flex" width="100%" paddingTop="40px">
             <Box width="100%">
-              <Accordion
-                expanded={inputsExpanded}
-                onChange={() => {
-                  setInputsExpanded(!inputsExpanded);
-                }}
-              >
-                <AccordionSummary
-                  expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
-                  sx={{
-                    '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-                      transform: 'rotate(90deg)',
-                    },
-                  }}
-                  aria-controls="input-accordion-content"
-                  id="input-accordion-header"
-                >
-                  <Typography
-                    sx={{ width: '33%', flexShrink: 0 }}
-                    variant="h5"
-                    component="div"
-                    marginBottom="8px"
-                  >
-                    Inputs:
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <List sx={listStyle}>{operatorInputsList}</List>
-                </AccordionDetails>
-              </Accordion>
+              <ArtifactSummaryList
+                title={'Inputs:'}
+                workflowId={workflowId}
+                dagResultId={workflowDagResultId}
+                artifactResults={inputs}
+              />
             </Box>
             <Box width="32px" />
             <Box width="100%">
-              <Accordion
-                expanded={outputsExpanded}
-                onChange={() => {
-                  setOutputsExpanded(!outputsExpanded);
-                }}
-              >
-                <AccordionSummary
-                  expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
-                  sx={{
-                    '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-                      transform: 'rotate(90deg)',
-                    },
-                  }}
-                  aria-controls="panel1bh-content"
-                  id="panel1bh-header"
-                >
-                  <Typography
-                    sx={{ width: '33%', flexShrink: 0 }}
-                    variant="h5"
-                    component="div"
-                    marginBottom="8px"
-                  >
-                    Output:
-                  </Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <React.Fragment>{operatorOutputsList}</React.Fragment>
-                </AccordionDetails>
-              </Accordion>
+              <ArtifactSummaryList
+                title={'Outputs:'}
+                workflowId={workflowId}
+                dagResultId={workflowDagResultId}
+                artifactResults={outputs}
+              />
             </Box>
           </Box>
 
@@ -335,7 +165,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
             <Typography variant="h5" component="div" marginBottom="8px">
               Historical Outputs:
             </Typography>
-            {historicalOutputsSection}
+            <MetricsHistory
+              historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
+            />
           </Box>
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -148,6 +148,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 artifactResults={inputs}
+                initiallyExpanded={true}
               />
             </Box>
             <Box width="32px" />
@@ -157,6 +158,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 artifactResults={outputs}
+                initiallyExpanded={true}
               />
             </Box>
           </Box>

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -27,6 +27,7 @@ const ArtifactContent: React.FC<Props> = ({
     );
   }
 
+  // intentional '!=' check for null or undefined.
   if (artifact.result.content_serialized != null) {
     return (
       <Typography variant="body1" component="div" marginBottom="8px">

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -1,0 +1,110 @@
+import { CircularProgress } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { ArtifactResultResponse } from '../../../handlers/responses/artifact';
+import { ContentWithLoadingStatus } from '../../../reducers/artifactResultContents';
+import { ArtifactType } from '../../../utils/artifacts';
+import { isFailed, isInitial, isLoading } from '../../../utils/shared';
+import { Button } from '../../primitives/Button.styles';
+import PaginatedTable from '../../tables/PaginatedTable';
+
+type Props = {
+  artifact: ArtifactResultResponse;
+  contentWithLoadingStatus?: ContentWithLoadingStatus;
+};
+
+const ArtifactContent: React.FC<Props> = ({
+  artifact,
+  contentWithLoadingStatus,
+}) => {
+  if (!artifact.result) {
+    return (
+      <Typography variant="h5" component="div" marginBottom="8px">
+        No result to show for this artifact.
+      </Typography>
+    );
+  }
+
+  if (artifact.result.content_serialized != null) {
+    return (
+      <Typography variant="body1" component="div" marginBottom="8px">
+        <code>{artifact.result.content_serialized}</code>
+      </Typography>
+    );
+  }
+
+  if (!contentWithLoadingStatus) {
+    return <CircularProgress />;
+  }
+  if (
+    isInitial(contentWithLoadingStatus.status) ||
+    isLoading(contentWithLoadingStatus.status)
+  ) {
+    return <CircularProgress />;
+  }
+
+  if (isFailed(contentWithLoadingStatus.status)) {
+    return (
+      <Alert title="Failed to load artifact contents.">
+        {contentWithLoadingStatus.status.err}
+      </Alert>
+    );
+  }
+
+  if (!contentWithLoadingStatus.data) {
+    return (
+      <Typography variant="h5" component="div" marginBottom="8px">
+        No result to show for this artifact.
+      </Typography>
+    );
+  }
+
+  if (
+    artifact.type === ArtifactType.Bytes ||
+    artifact.type === ArtifactType.Picklable
+  ) {
+    return (
+      <Button
+        variant="contained"
+        sx={{ maxHeight: '32px' }}
+        onClick={() => {
+          const content = contentWithLoadingStatus.data;
+          const blob = new Blob([content], { type: 'text' });
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = artifact.name;
+          a.click();
+
+          return true;
+        }}
+      >
+        Download
+      </Button>
+    );
+  }
+
+  if (artifact.type === ArtifactType.Table) {
+    try {
+      const data = JSON.parse(contentWithLoadingStatus.data);
+      return <PaginatedTable data={data} />;
+    } catch (err) {
+      return (
+        <Alert title="Cannot parse table data.">
+          {err}
+          {contentWithLoadingStatus.data}
+        </Alert>
+      );
+    }
+  }
+  // TODO: handle images here
+  return (
+    <Typography variant="body1" component="div" marginBottom="8px">
+      <code>{contentWithLoadingStatus.data}</code>
+    </Typography>
+  );
+};
+
+export default ArtifactContent;

--- a/src/ui/common/src/components/workflows/artifact/csvExporter.tsx
+++ b/src/ui/common/src/components/workflows/artifact/csvExporter.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { ArtifactResultResponse } from '../../../handlers/responses/artifact';
+import { ContentWithLoadingStatus } from '../../../reducers/artifactResultContents';
+import { ArtifactType } from '../../../utils/artifacts';
+import { exportCsv } from '../../../utils/preview';
+import { isFailed, isInitial, isLoading } from '../../../utils/shared';
+import { Button } from '../../primitives/Button.styles';
+import { LoadingButton } from '../../primitives/LoadingButton.styles';
+
+type Props = {
+  artifact: ArtifactResultResponse;
+  contentWithLoadingStatus?: ContentWithLoadingStatus;
+};
+
+// CsvExporter returns a CSV download button if the artifact is exportable.
+// Otherwise it returns `null`.
+const CsvExporter: React.FC<Props> = ({
+  artifact,
+  contentWithLoadingStatus,
+}) => {
+  if (artifact.type !== ArtifactType.Table) {
+    return null;
+  }
+
+  if (!contentWithLoadingStatus) {
+    return null;
+  }
+
+  if (
+    isInitial(contentWithLoadingStatus.status) ||
+    isLoading(contentWithLoadingStatus.status)
+  ) {
+    return (
+      <LoadingButton
+        variant="contained"
+        sx={{ maxHeight: '32px' }}
+        disabled
+        loading
+      >
+        Export
+      </LoadingButton>
+    );
+  }
+
+  if (
+    isFailed(contentWithLoadingStatus.status) ||
+    !contentWithLoadingStatus.data
+  ) {
+    return (
+      <Button variant="contained" sx={{ maxHeight: '32px' }} disabled>
+        Export
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      variant="contained"
+      sx={{ maxHeight: '32px' }}
+      onClick={() => {
+        exportCsv(
+          JSON.parse(contentWithLoadingStatus.data),
+          artifact.name ? artifact.name.replaceAll(' ', '_') : 'data'
+        );
+      }}
+    >
+      Export
+    </Button>
+  );
+};
+
+export default CsvExporter;

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -6,6 +6,7 @@ import Plot from 'react-plotly.js';
 
 import PaginatedTable from '../../../../components/tables/PaginatedTable';
 import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
+import { theme } from '../../../../styles/theme/theme';
 import { Data, DataSchema } from '../../../../utils/data';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 
@@ -65,9 +66,8 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
             y: values,
             type: 'scatter',
             mode: 'lines+markers',
-            // colors are 'blue.900'. Plot doesn't seem to accept color from theme.
-            marker: { color: '#002f5e' },
-            line: { color: '#002f5e' },
+            marker: { color: theme.palette.blue[900] },
+            line: { color: theme.palette.blue[900] },
           },
         ]}
         layout={{ width: '100%', height: '100%' }}

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -6,11 +6,20 @@ import Plot from 'react-plotly.js';
 
 import PaginatedTable from '../../../../components/tables/PaginatedTable';
 import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
-import { Data } from '../../../../utils/data';
+import { Data, DataSchema } from '../../../../utils/data';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 
 type Props = {
   historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
+};
+
+const metricHistorySchema: DataSchema = {
+  fields: [
+    { name: 'status', type: 'varchar' },
+    { name: 'timestamp', type: 'varchar' },
+    { name: 'value', type: 'float' },
+  ],
+  pandas_version: '',
 };
 
 const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
@@ -30,14 +39,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
   }
 
   const historicalData: Data = {
-    schema: {
-      fields: [
-        { name: 'status', type: 'varchar' },
-        { name: 'timestamp', type: 'varchar' },
-        { name: 'value', type: 'float' },
-      ],
-      pandas_version: '0.0.1',
-    },
+    schema: metricHistorySchema,
     data: (historyWithLoadingStatus.results?.results ?? []).map(
       (artifactStatusResult) => {
         return {
@@ -63,7 +65,9 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
             y: values,
             type: 'scatter',
             mode: 'lines+markers',
-            marker: { color: 'red' },
+            // colors are 'blue.900'. Plot doesn't seem to accept color from theme.
+            marker: { color: '#002f5e' },
+            line: { color: '#002f5e' },
           },
         ]}
         layout={{ width: '100%', height: '100%' }}

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -1,0 +1,76 @@
+import { CircularProgress } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import React from 'react';
+import Plot from 'react-plotly.js';
+
+import PaginatedTable from '../../../../components/tables/PaginatedTable';
+import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
+import { Data } from '../../../../utils/data';
+import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
+
+type Props = {
+  historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
+};
+
+const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
+  if (
+    !historyWithLoadingStatus ||
+    isInitial(historyWithLoadingStatus.status) ||
+    isLoading(historyWithLoadingStatus.status)
+  ) {
+    return <CircularProgress />;
+  }
+  if (isFailed(historyWithLoadingStatus.status)) {
+    return (
+      <Alert title="Failed to load historical data.">
+        {historyWithLoadingStatus.status.err}
+      </Alert>
+    );
+  }
+
+  const historicalData: Data = {
+    schema: {
+      fields: [
+        { name: 'status', type: 'varchar' },
+        { name: 'timestamp', type: 'varchar' },
+        { name: 'value', type: 'float' },
+      ],
+      pandas_version: '0.0.1',
+    },
+    data: (historyWithLoadingStatus.results?.results ?? []).map(
+      (artifactStatusResult) => {
+        return {
+          status: artifactStatusResult.exec_state?.status ?? 'Unknown',
+          timestamp: artifactStatusResult.exec_state?.timestamps?.finished_at,
+          value: artifactStatusResult.content_serialized,
+        };
+      }
+    ),
+  };
+
+  const dataToPlot = historicalData.data.filter(
+    (x) => !!x['timestamp'] && !!x['value']
+  );
+  const timestamps = dataToPlot.map((x) => x['timestamp']);
+  const values = dataToPlot.map((x) => x['value']);
+  return (
+    <Box display="flex" justifyContent="center" flexDirection="column">
+      <Plot
+        data={[
+          {
+            x: timestamps,
+            y: values,
+            type: 'scatter',
+            mode: 'lines+markers',
+            marker: { color: 'red' },
+          },
+        ]}
+        layout={{ width: '100%', height: '100%' }}
+      />
+      <PaginatedTable data={historicalData} />
+    </Box>
+  );
+};
+
+export default MetricsHistory;

--- a/src/ui/common/src/components/workflows/artifact/metricsAndChecksOverview.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metricsAndChecksOverview.tsx
@@ -1,0 +1,104 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { ArtifactResultResponse } from '../../../handlers/responses/artifact';
+import { DataSchema } from '../../../utils/data';
+import OperatorExecStateTable, {
+  OperatorExecStateTableType,
+} from '../../tables/OperatorExecStateTable';
+
+// This file contains two major components to show metrics and checks
+// associated with a given artifact.
+
+const schema: DataSchema = {
+  fields: [
+    { name: 'Title', type: 'varchar' },
+    { name: 'Value', type: 'varchar' },
+  ],
+  pandas_version: '',
+};
+
+type MetricsOverviewProps = {
+  metrics: ArtifactResultResponse[];
+};
+
+export const MetricsOverview: React.FC<MetricsOverviewProps> = ({
+  metrics,
+}) => {
+  const metricTableEntries = {
+    schema: schema,
+    data: metrics
+      .map((metricArtf) => {
+        let name = metricArtf.name;
+        if (name.endsWith('artifact') || name.endsWith('Aritfact')) {
+          name = name.slice(0, 0 - 'artifact'.length);
+        }
+        return {
+          title: name,
+          value: metricArtf.result?.content_serialized,
+        };
+      })
+      .filter((x) => !!x.value),
+  };
+
+  return (
+    <Box width="100%">
+      <Typography variant="h5" component="div" marginBottom="8px">
+        Metrics
+      </Typography>
+      {metricTableEntries.data.length > 0 ? (
+        <OperatorExecStateTable
+          schema={metricTableEntries.schema}
+          rows={metricTableEntries}
+          tableType={OperatorExecStateTableType.Metric}
+        />
+      ) : (
+        <Typography variant="body2">
+          This artifact has no associated downstream Metrics.
+        </Typography>
+      )}
+    </Box>
+  );
+};
+
+export type ChecksOverviewProps = {
+  checks: ArtifactResultResponse[];
+};
+
+export const ChecksOverview: React.FC<ChecksOverviewProps> = ({ checks }) => {
+  const checkTableEntries = {
+    schema: schema,
+    data: checks
+      .map((checkArtf) => {
+        let name = checkArtf.name;
+        if (name.endsWith('artifact') || name.endsWith('Aritfact')) {
+          name = name.slice(0, 0 - 'artifact'.length);
+        }
+        return {
+          title: name,
+          value: checkArtf.result?.content_serialized,
+        };
+      })
+      .filter((x) => !!x.value),
+  };
+
+  return (
+    <Box width="100%">
+      <Typography variant="h5" component="div" marginBottom="8px">
+        Checks
+      </Typography>
+      {checkTableEntries.data.length > 0 ? (
+        <OperatorExecStateTable
+          schema={checkTableEntries.schema}
+          rows={checkTableEntries}
+          tableType={OperatorExecStateTableType.Check}
+        />
+      ) : (
+        <Typography variant="body2">
+          This artifact has no associated downstream Checks.
+        </Typography>
+      )}
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/workflows/artifact/summaryList.tsx
+++ b/src/ui/common/src/components/workflows/artifact/summaryList.tsx
@@ -18,6 +18,7 @@ type Props = {
   workflowId: string;
   dagResultId: string;
   artifactResults: ArtifactResultResponse[];
+  initiallyExpanded: boolean;
 };
 
 const listStyle = {
@@ -31,8 +32,9 @@ const SummaryList: React.FC<Props> = ({
   workflowId,
   dagResultId,
   artifactResults,
+  initiallyExpanded,
 }) => {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(initiallyExpanded);
   const items = artifactResults.map((artifactResult) => {
     let content = null;
     if (artifactResult.result?.content_serialized) {

--- a/src/ui/common/src/components/workflows/artifact/summaryList.tsx
+++ b/src/ui/common/src/components/workflows/artifact/summaryList.tsx
@@ -1,0 +1,111 @@
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Link, List, ListItem } from '@mui/material';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React, { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
+
+import { ArtifactResultResponse } from '../../../handlers/responses/artifact';
+import { getPathPrefix } from '../../../utils/getPathPrefix';
+import { artifactTypeToIconMapping } from '../nodes/nodeTypes';
+
+type Props = {
+  title: string;
+  workflowId: string;
+  dagResultId: string;
+  artifactResults: ArtifactResultResponse[];
+};
+
+const listStyle = {
+  width: '100%',
+  maxWidth: 360,
+  bgcolor: 'background.paper',
+};
+
+const SummaryList: React.FC<Props> = ({
+  title,
+  workflowId,
+  dagResultId,
+  artifactResults,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const items = artifactResults.map((artifactResult) => {
+    let content = null;
+    if (artifactResult.result?.content_serialized) {
+      content = (
+        <Typography variant="body1">
+          {artifactResult.result.content_serialized}
+        </Typography>
+      );
+    } else {
+      content = (
+        <Box display="flex">
+          <Box
+            sx={{
+              width: '16px',
+              height: '16px',
+              color: 'rgba(0,0,0,0.54)',
+            }}
+          >
+            <FontAwesomeIcon
+              icon={artifactTypeToIconMapping[artifactResult.type]}
+            />
+          </Box>
+          <Link
+            to={`${getPathPrefix()}/workflow/${workflowId}/result/${dagResultId}/artifact/${
+              artifactResult.id
+            }`}
+            component={RouterLink as any}
+            sx={{ marginLeft: '16px' }}
+            underline="none"
+          >
+            {artifactResult.name}
+          </Link>
+        </Box>
+      );
+    }
+    return (
+      <ListItem divider key={artifactResult.id}>
+        {content}
+      </ListItem>
+    );
+  });
+
+  return (
+    <Accordion
+      expanded={expanded}
+      onChange={() => {
+        setExpanded(!expanded);
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
+        sx={{
+          '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+            transform: 'rotate(90deg)',
+          },
+        }}
+        aria-controls="input-accordion-content"
+        id="input-accordion-header"
+      >
+        <Typography
+          sx={{ width: '33%', flexShrink: 0 }}
+          variant="h5"
+          component="div"
+          marginBottom="8px"
+        >
+          {title}
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <List sx={listStyle}>{items}</List>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export default SummaryList;

--- a/src/ui/common/src/reducers/artifactResultContents.ts
+++ b/src/ui/common/src/reducers/artifactResultContents.ts
@@ -5,12 +5,13 @@ import { createSlice } from '@reduxjs/toolkit';
 import { handleGetArtifactResultContent } from '../handlers/getArtifactResultContent';
 import { LoadingStatus, LoadingStatusEnum } from '../utils/shared';
 
+export type ContentWithLoadingStatus = {
+  status: LoadingStatus;
+  data?: string;
+};
 export interface ArtifactResultContentState {
   contents: {
-    [artifactResultId: string]: {
-      status: LoadingStatus;
-      data?: string;
-    };
+    [artifactResultId: string]: ContentWithLoadingStatus;
   };
 }
 

--- a/src/ui/common/src/reducers/artifactResults.ts
+++ b/src/ui/common/src/reducers/artifactResults.ts
@@ -6,12 +6,14 @@ import { handleListArtifactResults } from '../handlers/listArtifactResults';
 import { ListArtifactResultsResponse } from '../handlers/responses/artifact';
 import { LoadingStatus, LoadingStatusEnum } from '../utils/shared';
 
+export type ArtifactResultsWithLoadingStatus = {
+  status: LoadingStatus;
+  results?: ListArtifactResultsResponse;
+};
+
 export interface ArtifactResultsState {
   artifacts: {
-    [id: string]: {
-      status: LoadingStatus;
-      results?: ListArtifactResultsResponse;
-    };
+    [id: string]: ArtifactResultsWithLoadingStatus;
   };
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR cleans up artifact and metrics page. By managing large components individually, we reduced `index` file of each page from ~300+ lines to ~150 lines. Some components are also reusable. For example, `artifact/summaryList` can be reused for inputs / outputs for operator details page as well.

## Related issue number (if any)
ENG-1747

## Demo (if any)
Verified these refactored pages works properly.
<img width="905" alt="Screen Shot 2022-09-26 at 11 51 49 PM" src="https://user-images.githubusercontent.com/10411887/192455984-d1b438bb-c415-4342-b076-ae2cc093ef93.png">
<img width="841" alt="Screen Shot 2022-09-26 at 11 52 37 PM" src="https://user-images.githubusercontent.com/10411887/192456070-3e17347b-e0fa-4aa1-88f1-617c228cb405.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


