### PR TITLE
Eng 1639 correctly switch op / artf results when switching between versions

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -38,7 +38,7 @@ import {
   getDataSideSheetContent,
   sideSheetSwitcher,
 } from '../../../../utils/sidesheets';
-import DefaultLayout, { MenuSidebarOffset } from '../../../layouts/default';
+import DefaultLayout from '../../../layouts/default';
 import { Button } from '../../../primitives/Button.styles';
 import ReactFlowCanvas from '../../../workflows/ReactFlowCanvas';
 import WorkflowHeader, {
@@ -138,7 +138,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
     }
 
     if (!(nodeId in workflow.artifactResults)) {
-      console.log('index ' + workflow.selectedResult.id);
       dispatch(
         handleGetArtifactResults({
           apiKey: user.apiKey,
@@ -222,12 +221,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   }
 
   const RightMarginInPx = 24;
-  const getSideSheetWidth = (baseWidth = '100%'): string | string[] => {
-    // RightMarginInPx: the white space on the right side of the Dag to show when side drawer is not visible.
-    return `calc(${baseWidth} - ${MenuSidebarOffset} - ${RightMarginInPx}px)`;
-  };
-
-  const fullWindowWidth = `calc(100% + ${MenuSidebarOffset})`;
 
   // TODO: Remove openSideSheet reducer, as it's no longer used in the ui-redesign project
   // const sideSheetOpen = currentNode.type !== NodeType.None;

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -131,13 +131,14 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
    * @param nodeId the UUID of the artifact for which we're retrieving
    * details.
    */
-  const updateArtifactDetails = (nodeId: string) => {
+  const getArtifactResultDetails = (nodeId: string) => {
     const artf = (workflow.selectedDag?.artifacts ?? {})[nodeId];
     if (!artf || !workflow.selectedResult) {
       return;
     }
 
     if (!(nodeId in workflow.artifactResults)) {
+      console.log('index ' + workflow.selectedResult.id);
       dispatch(
         handleGetArtifactResults({
           apiKey: user.apiKey,
@@ -159,7 +160,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
    * @param nodeId the UUID of an artifact for which we're retrieving
    * results.
    */
-  const updateOperatorDetails = (nodeId: string) => {
+  const getOperatorResultDetails = (nodeId: string) => {
     // Verify the node is indeed an operator, and a result is selected
     const op = (workflow.selectedDag?.operators ?? {})[nodeId];
     if (!op || !workflow.selectedResult) {
@@ -177,13 +178,13 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
     }
 
     for (const artfId of [...op.inputs, ...op.outputs]) {
-      updateArtifactDetails(artfId);
+      getArtifactResultDetails(artfId);
     }
   };
 
   useEffect(() => {
-    updateOperatorDetails(currentNode.id);
-    updateArtifactDetails(currentNode.id);
+    getOperatorResultDetails(currentNode.id);
+    getArtifactResultDetails(currentNode.id);
   }, [currentNode.id, workflow.selectedResult?.id]);
 
   const onPaneClicked = (event: React.MouseEvent) => {
@@ -195,20 +196,20 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   };
 
   const selectedDag = workflow.selectedDag;
-  const getDagDetails = () => {
+  const getDagResultDetails = () => {
     if (
       workflow.loadingStatus.loading === LoadingStatusEnum.Succeeded &&
       !!selectedDag
     ) {
       for (const op of Object.values(selectedDag.operators)) {
-        // We don't need to call updateArtifactDetails because
-        // updateOperatorDetails automatically does that for us.
-        updateOperatorDetails(op.id);
+        // We don't need to call getArtifactResultDetails because
+        // getOperatorResultDetails automatically does that for us.
+        getOperatorResultDetails(op.id);
       }
     }
   };
 
-  useEffect(getDagDetails, [workflow.selectedDag]);
+  useEffect(getDagResultDetails, [workflow.selectedResult?.id]);
 
   // This workflow doesn't exist.
   if (workflow.loadingStatus.loading === LoadingStatusEnum.Failed) {
@@ -230,13 +231,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
 
   // TODO: Remove openSideSheet reducer, as it's no longer used in the ui-redesign project
   // const sideSheetOpen = currentNode.type !== NodeType.None;
-
-  const contentWidth = getSideSheetWidth(
-    // in ui-redesign, sidesheet comes in from the right, and the status bar is now a popover, which means status bar no longer has a width to worry about
-    // with regards to expanding and contracting the page contents.
-    // the new sidesheet is shown when the current node is selected. the opensidesheet state reducer isn't being used.
-    fullWindowWidth
-  );
 
   const contentBottomOffsetInPx = `32px`;
   const getNodeLabel = () => {

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -398,7 +398,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
 
       // Check if artifactResult is in the map, if not fetch it.
       if (!artifactResult) {
-        console.log('status bar ' + workflow.selectedResult.id);
         dispatch(
           handleGetArtifactResults({
             apiKey: user.apiKey,

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -398,6 +398,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
 
       // Check if artifactResult is in the map, if not fetch it.
       if (!artifactResult) {
+        console.log('status bar ' + workflow.selectedResult.id);
         dispatch(
           handleGetArtifactResults({
             apiKey: user.apiKey,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the bug where we show wrong version for op / artf results esp. when a new workflow is created. The main change is to correct a condition so that we fetch op / artf results when a new dag result is selected.

## Related issue number (if any)
ENG-1639

## Loom demo (if any)
https://www.loom.com/share/62075c3cda5c462f8d259ab170615fa6

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


