### PR TITLE
Bump minimum version of pydantic and typing_extentions package

### DIFF
--- a/sdk/requirements/python-3-10.txt
+++ b/sdk/requirements/python-3-10.txt
@@ -5,7 +5,7 @@ requests
 pandas
 IPython
 croniter
-pydantic
+pydantic>=1.9.0
 plotly
 pyyaml
 great_expectations

--- a/sdk/requirements/python-3-7.txt
+++ b/sdk/requirements/python-3-7.txt
@@ -5,7 +5,7 @@ requests
 pandas<=1.3.5
 IPython
 croniter
-pydantic
+pydantic>=1.9.0
 plotly
 pyyaml
 great_expectations

--- a/sdk/requirements/python-3-8.txt
+++ b/sdk/requirements/python-3-8.txt
@@ -5,7 +5,7 @@ requests
 pandas
 IPython
 croniter
-pydantic
+pydantic>=1.9.0
 plotly
 pyyaml
 great_expectations

--- a/sdk/requirements/python-3-9.txt
+++ b/sdk/requirements/python-3-9.txt
@@ -5,7 +5,7 @@ requests
 pandas
 IPython
 croniter
-pydantic
+pydantic>=1.9.0
 plotly
 pyyaml
 great_expectations

--- a/src/dockerfiles/connectors/base.dockerfile
+++ b/src/dockerfiles/connectors/base.dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && \
   pydantic==1.9.0 \
   pyyaml \
   SQLAlchemy==1.4.30 \
-  typing_extensions
+  typing_extensions==4.3.0

--- a/src/dockerfiles/function/function37.dockerfile
+++ b/src/dockerfiles/function/function37.dockerfile
@@ -15,7 +15,7 @@ pyarrow==7.0.0 \
 boto3==1.18.0 \
 pydantic==1.9.0 \
 scikit_learn==1.0.2 \
-typing_extensions==4.2.0 \
+typing_extensions==4.3.0 \
 aqueduct-ml==0.0.16
 
 

--- a/src/dockerfiles/lambda/function/requirements-37.txt
+++ b/src/dockerfiles/lambda/function/requirements-37.txt
@@ -6,5 +6,5 @@ pyarrow==7.0.0
 boto3==1.18.0
 pydantic==1.9.0
 scikit_learn==1.0.2
-typing_extensions==4.2.0
+typing_extensions==4.3.0
 aqueduct-ml==0.0.16

--- a/src/dockerfiles/lambda/requirements.txt
+++ b/src/dockerfiles/lambda/requirements.txt
@@ -5,5 +5,5 @@ pandas==1.3.0
 pydantic==1.9.0
 pyyaml
 SQLAlchemy==1.4.30
-typing_extensions
+typing_extensions==4.3.0
 aqueduct-ml==0.0.16

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -7,7 +7,7 @@ pydantic
 SQLAlchemy
 distro
 pyyaml
-typing_extensions
+typing_extensions>=4.3.0
 Pillow
 packaging
 aqueduct-sdk==0.0.16


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We found that older version of these packages won't work. For our Dockerfiles we can just set them to a specific version that we know will work, and for our Pypi package we set a lower bound via `>=`.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


