### PR TITLE
Fix our API route to conform to the standard

### DIFF
--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -145,7 +145,7 @@ class APIClient:
     LIST_TABLES_ROUTE = "/api/tables"
     GET_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s"
     LIST_WORKFLOW_SAVED_OBJECTS_ROUTE = "/api/workflow/%s/objects"
-    GET_ARTIFACT_RESULT_TEMPLATE = "/api/artifact_result/%s/%s"
+    GET_ARTIFACT_RESULT_TEMPLATE = "/api/artifact/%s/%s/result"
     LIST_WORKFLOWS_ROUTE = "/api/workflows"
     REFRESH_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s/refresh"
     DELETE_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s/delete"

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -140,7 +140,7 @@ class APIClient:
 
     PREVIEW_ROUTE = "/api/preview"
     REGISTER_WORKFLOW_ROUTE = "/api/workflow/register"
-    REGISTER_AIRFLOW_WORKFLOW_ROUTE = "/api/workflow/register_airflow"
+    REGISTER_AIRFLOW_WORKFLOW_ROUTE = "/api/workflow/register/airflow"
     LIST_INTEGRATIONS_ROUTE = "/api/integrations"
     LIST_TABLES_ROUTE = "/api/tables"
     GET_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s"

--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -25,7 +25,7 @@ const (
 	dataFormFieldName     = "data"
 )
 
-// Route: /artifact_result/{workflowDagResultId}/{artifactId}
+// Route: /artifact/{workflowDagResultId}/{artifactId}/result
 // Method: GET
 // Params:
 //

--- a/src/golang/cmd/server/handler/get_artifact_versions.go
+++ b/src/golang/cmd/server/handler/get_artifact_versions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// Route: /artifact_versions
+// Route: /artifact/versions
 // Method: GET
 // Params: None
 // Request:

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// Route: /operator_result/{workflowDagResultId}/{operatorId}
+// Route: /operator/{workflowDagResultId}/{operatorId}/result
 // Method: GET
 // Params:
 //

--- a/src/golang/cmd/server/handler/preview_table.go
+++ b/src/golang/cmd/server/handler/preview_table.go
@@ -27,7 +27,7 @@ const (
 	PollPreviewTableTimeout  = 60 * time.Second
 )
 
-// Route: /integration/{integrationId}/preview_table
+// Route: /integration/{integrationId}/preview
 // Method: GET
 // Params:
 //	`integrationId`: ID of the relational database integration

--- a/src/golang/cmd/server/handler/register_airflow_workflow.go
+++ b/src/golang/cmd/server/handler/register_airflow_workflow.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// Route: /workflow/register_airflow
+// Route: /workflow/register/airflow
 // Method: POST
 // Params: none
 // Request

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -33,7 +33,7 @@ const (
 
 	ListWorkflowsRoute           = "/api/workflows"
 	RegisterWorkflowRoute        = "/api/workflow/register"
-	RegisterAirflowWorkflowRoute = "/api/workflow/register_airflow"
+	RegisterAirflowWorkflowRoute = "/api/workflow/register/airflow"
 	GetWorkflowRoute             = "/api/workflow/{workflowId}"
 	ListArtifactResultsRoute     = "/api/workflow/{workflowId}/artifact/{artifactId}/results"
 	ListWorkflowObjectsRoute     = "/api/workflow/{workflowId}/objects"

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -2,8 +2,8 @@ package routes
 
 // Please sort the route by their VALUEs
 const (
-	GetArtifactVersionsRoute = "/api/artifact_versions"
-	GetArtifactResultRoute   = "/api/artifact_result/{workflowDagResultId}/{artifactId}"
+	GetArtifactVersionsRoute = "/api/artifact/versions"
+	GetArtifactResultRoute   = "/api/artifact/{workflowDagResultId}/{artifactId}/result"
 
 	GetFunctionRoute    = "/api/function/{functionId}"
 	ExportFunctionRoute = "/api/function/{operatorId}/export"
@@ -24,7 +24,7 @@ const (
 	ListNotificationsRoute   = "/api/notifications"
 	ArchiveNotificationRoute = "/api/notifications/{notificationId}/archive"
 
-	GetOperatorResultRoute = "/api/operator_result/{workflowDagResultId}/{operatorId}"
+	GetOperatorResultRoute = "/api/operator/{workflowDagResultId}/{operatorId}/result"
 
 	GetNodePositionsRoute = "/api/positioning"
 	PreviewRoute          = "/api/preview"

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -15,7 +15,7 @@ const (
 	DiscoverRoute                    = "/api/integration/{integrationId}/discover"
 	EditIntegrationRoute             = "/api/integration/{integrationId}/edit"
 	ListIntegrationObjectsRoute      = "/api/integration/{integrationId}/objects"
-	PreviewTableRoute                = "/api/integration/{integrationId}/preview_table"
+	PreviewTableRoute                = "/api/integration/{integrationId}/preview"
 	ListOperatorsForIntegrationRoute = "/api/integration/{integrationId}/operators"
 	TestIntegrationRoute             = "/api/integration/{integrationId}/test"
 

--- a/src/ui/common/src/reducers/dataPreview.ts
+++ b/src/ui/common/src/reducers/dataPreview.ts
@@ -31,7 +31,7 @@ export const getDataArtifactPreview = createAsyncThunk<
     thunkAPI
   ) => {
     const { apiKey } = args;
-    const response = await fetch(`${apiAddress}/api/artifact_versions`, {
+    const response = await fetch(`${apiAddress}/api/artifact/versions`, {
       method: 'GET',
       headers: {
         'api-key': apiKey,

--- a/src/ui/common/src/reducers/integration.ts
+++ b/src/ui/common/src/reducers/integration.ts
@@ -136,7 +136,7 @@ export const handleLoadIntegrationObject = createAsyncThunk<
     }
 
     const objectResponse = await fetch(
-      `${apiAddress}/api/integration/${integrationId}/preview_table`,
+      `${apiAddress}/api/integration/${integrationId}/preview`,
       {
         method: 'GET',
         headers: {

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -114,7 +114,7 @@ export const handleGetOperatorResults = createAsyncThunk<
   ) => {
     const { apiKey, workflowDagResultId, operatorId } = args;
     const res = await fetch(
-      `${apiAddress}/api/operator_result/${workflowDagResultId}/${operatorId}`,
+      `${apiAddress}/api/operator/${workflowDagResultId}/${operatorId}/result`,
       {
         method: 'GET',
         headers: {
@@ -147,7 +147,7 @@ export const handleGetArtifactResults = createAsyncThunk<
   ) => {
     const { apiKey, workflowDagResultId, artifactId } = args;
     const res = await fetch(
-      `${apiAddress}/api/artifact_result/${workflowDagResultId}/${artifactId}`,
+      `${apiAddress}/api/artifact/${workflowDagResultId}/${artifactId}/result`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fix API route for "GetArtifactVersionsRoute", "GetArtifactResultRoute", "GetOperatorResultRoute", and "RegisterAirflowRoute". After route has been changed, there are subsequent change in UI and SDK to cope with the changes. 

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1221/fix-our-api-route-to-conform-to-the-standard

## Loom demo (if any)
<img width="713" alt="Screen Shot 2022-09-27 at 10 21 51 AM" src="https://user-images.githubusercontent.com/78303449/192594148-1fbc5f4b-477e-49df-a937-8af7172eb153.png">
Here is the route result when previewing a published workflow

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


