### PR TITLE
Show which engine the workflow is running on on the UI's workflow page

### DIFF
--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -130,7 +130,7 @@ class ListWorkflowResponseEntry(BaseModel):
             "created_at": human_readable_timestamp(self.created_at),
             "last_run_at": human_readable_timestamp(self.last_run_at),
             "last_run_status": str(self.status),
-            "engine": self.engine
+            "engine": self.engine,
         }
 
 

--- a/sdk/aqueduct/responses.py
+++ b/sdk/aqueduct/responses.py
@@ -120,6 +120,7 @@ class ListWorkflowResponseEntry(BaseModel):
     created_at: int
     last_run_at: int
     status: ExecutionStatus
+    engine: str
 
     def to_readable_dict(self) -> Dict[str, str]:
         return {
@@ -129,6 +130,7 @@ class ListWorkflowResponseEntry(BaseModel):
             "created_at": human_readable_timestamp(self.created_at),
             "last_run_at": human_readable_timestamp(self.last_run_at),
             "last_run_status": str(self.status),
+            "engine": self.engine
         }
 
 

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -42,6 +42,7 @@ type workflowResponse struct {
 	CreatedAt       int64                  `json:"created_at"`
 	LastRunAt       int64                  `json:"last_run_at"`
 	Status          shared.ExecutionStatus `json:"status"`
+	Engine          string                 `json:"engine"`
 	WatcherAuth0Ids []string               `json:"watcher_auth0_id"`
 }
 
@@ -125,9 +126,9 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 				Name:            dbWorkflow.Name,
 				Description:     dbWorkflow.Description,
 				CreatedAt:       dbWorkflow.CreatedAt.Unix(),
+				Engine:          dbWorkflow.Engine,
 				WatcherAuth0Ids: watchersMap[dbWorkflow.Id],
 			}
-
 			if !dbWorkflow.LastRunAt.IsNull {
 				response.LastRunAt = dbWorkflow.LastRunAt.Time.Unix()
 			}
@@ -139,11 +140,9 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 				// that the workflow has been registered
 				response.Status = shared.RegisteredExecutionStatus
 			}
-
 			workflows = append(workflows, response)
 		}
 	}
-
 	return workflows, http.StatusOK, nil
 }
 

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -129,6 +129,7 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 				Engine:          dbWorkflow.Engine,
 				WatcherAuth0Ids: watchersMap[dbWorkflow.Id],
 			}
+
 			if !dbWorkflow.LastRunAt.IsNull {
 				response.LastRunAt = dbWorkflow.LastRunAt.Time.Unix()
 			}
@@ -140,9 +141,11 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 				// that the workflow has been registered
 				response.Status = shared.RegisteredExecutionStatus
 			}
+
 			workflows = append(workflows, response)
 		}
 	}
+
 	return workflows, http.StatusOK, nil
 }
 

--- a/src/golang/lib/collections/tests/workflow_test.go
+++ b/src/golang/lib/collections/tests/workflow_test.go
@@ -243,7 +243,7 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 				ExecutionStatus: testWorkflow1Result.Status,
 				IsNull:          false,
 			},
-			Engine: string(testWorkflow1DAGs[0].EngineConfig.Type),
+			Engine: string(testWorkflow1DAG.EngineConfig.Type),
 		},
 		{
 			Id:          testWorkflow2.Id,
@@ -256,7 +256,7 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 			Status: shared.NullExecutionStatus{
 				IsNull: true,
 			},
-			Engine: string(testWorkflow2DAGs[0].EngineConfig.Type),
+			Engine: string(testWorkflow2DAG.EngineConfig.Type),
 		},
 	}
 

--- a/src/golang/lib/collections/tests/workflow_test.go
+++ b/src/golang/lib/collections/tests/workflow_test.go
@@ -218,7 +218,8 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 	testWorkflow1DAG := testWorkflow1DAGs[0]
 
 	// Create DAG for workflow 2
-	seedWorkflowDagWithWorkflows(t, 1, []uuid.UUID{testWorkflow2.Id})
+	testWorkflow2DAGs := seedWorkflowDagWithWorkflows(t, 1, []uuid.UUID{testWorkflow2.Id})
+	testWorkflow2DAG := testWorkflow2DAGs[0]
 
 	// Create DAG result for workflow 1 only
 	testWorkflow1Results := seedWorkflowDagResultWithDags(t, 1, []uuid.UUID{testWorkflow1DAG.Id})
@@ -242,7 +243,7 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 				ExecutionStatus: testWorkflow1Result.Status,
 				IsNull:          false,
 			},
-			Engine: testWorkflow1.Engine,
+			Engine: string(testWorkflow1DAGs[0].EngineConfig.Type),
 		},
 		{
 			Id:          testWorkflow2.Id,
@@ -255,7 +256,7 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 			Status: shared.NullExecutionStatus{
 				IsNull: true,
 			},
-			Engine: testWorkflow2.Engine,
+			Engine: string(testWorkflow2DAGs[0].EngineConfig.Type),
 		},
 	}
 

--- a/src/golang/lib/collections/tests/workflow_test.go
+++ b/src/golang/lib/collections/tests/workflow_test.go
@@ -242,6 +242,7 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 				ExecutionStatus: testWorkflow1Result.Status,
 				IsNull:          false,
 			},
+			Engine: testWorkflow1.Engine,
 		},
 		{
 			Id:          testWorkflow2.Id,
@@ -254,6 +255,7 @@ func TestGetWorkflowsWithLatestRunResult(t *testing.T) {
 			Status: shared.NullExecutionStatus{
 				IsNull: true,
 			},
+			Engine: testWorkflow2.Engine,
 		},
 	}
 

--- a/src/golang/lib/collections/workflow/postgres.go
+++ b/src/golang/lib/collections/workflow/postgres.go
@@ -43,7 +43,7 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 			(wf.id) wf.id AS id, wf.name AS name, 
 		 	wf.description AS description, wf.created_at AS created_at, 
 		 	wfdr.created_at AS last_run_at, wfdr.status as status, 
-			 son_extract_path_text(wfd.engine_config, 'type') as engine
+			json_extract_path_text(wfd.engine_config, 'type') as engine
 		FROM 
 			workflow AS wf 
 			INNER JOIN app_user ON wf.user_id = app_user.id

--- a/src/golang/lib/collections/workflow/postgres.go
+++ b/src/golang/lib/collections/workflow/postgres.go
@@ -42,7 +42,8 @@ func (r *postgresReaderImpl) GetWorkflowsWithLatestRunResult(
 		SELECT DISTINCT ON 
 			(wf.id) wf.id AS id, wf.name AS name, 
 		 	wf.description AS description, wf.created_at AS created_at, 
-		 	wfdr.created_at AS last_run_at, wfdr.status as status 
+		 	wfdr.created_at AS last_run_at, wfdr.status as status, 
+			 son_extract_path_text(wfd.engine_config, 'type') as engine
 		FROM 
 			workflow AS wf 
 			INNER JOIN app_user ON wf.user_id = app_user.id

--- a/src/golang/lib/collections/workflow/sqlite.go
+++ b/src/golang/lib/collections/workflow/sqlite.go
@@ -69,7 +69,7 @@ func (r *sqliteReaderImpl) GetWorkflowsWithLatestRunResult(
 		(
 			SELECT wf.id AS id, wf.name AS name,
 		 		wf.description AS description, wf.created_at AS created_at,
-		 		wfdr.created_at AS run_at, wfdr.status as status
+		 		wfdr.created_at AS run_at, wfdr.status as status, json_extract(wfd.engine_config, '$.type') as engine
 			FROM workflow AS wf
 				INNER JOIN app_user ON wf.user_id = app_user.id
 				INNER JOIN workflow_dag AS wfd ON wf.id = wfd.workflow_id
@@ -82,7 +82,7 @@ func (r *sqliteReaderImpl) GetWorkflowsWithLatestRunResult(
 	  		FROM workflow_results
 	  		GROUP BY id
 		)
-		SELECT wfr.id, wfr.name, wfr.description, wfr.created_at, wfr.run_at AS last_run_at, wfr.status
+		SELECT wfr.id, wfr.name, wfr.description, wfr.created_at, wfr.run_at AS last_run_at, wfr.status, wfr.engine
 		FROM workflow_results AS wfr, latest_result AS lr
 		WHERE wfr.id = lr.id
 		AND 

--- a/src/golang/lib/collections/workflow/workflow.go
+++ b/src/golang/lib/collections/workflow/workflow.go
@@ -27,6 +27,7 @@ type LatestWorkflowResponse struct {
 	CreatedAt   time.Time                  `db:"created_at" json:"created_at"`
 	LastRunAt   utils.NullTime             `db:"last_run_at" json:"last_run_at"`
 	Status      shared.NullExecutionStatus `db:"status" json:"status"`
+	Engine      string                     `db:"engine" json:"engine"`
 }
 
 // Use to associate a workflow.name, workflow.id with workflow_dag_result.id (ENG-625)

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -25,7 +25,7 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
 
   const lastRunComponent = workflow['last_run_at'] ? (
     <Box sx={{ fontSize: 1, my: 1 }}>
-          <Typography variant="subtitle1">
+      <Typography variant="subtitle1">
         <strong>Workflow Engine:</strong> {workflow.engine}
       </Typography>
       <Typography variant="subtitle1">

--- a/src/ui/common/src/components/workflows/workflowCard.tsx
+++ b/src/ui/common/src/components/workflows/workflowCard.tsx
@@ -25,6 +25,9 @@ const WorkflowCard: React.FC<Props> = ({ workflow }) => {
 
   const lastRunComponent = workflow['last_run_at'] ? (
     <Box sx={{ fontSize: 1, my: 1 }}>
+          <Typography variant="subtitle1">
+        <strong>Workflow Engine:</strong> {workflow.engine}
+      </Typography>
       <Typography variant="subtitle1">
         <strong>Workflow Last Run:</strong> {lastUpdatedTime.toLocaleString()}
       </Typography>

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -92,8 +92,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
     nextUpdateComponent = (
       <Box sx={{ mt: 1 }}>
         <Typography variant="body2">
-          <strong> Workflow Engine: </strong>{' '}
-          {workflowDag.engine_config.type}
+          <strong> Workflow Engine: </strong>{workflowDag.engine_config.type}
         </Typography>
         <Typography variant="body2">
           <strong> Next Workflow Run: </strong>{' '}

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -92,6 +92,10 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
     nextUpdateComponent = (
       <Box sx={{ mt: 1 }}>
         <Typography variant="body2">
+          <strong> Workflow Engine: </strong>{' '}
+          {workflowDag.engine_config.type}
+        </Typography>
+        <Typography variant="body2">
           <strong> Next Workflow Run: </strong>{' '}
           {nextUpdateTime.toDate().toLocaleString()}
         </Typography>

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -92,7 +92,8 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
     nextUpdateComponent = (
       <Box sx={{ mt: 1 }}>
         <Typography variant="body2">
-          <strong> Workflow Engine: </strong>{workflowDag.engine_config.type}
+          <strong> Workflow Engine: </strong>
+          {workflowDag.engine_config.type}
         </Typography>
         <Typography variant="body2">
           <strong> Next Workflow Run: </strong>{' '}

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -32,6 +32,7 @@ export type ListWorkflowSummary = {
   created_at: number;
   last_run_at: number;
   status: ExecutionStatus;
+  engine: string;
   watcher_auth0_id: string[];
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds display to what engine the workflow is running on in two locations, the workflow browsing page and the workflow detail page. 
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1812/show-which-engine-the-workflow-is-running-on-on-the-uis-workflow-page
## Loom demo (if any)
![Screen Shot 2022-10-12 at 1 14 41 PM](https://user-images.githubusercontent.com/78303449/195439060-5edbd09f-3655-4153-b441-067ceb367a06.png)
![Screen Shot 2022-10-12 at 1 14 31 PM](https://user-images.githubusercontent.com/78303449/195439185-9604ff5c-947c-49a5-88f8-58ce9ef4a39f.png)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


