### PR TITLE
Requires workflow executor to check for paused workflow execution

### DIFF
--- a/src/golang/cmd/executor/executor/workflow.go
+++ b/src/golang/cmd/executor/executor/workflow.go
@@ -70,7 +70,12 @@ func (ex *WorkflowExecutor) Run(ctx context.Context) error {
 	if err := lock.RLock(); err != nil {
 		return err
 	}
-	defer lock.RUnlock()
+	defer func() {
+		unlockErr := lock.RUnlock()
+		if unlockErr != nil {
+			log.Errorf("Unexpected error when unlocking execution lock: %v", unlockErr)
+		}
+	}()
 
 	status, err := ex.Engine.ExecuteWorkflow(
 		ctx,

--- a/src/golang/cmd/executor/executor/workflow.go
+++ b/src/golang/cmd/executor/executor/workflow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/engine"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
-	"github.com/dropbox/godropbox/sys/filelock"
+	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -65,7 +65,7 @@ func NewWorkflowExecutor(spec *job.WorkflowSpec, base *BaseExecutor) (*WorkflowE
 
 func (ex *WorkflowExecutor) Run(ctx context.Context) error {
 	// First, ensure that workflow execution is not paused
-	lock := filelock.New(engine.ExecutionLock)
+	lock := utils.NewExecutionLock()
 	// The following will block until the RLock can be acquired
 	if err := lock.RLock(); err != nil {
 		return err

--- a/src/golang/lib/engine/lock.go
+++ b/src/golang/lib/engine/lock.go
@@ -1,4 +1,0 @@
-package engine
-
-// ExecutionLock is the name of the shared filelock for blocking workflow run execution
-const ExecutionLock = "ExecutionLock"

--- a/src/golang/lib/engine/lock.go
+++ b/src/golang/lib/engine/lock.go
@@ -1,0 +1,4 @@
+package engine
+
+// ExecutionLock is the name of the shared filelock for blocking workflow run execution
+const ExecutionLock = "ExecutionLock"

--- a/src/golang/lib/workflow/utils/lock.go
+++ b/src/golang/lib/workflow/utils/lock.go
@@ -1,0 +1,11 @@
+package utils
+
+import "github.com/dropbox/godropbox/sys/filelock"
+
+// executionLock is the name of the shared filelock for blocking workflow run execution
+const executionLock = "ExecutionLock"
+
+// NewExecutionLock returns a new workflow execution mutex
+func NewExecutionLock() *filelock.FileLock {
+	return filelock.New(executionLock)
+}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR requires the workflow executor to acquire a read lock at the beginning of each workflow run execution. This allows us to pause new workflow runs if there are certain system maintenance jobs that need to be performed, such as metadata store migration (this work will be in a later PR).

The PR uses a `filelock` to perform synchronization across processes, since each `executor` is its running in its own process. Once we turn these processes into goroutines, we can trade the `filelock` for a generic `mutex`.

## Related issue number (if any)
ENG 1779

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


