### PR TITLE
[UI redesign] Updates design of operator page

### DIFF
--- a/src/ui/common/src/components/MultiFileViewer/index.tsx
+++ b/src/ui/common/src/components/MultiFileViewer/index.tsx
@@ -8,16 +8,19 @@ import { TreeItem, TreeView } from '@mui/lab';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
-
-import { MenuSidebarOffset } from '../layouts/default';
+import { makeStyles } from '@mui/material';
 
 type Props = {
   files: Record<string, any>;
   codeHeight?: string;
+  defaultFile?: string;
 };
 
-const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh' }) => {
-  const [selectedFile, setSelectedFile] = useState('');
+
+const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh', defaultFile = '' }) => {
+  // NOTE: We're making a strong-ish assumption here that we're going to have files in a format
+  // where the root dir is the name of the operator and the main function is {operator_name}.py.
+  const [selectedFile, setSelectedFile] = useState(defaultFile ? `/${defaultFile}/${defaultFile}.py` : '');
   const [matches, setMatches] = useState(false);
 
   useEffect(() => {
@@ -69,8 +72,10 @@ const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh' }) => {
           folders.push(section);
         }
       });
+
       files.sort();
       folders.sort();
+
       const fileItems = files.map((section) => {
         const fullPrefix = `${prefix}/${section}`;
         return (
@@ -79,33 +84,37 @@ const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh' }) => {
             nodeId={fullPrefix}
             label={section}
             onClick={() => setSelectedFile(fullPrefix)}
-          ></TreeItem>
+          />
         );
       });
+
       const folderItems = folders.map((section) => {
         const fullPrefix = `${prefix}/${section}`;
         return (
-          <TreeItem key={fullPrefix} nodeId={fullPrefix} label={section}>
+          <TreeItem 
+            key={fullPrefix} 
+            nodeId={fullPrefix} 
+            label={section}
+          >
             {buildTree(currentDirectory[section], fullPrefix)}
           </TreeItem>
         );
       });
+
       return [...folderItems, ...fileItems];
     }
   };
 
-  const options = { readOnly: true, minimap: { enabled: false } };
-  if (matches) {
-    options.minimap.enabled = true;
-  }
-
+  const options = { readOnly: true, minimap: { enabled: false }, wordWrap: 'on' as 'on' | 'off' | 'wordWrapColumn' | 'bounded' };
   return (
-    <Box style={{ height: codeHeight }}>
-      <Box style={{ width: MenuSidebarOffset, float: 'left', height: '100%' }}>
+    <Box style={{ height: codeHeight, display: 'flex' }}>
+      <Box style={{ width: '200px', height: '100%' }}>
         <TreeView
           aria-label="file system navigator"
           defaultCollapseIcon={<FontAwesomeIcon icon={faChevronDown} />}
           defaultExpandIcon={<FontAwesomeIcon icon={faChevronRight} />}
+          defaultExpanded={[`/${defaultFile}`]}
+          defaultSelected={[`/${defaultFile}/${defaultFile}.py`]}
         >
           {hasFiles ? (
             buildTree(files, '')
@@ -114,10 +123,10 @@ const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh' }) => {
           )}
         </TreeView>
       </Box>
+
       <Box
         style={{
-          width: `calc(100% - ${MenuSidebarOffset})`,
-          float: 'right',
+          width: `calc(100% - 200px)`,
           height: '100%',
         }}
       >

--- a/src/ui/common/src/components/MultiFileViewer/index.tsx
+++ b/src/ui/common/src/components/MultiFileViewer/index.tsx
@@ -8,7 +8,6 @@ import { TreeItem, TreeView } from '@mui/lab';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
-import { makeStyles } from '@mui/material';
 
 type Props = {
   files: Record<string, any>;
@@ -16,11 +15,16 @@ type Props = {
   defaultFile?: string;
 };
 
-
-const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh', defaultFile = '' }) => {
+const MultiFileViewer: React.FC<Props> = ({
+  files,
+  codeHeight = '30vh',
+  defaultFile = '',
+}) => {
   // NOTE: We're making a strong-ish assumption here that we're going to have files in a format
   // where the root dir is the name of the operator and the main function is {operator_name}.py.
-  const [selectedFile, setSelectedFile] = useState(defaultFile ? `/${defaultFile}/${defaultFile}.py` : '');
+  const [selectedFile, setSelectedFile] = useState(
+    defaultFile ? `/${defaultFile}/${defaultFile}.py` : ''
+  );
   const [matches, setMatches] = useState(false);
 
   useEffect(() => {
@@ -91,11 +95,7 @@ const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh', defaultF
       const folderItems = folders.map((section) => {
         const fullPrefix = `${prefix}/${section}`;
         return (
-          <TreeItem 
-            key={fullPrefix} 
-            nodeId={fullPrefix} 
-            label={section}
-          >
+          <TreeItem key={fullPrefix} nodeId={fullPrefix} label={section}>
             {buildTree(currentDirectory[section], fullPrefix)}
           </TreeItem>
         );
@@ -105,7 +105,11 @@ const MultiFileViewer: React.FC<Props> = ({ files, codeHeight = '30vh', defaultF
     }
   };
 
-  const options = { readOnly: true, minimap: { enabled: false }, wordWrap: 'on' as 'on' | 'off' | 'wordWrapColumn' | 'bounded' };
+  const options = {
+    readOnly: true,
+    minimap: { enabled: false },
+    wordWrap: 'on' as 'on' | 'off' | 'wordWrapColumn' | 'bounded',
+  };
   return (
     <Box style={{ height: codeHeight, display: 'flex' }}>
       <Box style={{ width: '200px', height: '100%' }}>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -1,4 +1,4 @@
-import { CircularProgress } from '@mui/material';
+import { CircularProgress, Divider } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -33,8 +33,10 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     (state: RootState) =>
       state.workflowDagResultsReducer.results[workflowDagResultId]
   );
+
   const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
     {})[metricOperatorId];
+
   const artifactId = operator?.outputs[0];
   const artifactHistoryWithLoadingStatus = useSelector((state: RootState) =>
     !!artifactId
@@ -123,7 +125,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   return (
     <Layout user={user}>
       <Box width={'800px'}>
-        <Box width="100%">
+        <Box width="100%" mb={3}>
           <Box width="100%">
             <DetailsPageHeader name={operator.name} />
             {operator.description && (
@@ -134,7 +136,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
           <Box display="flex" width="100%" paddingTop="40px">
             <Box width="100%">
               <ArtifactSummaryList
-                title={'Inputs:'}
+                title={'Inputs'}
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 artifactResults={inputs}
@@ -144,7 +146,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
             <Box width="32px" />
             <Box width="100%">
               <ArtifactSummaryList
-                title={'Outputs:'}
+                title={'Outputs'}
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
                 artifactResults={outputs}
@@ -153,10 +155,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
             </Box>
           </Box>
 
-          <Box width="100%" marginTop="12px">
-            <Typography variant="h5" component="div" marginBottom="8px">
-              Historical Outputs:
-            </Typography>
+          <Divider sx={{ my: '32px' }} />
+
+          <Box width="100%">
             <MetricsHistory
               historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             />

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -9,22 +9,22 @@ import { useNavigate, useParams } from 'react-router-dom';
 import DefaultLayout from '../../../../components/layouts/default';
 import LogViewer from '../../../../components/LogViewer';
 import MultiFileViewer from '../../../../components/MultiFileViewer';
+import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
 import { exportFunction } from '../../../../utils/operators';
 import { LoadingStatusEnum } from '../../../../utils/shared';
+import { isInitial, isLoading } from '../../../../utils/shared';
+import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
-import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
-import { isInitial, isLoading } from '../../../../utils/shared';
-import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 
 type OperatorDetailsPageProps = {
   user: UserProfile;
   Layout?: React.FC<LayoutProps>;
   maxRenderSize?: number;
 };
-  
+
 // Checked with file size=313285391 and handles that smoothly once loaded. However, takes a while to load.
 const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   user,
@@ -53,8 +53,9 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
 
   useEffect(() => {
     document.title = 'Operator Details | Aqueduct';
-    
-    if ( // Load workflow dag result if it's not cached
+
+    if (
+      // Load workflow dag result if it's not cached
       !workflowDagResultWithLoadingStatus ||
       isInitial(workflowDagResultWithLoadingStatus.status)
     ) {
@@ -67,13 +68,13 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       );
     }
   }, []);
-  
+
   useEffect(() => {
     if (!!operator) {
       document.title = `${operator.name} | Aqueduct`;
     }
   }, [operator]);
-  
+
   const logs = operator?.result?.exec_state?.user_logs ?? {};
   const operatorError = operator?.result?.exec_state?.error;
 
@@ -149,12 +150,14 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   }
 
   // This workflow doesn't exist.
-  if (workflowDagResultWithLoadingStatus.status.loading === LoadingStatusEnum.Failed) {
+  if (
+    workflowDagResultWithLoadingStatus.status.loading ===
+    LoadingStatusEnum.Failed
+  ) {
     navigate('/404');
     return null;
-  } 
+  }
 
-  
   const mapArtifacts = (artfIds: string[]) =>
     artfIds
       .map(
@@ -183,19 +186,13 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
           <Box width="100%">
             <DetailsPageHeader name={operator?.name} />
             {operator?.description && (
-              <Typography variant="body1">
-                {operator?.description}
-              </Typography>
+              <Typography variant="body1">{operator?.description}</Typography>
             )}
           </Box>
 
-          <Box
-            display="flex"
-            width="100%"
-            pt="40px"
-          >
+          <Box display="flex" width="100%" pt="40px">
             <Box width="100%" mr="32px">
-              <ArtifactSummaryList 
+              <ArtifactSummaryList
                 title="Inputs"
                 workflowId={workflowId}
                 dagResultId={workflowDagResultId}
@@ -218,16 +215,18 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
           <Divider sx={{ my: '32px' }} />
 
           <Box>
-            <Typography variant="h6" fontWeight="normal">Logs</Typography>
-            {logs !== {} && (
-              <LogViewer logs={logs} err={operatorError} />
-            )}
+            <Typography variant="h6" fontWeight="normal">
+              Logs
+            </Typography>
+            {logs !== {} && <LogViewer logs={logs} err={operatorError} />}
           </Box>
-          
+
           <Divider sx={{ my: '32px' }} />
 
           <Box>
-            <Typography variant="h6" fontWeight="normal" mb={1}>Code Preview</Typography>
+            <Typography variant="h6" fontWeight="normal" mb={1}>
+              Code Preview
+            </Typography>
             <MultiFileViewer files={files} defaultFile={operator.name} />
           </Box>
         </Box>

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -1,45 +1,23 @@
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { CircularProgress, Link, List, ListItem } from '@mui/material';
-import Accordion from '@mui/material/Accordion';
-import AccordionDetails from '@mui/material/AccordionDetails';
-import AccordionSummary from '@mui/material/AccordionSummary';
+import { CircularProgress, Divider } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import DefaultLayout from '../../../../components/layouts/default';
 import LogViewer from '../../../../components/LogViewer';
 import MultiFileViewer from '../../../../components/MultiFileViewer';
-import { boolArtifactNodeIcon } from '../../../../components/workflows/nodes/BoolArtifactNode';
-import { dictArtifactNodeIcon } from '../../../../components/workflows/nodes/DictArtifactNode';
-import { imageArtifactNodeIcon } from '../../../../components/workflows/nodes/ImageArtifactNode';
-import { jsonArtifactNodeIcon } from '../../../../components/workflows/nodes/JsonArtifactNode';
-import { numericArtifactNodeIcon } from '../../../../components/workflows/nodes/NumericArtifactNode';
-import { stringArtifactNodeIcon } from '../../../../components/workflows/nodes/StringArtifactNode';
-import { tableArtifactNodeIcon } from '../../../../components/workflows/nodes/TableArtifactNode';
-import {
-  handleGetArtifactResults,
-  handleGetOperatorResults,
-  handleGetWorkflow,
-  selectResultIdx,
-} from '../../../../reducers/workflow';
 import { AppDispatch, RootState } from '../../../../stores/store';
-import { ArtifactType } from '../../../../utils/artifacts';
 import UserProfile from '../../../../utils/auth';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { exportFunction } from '../../../../utils/operators';
 import { LoadingStatusEnum } from '../../../../utils/shared';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
 import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
-import { ArtifactResultResponse } from 'src/handlers/responses/artifact';
-import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
+import { isInitial, isLoading } from '../../../../utils/shared';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
-import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
 
 type OperatorDetailsPageProps = {
   user: UserProfile;
@@ -214,40 +192,43 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
           <Box
             display="flex"
             width="100%"
-            paddingTop="40px"
-            paddingBottom="40px"
+            pt="40px"
           >
-            <ArtifactSummaryList 
-              title="Inputs"
-              workflowId={workflowId}
-              dagResultId={workflowDagResultId}
-              artifactResults={inputs}
-              initiallyExpanded={true}
-            />
-            
-            <ArtifactSummaryList 
-              title="Outputs"
-              workflowId={workflowId}
-              dagResultId={workflowDagResultId}
-              artifactResults={outputs}
-              initiallyExpanded={true}
-            />
+            <Box width="100%" mr="32px">
+              <ArtifactSummaryList 
+                title="Inputs"
+                workflowId={workflowId}
+                dagResultId={workflowDagResultId}
+                artifactResults={inputs}
+                initiallyExpanded={true}
+              />
+            </Box>
+
+            <Box width="100%">
+              <ArtifactSummaryList
+                title="Outputs"
+                workflowId={workflowId}
+                dagResultId={workflowDagResultId}
+                artifactResults={outputs}
+                initiallyExpanded={true}
+              />
+            </Box>
           </Box>
 
+          <Divider sx={{ my: '32px' }} />
+
           <Box>
-            <Typography variant="h4">Logs</Typography>
+            <Typography variant="h6" fontWeight="normal">Logs</Typography>
             {logs !== {} && (
-              <Box sx={border}>
-                <LogViewer logs={logs} err={operatorError} />
-              </Box>
+              <LogViewer logs={logs} err={operatorError} />
             )}
           </Box>
+          
+          <Divider sx={{ my: '32px' }} />
 
           <Box>
-            <Typography variant="h4">Code Preview</Typography>
-            <Box sx={border}>
-              <MultiFileViewer files={files} />
-            </Box>
+            <Typography variant="h6" fontWeight="normal" mb={1}>Code Preview</Typography>
+            <MultiFileViewer files={files} defaultFile={operator.name} />
           </Box>
         </Box>
       </Box>

--- a/src/ui/common/src/components/workflows/operator/summaryList.tsx
+++ b/src/ui/common/src/components/workflows/operator/summaryList.tsx
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import React, { useState } from 'react';
+import React from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 
 import { OperatorResultResponse } from '../../../handlers/responses/operator';
@@ -19,12 +19,6 @@ type Props = {
   initiallyExpanded: boolean;
 };
 
-const listStyle = {
-  width: '100%',
-  maxWidth: 360,
-  bgcolor: 'background.paper',
-};
-
 const SummaryList: React.FC<Props> = ({
   title,
   workflowId,
@@ -32,7 +26,6 @@ const SummaryList: React.FC<Props> = ({
   operatorResults,
   initiallyExpanded,
 }) => {
-  const [expanded, setExpanded] = useState(initiallyExpanded);
   const items = operatorResults.map((opResult, index) => {
     let link = `${getPathPrefix()}/workflow/${workflowId}/result/${dagResultId}/operator/${
       opResult.id
@@ -51,7 +44,12 @@ const SummaryList: React.FC<Props> = ({
     }
 
     return (
-      <Link to={link} component={RouterLink as any} underline="none">
+      <Link
+        to={link}
+        component={RouterLink as any}
+        underline="none"
+        key={opResult.id}
+      >
         <Box
           display="flex"
           p={1}


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR updates the operator details page to match the design of the rest of the pages with the latest design tweaks. In particular it: 

* Updates the Redux state management on the operator details page to match the simplified version that is on the metric details page -- the previous version was quite convoluted.
* Reuses the `SummaryList` components that is used on the metric & check details pages.
* Simplifies the design by removing the bordered boxes and adding horizontal dividers between sections.
* Updates the multi-file viewer to open the default function's code.

## Related issue number (if any)

## Loom demo (if any)

<img width="2160" alt="image" src="https://user-images.githubusercontent.com/867892/193977720-7b02e9be-d917-420e-b96f-944a216a492d.png">


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


