### PR TITLE
Eng 1756 status popover improvements

### DIFF
--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -62,8 +62,8 @@ interface ActiveWorkflowStatusTabProps {
 
 export const StatusBarHeaderHeightInPx = 41;
 export const CollapsedStatusBarWidthInPx = 75;
-export const StatusBarWidthInPx = 432;
-export const MaxStatusBarListHeightInPx = 800;
+export const StatusBarWidthInPx = 384;
+export const MaxStatusBarListHeightInPx = 384;
 
 const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
   activeWorkflowStatusTab,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adjusts the max width and height of the Workflow Status Bar's list component to look better on smaller screen sizes.

These numbers were found simply by playing around with units of 8 to see what looks good on my 14 inch Macbook Pro. I tried to find values that looked good without media queries here for both opened and closed side bar.

## Related issue number (if any)
ENG-1756

## Loom demo (if any)
https://www.loom.com/share/027085ea8eaf45208b8a11374f1f0573

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


