### PR TITLE
Eng 1825 fix a bug where preview is showing spinner in sidesheet

### DIFF
--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -53,7 +53,7 @@ export class BreadcrumbLink {
     'Page Not Found'
   );
 
-  constructor(public readonly address: string, public readonly name: any) { }
+  constructor(public readonly address: string, public readonly name: any) {}
 
   toString() {
     return this.name;
@@ -157,7 +157,10 @@ const NavBar: React.FC<{
         </Breadcrumbs>
 
         <Box sx={{ marginLeft: 'auto' }}>
-          <Box onClick={handleClick} sx={{ display: 'flex', cursor: 'pointer' }}>
+          <Box
+            onClick={handleClick}
+            sx={{ display: 'flex', cursor: 'pointer' }}
+          >
             {!!numUnreadNotifications && (
               <Box className={styles['notification-alert']}>
                 <Typography
@@ -216,7 +219,7 @@ const NavBar: React.FC<{
           </Menu>
         </Box>
       </Toolbar>
-    </AppBar >
+    </AppBar>
   );
 };
 

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -120,10 +120,12 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!!artifact && !sideSheetMode) {
-      document.title = `${
-        artifact ? artifact.name : 'Artifact Details'
-      } | Aqueduct`;
+    if (!!artifact) {
+      if (!sideSheetMode) {
+        document.title = `${
+          artifact ? artifact.name : 'Artifact Details'
+        } | Aqueduct`;
+      }
 
       if (
         !!artifact.result &&


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the preview doesn't load in workflow sidesheet mode. The fix ensures the request to fetch data is properly dispatched.
## Related issue number (if any)
ENG-1825

## Loom demo (if any)
Now the preview loads in sidesheet:
<img width="1557" alt="Screen Shot 2022-10-12 at 10 55 28 AM" src="https://user-images.githubusercontent.com/10411887/195414655-37456b9c-68d0-4488-83a2-ea00597b847c.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


