### PR TITLE
Fix bug where kubeconfig placeholder is missing leading slash

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -5,7 +5,7 @@ import { KubernetesConfig } from '../../../utils/integrations';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: KubernetesConfig = {
-  kubeconfig_path: 'home/ubuntu/.kube/config',
+  kubeconfig_path: '/home/ubuntu/.kube/config',
   cluster_name: 'aqueduct',
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Quick Fix to standardize the kubeconfig path 
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1718/fix-bug-where-kubeconfig-placeholder-is-missing-leading-slash
## Loom demo (if any)
<img width="1183" alt="Screen Shot 2022-10-06 at 11 45 34 AM" src="https://user-images.githubusercontent.com/78303449/194393753-b05039c1-57d0-463d-b4e0-5daba655e84d.png">

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


