### PR TITLE
Fix Table Type Errors

### DIFF
--- a/src/ui/common/src/components/tables/OperatorExecStateTable.tsx
+++ b/src/ui/common/src/components/tables/OperatorExecStateTable.tsx
@@ -82,7 +82,7 @@ export const OperatorExecStateTable: React.FC<OperatorExecStateTableProps> = ({
                     >
                       {tableType === OperatorExecStateTableType.Metric ||
                       column.name === 'title' ? (
-                        value
+                        value.toString()
                       ) : (
                         <CheckTableItem checkValue={value as string} />
                       )}

--- a/src/ui/common/src/components/tables/PaginatedTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedTable.tsx
@@ -96,7 +96,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({ data }) => {
                           key={`table-col-${columnIndex}`}
                           align={'left'}
                         >
-                          {value}
+                          {value.toString()}
                         </TableCell>
                       );
                     })}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fix type error on PaginatedTable causing app to not be able to build.

Fix here is to use toString() to turn Dates to strings when rendering.

Relevant Stack overflow: https://stackoverflow.com/questions/71926536/type-string-date-is-not-assignable-to-type-reactnode-typescript

Error message that was fixed:
```
✓ Creating entry file 1.6 secs
(typescript) Error: /Users/andre/Documents/Code/aqueduct/src/ui/common/src/components/tables/PaginatedTable.tsx(99,27): semantic error TS2322: Type 'string | number | boolean | Date' is not assignable to type 'ReactNode'.
  Type 'Date' is not assignable to type 'ReactNode'.
    Type 'Date' is not assignable to type 'number'.
Error: /Users/andre/Documents/Code/aqueduct/src/ui/common/src/components/tables/PaginatedTable.tsx(99,27): semantic error TS2322: Type 'string | number | boolean | Date' is not assignable to type 'ReactNode'.
  Type 'Date' is not assignable to type 'ReactNode'.
    Type 'Date' is not assignable to type 'number'.
    at error (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:5400:30)
    at throwPluginError (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:11878:12)
    at Object.error (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:12912:24)
    at Object.error (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:12081:38)
    at RollupContext.error (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:17237:30)
    at /Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25033:23
    at arrayEach (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:545:11)
    at Function.forEach (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:9397:14)
    at printDiagnostics (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25006:12)
    at Object.transform (/Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29277:17)
    at /Users/andre/Documents/Code/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:13117:25
    at runNextTicks (node:internal/process/task_queues:61:5)
    at processImmediate (node:internal/timers:437:9)

npm ERR! code 1
npm ERR! path /Users/andre/Documents/Code/aqueduct/src/ui/common
npm ERR! command failed
npm ERR! command sh -c tsdx build

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/andre/.npm/_logs/2022-10-05T18_52_15_277Z-debug-0.log
(base) ➜  common git:(ui-redesign) 

```



## Related issue number (if any)
NA
## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


