### PR TITLE
ENG-1823: Clicking settings gear does nothing

### DIFF
--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -6,7 +6,6 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   AppBar,
-  Avatar,
   Breadcrumbs,
   Link,
   Menu,
@@ -102,25 +101,6 @@ const NavBar: React.FC<{
 
   const notificationsPopoverId = open ? 'simple-popover' : undefined;
   const userPopoverId = userPopoverOpen ? 'user-popover' : undefined;
-
-  const avatarStyling = { width: '24px', height: '24px', marginLeft: '16px' };
-
-  const avatar = user.picture ? (
-    <Avatar
-      className={styles['user-avatar']}
-      sx={avatarStyling}
-      src={user.picture}
-      onClick={handleUserPopoverClick}
-    />
-  ) : (
-    <Avatar
-      className={styles['user-avatar']}
-      sx={avatarStyling}
-      onClick={handleUserPopoverClick}
-    >
-      {user.name !== 'aqueduct user' ? user.name : null}
-    </Avatar>
-  );
 
   return (
     <AppBar

--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -188,6 +188,7 @@ const NavBar: React.FC<{
           <FontAwesomeIcon
             className={styles['menu-sidebar-icon']}
             icon={faGear}
+            onClick={handleUserPopoverClick}
           />
           <Menu
             id={userPopoverId}

--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -52,7 +52,7 @@ export class BreadcrumbLink {
     'Page Not Found'
   );
 
-  constructor(public readonly address: string, public readonly name: any) { }
+  constructor(public readonly address: string, public readonly name: any) {}
 
   toString() {
     return this.name;
@@ -137,7 +137,10 @@ const NavBar: React.FC<{
         </Breadcrumbs>
 
         <Box sx={{ marginLeft: 'auto' }}>
-          <Box onClick={handleClick} sx={{ display: 'flex', cursor: 'pointer' }}>
+          <Box
+            onClick={handleClick}
+            sx={{ display: 'flex', cursor: 'pointer' }}
+          >
             {!!numUnreadNotifications && (
               <Box className={styles['notification-alert']}>
                 <Typography
@@ -197,7 +200,7 @@ const NavBar: React.FC<{
           </Menu>
         </Box>
       </Toolbar>
-    </AppBar >
+    </AppBar>
   );
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR brings back the click listener that was attached to the avatar component. I forgot to move this over when replacing with the settings gear 🤦 .

This PR also removes the unused avatar component.

## Related issue number (if any)
ENG-1823

## Loom demo (if any)
NA: clicking settings gear now shows menu with Account option as it did before.

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


