### PR TITLE
fix build error referencing WorkflowRetentionPolicy, which should be …

### DIFF
--- a/src/ui/common/src/handlers/responses/dag.ts
+++ b/src/ui/common/src/handlers/responses/dag.ts
@@ -4,7 +4,7 @@ import { OperatorType } from '../../utils/operators';
 import { ExecState } from '../../utils/shared';
 import { StorageConfig } from '../../utils/storage';
 import {
-  WorkflowRetentionPolicy,
+  RetentionPolicy,
   WorkflowSchedule,
 } from '../../utils/workflows';
 import { ArtifactResponse, ArtifactResultResponse } from './artifact';
@@ -22,7 +22,7 @@ export type DagMetadataResponse = {
   name: string;
   description: string;
   schedule?: WorkflowSchedule;
-  retention_policy?: WorkflowRetentionPolicy;
+  retention_policy?: RetentionPolicy;
 };
 
 export type DagResponse = DagMetadataResponse & {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes build error:
```
(typescript) Error: /home/ubuntu/repos/aqueduct/src/ui/common/src/handlers/responses/dag.ts(7,3): semantic error TS2305: Module '"../../utils/workflows"' has no exported member 'WorkflowRetentionPolicy'.
Error: /home/ubuntu/repos/aqueduct/src/ui/common/src/handlers/responses/dag.ts(7,3): semantic error TS2305: Module '"../../utils/workflows"' has no exported member 'WorkflowRetentionPolicy'.
    at error (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:5400:30)
    at throwPluginError (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:11878:12)
    at Object.error (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:12912:24)
    at Object.error (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:12081:38)
    at RollupContext.error (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:17237:30)
    at /home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25033:23
    at arrayEach (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:545:11)
    at Function.forEach (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:9397:14)
    at printDiagnostics (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25006:12)
    at Object.transform (/home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29277:17)
    at /home/ubuntu/repos/aqueduct/src/ui/common/node_modules/rollup/dist/shared/node-entry.js:13117:25
    at runNextTicks (node:internal/process/task_queues:61:5)
    at processImmediate (node:internal/timers:437:9)

npm ERR! code 1
npm ERR! path /home/ubuntu/repos/aqueduct/src/ui/common
npm ERR! command failed
npm ERR! command sh -c tsdx build

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ubuntu/.npm/_logs/2022-10-10T22_22_16_865Z-debug-0.log
Traceback (most recent call last):
  File "scripts/install_local.py", line 161, in <module>
    execute_command(["npm", "install", "--force"], cwd=join(cwd, UI_COMMON_PATH))
  File "scripts/install_local.py", line 36, in execute_command
    raise Exception("Error executing command: %s" % args)
Exception: Error executing command: ['npm', 'install', '--force']
```

## Related issue number (if any)
NA

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


