### PR TITLE
Eng 1751 refine input and output list for operator / metric details page

### DIFF
--- a/src/ui/common/src/components/pages/ErrorPage.tsx
+++ b/src/ui/common/src/components/pages/ErrorPage.tsx
@@ -45,12 +45,10 @@ const ErrorPage: React.FC<ErrorPageProps> = ({
             height="150px"
           />
           <Typography variant="body1" sx={{ fontSize: '20px' }}>
-            Something went wrong &mdash; we can't find the page you're looking for.
+            Something went wrong &mdash; we can't find the page you're looking
+            for.
           </Typography>
-          <Typography
-            variant="body1"
-            sx={{ fontSize: '15px', mt: '16px' }}
-          >
+          <Typography variant="body1" sx={{ fontSize: '15px', mt: '16px' }}>
             If this problem continues to persist, you can make a post in our{' '}
             <Link href="https://join.slack.com/t/aqueductusers/shared_invite/zt-11hby91cx-cpmgfK0qfXqEYXv25hqD6A">
               Slack community

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -162,7 +162,6 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 operatorResults={inputs}
-                initiallyExpanded={true}
               />
             </Box>
 
@@ -172,7 +171,6 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 operatorResults={outputs}
-                initiallyExpanded={true}
               />
             </Box>
           </Box>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -138,7 +138,6 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 artifactResults={inputs}
-                initiallyExpanded={true}
               />
             </Box>
             <Box width="32px" />
@@ -148,7 +147,6 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 artifactResults={outputs}
-                initiallyExpanded={true}
               />
             </Box>
           </Box>

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -55,20 +55,17 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     workflow.selectedDag?.operators[params.operatorId]?.inputs ?? [];
   const outputs =
     workflow.selectedDag?.operators[params.operatorId]?.outputs ?? [];
-  if (inputs || outputs) {
-    const operatorArtifacts = [...inputs, ...outputs];
-    // fetch output artifacts.
-    operatorArtifacts.map((artifactId) => {
-      if (!workflow.artifactResults[artifactId])
-        dispatch(
-          handleGetArtifactResults({
-            apiKey: user.apiKey,
-            workflowDagResultId: params.workflowDagResultId,
-            artifactId: artifactId,
-          })
-        );
-    });
-  }
+
+  [...inputs, ...outputs].map((artifactId) => {
+    if (!workflow.artifactResults[artifactId])
+      dispatch(
+        handleGetArtifactResults({
+          apiKey: user.apiKey,
+          workflowDagResultId: params.workflowDagResultId,
+          artifactId: artifactId,
+        })
+      );
+  });
 
   useEffect(() => {
     document.title = 'Operator Details | Aqueduct';
@@ -233,16 +230,23 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     });
   };
 
-  const inputItems = !!inputs ? (
-    mapArtfIds(inputs)
-  ) : (
-    <Typography ml="16px"> This operator has no inputs </Typography>
-  );
-  const outputItems = !!outputs ? (
-    mapArtfIds(outputs)
-  ) : (
-    <Typography ml="16px"> This operator has no outputs </Typography>
-  );
+  const inputItems =
+    inputs.length > 0 ? (
+      mapArtfIds(inputs)
+    ) : (
+      <Typography ml="16px"> This operator has no inputs </Typography>
+    );
+
+  const outputItems =
+    outputs.length > 0 ? (
+      mapArtfIds(outputs)
+    ) : (
+      <Box display="flex" p={1} alignItems="center">
+        <Typography height="16px" ml="16px" color="gray.700">
+          This operator has no outputs
+        </Typography>
+      </Box>
+    );
 
   const border = {
     border: '2px',

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -234,7 +234,11 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     inputs.length > 0 ? (
       mapArtfIds(inputs)
     ) : (
-      <Typography ml="16px"> This operator has no inputs </Typography>
+      <Box display="flex" p={1} alignItems="center">
+        <Typography height="16px" ml="16px" color="gray.700">
+          This operator has no input.
+        </Typography>
+      </Box>
     );
 
   const outputItems =
@@ -243,7 +247,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     ) : (
       <Box display="flex" p={1} alignItems="center">
         <Typography height="16px" ml="16px" color="gray.700">
-          This operator has no outputs
+          This operator has no output.
         </Typography>
       </Box>
     );

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -47,7 +47,6 @@ const ArtifactContent: React.FC<Props> = ({
   }
 
   if (isFailed(contentWithLoadingStatus.status)) {
-    console.log(contentWithLoadingStatus);
     return (
       <Alert severity="error">
         <AlertTitle>Failed to load artifact contents.</AlertTitle>

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -50,9 +50,7 @@ const ArtifactContent: React.FC<Props> = ({
     console.log(contentWithLoadingStatus);
     return (
       <Alert severity="error">
-        <AlertTitle>
-          Failed to load artifact contents.
-        </AlertTitle>
+        <AlertTitle>Failed to load artifact contents.</AlertTitle>
         {contentWithLoadingStatus.status.err}
       </Alert>
     );

--- a/src/ui/common/src/components/workflows/artifact/summaryList.tsx
+++ b/src/ui/common/src/components/workflows/artifact/summaryList.tsx
@@ -1,15 +1,12 @@
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link, List, ListItem } from '@mui/material';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import AccordionSummary from '@mui/material/AccordionSummary';
+import { Link } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import React, { useState } from 'react';
+import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { ArtifactResultResponse } from '../../../handlers/responses/artifact';
+import { theme } from '../../../styles/theme/theme';
 import { getPathPrefix } from '../../../utils/getPathPrefix';
 import { artifactTypeToIconMapping } from '../nodes/nodeTypes';
 
@@ -18,13 +15,6 @@ type Props = {
   workflowId: string;
   dagResultId: string;
   artifactResults: ArtifactResultResponse[];
-  initiallyExpanded: boolean;
-};
-
-const listStyle = {
-  width: '100%',
-  maxWidth: 360,
-  bgcolor: 'background.paper',
 };
 
 const SummaryList: React.FC<Props> = ({
@@ -32,81 +22,55 @@ const SummaryList: React.FC<Props> = ({
   workflowId,
   dagResultId,
   artifactResults,
-  initiallyExpanded,
 }) => {
-  const [expanded, setExpanded] = useState(initiallyExpanded);
-  const items = artifactResults.map((artifactResult) => {
-    let content = null;
-    if (artifactResult.result?.content_serialized) {
-      content = (
-        <Typography variant="body1">
-          {artifactResult.result.content_serialized}
-        </Typography>
-      );
-    } else {
-      content = (
-        <Box display="flex">
+  const items = artifactResults.map((artifactResult, idx) => {
+    return (
+      <Link
+        key={artifactResult.id}
+        to={`${getPathPrefix()}/workflow/${workflowId}/result/${dagResultId}/artifact/${
+          artifactResult.id
+        }`}
+        component={RouterLink as any}
+        underline="none"
+      >
+        <Box
+          display="flex"
+          p={1}
+          sx={{
+            alignItems: 'center',
+            '&:hover': { backgroundColor: 'gray.100' },
+            borderBottom:
+              idx === artifactResults.length - 1
+                ? ''
+                : `1px solid ${theme.palette.gray[400]}`,
+          }}
+        >
           <Box
-            sx={{
-              width: '16px',
-              height: '16px',
-              color: 'rgba(0,0,0,0.54)',
-            }}
+            width="16px"
+            height="16px"
+            alignItems="center"
+            display="flex"
+            flexDirection="column"
           >
             <FontAwesomeIcon
+              fontSize="16px"
+              color={`${theme.palette.gray[700]}`}
               icon={artifactTypeToIconMapping[artifactResult.type]}
             />
           </Box>
-          <Link
-            to={`${getPathPrefix()}/workflow/${workflowId}/result/${dagResultId}/artifact/${
-              artifactResult.id
-            }`}
-            component={RouterLink as any}
-            sx={{ marginLeft: '16px' }}
-            underline="none"
-          >
-            {artifactResult.name}
-          </Link>
+          <Typography ml="16px">{artifactResult.name}</Typography>
         </Box>
-      );
-    }
-    return (
-      <ListItem divider key={artifactResult.id}>
-        {content}
-      </ListItem>
+      </Link>
     );
   });
 
   return (
-    <Accordion
-      expanded={expanded}
-      onChange={() => {
-        setExpanded(!expanded);
-      }}
-    >
-      <AccordionSummary
-        expandIcon={<FontAwesomeIcon icon={faChevronRight} />}
-        sx={{
-          '& .MuiAccordionSummary-expandIconWrapper.Mui-expanded': {
-            transform: 'rotate(90deg)',
-          },
-        }}
-        aria-controls="input-accordion-content"
-        id="input-accordion-header"
-      >
-        <Typography
-          sx={{ width: '33%', flexShrink: 0 }}
-          variant="h5"
-          component="div"
-          marginBottom="8px"
-        >
-          {title}
-        </Typography>
-      </AccordionSummary>
-      <AccordionDetails>
-        <List sx={listStyle}>{items}</List>
-      </AccordionDetails>
-    </Accordion>
+    <Box>
+      <Typography variant="h6" mb="8px" fontWeight="normal">
+        {title}
+      </Typography>
+      {items}
+    </Box>
   );
 };
 

--- a/src/ui/common/src/components/workflows/operator/summaryList.tsx
+++ b/src/ui/common/src/components/workflows/operator/summaryList.tsx
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import React, { useState } from 'react';
+import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { OperatorResultResponse } from '../../../handlers/responses/operator';
@@ -16,13 +16,6 @@ type Props = {
   workflowId: string;
   dagResultId: string;
   operatorResults: OperatorResultResponse[];
-  initiallyExpanded: boolean;
-};
-
-const listStyle = {
-  width: '100%',
-  maxWidth: 360,
-  bgcolor: 'background.paper',
 };
 
 const SummaryList: React.FC<Props> = ({
@@ -30,9 +23,7 @@ const SummaryList: React.FC<Props> = ({
   workflowId,
   dagResultId,
   operatorResults,
-  initiallyExpanded,
 }) => {
-  const [expanded, setExpanded] = useState(initiallyExpanded);
   const items = operatorResults.map((opResult, index) => {
     let link = `${getPathPrefix()}/workflow/${workflowId}/result/${dagResultId}/operator/${
       opResult.id
@@ -51,7 +42,12 @@ const SummaryList: React.FC<Props> = ({
     }
 
     return (
-      <Link to={link} component={RouterLink as any} underline="none">
+      <Link
+        key={opResult.id}
+        to={link}
+        component={RouterLink as any}
+        underline="none"
+      >
         <Box
           display="flex"
           p={1}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR improves inputs / outputs section for operator details page and metrics detail page. The style follows @vsreekanti 's change on artifact details page.

Note that some changes are repeated, this is because we are not yet merging the operator / artifact list into one, and we are also using a different redux for operator detail page. Both problems will be addressed separately after we finished user-facing features.

## Related issue number (if any)
ENG-1751

## Loom demo (if any)
Note how this section is now consistent for operator / artifacts.
https://www.loom.com/share/738acb55a2e6435793c7ad5852dde072

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


