### PR TITLE
ENG-1645 Fix for aqueduct logo appearing cut off on the home page.

### DIFF
--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -86,6 +86,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
       <img
         src="https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct-logo-two-tone/1x/aqueduct-logo-two-tone-1x.png"
         width="300px"
+        style={{ marginTop: '64px' }}
       />
 
       <Box

--- a/src/ui/common/src/components/pages/HomePage.tsx
+++ b/src/ui/common/src/components/pages/HomePage.tsx
@@ -21,7 +21,6 @@ const HomePage: React.FC<HomePageProps> = ({
 
   return (
     <Layout user={user}>
-      <div />
       <GettingStartedTutorial user={user} />
     </Layout>
   );


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where the aqueduct logo appeared cut off on the home page.

## Related issue number (if any)
ENG-1645

## Loom demo (if any)
Screenshot:
<img width="1481" alt="image" src="https://user-images.githubusercontent.com/1031759/193464195-2c793712-2160-4a0b-bd3c-6c18af1aa5a5.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


