### PR TITLE
[UI redesign] Simplifies workflow header and improves responsiveness

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -44,6 +44,8 @@ import ReactFlowCanvas from '../../../workflows/ReactFlowCanvas';
 import WorkflowHeader from '../../../workflows/workflowHeader';
 import { LayoutProps } from '../../types';
 
+export const WorkflowPageContentId = 'workflow-page-main';
+
 type WorkflowPageProps = {
   user: UserProfile;
   Layout?: React.FC<LayoutProps>;
@@ -347,6 +349,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           transition: WidthTransition,
           transitionDelay: '-150ms',
         }}
+        id={WorkflowPageContentId}
       >
         {workflow.selectedDag && (
           <WorkflowHeader

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -27,7 +27,6 @@ import FormControlLabel, {
 import MenuItem from '@mui/material/MenuItem';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
-import StorageSelector from './storageSelector';
 import Select from '@mui/material/Select';
 import Snackbar from '@mui/material/Snackbar';
 import Switch from '@mui/material/Switch';
@@ -60,6 +59,7 @@ import {
 import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import { LoadingButton } from '../primitives/LoadingButton.styles';
+import StorageSelector from './storageSelector';
 
 type PeriodicScheduleSelectorProps = {
   cronString: string;
@@ -213,7 +213,9 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     new Set<SavedObject>()
   );
 
-  const dagResults = useSelector((state: RootState) => state.workflowReducer.dagResults);
+  const dagResults = useSelector(
+    (state: RootState) => state.workflowReducer.dagResults
+  );
 
   const [name, setName] = useState(workflowDag.metadata?.name);
   const [description, setDescription] = useState(
@@ -738,7 +740,10 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               <Typography sx={{ fontWeight: 'bold' }} component="span">
                 ID:
               </Typography>
-              <Typography component="span"> {workflowDag.workflow_id}</Typography>
+              <Typography component="span">
+                {' '}
+                {workflowDag.workflow_id}
+              </Typography>
             </Box>
           </Box>
 
@@ -769,10 +774,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               onChange={(e) => setDescription(e.target.value)}
             />
           </Box>
-          
-          {dagResults && dagResults.length > 0 && (
-            <StorageSelector />
-          )}
+
+          {dagResults && dagResults.length > 0 && <StorageSelector />}
 
           <Box sx={{ my: 2 }}>
             <Typography style={{ fontWeight: 'bold' }}> Schedule </Typography>

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -27,6 +27,7 @@ import FormControlLabel, {
 import MenuItem from '@mui/material/MenuItem';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
+import StorageSelector from './storageSelector';
 import Select from '@mui/material/Select';
 import Snackbar from '@mui/material/Snackbar';
 import Switch from '@mui/material/Switch';
@@ -211,6 +212,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const [selectedObjects, setSelectedObjects] = useState(
     new Set<SavedObject>()
   );
+
+  const dagResults = useSelector((state: RootState) => state.workflowReducer.dagResults);
 
   const [name, setName] = useState(workflowDag.metadata?.name);
   const [description, setDescription] = useState(
@@ -735,7 +738,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               <Typography sx={{ fontWeight: 'bold' }} component="span">
                 ID:
               </Typography>
-              <Typography> {workflowDag.workflow_id}</Typography>
+              <Typography component="span"> {workflowDag.workflow_id}</Typography>
             </Box>
           </Box>
 
@@ -766,6 +769,10 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               onChange={(e) => setDescription(e.target.value)}
             />
           </Box>
+          
+          {dagResults && dagResults.length > 0 && (
+            <StorageSelector />
+          )}
 
           <Box sx={{ my: 2 }}>
             <Typography style={{ fontWeight: 'bold' }}> Schedule </Typography>

--- a/src/ui/common/src/components/workflows/storageSelector.tsx
+++ b/src/ui/common/src/components/workflows/storageSelector.tsx
@@ -1,9 +1,9 @@
+import { Link } from '@mui/material';
 import Box from '@mui/material/Box';
 import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
-import { Link } from '@mui/material';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
@@ -42,10 +42,16 @@ export const StorageSelector: React.FC = () => {
 
   return (
     <Box>
-      <Typography style={{ fontWeight: 'bold' }}> Metadata Storage Location </Typography>
-      <Typography variant="body2"> 
+      <Typography style={{ fontWeight: 'bold' }}>
+        {' '}
+        Metadata Storage Location{' '}
+      </Typography>
+      <Typography variant="body2">
         For more details on modifying the Aqueduct metadata store, please see{' '}
-        <Link href="https://docs.aqueducthq.com/guides/changing-metadata-store">our documentation</Link>.
+        <Link href="https://docs.aqueducthq.com/guides/changing-metadata-store">
+          our documentation
+        </Link>
+        .
       </Typography>
       <FormControl disabled sx={{ minWidth: 120 }} size="small">
         <Select

--- a/src/ui/common/src/components/workflows/storageSelector.tsx
+++ b/src/ui/common/src/components/workflows/storageSelector.tsx
@@ -3,6 +3,7 @@ import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
+import { Link } from '@mui/material';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
@@ -30,9 +31,7 @@ export const StorageSelector: React.FC = () => {
           sx={{ backgroundColor: selected ? 'blueTint' : null }}
         >
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Typography sx={{ ml: 1 }}>
-              {StorageTypeNames[storageType]}
-            </Typography>
+            <Typography>{StorageTypeNames[storageType]}</Typography>
           </Box>
         </MenuItem>
       );
@@ -42,9 +41,13 @@ export const StorageSelector: React.FC = () => {
   const menuItems = getMenuItems();
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      Storage Type:{' '}
-      <FormControl disabled sx={{ m: 1, minWidth: 120 }} size="small">
+    <Box>
+      <Typography style={{ fontWeight: 'bold' }}> Metadata Storage Location </Typography>
+      <Typography variant="body2"> 
+        For more details on modifying the Aqueduct metadata store, please see{' '}
+        <Link href="https://docs.aqueducthq.com/guides/changing-metadata-store">our documentation</Link>.
+      </Typography>
+      <FormControl disabled sx={{ minWidth: 120 }} size="small">
         <Select
           sx={{ maxHeight: 48 }}
           id="grouped-select"

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -7,7 +7,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
@@ -28,9 +28,9 @@ import { getNextUpdateTime } from '../../utils/cron';
 import { EngineType } from '../../utils/engine';
 import { WorkflowDag, WorkflowUpdateTrigger } from '../../utils/workflows';
 import { useAqueductConsts } from '../hooks/useAqueductConsts';
+import { WorkflowPageContentId } from '../pages/workflow/id';
 import { Button } from '../primitives/Button.styles';
 import { WorkflowStatusBar } from './StatusBar';
-import StorageSelector from './storageSelector';
 import VersionSelector from './version_selector';
 import WorkflowSettings from './WorkflowSettings';
 import Status from './workflowStatus';
@@ -41,10 +41,29 @@ type Props = {
   workflowId: string;
 };
 
+const ContainerWidthBreakpoint = 700;
+
 const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   const dispatch: AppDispatch = useDispatch();
   const { apiAddress } = useAqueductConsts();
   const navigate = useNavigate();
+  
+  const currentNode = useSelector(
+    (state: RootState) => state.nodeSelectionReducer.selected
+  );
+
+  // NOTE: The 1000 here is just a placeholder. By the time the page snaps into place, 
+  // it will be overridden.
+  const [containerWidth, setContainerWidth] = useState(1000);
+  const narrowView = containerWidth < ContainerWidthBreakpoint;
+
+  const getContainerSize = () => {
+    const container = document.getElementById(WorkflowPageContentId);
+    setContainerWidth(container.clientWidth);
+  };
+
+  useEffect(getContainerSize, [currentNode]);
+  window.addEventListener('resize', getContainerSize);
 
   const [showRunWorkflowDialog, setShowRunWorkflowDialog] = useState(false);
   const workflow = useSelector((state: RootState) => state.workflowReducer);
@@ -276,19 +295,30 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', alignItems: 'center', my: 1 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: narrowView ? 'start' : 'center', my: 1, flexDirection: narrowView ? 'column' : 'row' }}>
+        <Box sx={{ flex: 1 }}>
+          <Status status={workflow.dagResults[0].status} />
+
           <Typography
             variant="h3"
-            sx={{ fontFamily: 'Monospace', mr: 2, lineHeight: 1 }}
+            sx={{ my: 1, lineHeight: 1 }}
+            fontWeight="normal"
           >
             {name}
           </Typography>
-
-          <Status status={workflow.dagResults[0].status} />
         </Box>
 
         <Box sx={{ mr: 4 }}>
+          <Button
+            color="primary"
+            sx={{ height: '100%', mr: 2, fontSize: '20px' }}
+            onClick={() => setShowRunWorkflowDialog(true)}
+            size="large"
+          >
+            <FontAwesomeIcon icon={faPlay} />
+            <Typography sx={{ ml: 1 }}>Run Workflow</Typography>
+          </Button>
+
           <Button
             variant="outlined"
             color="primary"
@@ -319,28 +349,14 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
 
       {nextUpdateComponent}
 
-      <Box sx={{ mx: 1 }}>
-        {workflow.dagResults && workflow.dagResults.length > 0 && (
-          <StorageSelector />
-        )}
-      </Box>
-
-      <Box sx={{ display: 'flex', alignItems: 'center', my: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: narrowView ? 'start' : 'center', my: 1, flexDirection: narrowView ? 'column' : 'row' }}>
         {workflow.dagResults && workflow.dagResults.length > 0 && (
           <VersionSelector />
         )}
 
-        <Button
-          color="primary"
-          sx={{ height: '100%', mx: 2 }}
-          onClick={() => setShowRunWorkflowDialog(true)}
-          size="large"
-        >
-          <FontAwesomeIcon icon={faPlay} />
-          <Typography sx={{ ml: 1 }}>Run Workflow</Typography>
-        </Button>
-
-        <WorkflowStatusBar user={user} />
+        <Box mx={narrowView ? 0 : 2} my={narrowView ? 1 : 0}>
+          <WorkflowStatusBar user={user} />
+        </Box>
       </Box>
 
       {runWorkflowDialog}

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -47,12 +47,12 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   const dispatch: AppDispatch = useDispatch();
   const { apiAddress } = useAqueductConsts();
   const navigate = useNavigate();
-  
+
   const currentNode = useSelector(
     (state: RootState) => state.nodeSelectionReducer.selected
   );
 
-  // NOTE: The 1000 here is just a placeholder. By the time the page snaps into place, 
+  // NOTE: The 1000 here is just a placeholder. By the time the page snaps into place,
   // it will be overridden.
   const [containerWidth, setContainerWidth] = useState(1000);
   const narrowView = containerWidth < ContainerWidthBreakpoint;
@@ -295,7 +295,14 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
 
   return (
     <Box>
-      <Box sx={{ display: 'flex', alignItems: narrowView ? 'start' : 'center', my: 1, flexDirection: narrowView ? 'column' : 'row' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: narrowView ? 'start' : 'center',
+          my: 1,
+          flexDirection: narrowView ? 'column' : 'row',
+        }}
+      >
         <Box sx={{ flex: 1 }}>
           <Status status={workflow.dagResults[0].status} />
 
@@ -349,7 +356,14 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
 
       {nextUpdateComponent}
 
-      <Box sx={{ display: 'flex', alignItems: narrowView ? 'start' : 'center', my: 1, flexDirection: narrowView ? 'column' : 'row' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: narrowView ? 'start' : 'center',
+          my: 1,
+          flexDirection: narrowView ? 'column' : 'row',
+        }}
+      >
         {workflow.dagResults && workflow.dagResults.length > 0 && (
           <VersionSelector />
         )}

--- a/src/ui/common/src/utils/storage.ts
+++ b/src/ui/common/src/utils/storage.ts
@@ -5,8 +5,8 @@ export enum StorageType {
 }
 
 export const StorageTypeNames = {
-  s3: 'S3',
-  file: 'File',
+  s3: 'AWS S3',
+  file: 'Local File System',
   gcs: 'Google Cloud Storage',
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR does 3 things:
1. It improves the layout of the workflow header by moving the success pill above the workflow title and movig the run workflow button next to the settings gear.
2. It moves the metadata storage indicator into the settings modal.
3. It uses the size of the workflow page to make the header itself responsive.

## Related issue number (if any)

ENG-1763, ENG-1770

## Loom demo (if any)

https://www.loom.com/share/db899c5f6e554bc7b5744f358308c628

Here's a screenshot of the page with the drawer open on my 13" MBP screen: 
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/867892/194174357-58570828-69dd-48b0-ac6d-f23975364666.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


