### PR TITLE
ENG-919 Check Details Page

### DIFF
--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { HomePage, DataPage, IntegrationsPage, IntegrationDetailsPage, WorkflowPage, WorkflowsPage, LoginPage, AccountPage, FunctionDetailsPage, ArtifactDetailsPage, MetricDetailsPage } from '@aqueducthq/common';
+import { HomePage, DataPage, IntegrationsPage, IntegrationDetailsPage, WorkflowPage, WorkflowsPage, LoginPage, AccountPage, FunctionDetailsPage, ArtifactDetailsPage, MetricDetailsPage, CheckDetailsPage } from '@aqueducthq/common';
 import { store } from './stores/store';
 import { Provider } from 'react-redux';
 import { useUser, UserProfile } from '@aqueducthq/common';
@@ -42,6 +42,7 @@ const App = () => {
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/operator/:operatorId`} element={<RequireAuth user={user}><FunctionDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/artifact/:artifactId`} element={<RequireAuth user={user}><ArtifactDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/metric/:metricOperatorId`} element={<RequireAuth user={user}><MetricDetailsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/check/:checkOperatorId`} element={<RequireAuth user={user}><CheckDetailsPage user={user} /> </RequireAuth>} />
     </Routes>
   );
 

--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -17,8 +17,6 @@ const LogViewer: React.FC<Props> = ({ logs, err, contentHeight = '10vh' }) => {
 
   const [currentTab, setCurrentTab] = useState('1');
 
-  console.log(currentTab);
-
   const tabPanelOptions = {
     height: contentHeight,
     overflow: 'scroll',

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -57,14 +57,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             : undefined
     );
 
-    console.log('workflowDagResultWithLoadingStatus: ', workflowDagResultWithLoadingStatus);
-
-    console.log('workflowId: ', workflowId);
-    console.log('workflowDagResultId: ', workflowDagResultId);
-    console.log('checkOperatorId: ', checkOperatorId);
-
-    console.log('level: ', operator?.spec?.check?.level)
-
     useEffect(() => {
         document.title = 'Check Details | Aqueduct';
 
@@ -73,7 +65,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             !workflowDagResultWithLoadingStatus ||
             isInitial(workflowDagResultWithLoadingStatus.status)
         ) {
-            console.log('Loading workflowDagResult');
             dispatch(
                 handleGetWorkflowDagResult({
                     apiKey: user.apiKey,
@@ -94,7 +85,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             !isInitial(workflowDagResultWithLoadingStatus.status) &&
             !isLoading(workflowDagResultWithLoadingStatus.status)
         ) {
-            console.log('dispatching handleListArtifactResults');
             // Queue up the artifacts historical results for loading.
             dispatch(
                 handleListArtifactResults({
@@ -106,19 +96,11 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
         }
     }, [workflowDagResultWithLoadingStatus, artifactId]);
 
-    console.log('operator: ', operator);
-
     useEffect(() => {
         if (!!operator) {
             document.title = `${operator.name} | Aqueduct`;
         }
     }, [operator]);
-
-    const listStyle = {
-        width: '100%',
-        maxWidth: 360,
-        bgcolor: 'background.paper',
-    };
 
     if (
         !workflowDagResultWithLoadingStatus ||
@@ -170,8 +152,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
         if (!artifactResult) {
             return null;
         }
-
-        console.log('operator output artifactResult: ', artifactResult);
 
         if (
             !artifactResult.result ||

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -12,7 +12,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import CheckTableItem from '../../../tables/CheckTableItem';
 
-import PaginatedTable from '../../../../components/tables/PaginatedTable';
+//import PaginatedTable from '../../../../components/tables/PaginatedTable';
 import { artifactTypeToIconMapping } from '../../../../components/workflows/nodes/nodeTypes';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
@@ -24,6 +24,7 @@ import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import DefaultLayout from '../../../layouts/default';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
+import CheckHistory from '../../../workflows/artifact/check/history';
 
 type CheckDetailsPageProps = {
     user: UserProfile;
@@ -62,6 +63,8 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
     console.log('workflowDagResultId: ', workflowDagResultId);
     console.log('checkOperatorId: ', checkOperatorId);
 
+    console.log('level: ', operator?.spec?.check?.level)
+
     useEffect(() => {
         document.title = 'Check Details | Aqueduct';
 
@@ -91,6 +94,8 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             !isInitial(workflowDagResultWithLoadingStatus.status) &&
             !isLoading(workflowDagResultWithLoadingStatus.status)
         ) {
+            console.log('dispatching handleListArtifactResults');
+            // Queue up the artifacts historical results for loading.
             dispatch(
                 handleListArtifactResults({
                     apiKey: user.apiKey,
@@ -220,7 +225,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
                 <Box width="100%" marginTop="32px">
                     <Typography variant="h5" marginBottom="8px">Recent Results</Typography>
-                    <PaginatedTable data={historicalCheckData} />
+                    <CheckHistory historyWithLoadingStatus={artifactHistoryWithLoadingStatus} checkLevel={operator?.spec?.check?.level} />
                 </Box>
                 {/* commenting out metrics for now as we figure out what to do with them */}
                 {/* <Box width="100%" marginTop="32px">

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -12,7 +12,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import CheckTableItem from '../../../tables/CheckTableItem';
 
-//import PaginatedTable from '../../../../components/tables/PaginatedTable';
 import { artifactTypeToIconMapping } from '../../../../components/workflows/nodes/nodeTypes';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
@@ -175,9 +174,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
         return (
             <Box key={artifactId} display="flex">
-                {/* <Typography variant="body1" marginRight="24px">
-                    {artifactResult.result.content_serialized}
-                </Typography> */}
                 <CheckTableItem checkValue={artifactResult.result.content_serialized} />
                 <Link
                     to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -1,0 +1,224 @@
+import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { CircularProgress, Link, List, ListItem } from '@mui/material';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React, { useEffect, useState } from 'react';
+import Plot from 'react-plotly.js';
+import { useDispatch, useSelector } from 'react-redux';
+import { Link as RouterLink, useParams } from 'react-router-dom';
+
+import PaginatedTable from '../../../../components/tables/PaginatedTable';
+import { artifactTypeToIconMapping } from '../../../../components/workflows/nodes/nodeTypes';
+import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
+import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
+import { AppDispatch, RootState } from '../../../../stores/store';
+import UserProfile from '../../../../utils/auth';
+import { Data } from '../../../../utils/data';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
+import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
+import DefaultLayout from '../../../layouts/default';
+import DetailsPageHeader from '../../components/DetailsPageHeader';
+import { LayoutProps } from '../../types';
+
+type CheckDetailsPageProps = {
+    user: UserProfile;
+    Layout?: React.FC<LayoutProps>;
+};
+
+const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
+    user,
+    Layout = DefaultLayout,
+}) => {
+    const dispatch: AppDispatch = useDispatch();
+    const { workflowId, workflowDagResultId, checkOperatorId } = useParams();
+
+    const [inputsExpanded, setInputsExpanded] = useState<boolean>(true);
+    const [outputsExpanded, setOutputsExpanded] = useState<boolean>(true);
+
+    const workflowDagResultWithLoadingStatus = useSelector(
+        (state: RootState) =>
+            state.workflowDagResultsReducer.results[workflowDagResultId]
+    );
+
+    const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
+        {})[checkOperatorId];
+
+    const artifactId = operator?.outputs[0];
+
+    const artifactHistoryWithLoadingStatus = useSelector((state: RootState) =>
+        !!artifactId
+            ? state.artifactResultsReducer.artifacts[artifactId]
+            : undefined
+    );
+
+    console.log('workflowDagResultWithLoadingStatus: ', workflowDagResultWithLoadingStatus);
+
+    console.log('workflowId: ', workflowId);
+    console.log('workflowDagResultId: ', workflowDagResultId);
+    console.log('checkOperatorId: ', checkOperatorId);
+
+    useEffect(() => {
+        document.title = 'Check Details | Aqueduct';
+
+        // Load workflow dag result if it's not cached
+        if (
+            !workflowDagResultWithLoadingStatus ||
+            isInitial(workflowDagResultWithLoadingStatus.status)
+        ) {
+            console.log('Loading workflowDagResult');
+            dispatch(
+                handleGetWorkflowDagResult({
+                    apiKey: user.apiKey,
+                    workflowId,
+                    workflowDagResultId,
+                })
+            );
+        }
+    }, []);
+
+    useEffect(() => {
+        // Load artifact history once workflow dag results finished loading
+        // and the result is not cached
+        if (
+            !artifactHistoryWithLoadingStatus &&
+            !!artifactId &&
+            !!workflowDagResultWithLoadingStatus &&
+            !isInitial(workflowDagResultWithLoadingStatus.status) &&
+            !isLoading(workflowDagResultWithLoadingStatus.status)
+        ) {
+            dispatch(
+                handleListArtifactResults({
+                    apiKey: user.apiKey,
+                    workflowId,
+                    artifactId,
+                })
+            );
+        }
+    }, [workflowDagResultWithLoadingStatus, artifactId]);
+
+    console.log('operator: ', operator);
+
+    useEffect(() => {
+        if (!!operator) {
+            document.title = `${operator.name} | Aqueduct`;
+        }
+    }, [operator]);
+
+    const listStyle = {
+        width: '100%',
+        maxWidth: 360,
+        bgcolor: 'background.paper',
+    };
+
+    if (
+        !workflowDagResultWithLoadingStatus ||
+        isInitial(workflowDagResultWithLoadingStatus.status) ||
+        isLoading(workflowDagResultWithLoadingStatus.status)
+    ) {
+        return (
+            <Layout user={user}>
+                <CircularProgress />
+            </Layout>
+        );
+    }
+
+    if (isFailed(workflowDagResultWithLoadingStatus.status)) {
+        return (
+            <Layout user={user}>
+                <Alert title="Failed to load workflow">
+                    {workflowDagResultWithLoadingStatus.status.err}
+                </Alert>
+            </Layout>
+        );
+    }
+
+    const mockCheckArtifactData = [
+        // severity in the mock corresponnds with level in the API response.
+        { status: 'succeeded', level: 'warning', result: 'True', date_completed: '3/14/2022 4:00 PST' },
+        { status: 'succeeded', level: 'warning', result: 'False', date_completed: '3/14/2022 4:00 PST' },
+        { status: 'succeeded', level: 'error', result: 'True', date_completed: '3/14/2022 4:00 PST' }
+    ]
+    const historicalCheckData: Data = {
+        schema: {
+            fields: [
+                { name: 'status', type: 'varchar' },
+                { name: 'level', type: 'varchar' },
+                { name: 'result', type: 'varchar' },
+                { name: 'date_completed', type: 'varchar' }
+            ],
+            pandas_version: '0.0.1', // Not sure what actual value to put here, just filling in for now :)
+        },
+        data: mockCheckArtifactData
+    };
+
+    // Function to get the numerical value of the metric output
+    // TODO: Use this inside of the accordion component below.
+    // NOTE: This code is shared with the metric details page, perhaps we should make this into a hook or component.
+    const operatorOutputsList = operator.outputs.map((artifactId) => {
+        const artifactResult = (workflowDagResultWithLoadingStatus.result
+            ?.artifacts ?? {})[artifactId];
+        if (!artifactResult) {
+            return null;
+        }
+
+        if (
+            !artifactResult.result ||
+            artifactResult.result.content_serialized === undefined
+        ) {
+            // Link to appropriate artifact details page
+            // Show tableIcon here as part of the link.
+            return (
+                <Box key={artifactId}>
+                    <Link
+                        to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
+                        component={RouterLink as any}
+                        sx={{ marginLeft: '16px' }}
+                        underline="none"
+                    >
+                        {artifactResult.name}
+                    </Link>
+                </Box>
+            );
+        }
+
+        return (
+            <Box key={artifactId}>
+                <Typography variant="body1">
+                    {artifactResult.result.content_serialized}
+                </Typography>
+            </Box>
+        );
+    });
+
+    return (
+        <Layout user={user}>
+            <Box width={'800px'}>
+                <Box width="100%">
+                    <Box width="100%">
+                        <DetailsPageHeader name={operator?.name} />
+                        {operator?.description && (
+                            <Typography variant="body1">{operator.description}</Typography>
+                        )}
+                    </Box>
+                </Box>
+
+                <Box width="100%" marginTop="32px">
+                    <Typography variant="h5" marginBottom="8px">Recent Results</Typography>
+                    <PaginatedTable data={historicalCheckData} />
+                </Box>
+
+                <Box width="100%" marginTop="32px">
+                    <Typography variant="h5">Related Outputs</Typography>
+                </Box>
+
+            </Box>
+        </Layout>
+    );
+};
+
+export default CheckDetailsPage;

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -8,9 +8,9 @@ import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
-import Plot from 'react-plotly.js';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useParams } from 'react-router-dom';
+import CheckTableItem from '../../../tables/CheckTableItem';
 
 import PaginatedTable from '../../../../components/tables/PaginatedTable';
 import { artifactTypeToIconMapping } from '../../../../components/workflows/nodes/nodeTypes';
@@ -37,8 +37,8 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
     const dispatch: AppDispatch = useDispatch();
     const { workflowId, workflowDagResultId, checkOperatorId } = useParams();
 
-    const [inputsExpanded, setInputsExpanded] = useState<boolean>(true);
-    const [outputsExpanded, setOutputsExpanded] = useState<boolean>(true);
+    const [metricsExpanded, setMetricsExpanded] = useState<boolean>(true);
+    const [artifactsExpanded, setArtifactsExpanded] = useState<boolean>(true);
 
     const workflowDagResultWithLoadingStatus = useSelector(
         (state: RootState) =>
@@ -166,6 +166,8 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             return null;
         }
 
+        console.log('operator output artifactResult: ', artifactResult);
+
         if (
             !artifactResult.result ||
             artifactResult.result.content_serialized === undefined
@@ -187,10 +189,19 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
         }
 
         return (
-            <Box key={artifactId}>
-                <Typography variant="body1">
+            <Box key={artifactId} display="flex">
+                {/* <Typography variant="body1" marginRight="24px">
                     {artifactResult.result.content_serialized}
-                </Typography>
+                </Typography> */}
+                <CheckTableItem checkValue={artifactResult.result.content_serialized} />
+                <Link
+                    to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
+                    component={RouterLink as any}
+                    sx={{ marginLeft: '16px' }}
+                    underline="none"
+                >
+                    {artifactResult.name}
+                </Link>
             </Box>
         );
     });
@@ -211,9 +222,70 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
                     <Typography variant="h5" marginBottom="8px">Recent Results</Typography>
                     <PaginatedTable data={historicalCheckData} />
                 </Box>
+                {/* commenting out metrics for now as we figure out what to do with them */}
+                {/* <Box width="100%" marginTop="32px">
+                    <Typography variant="h5">Related Outputs</Typography>
+                    <Accordion
+                        expanded={metricsExpanded}
+                        onChange={() => {
+                            setMetricsExpanded(!metricsExpanded);
+                        }}
+                    >
+                        <AccordionSummary
+                            expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
+                            sx={{
+                                '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+                                    transform: 'rotate(90deg)',
+                                },
+                            }}
+                            aria-controls="input-accordion-content"
+                            id="input-accordion-header"
+                        >
+                            <Typography
+                                sx={{ width: '33%', flexShrink: 0 }}
+                                variant="h5"
+                                component="div"
+                                marginBottom="8px"
+                            >
+                                Metrics:
+                            </Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <React.Fragment>{operatorOutputsList}</React.Fragment>
+                        </AccordionDetails>
+                    </Accordion>
+                </Box> */}
 
                 <Box width="100%" marginTop="32px">
-                    <Typography variant="h5">Related Outputs</Typography>
+                    <Accordion
+                        expanded={artifactsExpanded}
+                        onChange={() => {
+                            setArtifactsExpanded(!artifactsExpanded);
+                        }}
+                    >
+                        <AccordionSummary
+                            expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
+                            sx={{
+                                '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+                                    transform: 'rotate(90deg)',
+                                },
+                            }}
+                            aria-controls="artifacts-accordion-content"
+                            id="artifacts-accordion-header"
+                        >
+                            <Typography
+                                sx={{ width: '33%', flexShrink: 0 }}
+                                variant="h5"
+                                component="div"
+                                marginBottom="8px"
+                            >
+                                Artifacts:
+                            </Typography>
+                        </AccordionSummary>
+                        <AccordionDetails>
+                            <React.Fragment>{operatorOutputsList}</React.Fragment>
+                        </AccordionDetails>
+                    </Accordion>
                 </Box>
 
             </Box>

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -1,6 +1,6 @@
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { CircularProgress, Link, List, ListItem } from '@mui/material';
+import { CircularProgress, Link } from '@mui/material';
 import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
@@ -10,9 +10,7 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link as RouterLink, useParams } from 'react-router-dom';
-import CheckTableItem from '../../../tables/CheckTableItem';
 
-import { artifactTypeToIconMapping } from '../../../../components/workflows/nodes/nodeTypes';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
 import { AppDispatch, RootState } from '../../../../stores/store';
@@ -21,190 +19,211 @@ import { Data } from '../../../../utils/data';
 import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import DefaultLayout from '../../../layouts/default';
+import CheckTableItem from '../../../tables/CheckTableItem';
+import CheckHistory from '../../../workflows/artifact/check/history';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
-import CheckHistory from '../../../workflows/artifact/check/history';
 
 type CheckDetailsPageProps = {
-    user: UserProfile;
-    Layout?: React.FC<LayoutProps>;
+  user: UserProfile;
+  Layout?: React.FC<LayoutProps>;
 };
 
 const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
-    user,
-    Layout = DefaultLayout,
+  user,
+  Layout = DefaultLayout,
 }) => {
-    const dispatch: AppDispatch = useDispatch();
-    const { workflowId, workflowDagResultId, checkOperatorId } = useParams();
+  const dispatch: AppDispatch = useDispatch();
+  const { workflowId, workflowDagResultId, checkOperatorId } = useParams();
 
-    const [metricsExpanded, setMetricsExpanded] = useState<boolean>(true);
-    const [artifactsExpanded, setArtifactsExpanded] = useState<boolean>(true);
+  const [metricsExpanded, setMetricsExpanded] = useState<boolean>(true);
+  const [artifactsExpanded, setArtifactsExpanded] = useState<boolean>(true);
 
-    const workflowDagResultWithLoadingStatus = useSelector(
-        (state: RootState) =>
-            state.workflowDagResultsReducer.results[workflowDagResultId]
+  const workflowDagResultWithLoadingStatus = useSelector(
+    (state: RootState) =>
+      state.workflowDagResultsReducer.results[workflowDagResultId]
+  );
+
+  const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
+    {})[checkOperatorId];
+
+  const artifactId = operator?.outputs[0];
+
+  const artifactHistoryWithLoadingStatus = useSelector((state: RootState) =>
+    !!artifactId
+      ? state.artifactResultsReducer.artifacts[artifactId]
+      : undefined
+  );
+
+  useEffect(() => {
+    document.title = 'Check Details | Aqueduct';
+
+    // Load workflow dag result if it's not cached
+    if (
+      !workflowDagResultWithLoadingStatus ||
+      isInitial(workflowDagResultWithLoadingStatus.status)
+    ) {
+      dispatch(
+        handleGetWorkflowDagResult({
+          apiKey: user.apiKey,
+          workflowId,
+          workflowDagResultId,
+        })
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    // Load artifact history once workflow dag results finished loading
+    // and the result is not cached
+    if (
+      !artifactHistoryWithLoadingStatus &&
+      !!artifactId &&
+      !!workflowDagResultWithLoadingStatus &&
+      !isInitial(workflowDagResultWithLoadingStatus.status) &&
+      !isLoading(workflowDagResultWithLoadingStatus.status)
+    ) {
+      // Queue up the artifacts historical results for loading.
+      dispatch(
+        handleListArtifactResults({
+          apiKey: user.apiKey,
+          workflowId,
+          artifactId,
+        })
+      );
+    }
+  }, [workflowDagResultWithLoadingStatus, artifactId]);
+
+  useEffect(() => {
+    if (!!operator) {
+      document.title = `${operator.name} | Aqueduct`;
+    }
+  }, [operator]);
+
+  if (
+    !workflowDagResultWithLoadingStatus ||
+    isInitial(workflowDagResultWithLoadingStatus.status) ||
+    isLoading(workflowDagResultWithLoadingStatus.status)
+  ) {
+    return (
+      <Layout user={user}>
+        <CircularProgress />
+      </Layout>
     );
+  }
 
-    const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
-        {})[checkOperatorId];
-
-    const artifactId = operator?.outputs[0];
-
-    const artifactHistoryWithLoadingStatus = useSelector((state: RootState) =>
-        !!artifactId
-            ? state.artifactResultsReducer.artifacts[artifactId]
-            : undefined
+  if (isFailed(workflowDagResultWithLoadingStatus.status)) {
+    return (
+      <Layout user={user}>
+        <Alert title="Failed to load workflow">
+          {workflowDagResultWithLoadingStatus.status.err}
+        </Alert>
+      </Layout>
     );
+  }
 
-    useEffect(() => {
-        document.title = 'Check Details | Aqueduct';
+  const mockCheckArtifactData = [
+    // severity in the mock corresponnds with level in the API response.
+    {
+      status: 'succeeded',
+      level: 'warning',
+      result: 'True',
+      date_completed: '3/14/2022 4:00 PST',
+    },
+    {
+      status: 'succeeded',
+      level: 'warning',
+      result: 'False',
+      date_completed: '3/14/2022 4:00 PST',
+    },
+    {
+      status: 'succeeded',
+      level: 'error',
+      result: 'True',
+      date_completed: '3/14/2022 4:00 PST',
+    },
+  ];
+  const historicalCheckData: Data = {
+    schema: {
+      fields: [
+        { name: 'status', type: 'varchar' },
+        { name: 'level', type: 'varchar' },
+        { name: 'result', type: 'varchar' },
+        { name: 'date_completed', type: 'varchar' },
+      ],
+      pandas_version: '0.0.1', // Not sure what actual value to put here, just filling in for now :)
+    },
+    data: mockCheckArtifactData,
+  };
 
-        // Load workflow dag result if it's not cached
-        if (
-            !workflowDagResultWithLoadingStatus ||
-            isInitial(workflowDagResultWithLoadingStatus.status)
-        ) {
-            dispatch(
-                handleGetWorkflowDagResult({
-                    apiKey: user.apiKey,
-                    workflowId,
-                    workflowDagResultId,
-                })
-            );
-        }
-    }, []);
-
-    useEffect(() => {
-        // Load artifact history once workflow dag results finished loading
-        // and the result is not cached
-        if (
-            !artifactHistoryWithLoadingStatus &&
-            !!artifactId &&
-            !!workflowDagResultWithLoadingStatus &&
-            !isInitial(workflowDagResultWithLoadingStatus.status) &&
-            !isLoading(workflowDagResultWithLoadingStatus.status)
-        ) {
-            // Queue up the artifacts historical results for loading.
-            dispatch(
-                handleListArtifactResults({
-                    apiKey: user.apiKey,
-                    workflowId,
-                    artifactId,
-                })
-            );
-        }
-    }, [workflowDagResultWithLoadingStatus, artifactId]);
-
-    useEffect(() => {
-        if (!!operator) {
-            document.title = `${operator.name} | Aqueduct`;
-        }
-    }, [operator]);
+  // Function to get the numerical value of the metric output
+  // TODO: Use this inside of the accordion component below.
+  // NOTE: This code is shared with the metric details page, perhaps we should make this into a hook or component.
+  const operatorOutputsList = operator.outputs.map((artifactId) => {
+    const artifactResult = (workflowDagResultWithLoadingStatus.result
+      ?.artifacts ?? {})[artifactId];
+    if (!artifactResult) {
+      return null;
+    }
 
     if (
-        !workflowDagResultWithLoadingStatus ||
-        isInitial(workflowDagResultWithLoadingStatus.status) ||
-        isLoading(workflowDagResultWithLoadingStatus.status)
+      !artifactResult.result ||
+      artifactResult.result.content_serialized === undefined
     ) {
-        return (
-            <Layout user={user}>
-                <CircularProgress />
-            </Layout>
-        );
+      // Link to appropriate artifact details page
+      // Show tableIcon here as part of the link.
+      return (
+        <Box key={artifactId}>
+          <Link
+            to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
+            component={RouterLink as any}
+            sx={{ marginLeft: '16px' }}
+            underline="none"
+          >
+            {artifactResult.name}
+          </Link>
+        </Box>
+      );
     }
-
-    if (isFailed(workflowDagResultWithLoadingStatus.status)) {
-        return (
-            <Layout user={user}>
-                <Alert title="Failed to load workflow">
-                    {workflowDagResultWithLoadingStatus.status.err}
-                </Alert>
-            </Layout>
-        );
-    }
-
-    const mockCheckArtifactData = [
-        // severity in the mock corresponnds with level in the API response.
-        { status: 'succeeded', level: 'warning', result: 'True', date_completed: '3/14/2022 4:00 PST' },
-        { status: 'succeeded', level: 'warning', result: 'False', date_completed: '3/14/2022 4:00 PST' },
-        { status: 'succeeded', level: 'error', result: 'True', date_completed: '3/14/2022 4:00 PST' }
-    ]
-    const historicalCheckData: Data = {
-        schema: {
-            fields: [
-                { name: 'status', type: 'varchar' },
-                { name: 'level', type: 'varchar' },
-                { name: 'result', type: 'varchar' },
-                { name: 'date_completed', type: 'varchar' }
-            ],
-            pandas_version: '0.0.1', // Not sure what actual value to put here, just filling in for now :)
-        },
-        data: mockCheckArtifactData
-    };
-
-    // Function to get the numerical value of the metric output
-    // TODO: Use this inside of the accordion component below.
-    // NOTE: This code is shared with the metric details page, perhaps we should make this into a hook or component.
-    const operatorOutputsList = operator.outputs.map((artifactId) => {
-        const artifactResult = (workflowDagResultWithLoadingStatus.result
-            ?.artifacts ?? {})[artifactId];
-        if (!artifactResult) {
-            return null;
-        }
-
-        if (
-            !artifactResult.result ||
-            artifactResult.result.content_serialized === undefined
-        ) {
-            // Link to appropriate artifact details page
-            // Show tableIcon here as part of the link.
-            return (
-                <Box key={artifactId}>
-                    <Link
-                        to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
-                        component={RouterLink as any}
-                        sx={{ marginLeft: '16px' }}
-                        underline="none"
-                    >
-                        {artifactResult.name}
-                    </Link>
-                </Box>
-            );
-        }
-
-        return (
-            <Box key={artifactId} display="flex">
-                <CheckTableItem checkValue={artifactResult.result.content_serialized} />
-                <Link
-                    to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
-                    component={RouterLink as any}
-                    sx={{ marginLeft: '16px' }}
-                    underline="none"
-                >
-                    {artifactResult.name}
-                </Link>
-            </Box>
-        );
-    });
 
     return (
-        <Layout user={user}>
-            <Box width={'800px'}>
-                <Box width="100%">
-                    <Box width="100%">
-                        <DetailsPageHeader name={operator?.name} />
-                        {operator?.description && (
-                            <Typography variant="body1">{operator.description}</Typography>
-                        )}
-                    </Box>
-                </Box>
+      <Box key={artifactId} display="flex">
+        <CheckTableItem checkValue={artifactResult.result.content_serialized} />
+        <Link
+          to={`${getPathPrefix()}/workflow/${workflowId}/result/${workflowDagResultId}/artifact/${artifactId}`}
+          component={RouterLink as any}
+          sx={{ marginLeft: '16px' }}
+          underline="none"
+        >
+          {artifactResult.name}
+        </Link>
+      </Box>
+    );
+  });
 
-                <Box width="100%" marginTop="32px">
-                    <Typography variant="h5" marginBottom="8px">Recent Results</Typography>
-                    <CheckHistory historyWithLoadingStatus={artifactHistoryWithLoadingStatus} checkLevel={operator?.spec?.check?.level} />
-                </Box>
-                {/* commenting out metrics for now as we figure out what to do with them */}
-                {/* <Box width="100%" marginTop="32px">
+  return (
+    <Layout user={user}>
+      <Box width={'800px'}>
+        <Box width="100%">
+          <Box width="100%">
+            <DetailsPageHeader name={operator?.name} />
+            {operator?.description && (
+              <Typography variant="body1">{operator.description}</Typography>
+            )}
+          </Box>
+        </Box>
+
+        <Box width="100%" marginTop="32px">
+          <Typography variant="h5" marginBottom="8px">
+            Recent Results
+          </Typography>
+          <CheckHistory
+            historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
+            checkLevel={operator?.spec?.check?.level}
+          />
+        </Box>
+        {/* commenting out metrics for now as we figure out what to do with them */}
+        {/* <Box width="100%" marginTop="32px">
                     <Typography variant="h5">Related Outputs</Typography>
                     <Accordion
                         expanded={metricsExpanded}
@@ -237,41 +256,40 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
                     </Accordion>
                 </Box> */}
 
-                <Box width="100%" marginTop="32px">
-                    <Accordion
-                        expanded={artifactsExpanded}
-                        onChange={() => {
-                            setArtifactsExpanded(!artifactsExpanded);
-                        }}
-                    >
-                        <AccordionSummary
-                            expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
-                            sx={{
-                                '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-                                    transform: 'rotate(90deg)',
-                                },
-                            }}
-                            aria-controls="artifacts-accordion-content"
-                            id="artifacts-accordion-header"
-                        >
-                            <Typography
-                                sx={{ width: '33%', flexShrink: 0 }}
-                                variant="h5"
-                                component="div"
-                                marginBottom="8px"
-                            >
-                                Artifacts:
-                            </Typography>
-                        </AccordionSummary>
-                        <AccordionDetails>
-                            <React.Fragment>{operatorOutputsList}</React.Fragment>
-                        </AccordionDetails>
-                    </Accordion>
-                </Box>
-
-            </Box>
-        </Layout>
-    );
+        <Box width="100%" marginTop="32px">
+          <Accordion
+            expanded={artifactsExpanded}
+            onChange={() => {
+              setArtifactsExpanded(!artifactsExpanded);
+            }}
+          >
+            <AccordionSummary
+              expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
+              sx={{
+                '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
+                  transform: 'rotate(90deg)',
+                },
+              }}
+              aria-controls="artifacts-accordion-content"
+              id="artifacts-accordion-header"
+            >
+              <Typography
+                sx={{ width: '33%', flexShrink: 0 }}
+                variant="h5"
+                component="div"
+                marginBottom="8px"
+              >
+                Artifacts:
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <React.Fragment>{operatorOutputsList}</React.Fragment>
+            </AccordionDetails>
+          </Accordion>
+        </Box>
+      </Box>
+    </Layout>
+  );
 };
 
 export default CheckDetailsPage;

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -320,7 +320,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         </Box>
       );
     } else if (currentNode.type === NodeType.CheckOp) {
-      // TODO: Show View Check Details
       // Get the check's id, and navigate to the check details page.
       return (
         <Box>

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -270,8 +270,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -295,8 +294,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -312,13 +310,30 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/function/${currentNode.id}`
               );
             }}
           >
             View Function Details
+          </Button>
+        </Box>
+      );
+    } else if (currentNode.type === NodeType.CheckOp) {
+      // TODO: Show View Check Details
+      // Get the check's id, and navigate to the check details page.
+      return (
+        <Box>
+          <Button
+            style={{ marginRight: '16px' }}
+            onClick={() => {
+              navigate(
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                }/check/${currentNode.id}`
+              );
+            }}
+          >
+            View Check Details
           </Button>
         </Box>
       );

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -270,7 +270,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -294,7 +295,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -310,7 +312,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/function/${currentNode.id}`
               );
             }}
@@ -327,7 +330,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={{ marginRight: '16px' }}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -2,11 +2,9 @@ import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import React from 'react';
-import Plot from 'react-plotly.js';
 
 import PaginatedTable from '../../../../components/tables/PaginatedTable';
 import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
-import { theme } from '../../../../styles/theme/theme';
 import { Data, DataSchema } from '../../../../utils/data';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 
@@ -15,7 +13,6 @@ type CheckHistoryProps = {
     checkLevel?: string;
 }
 
-// TODO: Bring over data schema from check details page
 const checkHistorySchema: DataSchema = {
     fields: [
         { name: 'status', type: 'varchar' },
@@ -23,7 +20,7 @@ const checkHistorySchema: DataSchema = {
         { name: 'value', type: 'varchar' },
         { name: 'timestamp', type: 'varchar' }
     ],
-    pandas_version: '0.0.1', // Not sure what actual value to put here, just filling in for now :)
+    pandas_version: '', // Not sure what actual value to put here, just filling in for now :)
 };
 
 const CheckHistory: React.FC<CheckHistoryProps> = ({ historyWithLoadingStatus, checkLevel }) => {

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -9,55 +9,58 @@ import { Data, DataSchema } from '../../../../utils/data';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 
 type CheckHistoryProps = {
-    historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
-    checkLevel?: string;
-}
-
-const checkHistorySchema: DataSchema = {
-    fields: [
-        { name: 'status', type: 'varchar' },
-        { name: 'level', type: 'varchar' },
-        { name: 'value', type: 'varchar' },
-        { name: 'timestamp', type: 'varchar' }
-    ],
-    pandas_version: '', // Not sure what actual value to put here, just filling in for now :)
+  historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
+  checkLevel?: string;
 };
 
-const CheckHistory: React.FC<CheckHistoryProps> = ({ historyWithLoadingStatus, checkLevel }) => {
-    if (
-        !historyWithLoadingStatus ||
-        isInitial(historyWithLoadingStatus.status) ||
-        isLoading(historyWithLoadingStatus.status)
-    ) {
-        return <CircularProgress />;
-    }
-    if (isFailed(historyWithLoadingStatus.status)) {
-        return (
-            <Alert title="Failed to load historical data.">
-                {historyWithLoadingStatus.status.err}
-            </Alert>
-        );
-    }
+const checkHistorySchema: DataSchema = {
+  fields: [
+    { name: 'status', type: 'varchar' },
+    { name: 'level', type: 'varchar' },
+    { name: 'value', type: 'varchar' },
+    { name: 'timestamp', type: 'varchar' },
+  ],
+  pandas_version: '', // Not sure what actual value to put here, just filling in for now :)
+};
 
-    const historicalData: Data = {
-        schema: checkHistorySchema,
-        data: (historyWithLoadingStatus.results?.results ?? []).map(
-            (artifactStatusResult) => {
-                return {
-                    status: artifactStatusResult.exec_state?.status ?? 'Unknown',
-                    level: checkLevel ? checkLevel : 'undefined',
-                    value: artifactStatusResult.content_serialized,
-                    timestamp: artifactStatusResult.exec_state?.timestamps?.finished_at,
-                };
-            }
-        ),
-    };
-
+const CheckHistory: React.FC<CheckHistoryProps> = ({
+  historyWithLoadingStatus,
+  checkLevel,
+}) => {
+  if (
+    !historyWithLoadingStatus ||
+    isInitial(historyWithLoadingStatus.status) ||
+    isLoading(historyWithLoadingStatus.status)
+  ) {
+    return <CircularProgress />;
+  }
+  if (isFailed(historyWithLoadingStatus.status)) {
     return (
-        <Box display="flex" justifyContent="center" flexDirection="column">
-            <PaginatedTable data={historicalData} />
-        </Box>
-    )
+      <Alert title="Failed to load historical data.">
+        {historyWithLoadingStatus.status.err}
+      </Alert>
+    );
+  }
+
+  const historicalData: Data = {
+    schema: checkHistorySchema,
+    data: (historyWithLoadingStatus.results?.results ?? []).map(
+      (artifactStatusResult) => {
+        return {
+          status: artifactStatusResult.exec_state?.status ?? 'Unknown',
+          level: checkLevel ? checkLevel : 'undefined',
+          value: artifactStatusResult.content_serialized,
+          timestamp: artifactStatusResult.exec_state?.timestamps?.finished_at,
+        };
+      }
+    ),
+  };
+
+  return (
+    <Box display="flex" justifyContent="center" flexDirection="column">
+      <PaginatedTable data={historicalData} />
+    </Box>
+  );
 };
 
 export default CheckHistory;

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -1,0 +1,67 @@
+import { CircularProgress } from '@mui/material';
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Box';
+import React from 'react';
+import Plot from 'react-plotly.js';
+
+import PaginatedTable from '../../../../components/tables/PaginatedTable';
+import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
+import { theme } from '../../../../styles/theme/theme';
+import { Data, DataSchema } from '../../../../utils/data';
+import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
+
+type CheckHistoryProps = {
+    historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
+    checkLevel?: string;
+}
+
+// TODO: Bring over data schema from check details page
+const checkHistorySchema: DataSchema = {
+    fields: [
+        { name: 'status', type: 'varchar' },
+        { name: 'level', type: 'varchar' },
+        { name: 'value', type: 'varchar' },
+        { name: 'timestamp', type: 'varchar' }
+    ],
+    pandas_version: '0.0.1', // Not sure what actual value to put here, just filling in for now :)
+};
+
+const CheckHistory: React.FC<CheckHistoryProps> = ({ historyWithLoadingStatus, checkLevel }) => {
+    if (
+        !historyWithLoadingStatus ||
+        isInitial(historyWithLoadingStatus.status) ||
+        isLoading(historyWithLoadingStatus.status)
+    ) {
+        return <CircularProgress />;
+    }
+    if (isFailed(historyWithLoadingStatus.status)) {
+        return (
+            <Alert title="Failed to load historical data.">
+                {historyWithLoadingStatus.status.err}
+            </Alert>
+        );
+    }
+
+    const historicalData: Data = {
+        schema: checkHistorySchema,
+        data: (historyWithLoadingStatus.results?.results ?? []).map(
+            (artifactStatusResult) => {
+                console.log('artifactStatusResult', artifactStatusResult);
+                return {
+                    status: artifactStatusResult.exec_state?.status ?? 'Unknown',
+                    level: checkLevel ? checkLevel : 'undefined',
+                    value: artifactStatusResult.content_serialized,
+                    timestamp: artifactStatusResult.exec_state?.timestamps?.finished_at,
+                };
+            }
+        ),
+    };
+
+    return (
+        <Box display="flex" justifyContent="center" flexDirection="column">
+            <PaginatedTable data={historicalData} />
+        </Box>
+    )
+};
+
+export default CheckHistory;

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -46,7 +46,6 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({ historyWithLoadingStatus, c
         schema: checkHistorySchema,
         data: (historyWithLoadingStatus.results?.results ?? []).map(
             (artifactStatusResult) => {
-                console.log('artifactStatusResult', artifactStatusResult);
                 return {
                     status: artifactStatusResult.exec_state?.status ?? 'Unknown',
                     level: checkLevel ? checkLevel : 'undefined',

--- a/src/ui/common/src/index.tsx
+++ b/src/ui/common/src/index.tsx
@@ -53,6 +53,7 @@ import IntegrationDetailsPage from './components/pages/integration/id';
 import IntegrationsPage from './components/pages/integrations';
 import LoginPage from './components/pages/LoginPage';
 import MetricDetailsPage from './components/pages/metric/id';
+import CheckDetailsPage from './components/pages/check/id';
 import WorkflowPage from './components/pages/workflow/id';
 import WorkflowsPage from './components/pages/workflows';
 import { Button } from './components/primitives/Button.styles';
@@ -309,6 +310,7 @@ export {
   Button,
   Card,
   Check,
+  CheckDetailsPage,
   CheckLevel,
   CheckOperatorNode,
   CheckStatus,

--- a/src/ui/common/src/index.tsx
+++ b/src/ui/common/src/index.tsx
@@ -45,6 +45,7 @@ import { NotificationListItem } from './components/notifications/NotificationLis
 import NotificationsPopover from './components/notifications/NotificationsPopover';
 import AccountPage from './components/pages/AccountPage';
 import ArtifactDetailsPage from './components/pages/artifact/id';
+import CheckDetailsPage from './components/pages/check/id';
 import DataPage from './components/pages/data';
 import FunctionDetailsPage from './components/pages/function/id';
 import { getServerSideProps } from './components/pages/getServerSideProps';
@@ -53,7 +54,6 @@ import IntegrationDetailsPage from './components/pages/integration/id';
 import IntegrationsPage from './components/pages/integrations';
 import LoginPage from './components/pages/LoginPage';
 import MetricDetailsPage from './components/pages/metric/id';
-import CheckDetailsPage from './components/pages/check/id';
 import WorkflowPage from './components/pages/workflow/id';
 import WorkflowsPage from './components/pages/workflows';
 import { Button } from './components/primitives/Button.styles';

--- a/src/ui/common/src/reducers/artifactResultContents.ts
+++ b/src/ui/common/src/reducers/artifactResultContents.ts
@@ -25,7 +25,6 @@ export const artifactResultContentsSlice = createSlice({
     builder.addCase(
       handleGetArtifactResultContent.pending,
       (state, { meta }) => {
-        console.log('pending');
         const id = meta.arg.artifactResultId;
         state.contents[id] = {
           status: { loading: LoadingStatusEnum.Loading, err: '' },
@@ -35,7 +34,6 @@ export const artifactResultContentsSlice = createSlice({
     builder.addCase(
       handleGetArtifactResultContent.fulfilled,
       (state, { meta, payload }) => {
-        console.log('fulfilled');
         const id = meta.arg.artifactResultId;
         state.contents[id] = {
           data: payload,
@@ -46,7 +44,6 @@ export const artifactResultContentsSlice = createSlice({
     builder.addCase(
       handleGetArtifactResultContent.rejected,
       (state, { meta, payload }) => {
-        console.log('rejected');
         const id = meta.arg.artifactResultId;
 
         state.contents[id] = {

--- a/src/ui/common/src/stores/store.ts
+++ b/src/ui/common/src/stores/store.ts
@@ -11,17 +11,6 @@ import notificationsReducer from '../reducers/notifications';
 import openSideSheetReducer from '../reducers/openSideSheet';
 import workflowReducer from '../reducers/workflow';
 import workflowDagResultsReducer from '../reducers/workflowDagResults';
-//import {AnyAction, CombinedState, configureStore, Reducer} from '@reduxjs/toolkit';
-
-/*
-const rootReducer: Reducer<CombinedState<{
-    nodeSelectionReducer
-    issuesDisplay: CurrentDisplayState;
-    repoDetails: RepoDetailsState;
-    issues: IssuesState;
-    comments: CommentsState;
-}>, AnyAction>
-*/
 
 export const store = configureStore({
   reducer: {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR implements the check details page. I took some liberties on the mocks, but I suspect my mocks were quite out of date.

See mock here:
https://www.figma.com/file/Qz2IiYJ4NAaDHojOf2YoTm/UI-V2-Screens?node-id=874%3A29070

Things I didn't do from the mock:
-Add color tints to the results table. Certainly something we can do, but I think we have some bigger questions to answer.
-Show associated metrics in the related outputs section. (I'm not sure if this is even possible at the moment) Instead, I think we should just show a list of artifacts associated with this Check.
-Render artifact's location. Went with rendering the check's serialized result instead.

Things we should perhaps add that were missing from the mock:
-It would be nice to know what the input to this check was.
-Perhaps we should show the code of the check operator
-Show logs for check if any

I worry that if we add the things above, there wouldn't be much difference at all between the Check Details page and the Metric details page. Are there any other Check specific things that we can do here to give users a better experience?

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-919/implement-check-details-page

## Loom demo (if any)
https://www.loom.com/share/5e5a92120e134bbc959b03306c417a03

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


