### PR TITLE
Eng 1818 Fix margins spacing on workflows and data page

### DIFF
--- a/src/ui/common/src/components/Search/index.tsx
+++ b/src/ui/common/src/components/Search/index.tsx
@@ -46,7 +46,6 @@ export const SearchBar: React.FC<Props> = ({
         return (
           <TextField
             {...params}
-            label="Search"
             variant="standard"
             onChange={(e) => setSearchTerm(e.target.value)}
           />

--- a/src/ui/common/src/components/layouts/card.tsx
+++ b/src/ui/common/src/components/layouts/card.tsx
@@ -3,6 +3,8 @@ import { styled } from '@mui/material/styles';
 
 import { theme } from '../../styles/theme/theme';
 
+export const CardPadding = '16px';
+
 export const Card = styled(Box)(({ theme: Theme }) => {
   return {
     borderRadius: 4,
@@ -10,6 +12,6 @@ export const Card = styled(Box)(({ theme: Theme }) => {
       backgroundColor: theme.palette.blue[50],
     },
     minWidth: '450px',
-    padding: '16px',
+    padding: CardPadding,
   };
 });

--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -9,7 +9,7 @@ import { handleLoadIntegrations } from '../../../reducers/integrations';
 import { AppDispatch, RootState } from '../../../stores/store';
 import UserProfile from '../../../utils/auth';
 import { DataCard } from '../../integrations/cards/card';
-import { Card } from '../../layouts/card';
+import { Card, CardPadding } from '../../layouts/card';
 import DefaultLayout from '../../layouts/default';
 import { filteredList, SearchBar } from '../../Search';
 import { LayoutProps } from '../types';
@@ -79,11 +79,14 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
           Data
         </Typography>
 
-        <SearchBar
-          options={Object.values(dataCardsInfo.data.latest_versions)}
-          getOptionLabel={getOptionLabel}
-          setSearchTerm={setFilterText}
-        />
+        <Box paddingLeft={CardPadding}>
+          {/* Aligns search bar to card text */}
+          <SearchBar
+            options={Object.values(dataCardsInfo.data.latest_versions)}
+            getOptionLabel={getOptionLabel}
+            setSearchTerm={setFilterText}
+          />
+        </Box>
         {dataCards}
       </Box>
     </Layout>

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -3,12 +3,13 @@ import Box from '@mui/material/Box';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { BreadcrumbLink } from '../../../components/layouts/NavBar';
 import { handleFetchAllWorkflowSummaries } from '../../../reducers/listWorkflowSummaries';
 import { AppDispatch, RootState } from '../../../stores/store';
 import UserProfile from '../../../utils/auth';
 import { LoadingStatusEnum } from '../../../utils/shared';
+import { CardPadding } from '../../layouts/card';
 import DefaultLayout from '../../layouts/default';
+import { BreadcrumbLink } from '../../layouts/NavBar';
 import { filteredList, SearchBar } from '../../Search';
 import WorkflowCard from '../../workflows/workflowCard';
 import { LayoutProps } from '../types';
@@ -90,11 +91,14 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
       <Box>
         {heading}
         {allWorkflows.workflows.length >= 1 && (
-          <SearchBar
-            options={allWorkflows.workflows}
-            getOptionLabel={(option) => option.name || ''}
-            setSearchTerm={setFilterText}
-          />
+          <Box marginLeft={CardPadding}>
+            {/* Align searchbar with card text */}
+            <SearchBar
+              options={allWorkflows.workflows}
+              getOptionLabel={(option) => option.name || ''}
+              setSearchTerm={setFilterText}
+            />
+          </Box>
         )}
         {workflowList}
       </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes title-searchbox-card alignments in workflows / data page. More details see https://linear.app/aqueducthq/issue/ENG-1818/fix-margins-and-spacing-on-workflows-page and https://linear.app/aqueducthq/issue/ENG-1810/fix-spacing-and-margins-on-data-page . Per discussion with @vsreekanti in https://linear.app/aqueducthq/issue/ENG-1818/fix-margins-and-spacing-on-workflows-page , we decided to indent the search box to align with card text, and also remove the 'search' label for it.

## Related issue number (if any)
ENG-1818
ENG-1810

## Loom demo (if any)
New look:
<img width="1061" alt="Screen Shot 2022-10-12 at 11 19 10 AM" src="https://user-images.githubusercontent.com/10411887/195419031-82fc4586-79f7-4eec-8a7c-1defd563ce8c.png">
<img width="1050" alt="Screen Shot 2022-10-12 at 11 19 17 AM" src="https://user-images.githubusercontent.com/10411887/195419057-14af394d-d807-4d73-a465-2bd47e7084b5.png">
## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


