### PR TITLE
Update k8s integration UI when the server runs in an existing cluster

### DIFF
--- a/src/aqueduct-helm/Chart.yaml
+++ b/src/aqueduct-helm/Chart.yaml
@@ -22,4 +22,3 @@ version: 0.0.16
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.16"
-namespace: aqueduct

--- a/src/aqueduct-helm/templates/clusterrole.yaml
+++ b/src/aqueduct-helm/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqueduct-admin-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["create", "get"]

--- a/src/aqueduct-helm/templates/clusterrolebinding.yaml
+++ b/src/aqueduct-helm/templates/clusterrolebinding.yaml
@@ -1,13 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: aqueduct-admin-role-binding
-  namespace: aqueduct
+  name: aqueduct-admin-cluster-role-binding
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: aqueduct-admin-role
+  kind: ClusterRole
+  name: aqueduct-admin-cluster-role

--- a/src/aqueduct-helm/templates/deployment.yaml
+++ b/src/aqueduct-helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:          
+            - name: "AQUEDUCT_IN_K8S_CLUSTER"
+              value: "1"
           ports:
             - name: http
               containerPort: 8080

--- a/src/aqueduct-helm/templates/deployment.yaml
+++ b/src/aqueduct-helm/templates/deployment.yaml
@@ -40,9 +40,6 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            - name: http2
-              containerPort: 8081
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /

--- a/src/aqueduct-helm/templates/role.yaml
+++ b/src/aqueduct-helm/templates/role.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace }}
-  name: aqueductadminrole
+  namespace: aqueduct
+  name: aqueduct-admin-role
 rules:
 - apiGroups: ["*"]
   resources: ["*"]

--- a/src/aqueduct-helm/templates/service.yaml
+++ b/src/aqueduct-helm/templates/service.yaml
@@ -11,9 +11,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: 8081
-      targetPort: http2
-      protocol: TCP
-      name: http2
   selector:
     {{- include "aqueduct-helm.selectorLabels" . | nindent 4 }}

--- a/src/aqueduct-helm/values.yaml
+++ b/src/aqueduct-helm/values.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "aqueductserviceaccount"
+  name: "aqueduct-service-account"
 
 podAnnotations: {}
 

--- a/src/golang/cmd/server/handler/get_server_environment.go
+++ b/src/golang/cmd/server/handler/get_server_environment.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const inK8sClusterEnvVarName = "AQUEDUCT_IN_K8S_CLUSTER"
+
+type getServerEnvironmentResponse struct {
+	// Whether the server is running within a k8s cluster.
+	InK8sCluster bool `json:"inK8sCluster"`
+}
+
+// Route: /api/environment
+// Method: GET
+// Request:
+//
+//	Headers:
+//		`api-key`: user's API Key
+//
+// Response: Aqueduct server's environment variables.
+type GetServerEnvironmentHandler struct {
+	GetHandler
+}
+
+func (*GetServerEnvironmentHandler) Name() string {
+	return "GetServerEnvironment"
+}
+
+func (*GetServerEnvironmentHandler) Prepare(r *http.Request) (interface{}, int, error) {
+	return nil, http.StatusOK, nil
+}
+
+func (h *GetServerEnvironmentHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
+	inCluster := false
+	if os.Getenv(inK8sClusterEnvVarName) == "1" {
+		inCluster = true
+	}
+
+	log.Info("Incluster is %s", inCluster)
+
+	return getServerEnvironmentResponse{
+		InK8sCluster: inCluster,
+	}, http.StatusOK, nil
+}

--- a/src/golang/cmd/server/handler/get_server_environment.go
+++ b/src/golang/cmd/server/handler/get_server_environment.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 	"os"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const inK8sClusterEnvVarName = "AQUEDUCT_IN_K8S_CLUSTER"
@@ -40,8 +38,6 @@ func (h *GetServerEnvironmentHandler) Perform(ctx context.Context, interfaceArgs
 	if os.Getenv(inK8sClusterEnvVarName) == "1" {
 		inCluster = true
 	}
-
-	log.Info("Incluster is %s", inCluster)
 
 	return getServerEnvironmentResponse{
 		InK8sCluster: inCluster,

--- a/src/golang/cmd/server/handler/get_server_environment.go
+++ b/src/golang/cmd/server/handler/get_server_environment.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"net/http"
 	"os"
+
+	"github.com/aqueducthq/aqueduct/lib"
 )
 
 const inK8sClusterEnvVarName = "AQUEDUCT_IN_K8S_CLUSTER"
 
 type getServerEnvironmentResponse struct {
 	// Whether the server is running within a k8s cluster.
-	InK8sCluster bool `json:"inK8sCluster"`
+	InK8sCluster bool   `json:"inK8sCluster"`
+	Version      string `json:"version"`
 }
 
 // Route: /api/environment
@@ -41,5 +44,6 @@ func (h *GetServerEnvironmentHandler) Perform(ctx context.Context, interfaceArgs
 
 	return getServerEnvironmentResponse{
 		InK8sCluster: inCluster,
+		Version:      lib.ServerVersionNumber,
 	}, http.StatusOK, nil
 }

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -44,5 +44,6 @@ const (
 	UnwatchWorkflowRoute         = "/api/workflow/{workflowId}/unwatch"
 	WatchWorkflowRoute           = "/api/workflow/{workflowId}/watch"
 
-	GetServerVersionRoute = "/api/version"
+	GetServerVersionRoute     = "/api/version"
+	GetServerEnvironmentRoute = "/api/environment"
 )

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -246,6 +246,7 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			JobManager:        s.JobManager,
 			Vault:             s.Vault,
 		},
-		routes.GetServerVersionRoute: &handler.GetServerVersionHandler{},
+		routes.GetServerVersionRoute:     &handler.GetServerVersionHandler{},
+		routes.GetServerEnvironmentRoute: &handler.GetServerEnvironmentHandler{},
 	}
 }

--- a/src/golang/lib/collections/integration/config.go
+++ b/src/golang/lib/collections/integration/config.go
@@ -36,8 +36,9 @@ type GCSConfig struct {
 }
 
 type K8sIntegrationConfig struct {
-	KubeconfigPath string `json:"kubeconfig_path" yaml:"kubeconfigPath"`
-	ClusterName    string `json:"cluster_name"  yaml:"clusterName"`
+	KubeconfigPath string     `json:"kubeconfig_path" yaml:"kubeconfigPath"`
+	ClusterName    string     `json:"cluster_name"  yaml:"clusterName"`
+	UseSameCluster ConfigBool `json:"use_same_cluster"  yaml:"useSameCluster"`
 }
 
 type LambdaIntegrationConfig struct {

--- a/src/golang/lib/engine/authenticate.go
+++ b/src/golang/lib/engine/authenticate.go
@@ -19,7 +19,7 @@ func AuthenticateK8sConfig(ctx context.Context, authConf auth.Config) error {
 	if err != nil {
 		return errors.Wrap(err, "Unable to parse configuration.")
 	}
-	_, err = k8s.CreateK8sClient(conf.KubeconfigPath)
+	_, err = k8s.CreateK8sClient(conf.KubeconfigPath, bool(conf.UseSameCluster))
 	if err != nil {
 		return errors.Wrap(err, "Unable to create kubernetes client.")
 	}

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -105,6 +105,7 @@ func generateJobManagerConfig(
 		return &job.K8sJobManagerConfig{
 			KubeconfigPath:     k8sConfig.KubeconfigPath,
 			ClusterName:        k8sConfig.ClusterName,
+			UseSameCluster:     bool(k8sConfig.UseSameCluster),
 			AwsAccessKeyId:     awsAccessKeyId,
 			AwsSecretAccessKey: awsSecretAccessKey,
 			AwsRegion:          DefaultAwsRegion,

--- a/src/golang/lib/job/config.go
+++ b/src/golang/lib/job/config.go
@@ -26,6 +26,7 @@ type ProcessConfig struct {
 type K8sJobManagerConfig struct {
 	KubeconfigPath     string `yaml:"kubeconfigPath" json:"kubeconfig_path"`
 	ClusterName        string `yaml:"clusterName" json:"cluster_name"`
+	UseSameCluster     bool   `json:"use_same_cluster"  yaml:"useSameCluster"`
 	AwsAccessKeyId     string `yaml:"awsAccessKeyId" json:"aws_access_key_id"`
 	AwsSecretAccessKey string `yaml:"awsSecretAccessKey" json:"aws_secret_access_key"`
 

--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -25,7 +25,7 @@ type k8sJobManager struct {
 }
 
 func NewK8sJobManager(conf *K8sJobManagerConfig) (*k8sJobManager, error) {
-	k8sClient, err := k8s.CreateK8sClient(conf.KubeconfigPath)
+	k8sClient, err := k8s.CreateK8sClient(conf.KubeconfigPath, conf.UseSameCluster)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error while creating K8sJobManager")
 	}

--- a/src/golang/lib/k8s/clients.go
+++ b/src/golang/lib/k8s/clients.go
@@ -12,9 +12,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func CreateK8sClient(kubeconfigPath string) (*kubernetes.Clientset, error) {
-	// TODO(ENG-1792) Change this check to use param from UI.
-	if kubeconfigPath == "incluster" {
+func CreateK8sClient(kubeconfigPath string, inCluster bool) (*kubernetes.Clientset, error) {
+	if inCluster {
 		return CreateClientInCluster()
 	} else {
 		return CreateClientOutsideCluster(kubeconfigPath)

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -46,7 +46,7 @@ import { AthenaDialog, isAthenaConfigComplete } from './athenaDialog';
 import { BigQueryDialog } from './bigqueryDialog';
 import { GCSDialog } from './gcsDialog';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
-import { KubernetesDialog } from './kubernetesDialog';
+import { isK8sConfigComplete, KubernetesDialog } from './kubernetesDialog';
 import { LambdaDialog } from './lambdaDialog';
 import { MariaDbDialog } from './mariadbDialog';
 import { MysqlDialog } from './mysqlDialog';
@@ -238,6 +238,7 @@ const IntegrationDialog: React.FC<Props> = ({
         <KubernetesDialog
           onUpdateField={setConfigField}
           value={config as KubernetesConfig}
+          apiKey={user.apiKey}
         />
       );
       break;
@@ -349,6 +350,8 @@ export function isConfigComplete(
       return isS3ConfigComplete(config as S3Config);
     case 'Athena':
       return isAthenaConfigComplete(config as AthenaConfig);
+    case 'Kubernetes':
+      return isK8sConfigComplete(config as KubernetesConfig);
 
     default:
       // Make sure config is not empty and all fields are not empty as well.

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -98,5 +98,6 @@ export function isK8sConfigComplete(config: KubernetesConfig): boolean {
     return !!config.kubeconfig_path && !!config.cluster_name;
   }
 
+  // If the user configures to run compute from within the same k8s cluster, we don't need parameters above.
   return true;
 }

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -1,10 +1,11 @@
+import { Checkbox, FormControlLabel } from '@mui/material';
 import Box from '@mui/material/Box';
 import React from 'react';
-import { Checkbox, FormControlLabel } from '@mui/material';
+import { useEffect, useState } from 'react';
 
 import { KubernetesConfig } from '../../../utils/integrations';
+import { useAqueductConsts } from '../../hooks/useAqueductConsts';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
-import { useEffect } from 'react';
 
 const Placeholders: KubernetesConfig = {
   kubeconfig_path: 'home/ubuntu/.kube/config',
@@ -15,37 +16,59 @@ const Placeholders: KubernetesConfig = {
 type Props = {
   onUpdateField: (field: keyof KubernetesConfig, value: string) => void;
   value?: KubernetesConfig;
+  apiKey: string;
 };
 
-export const KubernetesDialog: React.FC<Props> = ({ onUpdateField, value }) => {
+const { apiAddress } = useAqueductConsts();
+
+export const KubernetesDialog: React.FC<Props> = ({
+  onUpdateField,
+  value,
+  apiKey,
+}) => {
+  const [inK8sCluster, setInK8sCluster] = useState(false);
   useEffect(() => {
     if (!value?.use_same_cluster) {
       onUpdateField('use_same_cluster', 'false');
     }
+
+    const fetchEnvironment = async () => {
+      const environmentResponse = await fetch(`${apiAddress}/api/environment`, {
+        method: 'GET',
+        headers: {
+          'api-key': apiKey,
+        },
+      });
+
+      const responseBody = await environmentResponse.json();
+      setInK8sCluster(responseBody['inK8sCluster']);
+    };
+
+    fetchEnvironment().catch(console.error);
   }, []);
 
   return (
     <Box sx={{ mt: 2 }}>
-
-      <FormControlLabel
-        label="Use the same Kubernetes cluster that the server is running on."
-        control={
-          <Checkbox
-            checked={value?.use_same_cluster === 'true'}
-            onChange={(event) =>
-              onUpdateField(
-                'use_same_cluster',
-                event.target.checked ? 'true' : 'false'
-              )
-            }
-          />
-        }
-      />
-      
+      {inK8sCluster && (
+        <FormControlLabel
+          label="Use the same Kubernetes cluster that the server is running on."
+          control={
+            <Checkbox
+              checked={value?.use_same_cluster === 'true'}
+              onChange={(event) =>
+                onUpdateField(
+                  'use_same_cluster',
+                  event.target.checked ? 'true' : 'false'
+                )
+              }
+            />
+          }
+        />
+      )}
 
       <IntegrationTextInputField
         spellCheck={false}
-        required={true}
+        required={!(value?.use_same_cluster === 'true')}
         label="Kubernetes Config Path*"
         description="The path to the kubeconfig file."
         placeholder={Placeholders.kubeconfig_path}
@@ -58,7 +81,7 @@ export const KubernetesDialog: React.FC<Props> = ({ onUpdateField, value }) => {
 
       <IntegrationTextInputField
         spellCheck={false}
-        required={true}
+        required={!(value?.use_same_cluster === 'true')}
         label="Cluster Name*"
         description="The name of the cluster that will be used."
         placeholder={Placeholders.cluster_name}
@@ -69,3 +92,11 @@ export const KubernetesDialog: React.FC<Props> = ({ onUpdateField, value }) => {
     </Box>
   );
 };
+
+export function isK8sConfigComplete(config: KubernetesConfig): boolean {
+  if (config.use_same_cluster !== 'true') {
+    return !!config.kubeconfig_path && !!config.cluster_name;
+  }
+
+  return true;
+}

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -1,12 +1,15 @@
 import Box from '@mui/material/Box';
 import React from 'react';
+import { Checkbox, FormControlLabel } from '@mui/material';
 
 import { KubernetesConfig } from '../../../utils/integrations';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
+import { useEffect } from 'react';
 
 const Placeholders: KubernetesConfig = {
   kubeconfig_path: 'home/ubuntu/.kube/config',
   cluster_name: 'aqueduct',
+  use_same_cluster: 'false',
 };
 
 type Props = {
@@ -15,8 +18,31 @@ type Props = {
 };
 
 export const KubernetesDialog: React.FC<Props> = ({ onUpdateField, value }) => {
+  useEffect(() => {
+    if (!value?.use_same_cluster) {
+      onUpdateField('use_same_cluster', 'false');
+    }
+  }, []);
+
   return (
     <Box sx={{ mt: 2 }}>
+
+      <FormControlLabel
+        label="Use the same Kubernetes cluster that the server is running on."
+        control={
+          <Checkbox
+            checked={value?.use_same_cluster === 'true'}
+            onChange={(event) =>
+              onUpdateField(
+                'use_same_cluster',
+                event.target.checked ? 'true' : 'false'
+              )
+            }
+          />
+        }
+      />
+      
+
       <IntegrationTextInputField
         spellCheck={false}
         required={true}
@@ -27,6 +53,7 @@ export const KubernetesDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           onUpdateField('kubeconfig_path', event.target.value)
         }
         value={value?.kubeconfig_path ?? null}
+        disabled={value?.use_same_cluster === 'true'}
       />
 
       <IntegrationTextInputField
@@ -37,6 +64,7 @@ export const KubernetesDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         placeholder={Placeholders.cluster_name}
         onChange={(event) => onUpdateField('cluster_name', event.target.value)}
         value={value?.cluster_name ?? null}
+        disabled={value?.use_same_cluster === 'true'}
       />
     </Box>
   );

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -138,6 +138,7 @@ export type SQLiteConfig = {
 export type KubernetesConfig = {
   kubeconfig_path: string;
   cluster_name: string;
+  use_same_cluster: string;
 };
 
 export type LambdaConfig = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When the Aqueduct server is already running in a k8s cluster, when connecting to a k8s integration we want to give users the option to use the same cluster to launch their operators. We implement this by setting an environment variable in the helm chart template and adding an endpoint to the server that returns the value of this env var to the UI. Based on its value, the UI decides whether to show the check box to run the compute from within the same cluster.

There are a few more fixes on the backend side that I'll patch in a subsequent PR, but this PR completes the UI portion.

## Related issue number (if any)

## Loom demo (if any)
https://www.loom.com/share/f68f10ae548e44199e1b43975bcb1fe8

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


