### PR TITLE
ENG-1771 status bar message formatting

### DIFF
--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -260,7 +260,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
 
   useEffect(() => {
     const workflowStatusItems = normalizeWorkflowStatusItems();
-    console.log('workflowStatusItems: ', workflowStatusItems);
     setWorkflowStatusItems(workflowStatusItems);
   }, [workflow, selectedDag, artifacts, operators]); // recompute state when all derived values change.
 

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -116,6 +116,16 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
     dispatch(setBottomSideSheetOpenState(true));
   };
 
+  const getTypeLabel = (nodeType: string) => {
+    if (nodeType.includes('Op')) {
+      return 'Operator';
+    }
+
+    // otherwise, it's an Artifact
+    // nodeType will be "tableArtifact", etc.
+    return 'Artifact';
+  };
+
   return (
     <Box
       sx={{
@@ -190,21 +200,17 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
                 <Typography
                   sx={{
                     fontFamily: 'Monospace',
-                    fontWeight: 'medium',
+                    fontWeight: 'bold',
                     marginTop: '4px',
                     fontSize: '12px',
                     whiteSpace: 'pre-wrap',
-                    marginLeft: 'auto'
+                    marginLeft: 'auto',
                   }}
                 >
-                  {listItem.type}
+                  {getTypeLabel(listItem.type)}
                 </Typography>
               </Box>
-
             </Box>
-
-
-
           </Box>
         );
       })}
@@ -421,7 +427,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         newWorkflowStatusItem.message = `Unable to create artifact ${artifactName} (${artifactId}).`;
       } else if (artifactStatus === ExecutionStatus.Succeeded) {
         newWorkflowStatusItem.level = WorkflowStatusTabs.Checks;
-        newWorkflowStatusItem.title = `Artifact ${artifactName} created.`;
+        newWorkflowStatusItem.title = `${artifactName} created.`;
         newWorkflowStatusItem.message = `Successfully created artifact ${artifactName} (${artifactId})`;
       } else {
         // artifact is still pending, skip adding to list of workflow status items.
@@ -482,8 +488,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -185,7 +185,26 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
               >
                 {listItem.message}
               </Typography>
+
+              <Box width="100%">
+                <Typography
+                  sx={{
+                    fontFamily: 'Monospace',
+                    fontWeight: 'medium',
+                    marginTop: '4px',
+                    fontSize: '12px',
+                    whiteSpace: 'pre-wrap',
+                    marginLeft: 'auto'
+                  }}
+                >
+                  {listItem.type}
+                </Typography>
+              </Box>
+
             </Box>
+
+
+
           </Box>
         );
       })}
@@ -226,7 +245,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   const [listItems, setListItems] = useState<WorkflowStatusItem[]>([]);
 
   useEffect(() => {
-    setWorkflowStatusItems(normalizeWorkflowStatusItems());
+    const workflowStatusItems = normalizeWorkflowStatusItems();
+    console.log('workflowStatusItems: ', workflowStatusItems);
+    setWorkflowStatusItems(workflowStatusItems);
   }, [workflow, selectedDag, artifacts, operators]); // recompute state when all derived values change.
 
   useEffect(() => {
@@ -461,9 +482,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = `Error executing ${operatorName} (${operatorId})`;
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/nodes/nodeTypes.tsx
+++ b/src/ui/common/src/components/workflows/nodes/nodeTypes.tsx
@@ -41,6 +41,24 @@ export const nodeTypes = {
   checkOp: CheckOperatorNode,
 };
 
+export const nodeTypeToStringLabel = {
+  tableArtifact: 'Table Artifact',
+  numericArtifact: 'Numeric Artifact',
+  boolArtifact: 'Boolean Artifact',
+  jsonArtifact: 'JSON Artifact',
+  stringArtifact: 'String Artifact',
+  imageArtifact: 'Image Artifact',
+  dictArtifact: 'Dictionary Artifact',
+  genericArtifact: 'Generic Artifact',
+  // NOTE function and functionOp are the same. Should remove one in the future?
+  function: 'Function Operator',
+  functionOp: 'Function Operator',
+  extractOp: 'Extract Operator',
+  loadOp: 'Load Operator',
+  metricOp: 'Metric Operator',
+  checkOp: 'Check Operator',
+};
+
 export const artifactTypeToIconMapping = {
   [ArtifactType.String]: stringArtifactNodeIcon,
   [ArtifactType.Bool]: boolArtifactNodeIcon,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Updates formatting of workflow status bar items. 
This PR removes the word "Artifact" which was prepended to each artifact.
Also adds the type of node (operator or artifact) at the bottom of the list item.

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1771/[workflow-page]-format-messages-in-status-widget-consistently

## Loom demo (if any)
Screenshot:
<img width="469" alt="image" src="https://user-images.githubusercontent.com/1031759/194148336-6e189bf5-72a7-4203-83eb-22050781e7d2.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


