### PR TITLE
ENG-1606 enable users to change retention policy via UI

### DIFF
--- a/src/golang/cmd/server/handler/edit_workflow.go
+++ b/src/golang/cmd/server/handler/edit_workflow.go
@@ -35,9 +35,10 @@ type EditWorkflowHandler struct {
 }
 
 type editWorkflowInput struct {
-	WorkflowName        string             `json:"name"`
-	WorkflowDescription string             `json:"description"`
-	Schedule            *workflow.Schedule `json:"schedule"`
+	WorkflowName        string                    `json:"name"`
+	WorkflowDescription string                    `json:"description"`
+	Schedule            *workflow.Schedule        `json:"schedule"`
+	RetentionPolicy     *workflow.RetentionPolicy `json:"retention_policy"`
 }
 
 type editWorkflowArgs struct {
@@ -45,6 +46,7 @@ type editWorkflowArgs struct {
 	workflowName        string
 	workflowDescription string
 	schedule            *workflow.Schedule
+	retentionPolicy     *workflow.RetentionPolicy
 }
 
 func (*EditWorkflowHandler) Name() string {
@@ -110,6 +112,7 @@ func (h *EditWorkflowHandler) Prepare(r *http.Request) (interface{}, int, error)
 		workflowName:        input.WorkflowName,
 		workflowDescription: input.WorkflowDescription,
 		schedule:            input.Schedule,
+		retentionPolicy:     input.RetentionPolicy,
 	}, http.StatusOK, nil
 }
 
@@ -128,6 +131,7 @@ func (h *EditWorkflowHandler) Perform(ctx context.Context, interfaceArgs interfa
 		args.workflowName,
 		args.workflowDescription,
 		args.schedule,
+		args.retentionPolicy,
 	)
 	if err != nil {
 		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to update workflow.")

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -191,6 +191,7 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 			args.dbWorkflowDag.Metadata.Name,
 			args.dbWorkflowDag.Metadata.Description,
 			&args.dbWorkflowDag.Metadata.Schedule,
+			&args.dbWorkflowDag.Metadata.RetentionPolicy,
 		)
 		if err != nil {
 			return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to update workflow.")

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -635,6 +635,7 @@ func (eng *aqEngine) EditWorkflow(
 	workflowName string,
 	workflowDescription string,
 	schedule *workflow.Schedule,
+	retentionPolicy *workflow.RetentionPolicy,
 ) error {
 	changes := map[string]interface{}{}
 	if workflowName != "" {
@@ -643,6 +644,10 @@ func (eng *aqEngine) EditWorkflow(
 
 	if workflowDescription != "" {
 		changes["description"] = workflowDescription
+	}
+
+	if retentionPolicy != nil {
+		changes["retention_policy"] = retentionPolicy
 	}
 
 	if schedule.Trigger != "" {

--- a/src/golang/lib/engine/engine.go
+++ b/src/golang/lib/engine/engine.go
@@ -48,6 +48,7 @@ type Engine interface {
 		workflowName string,
 		workflowDescription string,
 		schedule *workflow.Schedule,
+		retentionPolicy *workflow.RetentionPolicy,
 	) error
 
 	// TODO ENG-1444: Used as a wrapper to trigger a workflow via executor binary.

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -52,6 +52,7 @@ import {
 } from '../../utils/cron';
 import ExecutionStatus, { LoadingStatusEnum } from '../../utils/shared';
 import {
+  RetentionPolicy,
   SavedObject,
   WorkflowDag,
   WorkflowUpdateTrigger,
@@ -174,6 +175,45 @@ const PeriodicScheduleSelector: React.FC<PeriodicScheduleSelectorProps> = ({
   );
 };
 
+type RetentionPolicyProps = {
+  retentionPolicy?: RetentionPolicy;
+  setRetentionPolicy: (p?: RetentionPolicy) => void;
+};
+
+const RetentionPolicySelector: React.FC<RetentionPolicyProps> = ({
+  retentionPolicy,
+  setRetentionPolicy,
+}) => {
+  let value = '';
+  let helperText: string = undefined;
+  if (!retentionPolicy || retentionPolicy.k_latest_runs <= 0) {
+    helperText = 'We keep all versions of this workflow.';
+  } else {
+    value = retentionPolicy.k_latest_runs.toString();
+  }
+
+  return (
+    <TextField
+      size="small"
+      label="Number of latest versions to keep."
+      sx={{ width: '400px' }}
+      type="number"
+      value={value}
+      onChange={(e) => {
+        const kLatestRuns = parseInt(e.target.value);
+        if (kLatestRuns <= 0 || isNaN(kLatestRuns)) {
+          // Internal representation of no retention.
+          setRetentionPolicy({ k_latest_runs: -1 });
+          return;
+        }
+
+        setRetentionPolicy({ k_latest_runs: kLatestRuns });
+      }}
+      helperText={helperText}
+    />
+  );
+};
+
 type WorkflowSettingsProps = {
   user: UserProfile;
   workflowDag: WorkflowDag;
@@ -223,6 +263,12 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     workflowDag.metadata.schedule.cron_schedule
   );
   const [paused, setPaused] = useState(workflowDag.metadata.schedule.paused);
+  const [retentionPolicy, setRetentionPolicy] = useState(
+    workflowDag.metadata?.retention_policy
+  );
+  const retentionPolicyUpdated =
+    retentionPolicy.k_latest_runs !==
+    workflowDag.metadata?.retention_policy?.k_latest_runs;
 
   const settingsChanged =
     name !== workflowDag.metadata?.name || // The workflow name has been changed.
@@ -230,7 +276,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     triggerType !== workflowDag.metadata.schedule.trigger || // The type of the trigger has changed.
     (triggerType === WorkflowUpdateTrigger.Periodic &&
       schedule !== workflowDag.metadata.schedule.cron_schedule) || // The schedule type is still periodic but the schedule itself has changed.
-    paused !== workflowDag.metadata.schedule.paused; // The schedule type is periodic and we've changed the pausedness of the workflow.
+    paused !== workflowDag.metadata.schedule.paused || // The schedule type is periodic and we've changed the pausedness of the workflow.
+    retentionPolicyUpdated; // retention policy has changed.
 
   const triggerOptions = [
     { label: 'Update Manually', value: WorkflowUpdateTrigger.Manual },
@@ -238,7 +285,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   ];
 
   const scheduleSelector = (
-    <Box sx={{ my: 2 }}>
+    <Box sx={{ my: 1 }}>
       <RadioGroup
         onChange={(e) =>
           setTriggerType(e.target.value as WorkflowUpdateTrigger)
@@ -378,6 +425,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           triggerType === WorkflowUpdateTrigger.Periodic ? schedule : '', // Always set the schedule if the update type is periodic.
         paused, // Set whatever value of paused was set, which will be the previous value if it's not modified.
       },
+      retention_policy: retentionPolicyUpdated ? retentionPolicy : undefined,
     };
 
     fetch(`${apiAddress}/api/workflow/${workflowDag.workflow_id}/edit`, {
@@ -742,12 +790,14 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           <Box sx={{ my: 2 }}>
             <Typography style={{ fontWeight: 'bold' }}> Name </Typography>
 
-            <TextField
-              fullWidth
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              size="small"
-            />
+            <Box sx={{ my: 1 }}>
+              <TextField
+                fullWidth
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                size="small"
+              />
+            </Box>
           </Box>
 
           <Box sx={{ my: 2 }}>
@@ -756,33 +806,48 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               Description{' '}
             </Typography>
 
-            <TextField
-              fullWidth
-              placeholder="Your description goes here."
-              value={description}
-              multiline
-              rows={4}
-              size="small"
-              onChange={(e) => setDescription(e.target.value)}
-            />
+            <Box sx={{ my: 1 }}>
+              <TextField
+                fullWidth
+                placeholder="Your description goes here."
+                value={description}
+                multiline
+                rows={4}
+                size="small"
+                onChange={(e) => setDescription(e.target.value)}
+              />
+            </Box>
           </Box>
 
           <Box sx={{ my: 2 }}>
             <Typography style={{ fontWeight: 'bold' }}> Schedule </Typography>
             {scheduleSelector}
             {nextUpdateComponent}
-
-            <LoadingButton
-              loading={isUpdating}
-              onClick={updateSettings}
-              sx={{ mt: 1 }}
-              color="primary"
-              variant="contained"
-              disabled={!settingsChanged}
-            >
-              Save
-            </LoadingButton>
           </Box>
+
+          <Box sx={{ my: 2 }}>
+            <Typography style={{ fontWeight: 'bold' }}>
+              Retention Policy
+            </Typography>
+
+            <Box sx={{ my: 1 }}>
+              <RetentionPolicySelector
+                retentionPolicy={retentionPolicy}
+                setRetentionPolicy={setRetentionPolicy}
+              />
+            </Box>
+          </Box>
+
+          <LoadingButton
+            loading={isUpdating}
+            onClick={updateSettings}
+            sx={{ my: 1 }}
+            color="primary"
+            variant="contained"
+            disabled={!settingsChanged}
+          >
+            Save
+          </LoadingButton>
 
           <Divider />
 

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -195,7 +195,7 @@ const RetentionPolicySelector: React.FC<RetentionPolicyProps> = ({
   return (
     <TextField
       size="small"
-      label="The number of latest versions to keep. Older versions will be garbage collected."
+      label="The number of latest versions to keep. Older versions will be removed."
       fullWidth
       type="number"
       value={value}

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -187,7 +187,7 @@ const RetentionPolicySelector: React.FC<RetentionPolicyProps> = ({
   let value = '';
   let helperText: string = undefined;
   if (!retentionPolicy || retentionPolicy.k_latest_runs <= 0) {
-    helperText = 'We keep all versions of this workflow.';
+    helperText = 'Aqueduct will store all versions of this workflow.';
   } else {
     value = retentionPolicy.k_latest_runs.toString();
   }
@@ -195,8 +195,8 @@ const RetentionPolicySelector: React.FC<RetentionPolicyProps> = ({
   return (
     <TextField
       size="small"
-      label="Number of latest versions to keep."
-      sx={{ width: '400px' }}
+      label="The number of latest versions to keep. Older versions will be garbage collected."
+      fullWidth
       type="number"
       value={value}
       onChange={(e) => {

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -21,6 +21,10 @@ export type WorkflowSchedule = {
   paused: boolean;
 };
 
+export type RetentionPolicy = {
+  k_latest_runs: number;
+};
+
 export type ListWorkflowSummary = {
   id: string;
   name: string;
@@ -45,6 +49,7 @@ export type Workflow = {
   description: string;
   schedule: WorkflowSchedule;
   created_at: number;
+  retention_policy?: RetentionPolicy;
 };
 
 export type WorkflowDag = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a section in 'workflow settings' dialog to allow user to change retention policy. We slightly modified backend to be able to accept updated retention policy in API calls.

I noticed there are a few places to improve this dialog, which is out of scope of this PR:
https://linear.app/aqueducthq/issue/ENG-1781/improve-workflow-settings-dialog

## Related issue number (if any)
ENG-1606

## Loom demo (if any)
Somehow the audio is off. A few notes to pay attention to:
* we show the current value of retention policy when the user first open the dialog.
* If the value is empty we inform the user that all versions will be preserved.
https://www.loom.com/share/8fd37869934042e1b7938c672e5a6629

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


