### PR TITLE
Downloads Airflow DAG template as part of pkg install

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -138,6 +138,8 @@ def download_server_binaries(architecture):
     print("Downloading integration set up scripts...")
     with open(os.path.join(server_directory, "bin/start-function-executor.sh"), "wb") as f:
         _download_file(os.path.join(s3_server_prefix, f"bin/start-function-executor.sh"), f)
+    with open(os.path.join(server_directory, "bin/dag.template"), "wb") as f:
+        _download_file(os.path.join(s3_server_prefix, f"bin/dag.template"), f)
     with open(os.path.join(server_directory, "bin/install_sqlserver_ubuntu.sh"), "wb") as f:
         _download_file(os.path.join(s3_server_prefix, f"bin/install_sqlserver_ubuntu.sh"), f)
     print("Downloaded server binaries...")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the Airflow DAG template wasn't downloaded as part of the `aqueduct-ml` pkg installation.
@cw75 Will add add this file as part of the packaged code in the next release. (Instructions can be found in the OSS release runbook on Notion.)

## Related issue number (if any)
ENG 1757

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


