### PR TITLE
Eng 1488 bug fixes

### DIFF
--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -49,7 +49,7 @@ export class BreadcrumbLinks {
     'Page Not Found'
   );
 
-  constructor(public readonly address: string, public readonly name: any) {}
+  constructor(public readonly address: string, public readonly name: any) { }
 
   toString() {
     return this.name;
@@ -67,8 +67,6 @@ const NavBar: React.FC<{
 }> = ({ user, breadcrumbs }) => {
   const [userPopoverAnchorEl, setUserPopoverAnchorEl] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
-
-  console.log(breadcrumbs);
 
   const userPopoverOpen = Boolean(userPopoverAnchorEl);
   const open = Boolean(anchorEl);
@@ -157,16 +155,16 @@ const NavBar: React.FC<{
 
         <Box sx={{ marginLeft: 'auto' }}>
           <Box onClick={handleClick} sx={{ display: 'flex' }}>
-            <Box className={styles['notification-alert']}>
-              {!!numUnreadNotifications && (
+            {!!numUnreadNotifications && (
+              <Box className={styles['notification-alert']}>
                 <Typography
                   variant="body2"
                   sx={{ fontSize: '12px', fontWeight: 'light', color: 'white' }}
                 >
                   {numUnreadNotifications}
                 </Typography>
-              )}
-            </Box>
+              </Box>
+            )}
 
             <FontAwesomeIcon
               className={styles['menu-sidebar-icon']}

--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -49,7 +49,7 @@ export class BreadcrumbLinks {
     'Page Not Found'
   );
 
-  constructor(public readonly address: string, public readonly name: any) { }
+  constructor(public readonly address: string, public readonly name: any) {}
 
   toString() {
     return this.name;

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -125,7 +125,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
         >
           <img
             src={
-              'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct_logo_color_on_white.png'
+              'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct-logo-light/1x/logo_light_blue.png'
             }
             width="64px"
             height="64px"

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -110,7 +110,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!!artifact) {
+    if (!!artifact && !sideSheetMode) {
       document.title = `${
         artifact ? artifact.name : 'Artifact Details'
       } | Aqueduct`;

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -84,11 +84,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-      isSucceeded(workflowDagResultWithLoadingStatus.status)
+    isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-        workflowDagResultWithLoadingStatus?.result,
-        artifactId
-      )
+          workflowDagResultWithLoadingStatus?.result,
+          artifactId
+        )
       : { metrics: [], checks: [] };
 
   useEffect(() => {
@@ -111,7 +111,9 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   useEffect(() => {
     if (!!artifact) {
-      document.title = `${artifact ? artifact.name : 'Artifact Details'} | Aqueduct`;
+      document.title = `${
+        artifact ? artifact.name : 'Artifact Details'
+      } | Aqueduct`;
 
       if (
         !!artifact.result &&

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -84,11 +84,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-    isSucceeded(workflowDagResultWithLoadingStatus.status)
+      isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-          workflowDagResultWithLoadingStatus?.result,
-          artifactId
-        )
+        workflowDagResultWithLoadingStatus?.result,
+        artifactId
+      )
       : { metrics: [], checks: [] };
 
   useEffect(() => {
@@ -111,7 +111,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   useEffect(() => {
     if (!!artifact) {
-      document.title = `${artifact.name} | Aqueduct`;
+      document.title = `${artifact ? artifact.name : 'Artifact Details'} | Aqueduct`;
 
       if (
         !!artifact.result &&
@@ -145,7 +145,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             path.split('/artifact/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, artifact.name),
+          new BreadcrumbLinks(path, artifact ? artifact.name : 'Artifact'),
         ]}
         user={user}
       >
@@ -164,7 +164,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             path.split('/artifact/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, artifact.name),
+          new BreadcrumbLinks(path, artifact ? artifact.name : 'Artifact'),
         ]}
         user={user}
       >
@@ -186,7 +186,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             path.split('/artifact/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, artifact.name),
+          new BreadcrumbLinks(path, artifact ? artifact.name : 'Artifact'),
         ]}
         user={user}
       >
@@ -218,7 +218,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
           path.split('/artifact/')[0],
           workflow.selectedDag.metadata.name
         ),
-        new BreadcrumbLinks(path, artifact.name),
+        new BreadcrumbLinks(path, artifact ? artifact.name : 'Artifact'),
       ]}
       user={user}
     >
@@ -226,7 +226,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
         <Box width="100%">
           {!sideSheetMode && (
             <Box width="100%" display="flex" alignItems="center">
-              <DetailsPageHeader name={artifact.name} />
+              <DetailsPageHeader name={artifact ? artifact.name : 'Artifact'} />
               <CsvExporter
                 artifact={artifact}
                 contentWithLoadingStatus={contentWithLoadingStatus}

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -263,7 +263,9 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
       <Box width={'800px'}>
         {!sideSheetMode && (
           <Box width="100%">
-            <DetailsPageHeader name={operator ? operator.name : 'Check Details'} />
+            <DetailsPageHeader
+              name={operator ? operator.name : 'Check Details'}
+            />
             {operator?.description && (
               <Typography variant="body1">{operator.description}</Typography>
             )}

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -81,8 +81,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   );
 
   useEffect(() => {
-    document.title = 'Check Details | Aqueduct';
-
     // Load workflow dag result if it's not cached
     if (
       !workflowDagResultWithLoadingStatus ||
@@ -120,7 +118,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   }, [workflowDagResultWithLoadingStatus, artifactId]);
 
   useEffect(() => {
-    if (!!operator) {
+    if (!!operator && !sideSheetMode) {
       document.title = `${operator.name} | Aqueduct`;
     }
   }, [operator]);
@@ -139,7 +137,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             path.split('/check/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, operator.name),
+          new BreadcrumbLinks(path, operator ? operator.name : 'Check'),
         ]}
         user={user}
       >
@@ -158,7 +156,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
             path.split('/check/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, operator.name),
+          new BreadcrumbLinks(path, operator ? operator.name : 'Check'),
         ]}
         user={user}
       >
@@ -258,14 +256,14 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
           path.split('/check/')[0],
           workflow.selectedDag.metadata.name
         ),
-        new BreadcrumbLinks(path, operator.name),
+        new BreadcrumbLinks(path, operator ? operator.name : 'Check'),
       ]}
       user={user}
     >
       <Box width={'800px'}>
         {!sideSheetMode && (
           <Box width="100%">
-            <DetailsPageHeader name={operator?.name} />
+            <DetailsPageHeader name={operator ? operator.name : 'Check Details'} />
             {operator?.description && (
               <Typography variant="body1">{operator.description}</Typography>
             )}

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -111,7 +111,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   useEffect(() => {
     if (!!operator && !sideSheetMode) {
       // this should only be set when the user is viewing this as a full page, not side sheet.
-      document.title = `${operator ? operator.name : "Operator Details"} | Aqueduct`;
+      document.title = `${
+        operator ? operator.name : 'Operator Details'
+      } | Aqueduct`;
     }
   }, [operator]);
 
@@ -165,7 +167,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -109,8 +109,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   }, [workflowDagResultWithLoadingStatus, artifactId]);
 
   useEffect(() => {
-    if (!!operator) {
-      document.title = `${operator.name} | Aqueduct`;
+    if (!!operator && !sideSheetMode) {
+      // this should only be set when the user is viewing this as a full page, not side sheet.
+      document.title = `${operator ? operator.name : "Operator Details"} | Aqueduct`;
     }
   }, [operator]);
 
@@ -128,7 +129,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
             path.split('/metric/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, operator.name),
+          new BreadcrumbLinks(path, operator ? operator.name : 'Operator'),
         ]}
         user={user}
       >
@@ -147,7 +148,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
             path.split('/metric/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, operator.name),
+          new BreadcrumbLinks(path, operator ? operator.name : 'Operator'),
         ]}
         user={user}
       >
@@ -164,7 +165,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -180,7 +181,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
           path.split('/metric/')[0],
           workflow.selectedDag.metadata.name
         ),
-        new BreadcrumbLinks(path, operator.name),
+        new BreadcrumbLinks(path, operator ? operator.name : 'Operator'),
       ]}
       user={user}
     >
@@ -188,7 +189,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
         <Box width="100%" mb={3}>
           {!sideSheetMode && (
             <Box width="100%">
-              <DetailsPageHeader name={operator.name} />
+              <DetailsPageHeader name={operator ? operator.name : 'Operator'} />
               {operator.description && (
                 <Typography variant="body1">{operator.description}</Typography>
               )}

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -175,7 +175,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
             path.split('/operator/')[0],
             workflow.selectedDag.metadata.name
           ),
-          new BreadcrumbLinks(path, operator.name),
+          new BreadcrumbLinks(path, operator ? operator.name : 'Operator'),
         ]}
         user={user}
       >
@@ -198,7 +198,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -223,7 +223,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
           path.split('/operator/')[0],
           workflow.selectedDag.metadata.name
         ),
-        new BreadcrumbLinks(path, operator.name),
+        new BreadcrumbLinks(path, operator ? operator.name : 'Operator'),
       ]}
       user={user}
     >
@@ -231,7 +231,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
         <Box width="100%">
           {!sideSheetMode && (
             <Box width="100%">
-              <DetailsPageHeader name={operator?.name} />
+              <DetailsPageHeader name={operator ? operator.name : 'Operator'} />
               {operator?.description && (
                 <Typography variant="body1">{operator?.description}</Typography>
               )}
@@ -274,7 +274,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
             <Typography variant="h6" fontWeight="normal" mb={1}>
               Code Preview
             </Typography>
-            <MultiFileViewer files={files} defaultFile={operator.name} />
+            <MultiFileViewer files={files} defaultFile={operator ? operator.name : ''} />
           </Box>
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -198,7 +198,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -274,7 +274,10 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
             <Typography variant="h6" fontWeight="normal" mb={1}>
               Code Preview
             </Typography>
-            <MultiFileViewer files={files} defaultFile={operator ? operator.name : ''} />
+            <MultiFileViewer
+              files={files}
+              defaultFile={operator ? operator.name : ''}
+            />
           </Box>
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -94,7 +94,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!!operator) {
+    if (!!operator && !sideSheetMode) {
       document.title = `${operator.name} | Aqueduct`;
     }
   }, [operator]);


### PR DESCRIPTION
## Describe your changes and why you are making these changes
-This PR fixes crashes caused by artifacts or operators being undefined in the breadcrumb component.
-Updates aqueduct logo to use light aqueduct logo without words and with a transparent background. 
-Also fixes an issue where the red background for the notifications bell would show when there are no notifications. 


## Related issue number (if any)
ENG-1488

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


