### PR TITLE
Eng 1752 Make Paginated Table Size More Adaptable

### DIFF
--- a/src/ui/common/src/components/tables/PaginatedTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedTable.tsx
@@ -36,7 +36,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({ data }) => {
 
   return (
     <Paper sx={{ width: '800px', overflow: 'hidden' }}>
-      <TableContainer sx={{ maxHeight: 440, height: 440 }}>
+      <TableContainer sx={{ maxHeight: '400px' }}>
         <Table stickyHeader aria-label="sticky table">
           <TableHead>
             <TableRow>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR makes our PaginatedTable component's size more adaptable.

Sets a max height of 400px here for the table.

## Related issue number (if any)
ENG-1752

## Loom demo (if any)
https://www.loom.com/share/66525aa459c443dd8f7e52bdc60d1210

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


