### PR TITLE
Fix message wording when an artifact doesn't has downstream metrics or checks

### DIFF
--- a/src/ui/common/src/components/workflows/artifact/metricsAndChecksOverview.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metricsAndChecksOverview.tsx
@@ -55,7 +55,7 @@ export const MetricsOverview: React.FC<MetricsOverviewProps> = ({
         />
       ) : (
         <Typography variant="body2">
-          This artifact has no associated downstream Metrics.
+          This artifact has no associated metrics.
         </Typography>
       )}
     </Box>
@@ -96,7 +96,7 @@ export const ChecksOverview: React.FC<ChecksOverviewProps> = ({ checks }) => {
         />
       ) : (
         <Typography variant="body2">
-          This artifact has no associated downstream Checks.
+          This artifact has no associated checks.
         </Typography>
       )}
     </Box>

--- a/src/ui/common/src/handlers/getArtifactResultContent.ts
+++ b/src/ui/common/src/handlers/getArtifactResultContent.ts
@@ -25,7 +25,7 @@ export const handleGetArtifactResultContent = createAsyncThunk<
   ) => {
     const { apiKey, workflowDagResultId, artifactId } = args;
     const res = await fetch(
-      `${apiAddress}/api/artifact_result/${workflowDagResultId}/${artifactId}`,
+      `${apiAddress}/api/artifact/${workflowDagResultId}/${artifactId}/result`,
       {
         method: 'GET',
         headers: {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes wording when there's no metrics / checks to show in artifact details page. We noticed that the url to fetch artf content also needs to update.

## Related issue number (if any)
ENG-1772

## Loom demo (if any)
<img width="831" alt="Screen Shot 2022-10-03 at 6 27 27 PM" src="https://user-images.githubusercontent.com/10411887/193715344-70a20536-a734-44b0-9965-bd29c43bf28d.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


