### PR TITLE
Allow user functions to have multiple output artifacts

### DIFF
--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from aqueduct.error import AqueductError
 from utils import run_flow_test
 

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -1,0 +1,35 @@
+from aqueduct import op
+from utils import run_flow_test
+
+
+def test_multiple_outputs(client):
+    @op(num_outputs=2)
+    def generate_two_outputs():
+        return "hello", 1234
+
+    @op
+    def append_to_str(input_str):
+        return input_str + " world."
+
+    @op
+    def double_number(num):
+        return 2 * num
+
+    str_artifact, int_artifact = generate_two_outputs()
+    assert str_artifact.get() == "hello"
+    assert int_artifact.get() == 1234
+
+    str_output = append_to_str(str_artifact)
+    int_output = double_number(int_artifact)
+    assert str_output.get() == "hello world."
+    assert int_output.get() == 2468
+
+    run_flow_test(client, artifacts=[str_output, int_output], delete_flow_after=False)
+
+
+def test_multiple_outputs_user_failure(client):
+    @op(num_outputs=3)
+    def generate_two_outputs():
+        return "hello", 1234
+
+    generate_two_outputs()

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -1,3 +1,6 @@
+import pytest
+
+from aqueduct.error import AqueductError
 from utils import run_flow_test
 
 from aqueduct import op
@@ -33,4 +36,5 @@ def test_multiple_outputs_user_failure(client):
     def generate_two_outputs():
         return "hello", 1234
 
-    generate_two_outputs()
+    with pytest.raises(AqueductError):
+        generate_two_outputs()

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -1,5 +1,6 @@
-from aqueduct import op
 from utils import run_flow_test
+
+from aqueduct import op
 
 
 def test_multiple_outputs(client):

--- a/integration_tests/sdk/operator_test.py
+++ b/integration_tests/sdk/operator_test.py
@@ -1,7 +1,7 @@
 from aqueduct.decorator import to_operator
 from constants import SENTIMENT_SQL_QUERY
 from test_function import dummy_sentiment_model_function
-from utils import get_integration_name, run_sentiment_model
+from utils import get_integration_name
 
 from aqueduct import op
 

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -2,6 +2,7 @@ import time
 import uuid
 from typing import Dict, List, Optional, Union
 
+from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.bool_artifact import BoolArtifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.artifacts.table_artifact import TableArtifact
@@ -91,7 +92,7 @@ def run_sentiment_model_local_multiple_input(
 
 def run_flow_test(
     client: aqueduct.Client,
-    artifacts: List[Union[TableArtifact, NumericArtifact, BoolArtifact]],
+    artifacts: List[BaseArtifact],
     name: str = "",
     schedule: str = "",
     num_runs: int = 1,

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -167,9 +167,7 @@ class Client:
         """
         return Github(repo_url=repo, branch=branch)
 
-    def create_param(
-        self, name: str, default: Any, description: str = ""
-    ) -> Union[TableArtifact, NumericArtifact, BoolArtifact, GenericArtifact]:
+    def create_param(self, name: str, default: Any, description: str = "") -> BaseArtifact:
         """Creates a parameter artifact that can be fed into other operators.
 
         Parameter values are configurable at runtime.

--- a/sdk/aqueduct/artifacts/utils.py
+++ b/sdk/aqueduct/artifacts/utils.py
@@ -66,7 +66,9 @@ def preview_artifacts(
 
         # Fetch the content of the target artifact.
         artifact_name = dag.must_get_artifact(target_artifact_id).name
-        target_artifact_content = _get_content_from_artifact_result_resp(target_artifact_result, artifact_name)
+        target_artifact_content = _get_content_from_artifact_result_resp(
+            target_artifact_result, artifact_name
+        )
 
         # Create the target artifact.
         output_artifacts.append(
@@ -135,7 +137,9 @@ def _update_artifact_type(
         dag.update_artifact_type(artifact_id, new_artifact_type)
 
 
-def _get_content_from_artifact_result_resp(artifact_result: ArtifactResult, artifact_name: str) -> Any:
+def _get_content_from_artifact_result_resp(
+    artifact_result: ArtifactResult, artifact_name: str
+) -> Any:
     """Deserialize and validate the type of the content for a given artifact result."""
     content = deserialize(
         artifact_result.serialization_type,
@@ -143,10 +147,11 @@ def _get_content_from_artifact_result_resp(artifact_result: ArtifactResult, arti
         artifact_result.content,
     )
     assert infer_artifact_type(content) == artifact_result.artifact_type, (
-            "Artifact `%s` has deserialized content with type %s, but preview request returned type %s" % (
-        artifact_name,
-        infer_artifact_type(content),
-        artifact_result.artifact_type,
-    )
+        "Artifact `%s` has deserialized content with type %s, but preview request returned type %s"
+        % (
+            artifact_name,
+            infer_artifact_type(content),
+            artifact_result.artifact_type,
+        )
     )
     return content

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -52,6 +52,7 @@ DecoratedCheckFunction = Callable[[CheckFunction], OutputArtifactFunction]
 def _is_input_artifact(elem: Any) -> bool:
     return isinstance(elem, BaseArtifact)
 
+
 def wrap_spec(
     spec: OperatorSpec,
     *input_artifacts: BaseArtifact,
@@ -85,7 +86,9 @@ def wrap_spec(
     Returns:
         A list of artifacts, representing the outputs of the function.
     """
-    assert len(output_artifact_type_hints) > 0, "Non-load operators must have at least one output artifact."
+    assert (
+        len(output_artifact_type_hints) > 0
+    ), "Non-load operators must have at least one output artifact."
 
     for artifact in input_artifacts:
         if artifact._from_flow_run:
@@ -103,7 +106,7 @@ def wrap_spec(
     operator_id = generate_uuid()
     output_artifact_ids = [generate_uuid() for _ in output_artifact_type_hints]
 
-    def _construct_artifact_name(i: int, op_name: str):
+    def _construct_artifact_name(i: int, op_name: str) -> str:
         """The artifact naming policy is "<op_name> artifact <optional counter>".
 
         The counter starts at 1, and is only present in the multi-output case.
@@ -267,7 +270,7 @@ def op(
             `pip freeze`.
         num_outputs:
             The number of outputs the decorated function is expected to return.
-            Will fail at runtime if the number of outputs.
+            Will fail at runtime if a different number of outputs is returned by the function.
 
     Examples:
         The op name is inferred from the function name. The description is pulled from the function

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Any, Callable, List, Optional, Sequence, Union, cast
+from typing import Any, Callable, List, Optional, Union, cast
 
 import numpy as np
 from aqueduct.artifacts import utils as artifact_utils

--- a/sdk/aqueduct/github.py
+++ b/sdk/aqueduct/github.py
@@ -1,7 +1,12 @@
 from typing import List, Optional, Tuple
 
 from aqueduct.artifacts.table_artifact import TableArtifact
-from aqueduct.enums import FunctionGranularity, FunctionType, GithubRepoConfigContentType, ArtifactType
+from aqueduct.enums import (
+    ArtifactType,
+    FunctionGranularity,
+    FunctionType,
+    GithubRepoConfigContentType,
+)
 from aqueduct.error import InvalidGithubQueryError
 from aqueduct.templates import DEFAULT_OP_METHOD_NAME
 from aqueduct.utils import MODEL_FILE_NAME
@@ -165,7 +170,7 @@ class Github:
                 op_name=_get_operator_name(
                     "github_function", self.repo_url, self.branch, path or ""
                 ),
-                output_artifact_type_hints=[ArtifactType.UNTYPED]
+                output_artifact_type_hints=[ArtifactType.UNTYPED],
             )
             assert isinstance(new_function_artifact, TableArtifact)
             return new_function_artifact

--- a/sdk/aqueduct/github.py
+++ b/sdk/aqueduct/github.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple
 
 from aqueduct.artifacts.table_artifact import TableArtifact
-from aqueduct.enums import FunctionGranularity, FunctionType, GithubRepoConfigContentType
+from aqueduct.enums import FunctionGranularity, FunctionType, GithubRepoConfigContentType, ArtifactType
 from aqueduct.error import InvalidGithubQueryError
 from aqueduct.templates import DEFAULT_OP_METHOD_NAME
 from aqueduct.utils import MODEL_FILE_NAME
@@ -165,6 +165,7 @@ class Github:
                 op_name=_get_operator_name(
                     "github_function", self.repo_url, self.branch, path or ""
                 ),
+                output_artifact_type_hints=[ArtifactType.UNTYPED]
             )
             assert isinstance(new_function_artifact, TableArtifact)
             return new_function_artifact

--- a/sdk/aqueduct/parameter_utils.py
+++ b/sdk/aqueduct/parameter_utils.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
+from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.artifacts.utils import to_artifact_class
 from aqueduct.dag import DAG
 from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.error import InvalidUserArgumentException
-from aqueduct.operators import Operator, OperatorSpec, ParamSpec
+from aqueduct.operators import Operator, OperatorSpec
 from aqueduct.utils import construct_param_spec, generate_uuid, infer_artifact_type
-
-if TYPE_CHECKING:
-    from aqueduct.artifacts.bool_artifact import BoolArtifact
-    from aqueduct.artifacts.generic_artifact import GenericArtifact
-    from aqueduct.artifacts.numeric_artifact import NumericArtifact
-    from aqueduct.artifacts.table_artifact import TableArtifact
 
 
 def create_param(
@@ -22,7 +17,7 @@ def create_param(
     name: str,
     default: Any,
     description: str = "",
-) -> Union[TableArtifact, NumericArtifact, BoolArtifact, GenericArtifact]:
+) -> BaseArtifact:
     """Creates a parameter operator and return an artifact that can be fed into other operators."""
     if default is None:
         raise InvalidUserArgumentException("Parameter default value cannot be None.")

--- a/src/golang/lib/workflow/dag/workflow_dag.go
+++ b/src/golang/lib/workflow/dag/workflow_dag.go
@@ -2,6 +2,7 @@ package dag
 
 import (
 	"context"
+
 	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/notification"

--- a/src/golang/lib/workflow/dag/workflow_dag.go
+++ b/src/golang/lib/workflow/dag/workflow_dag.go
@@ -110,9 +110,11 @@ func computeArtifactSignatures(
 
 		// Compute that signature for each output artifact.
 		for _, outputArtifactID := range currOp.Outputs {
-			// NOTE: is it important for correctness that we do not pre-allocate capacity for `inputBytesToHash`,
-			// so that append() will always assign a new slice to each `outputBytesToHash`. This allows us to use
+			// NOTE: is it important for correctness that we do not allocate additional capacity for `inputBytesToHash`.
+			// We need append() to always create a new slice for each `outputBytesToHash`. This allows us to use
 			// `inputBytesToHash` multiple times within this loop without worrying about it changing.
+			// From a performance standpoint, it can be suboptimal, since `inputBytesToHash` will be copied
+			// to a new location on each append() call.
 			outputBytesToHash := append(inputBytesToHash, []byte(outputArtifactID.String())...)
 
 			// Compute that final hash and add it to the map, then continue traversing.

--- a/src/golang/lib/workflow/dag/workflow_dag.go
+++ b/src/golang/lib/workflow/dag/workflow_dag.go
@@ -176,8 +176,7 @@ func NewWorkflowDag(
 		inputOpID := artifactIDToInputOpID[dbArtifact.Id]
 		opMetadataPath, ok := opIDToMetadataPath[inputOpID]
 		if !ok {
-			// TODO: This path is unused! Maybe we don't even need to initialize it at all.
-			opMetadataPath = utils.InitializePath(opExecMode == operator.Preview)
+			return nil, errors.Newf("DAGs cannot currently start with an artifact.")
 		}
 
 		artifactIDToExecPaths[dbArtifact.Id] = utils.InitializeExecOutputPaths(

--- a/src/golang/lib/workflow/operator/function.go
+++ b/src/golang/lib/workflow/operator/function.go
@@ -21,12 +21,6 @@ func newFunctionOperator(
 ) (Operator, error) {
 	base.jobName = generateFunctionJobName()
 
-	outputs := base.outputs
-
-	if len(outputs) == 0 {
-		return nil, errWrongNumOutputs
-	}
-
 	return &functionOperatorImpl{
 		base,
 	}, nil

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -99,10 +99,6 @@ func NewOperator(
 		return nil, errors.New("Internal error: mismatched number of input arguments.")
 	}
 
-	if len(outputs) > 1 || len(outputExecPaths) > 1 {
-		return nil, errors.New("Operator cannot have multiple artifact outputs.")
-	}
-
 	// If this operator has no outputs, we will need to allocate a new metadata path.
 	// This is because the operator's metadata path is defined on the operator's outputs.
 	metadataPath := uuid.New().String()

--- a/src/golang/lib/workflow/utils/exec_output_paths.go
+++ b/src/golang/lib/workflow/utils/exec_output_paths.go
@@ -17,15 +17,18 @@ type ExecPaths struct {
 	ArtifactMetadataPath string
 }
 
-func InitializeExecOutputPaths(isPreview bool) *ExecPaths {
+func InitializeExecOutputPaths(isPreview bool, opMetadataPath string) *ExecPaths {
+	return &ExecPaths{
+		OpMetadataPath:       opMetadataPath,
+		ArtifactContentPath:  InitializePath(isPreview),
+		ArtifactMetadataPath: InitializePath(isPreview),
+	}
+}
+
+func InitializePath(isPreview bool) string {
 	var pathPrefix string
 	if isPreview {
 		pathPrefix = previewDir
 	}
-
-	return &ExecPaths{
-		OpMetadataPath:       filepath.Join(pathPrefix, uuid.New().String()),
-		ArtifactContentPath:  filepath.Join(pathPrefix, uuid.New().String()),
-		ArtifactMetadataPath: filepath.Join(pathPrefix, uuid.New().String()),
-	}
+	return filepath.Join(pathPrefix, uuid.New().String())
 }

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -173,11 +173,12 @@ def validate_spec(spec: FunctionSpec) -> None:
         )
 
     # Check and Metric operators must only have a single output.
-    if (
-        spec.operator_type == OperatorType.CHECK or spec.operator_type == OperatorType.METRIC) and \
-        (spec.expected_output_artifact_types is not None and len(spec.expected_output_artifact_types) != 1
+    if (spec.operator_type == OperatorType.CHECK or spec.operator_type == OperatorType.METRIC) and (
+        spec.expected_output_artifact_types is not None
+        and len(spec.expected_output_artifact_types) != 1
     ):
         raise Exception("%s operators must only have a single output." % spec.operator_type)
+
 
 def _cleanup(spec: FunctionSpec) -> None:
     """
@@ -252,7 +253,8 @@ def run(spec: FunctionSpec) -> None:
             if len(results) != len(spec.expected_output_artifact_types):
                 raise ExecFailureException(
                     failure_type=FailureType.USER_FATAL,
-                    tip="Expected function to return %d outputs, but instead got %d." % (len(spec.expected_output_artifact_types), len(results)),
+                    tip="Expected function to return %d outputs, but instead got %d."
+                    % (len(spec.expected_output_artifact_types), len(results)),
                 )
 
             for i, expected_output_type in enumerate(spec.expected_output_artifact_types):

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -122,6 +122,15 @@ def _execute_function(
         return invoke(*inputs)
 
     results = _invoke()
+
+    # We only validate the number of results if multiple outputs are expected.
+    # Otherwise, we treat the results as a single object.
+    if len(spec.output_content_paths) > 1 and len(spec.output_content_paths) != len(results):
+        raise ExecFailureException(
+            failure_type=FailureType.USER_FATAL,
+            tip="Expected function to have %s outputs, but instead it had %s." % (len(spec.output_content_paths), len(results))
+        )
+
     if len(spec.output_content_paths) == 1:
         results = [results]
 

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -128,7 +128,8 @@ def _execute_function(
     if len(spec.output_content_paths) > 1 and len(spec.output_content_paths) != len(results):
         raise ExecFailureException(
             failure_type=FailureType.USER_FATAL,
-            tip="Expected function to have %s outputs, but instead it had %s." % (len(spec.output_content_paths), len(results))
+            tip="Expected function to have %s outputs, but instead it had %s."
+            % (len(spec.output_content_paths), len(results)),
         )
 
     if len(spec.output_content_paths) == 1:
@@ -270,7 +271,9 @@ def run(spec: FunctionSpec) -> None:
 
                 check_severity = spec.check_severity
                 if spec.check_severity is None:
-                    print("Check operator has an unspecified severity on spec. Defaulting to ERROR.")
+                    print(
+                        "Check operator has an unspecified severity on spec. Defaulting to ERROR."
+                    )
                     check_severity = CheckSeverityLevel.ERROR
 
                 failure_type = FailureType.USER_FATAL

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -334,17 +334,6 @@ def write_discover_results(storage: Storage, path: str, tables: List[str]) -> No
     storage.put(path, bytes(table_names_str, encoding=_DEFAULT_ENCODING))
 
 
-def check_passed(content: Union[bool, np.bool_]) -> bool:
-    """Given the output of a check operator, return whether the check passed or not."""
-    if isinstance(content, bool) or isinstance(content, np.bool_):
-        return bool(content)
-    else:
-        raise Exception(
-            "Expected output type of check to be either a bool or a series of booleans, "
-            "instead got %s" % type(content).__name__
-        )
-
-
 def write_compile_airflow_output(storage: Storage, path: str, dag_file: bytes) -> None:
     """
     Writes the provided Airflow DAG file to storage.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The user can not specify whether they want an @op to return multiple output artifacts, by using `@op(num_outputs)`.

@cw75 as lead reviewer.

## Related issue number (if any)
ENG-455

## Loom demo (if any)
https://www.loom.com/share/1277c3c87b5a4394bea08728d8e9455f

[EDIT] the bug shown in the video is fixed by this: https://github.com/aqueducthq/aqueduct/pull/515

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


