### PR TITLE
Chunk SQL insert for sqlite3 integration

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/sqlite.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/sqlite.py
@@ -26,6 +26,7 @@ class SqliteConnector(relational.RelationalConnector):
             if_exists=params.update_mode.value,
             index=False,
             method="multi",
+            # We need to specify chunksize due to sqlite3's variable number limit.
             chunksize=int(SQLITE_MAX_VARIABLE_NUMBER / len(df.columns)),
         )
 

--- a/src/python/aqueduct_executor/operators/connectors/data/sqlite.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/sqlite.py
@@ -1,11 +1,33 @@
-from aqueduct_executor.operators.connectors.data import config, relational
+import pandas as pd
+from aqueduct_executor.operators.connectors.data import config, load, relational
+from aqueduct_executor.operators.utils.enums import ArtifactType
 from sqlalchemy import create_engine, engine
+
+SQLITE_MAX_VARIABLE_NUMBER = 32766
 
 
 class SqliteConnector(relational.RelationalConnector):
     def __init__(self, config: config.SqliteConfig):
         conn_engine = _create_engine(config)
         super().__init__(conn_engine)
+
+    def load(
+        self, params: load.RelationalParams, df: pd.DataFrame, artifact_type: ArtifactType
+    ) -> None:
+        if artifact_type != ArtifactType.TABLE:
+            raise Exception("The data being loaded must be of type table, found %s" % artifact_type)
+        # NOTE (saurav): df._to_sql has known performance issues. Using `method="multi"` helps incrementally,
+        # since pandas will pass multiple rows in a single INSERT. If this still remains an issue, we can pass in a
+        # callable function for `method` that does bulk loading.
+        # See: https://pandas.pydata.org/docs/user_guide/io.html#io-sql-method
+        df.to_sql(
+            params.table,
+            con=self.engine,
+            if_exists=params.update_mode.value,
+            index=False,
+            method="multi",
+            chunksize=int(SQLITE_MAX_VARIABLE_NUMBER / len(df.columns)),
+        )
 
 
 def _create_engine(config: config.SqliteConfig) -> engine.Engine:

--- a/src/python/aqueduct_executor/operators/connectors/data/sqlite.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/sqlite.py
@@ -3,6 +3,7 @@ from aqueduct_executor.operators.connectors.data import config, load, relational
 from aqueduct_executor.operators.utils.enums import ArtifactType
 from sqlalchemy import create_engine, engine
 
+# https://www.sqlite.org/limits.html#max_variable_number
 SQLITE_MAX_VARIABLE_NUMBER = 32766
 
 
@@ -27,6 +28,9 @@ class SqliteConnector(relational.RelationalConnector):
             index=False,
             method="multi",
             # We need to specify chunksize due to sqlite3's variable number limit.
+            # chunksize corresponds to the max number of rows in each batch to be written at a time.
+            # Variable number is the multiplication of the row count and the column count, so we can
+            # calculate chunksize by dividing the max variable number with the number of columns.
             chunksize=int(SQLITE_MAX_VARIABLE_NUMBER / len(df.columns)),
         )
 

--- a/src/resources/demo_db/sqlite/v0.1/create_tables.py
+++ b/src/resources/demo_db/sqlite/v0.1/create_tables.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pandas as pd
 from sqlalchemy import create_engine, engine
 
+
 def create_diabetes_table(engine):
     df = pd.read_csv(
         "https://raw.githubusercontent.com/aqueducthq/aqueduct/main/src/resources/demo_db/sqlite/v0.1/diabetes.csv",


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Due to SQLITE's variable number limit, we need to chunk the data insertion operation so that the number of variables is less than 32766. Verified that this fixes the issue on the wine workflow.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


