### PR TITLE
Eng 1782 improve error handlings in artifact / metrics / check details page

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress, Divider } from '@mui/material';
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
@@ -121,7 +122,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
       <Layout user={user}>
-        <Alert title="Failed to load workflow">
+        <Alert severity="error">
+          <AlertTitle>Failed to load workflow.</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
         </Alert>
       </Layout>
@@ -131,7 +133,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   if (!artifact) {
     return (
       <Layout user={user}>
-        <Alert title="Failed to load artifact">
+        <Alert severity="error">
+          <AlertTitle>Failed to load artifact.</AlertTitle>
           Artifact {artifactId} does not exist on this workflow.
         </Alert>
       </Layout>

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -5,6 +5,7 @@ import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
@@ -115,7 +116,8 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
       <Layout user={user}>
-        <Alert title="Failed to load workflow">
+        <Alert severity="error">
+          <AlertTitle>Failed to load workflow.</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
         </Alert>
       </Layout>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress, Divider } from '@mui/material';
 import Alert from '@mui/material/Alert';
+import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
@@ -101,7 +102,8 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
       <Layout user={user}>
-        <Alert title="Failed to load workflow">
+        <Alert severity="error">
+          <AlertTitle>Failed to load workflow</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
         </Alert>
       </Layout>

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -47,7 +47,6 @@ const ArtifactContent: React.FC<Props> = ({
   }
 
   if (isFailed(contentWithLoadingStatus.status)) {
-    console.log(contentWithLoadingStatus);
     return (
       <Alert severity="error">
         <AlertTitle>Failed to load artifact contents.</AlertTitle>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixed the bug where we show a 'success' alert when we failed to fetch from REST endpoints in artf / metrics / check details page.

## Related issue number (if any)
ENG-1782

## Loom demo (if any)
Before:
<img width="839" alt="Screen Shot 2022-10-03 at 6 44 18 PM" src="https://user-images.githubusercontent.com/10411887/193975942-9aa09ab6-49dd-49fb-80a1-eed4aeb0a454.png">
After (this is done by hacking the API to return a test error message):
<img width="704" alt="Screen Shot 2022-10-04 at 8 31 43 PM" src="https://user-images.githubusercontent.com/10411887/193975968-393e48a6-04a6-4191-8077-37f7982fd78f.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


