### PR TITLE
Fix a number of bugs in the helm chart

### DIFF
--- a/src/aqueduct-helm/Chart.yaml
+++ b/src/aqueduct-helm/Chart.yaml
@@ -22,4 +22,3 @@ version: 0.0.16
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.0.16"
-namespace: aqueduct

--- a/src/aqueduct-helm/templates/clusterrole.yaml
+++ b/src/aqueduct-helm/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aqueduct-admin-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["create", "get"]

--- a/src/aqueduct-helm/templates/clusterrolebinding.yaml
+++ b/src/aqueduct-helm/templates/clusterrolebinding.yaml
@@ -1,13 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: aqueduct-admin-role-binding
-  namespace: aqueduct
+  name: aqueduct-admin-cluster-role-binding
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: aqueduct-admin-role
+  kind: ClusterRole
+  name: aqueduct-admin-cluster-role

--- a/src/aqueduct-helm/templates/deployment.yaml
+++ b/src/aqueduct-helm/templates/deployment.yaml
@@ -40,9 +40,6 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            - name: http2
-              containerPort: 8081
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /

--- a/src/aqueduct-helm/templates/role.yaml
+++ b/src/aqueduct-helm/templates/role.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace }}
-  name: aqueductadminrole
+  namespace: aqueduct
+  name: aqueduct-admin-role
 rules:
 - apiGroups: ["*"]
   resources: ["*"]

--- a/src/aqueduct-helm/templates/service.yaml
+++ b/src/aqueduct-helm/templates/service.yaml
@@ -11,9 +11,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: 8081
-      targetPort: http2
-      protocol: TCP
-      name: http2
   selector:
     {{- include "aqueduct-helm.selectorLabels" . | nindent 4 }}

--- a/src/aqueduct-helm/values.yaml
+++ b/src/aqueduct-helm/values.yaml
@@ -21,7 +21,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: "aqueductserviceaccount"
+  name: "aqueduct-service-account"
 
 podAnnotations: {}
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There are two main fixes:
1. Since our executor attempts to create jobs in the `aqueduct` namespace, in the helm chart we need to define role and rolebinding in the `aqueduct` namespace.
2. In our Golang code we have logic to create namespace `aqueduct` if not exist. Since namespace is a cluster resource, we need to use clusterrole and clusterrolebinding for this.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


