### PR TITLE
Eng 1817 fix enter bug ENG-1809 Only show search bar if there are workflows

### DIFF
--- a/src/ui/common/src/components/Search/index.tsx
+++ b/src/ui/common/src/components/Search/index.tsx
@@ -30,12 +30,13 @@ export const SearchBar: React.FC<Props> = ({
       onInputChange={(_, val, reason) => {
         if (reason === 'clear') {
           setSearchTerm('');
+          return;
         }
 
         setSearchTerm(val);
       }}
       freeSolo
-      getOptionLabel={getOptionLabel}
+      getOptionLabel={(option) => option.name || ""}
       renderInput={(params) => {
         params['InputProps']['startAdornment'] = (
           <InputAdornment position="start">
@@ -52,7 +53,8 @@ export const SearchBar: React.FC<Props> = ({
         );
       }}
       renderOption={(props, option, { inputValue }) => {
-        const label = getOptionLabel(option);
+        const label = option.name || "";
+
         // Matches only matches if the inputValue matches the start of any word (separated by space.)
         // We may want to modify the functionality in the future because many workflow and artifact names
         // are also hypen or underscore separated.
@@ -99,7 +101,7 @@ export const filteredList = (
     })
     .map(listItems);
 
-  const noMatchesText = <Typography variant="h5">No matches found.</Typography>;
+  const noMatchesText = <Typography variant="h5" marginTop='16px'>No matches found.</Typography>;
 
   return matches.length === 0 ? (
     noMatchesText

--- a/src/ui/common/src/components/Search/index.tsx
+++ b/src/ui/common/src/components/Search/index.tsx
@@ -36,7 +36,7 @@ export const SearchBar: React.FC<Props> = ({
         setSearchTerm(val);
       }}
       freeSolo
-      getOptionLabel={(option) => option.name || ""}
+      getOptionLabel={(option) => option.name || ''}
       renderInput={(params) => {
         params['InputProps']['startAdornment'] = (
           <InputAdornment position="start">
@@ -53,7 +53,7 @@ export const SearchBar: React.FC<Props> = ({
         );
       }}
       renderOption={(props, option, { inputValue }) => {
-        const label = option.name || "";
+        const label = option.name || '';
 
         // Matches only matches if the inputValue matches the start of any word (separated by space.)
         // We may want to modify the functionality in the future because many workflow and artifact names
@@ -101,7 +101,11 @@ export const filteredList = (
     })
     .map(listItems);
 
-  const noMatchesText = <Typography variant="h5" marginTop='16px'>No matches found.</Typography>;
+  const noMatchesText = (
+    <Typography variant="h5" marginTop="16px">
+      No matches found.
+    </Typography>
+  );
 
   return matches.length === 0 ? (
     noMatchesText

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -1,7 +1,5 @@
 import {
-  faBell,
   faBook,
-  faCircleUser,
   faDatabase,
   faMessage,
   faPlug,

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -6,7 +6,6 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
 import { handleGetArtifactResultContent } from '../../../../handlers/getArtifactResultContent';
@@ -14,6 +13,7 @@ import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagR
 import { getMetricsAndChecksOnArtifact } from '../../../../handlers/responses/dag';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import {
   isFailed,
   isInitial,
@@ -97,10 +97,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, artifact ? artifact.name : 'Artifact'),
   ];
 
@@ -152,10 +149,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -163,10 +157,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load workflow.</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
@@ -177,10 +168,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   if (!artifact) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load artifact.</AlertTitle>
           Artifact {artifactId} does not exist on this workflow.
@@ -201,10 +189,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const outputs = mapOperators(artifact.to ? artifact.to : []);
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         <Box width="100%">
           {!sideSheetMode && (

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -72,19 +72,14 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
     {})[checkOperatorId];
 
-
   const pathPrefix = getPathPrefix();
   const workflowLink = `${pathPrefix}/workflow/${workflowId}?workflowDagResultId=${workflowDagResultId}`;
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, operator ? operator.name : 'Check'),
   ];
-
 
   const artifactId = operator?.outputs[0];
 
@@ -143,10 +138,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -154,10 +146,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load workflow.</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
@@ -246,10 +235,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   });
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         {!sideSheetMode && (
           <Box width="100%">

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -79,14 +79,20 @@ const IntegrationsPage: React.FC<Props> = ({
         <Divider sx={{ width: '950px' }} />
 
         <Box sx={{ my: 3, ml: 1 }}>
-          <Typography variant="h4" marginBottom={3}>Add an Integration</Typography>
-          <Typography variant="h6" marginBottom={2}>Data</Typography>
+          <Typography variant="h4" marginBottom={3}>
+            Add an Integration
+          </Typography>
+          <Typography variant="h6" marginBottom={2}>
+            Data
+          </Typography>
           <AddIntegrations
             user={user}
             category="data"
             supportedIntegrations={SupportedIntegrations}
           />
-          <Typography variant="h6" marginTop={4} marginBottom={3}>Compute</Typography>
+          <Typography variant="h6" marginTop={4} marginBottom={3}>
+            Compute
+          </Typography>
           <AddIntegrations
             user={user}
             category="compute"
@@ -99,7 +105,9 @@ const IntegrationsPage: React.FC<Props> = ({
         </Box>
 
         <Box sx={{ marginTop: 3, marginBottom: 3, ml: 1 }}>
-          <Typography variant="h4" marginBottom={3}>Connected Integrations</Typography>
+          <Typography variant="h4" marginBottom={3}>
+            Connected Integrations
+          </Typography>
           <ConnectedIntegrations user={user} forceLoad={forceLoad} />
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -6,13 +6,13 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import DefaultLayout from '../../../layouts/default';
 import MetricsHistory from '../../../workflows/artifact/metric/history';
@@ -76,10 +76,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, operator ? operator.name : 'Metric'),
   ];
 
@@ -136,10 +133,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -147,10 +141,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load workflow</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
@@ -172,10 +163,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   const outputs = mapArtifacts(operator.outputs);
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         <Box width="100%" mb={3}>
           {!sideSheetMode && (

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -5,7 +5,6 @@ import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 
 import DefaultLayout from '../../../../components/layouts/default';
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
@@ -14,6 +13,7 @@ import MultiFileViewer from '../../../../components/MultiFileViewer';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { exportFunction } from '../../../../utils/operators';
 import { LoadingStatusEnum } from '../../../../utils/shared';
 import { isInitial, isLoading } from '../../../../utils/shared';
@@ -81,13 +81,9 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, operator ? operator.name : 'Operator'),
   ];
-
 
   useEffect(() => {
     document.title = 'Operator Details | Aqueduct';
@@ -181,10 +177,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -218,13 +211,10 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     borderColor: 'gray.400',
     margin: '16px',
     padding: '16px',
-  };  
+  };
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         <Box width="100%">
           {!sideSheetMode && (

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -89,15 +89,13 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     >
       <Box p={2}>
         {heading}
-        {
-          allWorkflows.workflows.length >= 1 && (
-            <SearchBar
-              options={allWorkflows.workflows}
-              getOptionLabel={(option) => option.name || ""}
-              setSearchTerm={setFilterText}
-            />
-          )
-        }
+        {allWorkflows.workflows.length >= 1 && (
+          <SearchBar
+            options={allWorkflows.workflows}
+            getOptionLabel={(option) => option.name || ''}
+            setSearchTerm={setFilterText}
+          />
+        )}
         {workflowList}
       </Box>
     </Layout>

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -89,11 +89,15 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     >
       <Box p={2}>
         {heading}
-        <SearchBar
-          options={allWorkflows.workflows}
-          getOptionLabel={getOptionLabel}
-          setSearchTerm={setFilterText}
-        />
+        {
+          allWorkflows.workflows.length >= 1 && (
+            <SearchBar
+              options={allWorkflows.workflows}
+              getOptionLabel={(option) => option.name || ""}
+              setSearchTerm={setFilterText}
+            />
+          )
+        }
         {workflowList}
       </Box>
     </Layout>

--- a/src/ui/common/src/handlers/responses/dag.ts
+++ b/src/ui/common/src/handlers/responses/dag.ts
@@ -3,10 +3,7 @@ import { EngineConfig } from '../../utils/engine';
 import { OperatorType } from '../../utils/operators';
 import { ExecState } from '../../utils/shared';
 import { StorageConfig } from '../../utils/storage';
-import {
-  RetentionPolicy,
-  WorkflowSchedule,
-} from '../../utils/workflows';
+import { RetentionPolicy, WorkflowSchedule } from '../../utils/workflows';
 import { ArtifactResponse, ArtifactResultResponse } from './artifact';
 import { OperatorResponse, OperatorResultResponse } from './operator';
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes two bugs:
1. ENG-1817: No longer show "undefined" after the user presses enter after entering a search query on the workflow page search bar

2. ENG-1809: Only show the search bar on workflow list page if there are workflows to search.

## Related issue number (if any)
ENG-1817
ENG-1809

## Loom demo (if any)
https://www.loom.com/share/a881f074bae44cbda5f30b26612b2dc4

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


