### PR TITLE
Eng 1760 workflow version switching bug

### DIFF
--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -58,6 +58,7 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     const metricArtifactNodes = [];
 
     // first find all check operators.
+    console.log('checking dagPositionState.result');
     if (dagPositionState.result) {
       const nodes = dagPositionState.result.nodes;
       nodes.forEach((node) => {
@@ -87,39 +88,52 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
 
     // Remove artifactNodes from the DAG
     // Take artifact result and set inside operator's data.result field.
+    console.log('checking dagPositionState.result two: ', dagPositionState);
     const nodes = dagPositionState.result?.nodes;
-    const enrichedNodes = produce(nodes, (draftState) => {
-      // NOTE: only mutate the draftState variable here.
-      // See docs here for more information: https://redux-toolkit.js.org/usage/immer-reducers#immutable-updates-with-immer
-      if (nodes) {
-        // loop through and find checkOpNodes, doing fancy logic stuffs.
-        for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
-          // boolArtifactNodes and checkOps are sorted and now have the same index as one another.
-          // Let's take the operators and set their data.result fields accordingly.
-          for (let i = 0; i < checkOpNodes.length; i++) {
-            if (nodes[nodeIndex].id === checkOpNodes[i].id) {
-              // Let's find the artifact result of the corresponding booleanArtifactNode.
-              const boolArtifactResult =
-                artifactResults[boolArtifactNodes[i].id].result?.data;
-              if (boolArtifactResult) {
-                draftState[nodeIndex].data.result = boolArtifactResult;
-              }
-            }
-          }
+    let enrichedNodes = [];
 
-          // find metric nodes and put the result into the operator's data field
-          for (let i = 0; i < metricOpNodes.length; i++) {
-            if (nodes[nodeIndex].id === metricOpNodes[i].id) {
-              const metricArtifactResult =
-                artifactResults[metricArtifactNodes[i].id].result?.data;
-              if (metricArtifactResult) {
-                draftState[nodeIndex].data.result = metricArtifactResult;
+    if (nodes) {
+      console.log('nodes: ', nodes);
+      enrichedNodes = produce(nodes, (draftState) => {
+        // NOTE: only mutate the draftState variable here.
+        // See docs here for more information: https://redux-toolkit.js.org/usage/immer-reducers#immutable-updates-with-immer
+        if (nodes) {
+          // loop through and find checkOpNodes, doing fancy logic stuffs.
+          for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
+            // boolArtifactNodes and checkOps are sorted and now have the same index as one another.
+            // Let's take the operators and set their data.result fields accordingly.
+            for (let i = 0; i < checkOpNodes.length; i++) {
+              if (nodes[nodeIndex].id === checkOpNodes[i].id) {
+                // Let's find the artifact result of the corresponding booleanArtifactNode.
+                const boolArtifactResult =
+                  artifactResults[boolArtifactNodes[i].id]?.result?.data;
+                if (boolArtifactResult) {
+                  draftState[nodeIndex].data.result = boolArtifactResult;
+                }
+              }
+            }
+
+            // find metric nodes and put the result into the operator's data field
+            for (let i = 0; i < metricOpNodes.length; i++) {
+              if (nodes[nodeIndex].id === metricOpNodes[i].id) {
+                const metricArtifactResult =
+                  artifactResults[metricArtifactNodes[i].id]?.result?.data;
+                if (metricArtifactResult) {
+                  draftState[nodeIndex].data.result = metricArtifactResult;
+                }
               }
             }
           }
+        } else {
+          console.log('in else statement');
+          return [];
         }
-      }
-    });
+      });
+    } else {
+      console.log('nodes else: ', nodes);
+    }
+
+    console.log('enrichedNodes: ', enrichedNodes);
 
     //Finally, let's remove any boolean artifacts from the list
     // This has to be two separate steps or Immer will complain that we are producing a new value and modifying it's draft.
@@ -146,7 +160,12 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
       });
     });
 
+    console.log('filtered nodes: ', filteredNodes);
+
+    console.log('checking result three');
+    console.log('dagPositionState', dagPositionState);
     const edges = dagPositionState.result?.edges;
+    console.log('edges: ', edges);
     const updatedEdges = produce(edges, (edgeDraftState) => {
       if (!edges) {
         return [];

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -58,7 +58,6 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     const metricArtifactNodes = [];
 
     // first find all check operators.
-    console.log('checking dagPositionState.result');
     if (dagPositionState.result) {
       const nodes = dagPositionState.result.nodes;
       nodes.forEach((node) => {
@@ -88,12 +87,10 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
 
     // Remove artifactNodes from the DAG
     // Take artifact result and set inside operator's data.result field.
-    console.log('checking dagPositionState.result two: ', dagPositionState);
     const nodes = dagPositionState.result?.nodes;
     let enrichedNodes = [];
 
     if (nodes) {
-      console.log('nodes: ', nodes);
       enrichedNodes = produce(nodes, (draftState) => {
         // NOTE: only mutate the draftState variable here.
         // See docs here for more information: https://redux-toolkit.js.org/usage/immer-reducers#immutable-updates-with-immer
@@ -124,16 +121,9 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
               }
             }
           }
-        } else {
-          console.log('in else statement');
-          return [];
         }
       });
-    } else {
-      console.log('nodes else: ', nodes);
     }
-
-    console.log('enrichedNodes: ', enrichedNodes);
 
     //Finally, let's remove any boolean artifacts from the list
     // This has to be two separate steps or Immer will complain that we are producing a new value and modifying it's draft.
@@ -160,12 +150,7 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
       });
     });
 
-    console.log('filtered nodes: ', filteredNodes);
-
-    console.log('checking result three');
-    console.log('dagPositionState', dagPositionState);
     const edges = dagPositionState.result?.edges;
-    console.log('edges: ', edges);
     const updatedEdges = produce(edges, (edgeDraftState) => {
       if (!edges) {
         return [];


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug which caused the app to crash when the user switches workflow versions using the version dropdown in the workflow header.

## Related issue number (if any)
ENG-1760

## Loom demo (if any)
https://www.loom.com/share/78f11760e7b34b2bbe205d67523d2707

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


