### PR TITLE
Eng 1466 fix bug where csv upload modal doesnt show the full rows without scrolling

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/IntegrationFileUploadField.tsx
@@ -123,7 +123,7 @@ export const IntegrationFileUploadField: React.FC<
     const overlay = dragging && theme.palette.gray[100];
     const styling = {
       margin: '16px',
-      height: '16ch',
+      padding: '16px',
       width: `max(100%-16px, ${placeholder.length + 8}ch)`,
       display: 'flex',
       justifyContent: 'center',

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -59,13 +59,14 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     });
 
     return (
-      <DataGrid
-        rows={parsedRows}
-        columns={parsedColumns}
-        pageSize={5}
-        rowsPerPageOptions={[5]}
-        disableSelectionOnClick
-      />
+        <DataGrid
+          autoHeight
+          rows={parsedRows}
+          columns={parsedColumns}
+          pageSize={5}
+          rowsPerPageOptions={[5]}
+          disableSelectionOnClick
+        />
     );
   };
   return (

--- a/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/csvDialog.tsx
@@ -59,14 +59,14 @@ export const CSVDialog: React.FC<Props> = ({ setDialogConfig, setErrMsg }) => {
     });
 
     return (
-        <DataGrid
-          autoHeight
-          rows={parsedRows}
-          columns={parsedColumns}
-          pageSize={5}
-          rowsPerPageOptions={[5]}
-          disableSelectionOnClick
-        />
+      <DataGrid
+        autoHeight
+        rows={parsedRows}
+        columns={parsedColumns}
+        pageSize={5}
+        rowsPerPageOptions={[5]}
+        disableSelectionOnClick
+      />
     );
   };
   return (


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Show the full data table so we don't need to scroll through to see all the rows.

## Related issue number (if any)
ENG 1466 

## Loom demo (if any)
https://user-images.githubusercontent.com/30596854/192826902-d526b4b7-8506-4435-b14d-2557c69aead5.mov

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


