### PR TITLE
eng-1828 add spacing above the failed-to-load error

### DIFF
--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -40,7 +40,7 @@ export const DefaultLayout: React.FC<Props> = ({
         <Box
           sx={{
             boxSizing: 'border-box',
-            width: '100%',
+            width: `calc(100% - ${MenuSidebarOffset} - 50px)`,
             marginTop: breadcrumbsSize,
             marginLeft: MenuSidebarWidth,
             marginRight: 0,

--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -40,7 +40,7 @@ export const DefaultLayout: React.FC<Props> = ({
         <Box
           sx={{
             boxSizing: 'border-box',
-            width: `calc(100% - ${MenuSidebarOffset} - 50px)`,
+            width: `calc(100% - ${MenuSidebarWidth} - ${DefaultLayoutMargin})`,
             marginTop: breadcrumbsSize,
             marginLeft: MenuSidebarWidth,
             marginRight: 0,

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -85,11 +85,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-      isSucceeded(workflowDagResultWithLoadingStatus.status)
+    isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-        workflowDagResultWithLoadingStatus?.result,
-        artifactId
-      )
+          workflowDagResultWithLoadingStatus?.result,
+          artifactId
+        )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -122,8 +122,9 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${artifact ? artifact.name : 'Artifact Details'
-          } | Aqueduct`;
+        document.title = `${
+          artifact ? artifact.name : 'Artifact Details'
+        } | Aqueduct`;
       }
 
       if (

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -121,8 +121,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   useEffect(() => {
     if (!!operator && !sideSheetMode) {
       // this should only be set when the user is viewing this as a full page, not side sheet.
-      document.title = `${operator ? operator.name : 'Operator Details'
-        } | Aqueduct`;
+      document.title = `${
+        operator ? operator.name : 'Operator Details'
+      } | Aqueduct`;
     }
   }, [operator]);
 
@@ -154,7 +155,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -197,7 +197,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -438,7 +438,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
                 </Box>
               </Box>
             </Box>
-            <Box sx={{ marginTop: `${drawerHeaderHeightInPx}px` }}>
+            <Box sx={{ marginTop: `${drawerHeaderHeightInPx + 16}px` }}>
               {getDataSideSheetContent(
                 user,
                 currentNode,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fix spacing.
- Add spacing to the top of the sidesheet
- Fix width so error does not go off screen.

## Related issue number (if any)
eng-1828

## Loom demo (if any)
**Before: Little/no space at top of sidesheet**
<img width="1211" alt="Screen Shot 2022-10-13 at 8 35 54 AM" src="https://user-images.githubusercontent.com/30596854/195641884-21fed42e-21ee-4652-83dc-787f12735a7c.png">
<img width="1218" alt="Screen Shot 2022-10-13 at 8 35 41 AM" src="https://user-images.githubusercontent.com/30596854/195641619-026ce038-4e61-43ff-8f73-f00398be906a.png">

**After: More space at top of sidesheet**
<img width="1217" alt="Screen Shot 2022-10-13 at 8 31 45 AM" src="https://user-images.githubusercontent.com/30596854/195640835-ca179d48-c308-4b69-a563-488bfacd6837.png">
<img width="1212" alt="Screen Shot 2022-10-13 at 8 32 22 AM" src="https://user-images.githubusercontent.com/30596854/195640838-ce79a473-ffd2-46b1-b95e-0a977b2b9ca7.png">

**Before: Error goes off screen**
<img width="1215" alt="Screen Shot 2022-10-13 at 8 36 19 AM" src="https://user-images.githubusercontent.com/30596854/195641586-6513405c-30e2-450c-82f6-e7b2719b610f.png">

**After: Error ends on-screen**
<img width="1217" alt="Screen Shot 2022-10-13 at 8 31 54 AM" src="https://user-images.githubusercontent.com/30596854/195640781-d927164c-07b7-46b6-b9a0-00a2a34e1b1b.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


