### PR TITLE
Fix bug where tuples were being mishandled

### DIFF
--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -363,7 +363,17 @@ def test_non_jsonable_param_types(client):
     assert isinstance(string_output, GenericArtifact)
     assert string_output.get() == "I am a string"
 
-    run_flow_test(client, artifacts=[pickle_output, bytes_output, string_output])
+    @op
+    def must_be_tuple(input):
+        assert isinstance(input, tuple)
+        return input
+
+    tuple_param = client.create_param("tuple", default=(1, 2, 3))
+    tuple_output = must_be_tuple(tuple_param)
+    assert isinstance(tuple_output, GenericArtifact)
+    assert tuple_output.get() == (1, 2, 3)
+
+    run_flow_test(client, artifacts=[pickle_output, bytes_output, string_output, tuple_output])
 
 
 def test_parameter_type_changes(client):

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -73,3 +73,25 @@ def test_preview_artifact_backfilled_with_wrong_type(client):
     # Fails because the upstream operator should have a type mismatch.
     with pytest.raises(AqueductError, match="Operator `output_different_types` failed!"):
         noop_output.get(parameters={"output_type_toggle": False})
+
+
+def test_list_and_tuple_types_are_different(client):
+    """
+    Because we json-serialize both of these into the same bytes representation,
+    make sure type fidelity is actually preserved for each.
+    """
+    @op
+    def return_list():
+        return [1, 2, 3]
+    
+    @op
+    def return_tuple():
+        return (1, 2, 3)
+    
+    list_output = return_list()
+    assert isinstance(list_output.get(), list)
+    assert list_output.get() == [1, 2, 3]
+
+    tuple_output = return_tuple()
+    assert isinstance(tuple_output.get(), tuple)
+    assert tuple_output.get() == (1, 2, 3)

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -80,14 +80,15 @@ def test_list_and_tuple_types_are_different(client):
     Because we json-serialize both of these into the same bytes representation,
     make sure type fidelity is actually preserved for each.
     """
+
     @op
     def return_list():
         return [1, 2, 3]
-    
+
     @op
     def return_tuple():
         return (1, 2, 3)
-    
+
     list_output = return_list()
     assert isinstance(list_output.get(), list)
     assert list_output.get() == [1, 2, 3]

--- a/sdk/aqueduct/api_client.py
+++ b/sdk/aqueduct/api_client.py
@@ -29,7 +29,7 @@ from aqueduct.responses import (
     RegisterWorkflowResponse,
     SavedObjectUpdate,
 )
-from aqueduct.serialization import deserialization_function_mapping
+from aqueduct.serialization import deserialize
 from aqueduct.utils import GITHUB_ISSUE_LINK, indent_multiline_string
 from requests_toolbelt.multipart import decoder
 
@@ -479,11 +479,9 @@ class APIClient:
             return None, execution_status
 
         serialization_type = parsed_response["metadata"]["serialization_type"]
-        if serialization_type not in deserialization_function_mapping:
-            raise Exception("Unsupported serialization type %s." % serialization_type)
-
+        artifact_type = parsed_response["metadata"]["artifact_type"]
         return (
-            deserialization_function_mapping[serialization_type](parsed_response["data"]),
+            deserialize(serialization_type, artifact_type, parsed_response["data"]),
             execution_status,
         )
 

--- a/sdk/aqueduct/artifacts/utils.py
+++ b/sdk/aqueduct/artifacts/utils.py
@@ -9,12 +9,11 @@ from aqueduct.dag_deltas import (
     SubgraphDAGDelta,
     UpdateParametersDelta,
     apply_deltas_to_dag,
-    validate_overwriting_parameters,
 )
 from aqueduct.enums import ArtifactType
 from aqueduct.error import InvalidArtifactTypeException
 from aqueduct.responses import ArtifactResult
-from aqueduct.serialization import deserialization_function_mapping
+from aqueduct.serialization import deserialize
 from aqueduct.utils import infer_artifact_type
 
 from aqueduct import globals
@@ -116,10 +115,10 @@ def _update_artifact_type(
 
 def _get_content_from_artifact_result_resp(artifact_result: ArtifactResult) -> Any:
     """Deserialize and validate the type of the content for a given artifact result."""
-    serialization_type = artifact_result.serialization_type
-    if serialization_type not in deserialization_function_mapping:
-        raise Exception("Unsupported serialization type %s." % serialization_type)
-
-    content = deserialization_function_mapping[serialization_type](artifact_result.content)
+    content = deserialize(
+        artifact_result.serialization_type,
+        artifact_result.artifact_type,
+        artifact_result.content,
+    )
     assert infer_artifact_type(content) == artifact_result.artifact_type
     return content

--- a/sdk/aqueduct/artifacts/utils.py
+++ b/sdk/aqueduct/artifacts/utils.py
@@ -5,11 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from aqueduct.artifacts import bool_artifact, generic_artifact, numeric_artifact, table_artifact
 from aqueduct.dag import DAG
-from aqueduct.dag_deltas import (
-    SubgraphDAGDelta,
-    UpdateParametersDelta,
-    apply_deltas_to_dag,
-)
+from aqueduct.dag_deltas import SubgraphDAGDelta, UpdateParametersDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType
 from aqueduct.error import InvalidArtifactTypeException
 from aqueduct.responses import ArtifactResult

--- a/sdk/aqueduct/serialization.py
+++ b/sdk/aqueduct/serialization.py
@@ -48,7 +48,9 @@ __deserialization_function_mapping: Dict[str, Callable[[bytes], Any]] = {
 
 
 # WARNING: A copy of this function exists in `aqueduct_executor`. Make sure the two are in sync!
-def deserialize(serialization_type: SerializationType, artifact_type: ArtifactType, content: bytes) -> Any:
+def deserialize(
+    serialization_type: SerializationType, artifact_type: ArtifactType, content: bytes
+) -> Any:
     """Deserializes a byte string into the appropriate python object."""
     if serialization_type not in __deserialization_function_mapping:
         raise Exception("Unsupported serialization type %s" % serialization_type)

--- a/src/python/aqueduct_executor/operators/param_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/param_executor/execute.py
@@ -11,10 +11,7 @@ from aqueduct_executor.operators.utils.execution import (
     exception_traceback,
 )
 from aqueduct_executor.operators.utils.storage.parse import parse_storage
-from aqueduct_executor.operators.utils.utils import (
-    deserialization_function_mapping,
-    infer_artifact_type,
-)
+from aqueduct_executor.operators.utils.utils import (infer_artifact_type, deserialize)
 
 
 def run(spec: ParamSpec) -> None:
@@ -30,7 +27,7 @@ def run(spec: ParamSpec) -> None:
 
     try:
         val_bytes = storage.get(spec.output_content_path)
-        val = deserialization_function_mapping[spec.serialization_type](val_bytes)
+        val = deserialize(spec.serialization_type, spec.expected_type, val_bytes)
 
         inferred_type = infer_artifact_type(val)
         if inferred_type != spec.expected_type:

--- a/src/python/aqueduct_executor/operators/param_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/param_executor/execute.py
@@ -11,7 +11,7 @@ from aqueduct_executor.operators.utils.execution import (
     exception_traceback,
 )
 from aqueduct_executor.operators.utils.storage.parse import parse_storage
-from aqueduct_executor.operators.utils.utils import (infer_artifact_type, deserialize)
+from aqueduct_executor.operators.utils.utils import deserialize, infer_artifact_type
 
 
 def run(spec: ParamSpec) -> None:

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -76,7 +76,9 @@ __deserialization_function_mapping: Dict[SerializationType, Callable[[bytes], An
 }
 
 
-def deserialize(serialization_type: SerializationType, artifact_type: ArtifactType, content: bytes) -> Any:
+def deserialize(
+    serialization_type: SerializationType, artifact_type: ArtifactType, content: bytes
+) -> Any:
     """Deserializes a byte string into the appropriate python object."""
     if serialization_type not in __deserialization_function_mapping:
         raise Exception("Unsupported serialization type %s" % serialization_type)

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -65,7 +65,8 @@ def _read_bytes_input(input_bytes: bytes) -> bytes:
     return input_bytes
 
 
-deserialization_function_mapping: Dict[SerializationType, Callable[[bytes], Any]] = {
+# Not intended for use outside of `deserialize()`.
+__deserialization_function_mapping: Dict[SerializationType, Callable[[bytes], Any]] = {
     SerializationType.TABLE: _read_table_input,
     SerializationType.JSON: _read_json_input,
     SerializationType.PICKLE: _read_pickle_input,
@@ -73,6 +74,21 @@ deserialization_function_mapping: Dict[SerializationType, Callable[[bytes], Any]
     SerializationType.STRING: _read_string_input,
     SerializationType.BYTES: _read_bytes_input,
 }
+
+
+def deserialize(serialization_type: SerializationType, artifact_type: ArtifactType, content: bytes) -> Any:
+    """Deserializes a byte string into the appropriate python object."""
+    if serialization_type not in __deserialization_function_mapping:
+        raise Exception("Unsupported serialization type %s" % serialization_type)
+
+    deserialized_val = __deserialization_function_mapping[serialization_type](content)
+
+    # Because both list and tuple objects are json-serialized, they will have the same bytes representation.
+    # We wanted to keep the readability of json, particularly for the UI, so we decided to distinguish
+    # between the two here using the expected artifact type, at deserialization time.
+    if artifact_type == ArtifactType.TUPLE:
+        return tuple(deserialized_val)
+    return deserialized_val
 
 
 def read_artifacts(
@@ -108,10 +124,7 @@ def read_artifacts(
         input_types.append(artifact_type)
 
         serialization_type = artifact_metadata[_METADATA_SERIALIZATION_TYPE_KEY]
-        if serialization_type not in deserialization_function_mapping:
-            raise Exception("Unsupported serialization type %s" % serialization_type)
-
-        inputs.append(deserialization_function_mapping[serialization_type](storage.get(input_path)))
+        inputs.append(deserialize(serialization_type, artifact_type, storage.get(input_path)))
 
     return inputs, input_types
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Tuples and lists are serialized into the same json string representation. To prevent confusion, we'll need to include the `artifact_type` in the deserialization process, so that we can cast tuple types appropriately before returning.

This allows us to continue viewing these objects on the UI without too much work.

Adds `deserialize()` as the method everyone should call to deserialize bytes into their python objects.

## Related issue number (if any)
ENG-1748

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


