### PR TITLE
Fix a bug where we errors when the script is running in python interpreter

### DIFF
--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -224,8 +224,8 @@ def serialize_function(
         with open(os.path.join(dir_path, source_file), "w") as f:
             try:
                 source = inspect.getsource(func)
-            except Exception as e:
-                source = f"We cannot get source file due to:\n{str(e)}"
+            except Exception:
+                source = "unknown"
             f.write(source)
 
         zip_file_path = get_zip_file_path(dir_path)

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -222,7 +222,10 @@ def serialize_function(
         # Write function source code to file
         source_file = "{}.py".format(op_name)
         with open(os.path.join(dir_path, source_file), "w") as f:
-            source = inspect.getsource(func)
+            try:
+                source = inspect.getsource(func)
+            except Exception as e:
+                source = f"We cannot get source file due to:\n{str(e)}"
             f.write(source)
 
         zip_file_path = get_zip_file_path(dir_path)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When SDK is not running in a file-based environment (e.g. notebook or script), `inspect.getsource` will error complaining we couldn't find source file. This PR adds a simple fix by not attempting to add source file in such cases. Instead, we just let user know we failed fetch the file.

Context: https://aqueducthq.slack.com/archives/C01KF131001/p1665104258513939 . We can successfully run aqueduct in python interpreter after this fix. Verified existing notebook still works.

I think the only consequence is that the user won't be able to view source from UI for these workflows. But I think it's fine for now, assuming this use case is rare.

## Related issue number (if any)


## Loom demo (if any)

## Checklist before requesting a review
Integration tests should be sufficient.
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


