### PR TITLE
Fix mypy errors that resulted from numpy version > 1.19

### DIFF
--- a/sdk/aqueduct/artifacts/bool_artifact.py
+++ b/sdk/aqueduct/artifacts/bool_artifact.py
@@ -74,19 +74,19 @@ class BoolArtifact(BaseArtifact):
                     "Parameterizing historical artifacts is not currently supported."
                 )
 
-        if parameters is None and self._get_content() is not None:
-            return self._get_content()
+        content = self._get_content()
+        if parameters is not None or content is None:
+            previewed_artifact = artifact_utils.preview_artifact(
+                self._dag, self._artifact_id, parameters
+            )
+            content = previewed_artifact._get_content()
+            assert isinstance(content, bool) or isinstance(content, np.bool_)
 
-        previewed_artifact = artifact_utils.preview_artifact(
-            self._dag, self._artifact_id, parameters
-        )
-        content = previewed_artifact._get_content()
+            # If the artifact was previously generated lazily, materialize the contents.
+            if parameters is None and self._get_content() is None:
+                self._set_content(content)
+
         assert isinstance(content, bool) or isinstance(content, np.bool_)
-
-        # If the artifact was previously generated lazily, materialize the contents.
-        if parameters is None and self._get_content() is None:
-            self._set_content(content)
-
         return content
 
     def describe(self) -> None:

--- a/sdk/aqueduct/artifacts/bool_artifact.py
+++ b/sdk/aqueduct/artifacts/bool_artifact.py
@@ -80,7 +80,6 @@ class BoolArtifact(BaseArtifact):
                 self._dag, self._artifact_id, parameters
             )
             content = previewed_artifact._get_content()
-            assert isinstance(content, bool) or isinstance(content, np.bool_)
 
             # If the artifact was previously generated lazily, materialize the contents.
             if parameters is None and self._get_content() is None:

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -68,17 +68,16 @@ class GenericArtifact(BaseArtifact):
                 )
             return self._get_content()
 
-        if parameters is None and self._get_content() is not None:
-            return self._get_content()
+        content = self._get_content()
+        if parameters is not None or content is None:
+            previewed_artifact = artifact_utils.preview_artifact(
+                self._dag, self._artifact_id, parameters
+            )
+            content = previewed_artifact._get_content()
 
-        previewed_artifact = artifact_utils.preview_artifact(
-            self._dag, self._artifact_id, parameters
-        )
-        content = previewed_artifact._get_content()
-
-        # If the artifact was previously generated lazily, materialize the contents.
-        if parameters is None and self._get_content() is None:
-            self._set_content(content)
+            # If the artifact was previously generated lazily, materialize the contents.
+            if parameters is None and self._get_content() is None:
+                self._set_content(content)
 
         return content
 

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -26,6 +26,7 @@ from aqueduct.enums import (
 from aqueduct.error import AqueductError, ArtifactNeverComputedException
 from aqueduct.operators import CheckSpec, FunctionSpec, Operator, OperatorSpec, get_operator_type
 from aqueduct.utils import (
+    Number,
     artifact_name_from_op_name,
     format_header_for_print,
     generate_uuid,
@@ -65,7 +66,7 @@ class NumericArtifact(BaseArtifact):
         self,
         dag: DAG,
         artifact_id: uuid.UUID,
-        content: Optional[Union[int, float, np.number]] = None,
+        content: Optional[Number] = None,
         from_flow_run: bool = False,
     ):
         self._dag = dag
@@ -75,7 +76,7 @@ class NumericArtifact(BaseArtifact):
         self._from_flow_run = from_flow_run
         self._set_content(content)
 
-    def get(self, parameters: Optional[Dict[str, Any]] = None) -> Union[int, float, np.number]:
+    def get(self, parameters: Optional[Dict[str, Any]] = None) -> Number:
         """Materializes a NumericArtifact into its immediate float value.
 
         Returns:
@@ -99,21 +100,27 @@ class NumericArtifact(BaseArtifact):
                     "Parameterizing historical artifacts is not currently supported."
                 )
 
-        if parameters is None and self._get_content() is not None:
-            return self._get_content()
+        content = self._get_content()
+        if parameters is not None or content is None:
+            previewed_artifact = artifact_utils.preview_artifact(
+                self._dag, self._artifact_id, parameters
+            )
 
-        previewed_artifact = artifact_utils.preview_artifact(
-            self._dag, self._artifact_id, parameters
-        )
+            content = previewed_artifact._get_content()
+            assert (
+                isinstance(content, int)
+                or isinstance(content, float)
+                or isinstance(content, np.number)
+            )
 
-        content = previewed_artifact._get_content()
+            if parameters is None and self._get_content() is None:
+                self._set_content(content)
+
+            return content
+
         assert (
             isinstance(content, int) or isinstance(content, float) or isinstance(content, np.number)
         )
-
-        if parameters is None and self._get_content() is None:
-            self._set_content(content)
-
         return content
 
     def list_preset_checks(self) -> List[str]:

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -107,12 +107,6 @@ class NumericArtifact(BaseArtifact):
             )
 
             content = previewed_artifact._get_content()
-            assert (
-                isinstance(content, int)
-                or isinstance(content, float)
-                or isinstance(content, np.number)
-            )
-
             if parameters is None and self._get_content() is None:
                 self._set_content(content)
 

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -122,19 +122,18 @@ class TableArtifact(BaseArtifact):
                     "Parameterizing historical artifacts is not currently supported."
                 )
 
-        if parameters is None and self._get_content() is not None:
-            return self._get_content()
+        content = self._get_content()
+        if parameters is not None or content is None:
+            previewed_artifact = artifact_utils.preview_artifact(
+                self._dag, self._artifact_id, parameters
+            )
+            content = previewed_artifact._get_content()
 
-        previewed_artifact = artifact_utils.preview_artifact(
-            self._dag, self._artifact_id, parameters
-        )
-        content = previewed_artifact._get_content()
+            # If the artifact was previously generated lazily, materialize the contents.
+            if parameters is None and self._get_content() is None:
+                self._set_content(content)
+
         assert isinstance(content, pd.DataFrame)
-
-        # If the artifact was previously generated lazily, materialize the contents.
-        if parameters is None and self._get_content() is None:
-            self._set_content(content)
-
         return content
 
     def head(self, n: int = 5, parameters: Optional[Dict[str, Any]] = None) -> pd.DataFrame:

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -25,6 +25,7 @@ from aqueduct.parameter_utils import create_param
 from aqueduct.utils import (
     CheckFunction,
     MetricFunction,
+    Number,
     UserFunction,
     artifact_name_from_op_name,
     generate_uuid,
@@ -440,7 +441,7 @@ def metric(
             return _wrapped_util(*input_artifacts, execution_mode=ExecutionMode.EAGER)
 
         # Enable the .local(*args) attribute, which calls the original function with the raw inputs.
-        def local_func(*inputs: Any) -> Union[int, float, np.number]:
+        def local_func(*inputs: Any) -> Number:
             raw_inputs = [elem.get() if _is_input_artifact(elem) else elem for elem in inputs]
             return func(*raw_inputs)
 

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -141,7 +141,8 @@ REQUIREMENTS_FILE = "requirements.txt"
 BLACKLISTED_REQUIREMENTS = ["aqueduct_ml", "aqueduct_sdk", "aqueduct-ml", "aqueduct-sdk"]
 
 UserFunction = Callable[..., Any]
-MetricFunction = Callable[..., Union[int, float, np.number]]
+Number = Union[int, float, np.number]
+MetricFunction = Callable[..., Number]
 CheckFunction = Callable[..., Union[bool, np.bool_]]
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Once this merges, we can once again upgrade our numpy to whatever version and run `run_linters.py` without fear.

Turns out all we had to do to fix this was to make `Union[int, float, np.number]` its own type. Don't ask me why that works...

The other errors were stomped out why asserting that data was of the correct type before returning.

## Related issue number (if any)
ENG-1754

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


