### PR TITLE
Fixes issue where Parameter and Check operators were marked as "Cancelled" incorrectly

### DIFF
--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -506,6 +506,7 @@ def check(
 ) -> Union[DecoratedCheckFunction, OutputArtifactFunction]:
     """Decorator that converts a regular python function into a check.
 
+perator_
     Calling the decorated function returns a BoolArtifact. The decorated python function
     can have any number of artifact inputs.
 

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -506,7 +506,6 @@ def check(
 ) -> Union[DecoratedCheckFunction, OutputArtifactFunction]:
     """Decorator that converts a regular python function into a check.
 
-perator_
     Calling the decorated function returns a BoolArtifact. The decorated python function
     can have any number of artifact inputs.
 

--- a/src/golang/lib/workflow/artifact/artifact.go
+++ b/src/golang/lib/workflow/artifact/artifact.go
@@ -33,11 +33,11 @@ type Artifact interface {
 	// Finish is an end-of-lifecycle hook meant to do any final cleanup work.
 	Finish(ctx context.Context)
 
-	// Computed indicates whether this artifact has been computed or not.
-	// An artifact is only considered "computed" if its results have been written to storage.
+	// Computed indicates whether this artifact's contents have been computed or not.
+	// An artifact is only considered "computed" if its content has been written to storage.
 	// This is *NOT* the same as having the operator's execution state == SUCCEEDED. For example,
-	// for check operators, the artifact could have been computed even if the check operator did not
-	// pass (returned false).
+	// for check operators, the artifact is computed even if the check operator does not pass
+	// (returned false).
 	Computed(ctx context.Context) bool
 
 	// GetMetadata fetches the metadata for this artifact.
@@ -126,11 +126,11 @@ func (a *ArtifactImpl) Name() string {
 }
 
 func (a *ArtifactImpl) Computed(ctx context.Context) bool {
-	// An artifact is only considered computed if its results have been written.
+	// An artifact is only considered computed if its contents have been written.
 	res := utils.ObjectExistsInStorage(
 		ctx,
 		a.storageConfig,
-		a.execPaths.ArtifactMetadataPath,
+		a.execPaths.ArtifactContentPath,
 	)
 	return res
 }

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -283,6 +283,8 @@ func (bo *baseOperator) PersistResult(ctx context.Context) error {
 		// operator either never ran or did run but hit a user-generated exception.
 		// System-generated errors from things like the type checking of parameters will
 		// still generate downstream artifacts, so those will continue to be marked as "failed".
+		// Invariant: if an artifact is marked as failed, it's operator must also be marked failed,
+		// with the same error message and context.
 		artifactExecState := *execState
 		if !outputArtifact.Computed(ctx) {
 			artifactExecState.Status = shared.CanceledExecutionStatus

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -279,10 +279,12 @@ func (bo *baseOperator) PersistResult(ctx context.Context) error {
 	)
 
 	for _, outputArtifact := range bo.outputs {
-		// If the operator failed, for now, we assume the downstream artifact is never generated.
-		// In this case, we will mark these artifacts as cancelled.
+		// If the downstream artifact was never generated, we mark it as "cancelled", since the
+		// operator either never ran or did run but hit a user-generated exception.
+		// System-generated errors from things like the type checking of parameters will
+		// still generate downstream artifacts, so those will continue to be marked as "failed".
 		artifactExecState := *execState
-		if execState.Status == shared.FailedExecutionStatus {
+		if !outputArtifact.Computed(ctx) {
 			artifactExecState.Status = shared.CanceledExecutionStatus
 		}
 

--- a/src/golang/lib/workflow/operator/param.go
+++ b/src/golang/lib/workflow/operator/param.go
@@ -35,6 +35,8 @@ func newParamOperator(
 	// Write the parameter's value from the spec to the output content path.
 	// This is to avoid passing raw values in the spec, which can be of unbounded
 	// size (eg. images can be too large).
+	// This also means that parameter artifacts are automatically considered `Computed`,
+	// as soon they are constructed.
 	paramValBytes, err := base64.StdEncoding.DecodeString(base.dbOperator.Spec.Param().Val)
 	if err != nil {
 		return nil, err

--- a/src/python/aqueduct_executor/operators/param_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/param_executor/execute.py
@@ -20,6 +20,10 @@ def run(spec: ParamSpec) -> None:
     Therefore, this operator is responsible only for:
     - Checking that the parameter type matches the expected type.
     - Writing the operator and artifact metadata to storage, so that orchestration can proceed as normal.
+
+    The artifact output paths are written to before any type checking occurs, so all artifact-related paths are
+    expected to have been populated, even if the operator itself fails. However, this is not guaranteed to be the case,
+    since system errors are still possible.
     """
     print("Job Spec: \n{}".format(spec.json()))
 
@@ -29,6 +33,17 @@ def run(spec: ParamSpec) -> None:
         val_bytes = storage.get(spec.output_content_path)
         val = deserialize(spec.serialization_type, spec.expected_type, val_bytes)
 
+        # This does not write to the output artifact's content path as a performance optimization.
+        # That has already been written by the Golang Orchestrator.
+        utils.write_artifact(
+            storage,
+            spec.expected_type,
+            None,  # output_content_path
+            spec.output_metadata_path,
+            val,
+            system_metadata={},
+        )
+
         inferred_type = infer_artifact_type(val)
         if inferred_type != spec.expected_type:
             raise ExecFailureException(
@@ -36,15 +51,6 @@ def run(spec: ParamSpec) -> None:
                 tip="Supplied parameter expects type `%s`, but got `%s` instead."
                 % (spec.expected_type, inferred_type),
             )
-
-        utils.write_artifact(
-            storage,
-            spec.expected_type,
-            None,  # output_content_path: this is a performance optimization only, which avoids an unnecessary write to the output path.
-            spec.output_metadata_path,
-            val,
-            system_metadata={},
-        )
 
         utils.write_exec_state(
             storage,

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -383,10 +383,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         newWorkflowStatusItem.level = WorkflowStatusTabs.Warnings;
         newWorkflowStatusItem.title = `Non-fatal error occurred for ${artifactName}`;
         newWorkflowStatusItem.message = artifactExecState.error?.tip;
-      } else if (artifactStatus === ExecutionStatus.Failed) {
-        newWorkflowStatusItem.level = WorkflowStatusTabs.Errors;
-        newWorkflowStatusItem.title = `Error creating ${artifactName}.`;
-        newWorkflowStatusItem.message = `Unable to create artifact ${artifactName} (${artifactId}).`;
       } else if (artifactStatus === ExecutionStatus.Succeeded) {
         newWorkflowStatusItem.level = WorkflowStatusTabs.Checks;
         newWorkflowStatusItem.title = `Artifact ${artifactName} created.`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -388,7 +388,14 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         newWorkflowStatusItem.title = `Artifact ${artifactName} created.`;
         newWorkflowStatusItem.message = `Successfully created artifact ${artifactName} (${artifactId})`;
       } else {
-        // artifact is still pending, skip adding to list of workflow status items.
+        // artifact is either:
+        // 1) cancelled (the operator failed to run and did not write artifact content) .
+        // 2) failed (the operator failed to run but wrote artifact content).
+        // 3) pending.
+        // We do not display any sidebar message for any of these cases. The reason we do not display
+        // any error message on artifact failure status is because we expect the appropriate error message
+        // to be displayed by the operator. That is to say, if the artifact has failed, then the operator
+        // must have also failed.
         return;
       }
 

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -32,7 +32,7 @@ import { AppDispatch, RootState } from '../../stores/store';
 import { theme } from '../../styles/theme/theme';
 import { Artifact } from '../../utils/artifacts';
 import UserProfile from '../../utils/auth';
-import { Operator } from '../../utils/operators';
+import { Operator, OperatorType } from '../../utils/operators';
 import ExecutionStatus, { FailureType } from '../../utils/shared';
 import getUniqueListBy from '../utils/list_utils';
 
@@ -447,7 +447,12 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         // add to the errors array.
         newWorkflowStatusItem.level = WorkflowStatusTabs.Errors;
         if (!!opExecState.error) {
-          newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
+          // The message for a failed parameter is slightly different.
+          if (operators[operatorId].spec.type == OperatorType.Param) {
+            newWorkflowStatusItem.title = `Error with ${operatorName}`;
+          } else {
+            newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
+          }
           const err = opExecState.error;
           newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
             err.context ?? ''


### PR DESCRIPTION
@likawind as lead reviewer. @cw75 tagged to keep in the loop, since we previously discussed writing to the parameter output path in the golang orchestrator instead of the python operator.
@vsreekanti and @agiron123 for any product-related issues/questions about the coloring of nodes.

## Describe your changes and why you are making these changes
It used to be that, if an artifact is failed, we'd mark it as cancelled. However, this shouldn't necessarily be the case for checks and parameters. Parameters that fail type checking should be marked failed, as should checks that return false.

The solution proposed here is to decide whether an artifact is cancelled based on whether it has been "computed". Whether an artifact is "computed" simply means whether the artifact's content has been written to storage. This can happen even if the operator fails (once again, see parameters and checks).

This makes it so that failed check and parameter artifacts can be marked as red, instead of grey. This is especially noticeable for parameters - see the following parameterized flow who's parameter has failed a type check.

Before:
<img width="1409" alt="Screen Shot 2022-09-27 at 3 36 59 PM" src="https://user-images.githubusercontent.com/6466121/192652111-6736316b-bf73-4887-894c-d98e514a2d23.png">

After:
<img width="1421" alt="Screen Shot 2022-09-27 at 3 52 23 PM" src="https://user-images.githubusercontent.com/6466121/192652129-8a8e431e-2455-40ae-abc8-94f708a1e6cf.png">


## Related issue number (if any)
ENG-1715

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


