### PR TITLE
ENG-1787 Enable scroll for long stdout or stderr messages

### DIFF
--- a/src/ui/common/src/components/text/LogBlock.tsx
+++ b/src/ui/common/src/components/text/LogBlock.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 const LogBlock: React.FC<Props> = ({ logText, level, title }) => {
   return (
-    <Alert sx={{ overflowY: 'scroll' }} severity={level}>
+    <Alert sx={{ overflowY: 'scroll', maxHeight: '79vh' }} severity={level}>
       {title && <AlertTitle>{title}</AlertTitle>}
       <pre>{logText}</pre>
     </Alert>

--- a/src/ui/common/src/components/text/LogBlock.tsx
+++ b/src/ui/common/src/components/text/LogBlock.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 const LogBlock: React.FC<Props> = ({ logText, level, title }) => {
   return (
-    <Alert severity={level}>
+    <Alert sx={{ overflowY: 'scroll' }} severity={level}>
       {title && <AlertTitle>{title}</AlertTitle>}
       <pre>{logText}</pre>
     </Alert>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds overflow-y:scroll to the LogBlock component's Alert box to allow users to scroll and view contents of longer error messages.

## Related issue number (if any)
ENG-1787

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


