### PR TITLE
Fix navbar icon color and main page spacing

### DIFF
--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -153,10 +153,7 @@ const NavBar: React.FC<{
               </Box>
             )}
 
-            <FontAwesomeIcon
-              className={styles['menu-sidebar-icon']}
-              icon={faBell}
-            />
+            <FontAwesomeIcon className={styles['navbar-icon']} icon={faBell} />
           </Box>
 
           <NotificationsPopover
@@ -170,7 +167,7 @@ const NavBar: React.FC<{
 
         <Box sx={{ cursor: 'pointer', marginLeft: '8px' }}>
           <FontAwesomeIcon
-            className={styles['menu-sidebar-icon']}
+            className={styles['navbar-icon']}
             icon={faGear}
             onClick={handleUserPopoverClick}
           />
@@ -188,7 +185,7 @@ const NavBar: React.FC<{
             <Link
               to={`${pathPrefix}/account`}
               underline="none"
-              sx={{ color: 'blue.800' }}
+              sx={{ color: 'blue.900' }}
               component={RouterLink as any}
             >
               <MenuItem sx={{ width: '190px' }} disableRipple>

--- a/src/ui/common/src/components/layouts/menu-sidebar-styles.module.css
+++ b/src/ui/common/src/components/layouts/menu-sidebar-styles.module.css
@@ -51,7 +51,7 @@
   /* ensures height is 64px, which maps navbar */
   padding-top: 8px;
   padding-bottom: 6px;
-  border-bottom: 2px solid #E6E8F0;
+  border-bottom: 2px solid #E6E8F0; /* gray.300 */
 }
 
 .menu-sidebar-icon {
@@ -60,6 +60,7 @@
   min-height: 24px;
   max-width: 24px;
   max-height: 24px;
+  color: #002f5e; /* blue900 */
 }
 
 .user-avatar img {

--- a/src/ui/common/src/components/layouts/menu-sidebar-styles.module.css
+++ b/src/ui/common/src/components/layouts/menu-sidebar-styles.module.css
@@ -60,6 +60,14 @@
   min-height: 24px;
   max-width: 24px;
   max-height: 24px;
+}
+
+.navbar-icon {
+  /* All icons in sidebar button are fixed to 24. */
+  min-width: 24px;
+  min-height: 24px;
+  max-width: 24px;
+  max-height: 24px;
   color: #002f5e; /* blue900 */
 }
 

--- a/src/ui/common/src/components/pages/HomePage.tsx
+++ b/src/ui/common/src/components/pages/HomePage.tsx
@@ -1,9 +1,10 @@
+import Box from '@mui/material/Box';
 import React, { useEffect } from 'react';
 
 import { BreadcrumbLink } from '../../components/layouts/NavBar';
 import UserProfile from '../../utils/auth';
 import GettingStartedTutorial from '../cards/GettingStartedTutorial';
-import DefaultLayout from '../layouts/default';
+import DefaultLayout, { DefaultLayoutMargin } from '../layouts/default';
 import { LayoutProps } from './types';
 
 type HomePageProps = {
@@ -22,8 +23,9 @@ const HomePage: React.FC<HomePageProps> = ({
 
   return (
     <Layout breadcrumbs={[BreadcrumbLink.HOME]} user={user}>
-      <div />
-      <GettingStartedTutorial user={user} />
+      <Box paddingBottom={DefaultLayoutMargin}>
+        <GettingStartedTutorial user={user} />
+      </Box>
     </Layout>
   );
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes two minor issues:
* adjusted color for black navbar icon
* added a spacing in homepage bottom.
* 
## Related issue number (if any)
ENG-1829
ENG-1826
## Loom demo (if any)
Current PR uses blue icon color, the same as menu:
<img width="1143" alt="Screen Shot 2022-10-12 at 2 46 10 PM" src="https://user-images.githubusercontent.com/10411887/195454249-135c4581-58ff-4ec4-ab76-858ad582d752.png">


Gray version (this also shows the margin at the bottom of the page):
<img width="1649" alt="Screen Shot 2022-10-12 at 2 21 35 PM" src="https://user-images.githubusercontent.com/10411887/195451117-b7616852-7800-463a-a262-c4978b8a22cc.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


