### PR TITLE
ENG-1808 docs link fix

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -204,7 +204,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
                     icon={faBook}
                   />
                 }
-                text="Documentation"
+                text="Docs"
               />
             </Link>
           </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR renames the documentation link on the navigation bar to "Docs", which now properly renders without going over the width of the navbar.

## Related issue number (if any)
ENG-1808

## Loom demo (if any)
Screenshot:
<img width="1920" alt="image" src="https://user-images.githubusercontent.com/1031759/195215476-76b6f548-202a-4896-9e75-d4a092c6d801.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


