### PR TITLE
[Testing Performance] Decrease polling interval of integration testing suite

### DIFF
--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -151,7 +151,7 @@ def wait_for_flow_runs(
         The number of runs this flow has performed.
     """
     timeout = 500
-    poll_threshold = 5
+    poll_threshold = 1
     begin = time.time()
 
     while True:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There's no reason to wait 5 seconds between polls, this penalizes tests that should run a lot quicker.

This 2x's the speed of the integration test on my 8-core Mac (1:40 vs 3:20 to run the full speed). It does not appear to help our performance on github actions however, but I believe that is because these machines are underpowered with 2-cores. When we get the beefier github runners, I'd expect this to help a lot more.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


