### PR TITLE
ENG-1457 Adds Documentation link to menu sidebar

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   faBell,
+  faBook,
   faCircleUser,
   faDatabase,
   faMessage,
@@ -321,6 +322,20 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
         </Box>
 
         <Box sx={{ width: '100%' }}>
+          <Divider sx={{ width: '100%', backgroundColor: 'white' }} />
+          <Box sx={{ my: 2 }}>
+            <Link href="https://docs.aqueducthq.com" underline="none">
+              <SidebarButton
+                icon={
+                  <FontAwesomeIcon
+                    className={styles['menu-sidebar-icon']}
+                    icon={faBook}
+                  />
+                }
+                text="Documentation"
+              />
+            </Link>
+          </Box>
           <Divider sx={{ width: '100%', backgroundColor: 'white' }} />
           <Box sx={{ my: 2 }}>
             <Link href="mailto:support@aqueducthq.com" underline="none">


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a link to the documentation page in the bottom of the menu sidebar.

## Related issue number (if any)
ENG-1457

## Loom demo (if any)
Screenshot:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/1031759/193464651-b6a4c5b9-c448-4b58-8bca-4dd64c78667d.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


