### PR TITLE
ENG-1815 Details Sidesheets Spacing Fixes

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -85,11 +85,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-    isSucceeded(workflowDagResultWithLoadingStatus.status)
+      isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-          workflowDagResultWithLoadingStatus?.result,
-          artifactId
-        )
+        workflowDagResultWithLoadingStatus?.result,
+        artifactId
+      )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -122,9 +122,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${
-          artifact ? artifact.name : 'Artifact Details'
-        } | Aqueduct`;
+        document.title = `${artifact ? artifact.name : 'Artifact Details'
+          } | Aqueduct`;
       }
 
       if (
@@ -192,7 +191,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={'800px'}>
+      <Box width={!sideSheetMode ? '800px' : 'auto'}>
         <Box width="100%">
           {!sideSheetMode && (
             <Box width="100%" display="flex" alignItems="center">

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -236,7 +236,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={'800px'}>
+      <Box width={!sideSheetMode ? '800px' : 'auto'}>
         {!sideSheetMode && (
           <Box width="100%">
             <DetailsPageHeader

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -121,9 +121,8 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   useEffect(() => {
     if (!!operator && !sideSheetMode) {
       // this should only be set when the user is viewing this as a full page, not side sheet.
-      document.title = `${
-        operator ? operator.name : 'Operator Details'
-      } | Aqueduct`;
+      document.title = `${operator ? operator.name : 'Operator Details'
+        } | Aqueduct`;
     }
   }, [operator]);
 
@@ -155,7 +154,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -164,7 +163,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={'800px'}>
+      <Box width={!sideSheetMode ? '800px' : 'auto'}>
         <Box width="100%" mb={3}>
           {!sideSheetMode && (
             <Box width="100%">

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -197,7 +197,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -215,7 +215,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={'800px'}>
+      <Box width={!sideSheetMode ? '800px' : 'auto'}>
         <Box width="100%">
           {!sideSheetMode && (
             <Box width="100%">

--- a/src/ui/common/src/components/tables/PaginatedTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedTable.tsx
@@ -35,7 +35,7 @@ const PaginatedTable: React.FC<PaginatedTableProps> = ({ data }) => {
   };
 
   return (
-    <Paper sx={{ width: '800px', overflow: 'hidden' }}>
+    <Paper sx={{ maxWidth: '800px', overflow: 'hidden' }}>
       <TableContainer sx={{ maxHeight: '400px' }}>
         <Table stickyHeader aria-label="sticky table">
           <TableHead>

--- a/src/ui/common/src/utils/sidesheets.tsx
+++ b/src/ui/common/src/utils/sidesheets.tsx
@@ -34,7 +34,7 @@ export function getDataSideSheetContent(
       <Box
         px={'16px'}
         maxWidth="800px"
-        maxHeight="calc(100vh - 128px)"
+        height="100vh"
         sx={{ overflowY: 'scroll' }}
       >
         {children}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where the details sidesheets were too wide for their containers causing there to be some weird scroll for just a few pixels.

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1815/fix-bug-where-details-pages-are-too-wide-for-viewport

## Loom demo (if any)
https://www.loom.com/share/071eb6672918455c8ca48c31bb76dade

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


