### PR TITLE
ENG-1814 Workflow Status Bar label fixes

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -1,7 +1,5 @@
 import {
-  faBell,
   faBook,
-  faCircleUser,
   faDatabase,
   faMessage,
   faPlug,

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -6,7 +6,6 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
 import { handleGetArtifactResultContent } from '../../../../handlers/getArtifactResultContent';
@@ -14,6 +13,7 @@ import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagR
 import { getMetricsAndChecksOnArtifact } from '../../../../handlers/responses/dag';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import {
   isFailed,
   isInitial,
@@ -97,10 +97,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, artifact ? artifact.name : 'Artifact'),
   ];
 
@@ -152,10 +149,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -163,10 +157,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load workflow.</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
@@ -177,10 +168,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   if (!artifact) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load artifact.</AlertTitle>
           Artifact {artifactId} does not exist on this workflow.
@@ -201,10 +189,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const outputs = mapOperators(artifact.to ? artifact.to : []);
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         <Box width="100%">
           {!sideSheetMode && (

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -72,19 +72,14 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
     {})[checkOperatorId];
 
-
   const pathPrefix = getPathPrefix();
   const workflowLink = `${pathPrefix}/workflow/${workflowId}?workflowDagResultId=${workflowDagResultId}`;
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, operator ? operator.name : 'Check'),
   ];
-
 
   const artifactId = operator?.outputs[0];
 
@@ -143,10 +138,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -154,10 +146,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load workflow.</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
@@ -246,10 +235,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
   });
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         {!sideSheetMode && (
           <Box width="100%">

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -79,14 +79,20 @@ const IntegrationsPage: React.FC<Props> = ({
         <Divider sx={{ width: '950px' }} />
 
         <Box sx={{ my: 3, ml: 1 }}>
-          <Typography variant="h4" marginBottom={3}>Add an Integration</Typography>
-          <Typography variant="h6" marginBottom={2}>Data</Typography>
+          <Typography variant="h4" marginBottom={3}>
+            Add an Integration
+          </Typography>
+          <Typography variant="h6" marginBottom={2}>
+            Data
+          </Typography>
           <AddIntegrations
             user={user}
             category="data"
             supportedIntegrations={SupportedIntegrations}
           />
-          <Typography variant="h6" marginTop={4} marginBottom={3}>Compute</Typography>
+          <Typography variant="h6" marginTop={4} marginBottom={3}>
+            Compute
+          </Typography>
           <AddIntegrations
             user={user}
             category="compute"
@@ -99,7 +105,9 @@ const IntegrationsPage: React.FC<Props> = ({
         </Box>
 
         <Box sx={{ marginTop: 3, marginBottom: 3, ml: 1 }}>
-          <Typography variant="h4" marginBottom={3}>Connected Integrations</Typography>
+          <Typography variant="h4" marginBottom={3}>
+            Connected Integrations
+          </Typography>
           <ConnectedIntegrations user={user} forceLoad={forceLoad} />
         </Box>
       </Box>

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -6,13 +6,13 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { handleListArtifactResults } from '../../../../handlers/listArtifactResults';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import DefaultLayout from '../../../layouts/default';
 import MetricsHistory from '../../../workflows/artifact/metric/history';
@@ -76,10 +76,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, operator ? operator.name : 'Metric'),
   ];
 
@@ -136,10 +133,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -147,10 +141,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
   if (isFailed(workflowDagResultWithLoadingStatus.status)) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <Alert severity="error">
           <AlertTitle>Failed to load workflow</AlertTitle>
           {workflowDagResultWithLoadingStatus.status.err}
@@ -172,10 +163,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   const outputs = mapArtifacts(operator.outputs);
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         <Box width="100%" mb={3}>
           {!sideSheetMode && (

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -5,7 +5,6 @@ import { BlobReader, TextWriter, ZipReader } from '@zip.js/zip.js';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { getPathPrefix } from '../../../../utils/getPathPrefix';
 
 import DefaultLayout from '../../../../components/layouts/default';
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
@@ -14,6 +13,7 @@ import MultiFileViewer from '../../../../components/MultiFileViewer';
 import { handleGetWorkflowDagResult } from '../../../../handlers/getWorkflowDagResult';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { exportFunction } from '../../../../utils/operators';
 import { LoadingStatusEnum } from '../../../../utils/shared';
 import { isInitial, isLoading } from '../../../../utils/shared';
@@ -81,13 +81,9 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(
-      workflowLink,
-      workflow.selectedDag.metadata.name
-    ),
+    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
     new BreadcrumbLink(path, operator ? operator.name : 'Operator'),
   ];
-
 
   useEffect(() => {
     document.title = 'Operator Details | Aqueduct';
@@ -181,10 +177,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     isLoading(workflowDagResultWithLoadingStatus.status)
   ) {
     return (
-      <Layout
-        breadcrumbs={breadcrumbs}
-        user={user}
-      >
+      <Layout breadcrumbs={breadcrumbs} user={user}>
         <CircularProgress />
       </Layout>
     );
@@ -218,13 +211,10 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     borderColor: 'gray.400',
     margin: '16px',
     padding: '16px',
-  };  
+  };
 
   return (
-    <Layout
-      breadcrumbs={breadcrumbs}
-      user={user}
-    >
+    <Layout breadcrumbs={breadcrumbs} user={user}>
       <Box width={'800px'}>
         <Box width="100%">
           {!sideSheetMode && (

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -124,11 +124,11 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
     if (!label) {
       if (nodeType.includes('Op')) {
         return 'Operator';
+      } else if (nodeType.includes('Artifact')) {
+        return 'Artifact';
       }
 
-      // otherwise, it's an Artifact
-      // nodeType will be "tableArtifact", etc.
-      return 'Artifact';
+      return '';
     }
 
     return label;

--- a/src/ui/common/src/handlers/responses/dag.ts
+++ b/src/ui/common/src/handlers/responses/dag.ts
@@ -3,10 +3,7 @@ import { EngineConfig } from '../../utils/engine';
 import { OperatorType } from '../../utils/operators';
 import { ExecState } from '../../utils/shared';
 import { StorageConfig } from '../../utils/storage';
-import {
-  RetentionPolicy,
-  WorkflowSchedule,
-} from '../../utils/workflows';
+import { RetentionPolicy, WorkflowSchedule } from '../../utils/workflows';
 import { ArtifactResponse, ArtifactResultResponse } from './artifact';
 import { OperatorResponse, OperatorResultResponse } from './operator';
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes bug where 'artifact' and 'operator' labels were shown in workflow status bar when there were no errors or warnings or info events.

## Related issue number (if any)
ENG-1814
## Loom demo (if any)
https://www.loom.com/share/7a5ffc9e8316480780e4f8010aa6db5b

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


