### PR TITLE
ENG-1708 Makes spacing for sections on integrations page more consistent.

### DIFF
--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -72,15 +72,17 @@ const IntegrationsPage: React.FC<Props> = ({
           Integrations
         </Typography>
 
+        <Divider sx={{ width: '950px' }} />
+
         <Box sx={{ my: 3, ml: 1 }}>
-          <Typography variant="h4">Add an Integration</Typography>
-          <Typography variant="h6">Data</Typography>
+          <Typography variant="h4" marginBottom={3}>Add an Integration</Typography>
+          <Typography variant="h6" marginBottom={2}>Data</Typography>
           <AddIntegrations
             user={user}
             category="data"
             supportedIntegrations={SupportedIntegrations}
           />
-          <Typography variant="h6">Compute</Typography>
+          <Typography variant="h6" marginTop={4} marginBottom={3}>Compute</Typography>
           <AddIntegrations
             user={user}
             category="compute"
@@ -88,10 +90,12 @@ const IntegrationsPage: React.FC<Props> = ({
           />
         </Box>
 
-        <Divider sx={{ width: '950px' }} />
+        <Box marginTop="40px">
+          <Divider sx={{ width: '950px' }} />
+        </Box>
 
-        <Box sx={{ my: 3, ml: 1 }}>
-          <Typography variant="h4">Connected Integrations</Typography>
+        <Box sx={{ marginTop: 3, marginBottom: 3, ml: 1 }}>
+          <Typography variant="h4" marginBottom={3}>Connected Integrations</Typography>
           <ConnectedIntegrations user={user} forceLoad={forceLoad} />
         </Box>
       </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adjusts the spacing on the section headers of the integrations page to make them more consistent.

## Related issue number (if any)
ENG-1708

## Loom demo (if any)
https://www.loom.com/share/969aeeccaacd4feab93f806f4290dfc9

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


