### PR TITLE
[ENG-1833, 1834] Fix error surfacing in UI redesign

### DIFF
--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -7,18 +7,15 @@ import { Tab, Tabs } from '../primitives/Tabs.styles';
 type Props = {
   logs?: Logs;
   err?: Error;
-  contentHeight?: string;
 };
-const LogViewer: React.FC<Props> = ({ logs, err, contentHeight = '2vh' }) => {
+const LogViewer: React.FC<Props> = ({ logs, err }) => {
   const hasOutput = (obj) => {
     return obj !== undefined && obj.length > 0;
   };
 
   const [selectedTab, setSelectedTab] = useState(0);
   const emptyElement = (
-    <Box sx={{ p: 2, backgroundColor: 'gray.100' }}>
-      Nothing to see here!
-    </Box>
+    <Box sx={{ p: 2, backgroundColor: 'gray.100' }}>Nothing to see here!</Box>
   );
 
   return (
@@ -36,45 +33,45 @@ const LogViewer: React.FC<Props> = ({ logs, err, contentHeight = '2vh' }) => {
         <Tab label="stderr" key="strderr" />
       </Tabs>
 
-      <Box
-        key={0}
-        role="tabpanel"
-        hidden={selectedTab !== 0}
-      >
-        {err !== undefined && hasOutput(err?.tip) ?
-          <Box sx={{ backgroundColor: 'red.100', color: 'red.600', p: 2, height: 'fit-content' }}>
-            <pre style={{ margin: '0px' }}>
-              {`${err.tip}\n${err.context}`}
-            </pre>
-          </Box> :
+      <Box key={0} role="tabpanel" hidden={selectedTab !== 0}>
+        {err !== undefined && hasOutput(err?.tip) ? (
+          <Box
+            sx={{
+              backgroundColor: 'red.100',
+              color: 'red.600',
+              p: 2,
+              height: 'fit-content',
+            }}
+          >
+            <pre style={{ margin: '0px' }}>{`${err.tip}\n${err.context}`}</pre>
+          </Box>
+        ) : (
           emptyElement
-        }
+        )}
       </Box>
 
-      <Box
-        key={1}
-        role="tabpanel"
-        hidden={selectedTab !== 1}
-      >
-        {hasOutput(logs?.stdout) ? 
-          <Box sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content'}}>
-            logs.stdout
-          </Box> : 
+      <Box key={1} role="tabpanel" hidden={selectedTab !== 1}>
+        {hasOutput(logs?.stdout) ? (
+          <Box
+            sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
+          >
+            <pre style={{ margin: '0px' }}>logs.stdout</pre>
+          </Box>
+        ) : (
           emptyElement
-        }
+        )}
       </Box>
 
-      <Box
-        key={2}
-        role="tabpanel"
-        hidden={selectedTab !== 2}
-      >
-        {hasOutput(logs?.stderr) ? 
-          <Box sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content'}}>
-            logs.stderr
-          </Box> : 
+      <Box key={2} role="tabpanel" hidden={selectedTab !== 2}>
+        {hasOutput(logs?.stderr) ? (
+          <Box
+            sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
+          >
+            <pre style={{ margin: '0px' }}>logs.stderr</pre>
+          </Box>
+        ) : (
           emptyElement
-        }
+        )}
       </Box>
     </Box>
   );

--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -9,23 +9,17 @@ type Props = {
   err?: Error;
   contentHeight?: string;
 };
-const LogViewer: React.FC<Props> = ({ logs, err, contentHeight = '10vh' }) => {
+const LogViewer: React.FC<Props> = ({ logs, err, contentHeight = '2vh' }) => {
   const hasOutput = (obj) => {
     return obj !== undefined && obj.length > 0;
   };
 
   const [selectedTab, setSelectedTab] = useState(0);
-  const tabPanelOptions = {
-    height: contentHeight,
-    overflow: 'auto',
-    fontFamily: 'monospace, monospace',
-  };
-  const errorTabPanelOptions = { ...tabPanelOptions, color: 'red.500' };
-  const empty = { color: 'gray.200' };
-
-  const noStdOut = 'No output logs to display.';
-  const noStdErr = 'No error logs to display.';
-  const noErr = 'No errors to display.';
+  const emptyElement = (
+    <Box sx={{ p: 2, backgroundColor: 'gray.100' }}>
+      Nothing to see here!
+    </Box>
+  );
 
   return (
     <Box sx={{ mb: 4 }} pb={1}>
@@ -45,28 +39,42 @@ const LogViewer: React.FC<Props> = ({ logs, err, contentHeight = '10vh' }) => {
       <Box
         key={0}
         role="tabpanel"
-        sx={errorTabPanelOptions}
         hidden={selectedTab !== 0}
       >
-        {err !== undefined && hasOutput(err?.tip)
-          ? `${err.tip}:\n${err.context}`
-          : noErr}
+        {err !== undefined && hasOutput(err?.tip) ?
+          <Box sx={{ backgroundColor: 'red.100', color: 'red.600', p: 2, height: 'fit-content' }}>
+            <pre style={{ margin: '0px' }}>
+              {`${err.tip}\n${err.context}`}
+            </pre>
+          </Box> :
+          emptyElement
+        }
       </Box>
+
       <Box
         key={1}
         role="tabpanel"
-        sx={tabPanelOptions}
         hidden={selectedTab !== 1}
       >
-        {hasOutput(logs?.stdout) ? logs.stdout : noStdOut}
+        {hasOutput(logs?.stdout) ? 
+          <Box sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content'}}>
+            logs.stdout
+          </Box> : 
+          emptyElement
+        }
       </Box>
+
       <Box
         key={2}
         role="tabpanel"
-        sx={errorTabPanelOptions}
         hidden={selectedTab !== 2}
       >
-        {hasOutput(logs?.stderr) ? logs.stderr : noStdErr}
+        {hasOutput(logs?.stderr) ? 
+          <Box sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content'}}>
+            logs.stderr
+          </Box> : 
+          emptyElement
+        }
       </Box>
     </Box>
   );

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -85,11 +85,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-      isSucceeded(workflowDagResultWithLoadingStatus.status)
+    isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-        workflowDagResultWithLoadingStatus?.result,
-        artifactId
-      )
+          workflowDagResultWithLoadingStatus?.result,
+          artifactId
+        )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -122,8 +122,9 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${artifact ? artifact.name : 'Artifact Details'
-          } | Aqueduct`;
+        document.title = `${
+          artifact ? artifact.name : 'Artifact Details'
+        } | Aqueduct`;
       }
 
       if (

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -121,8 +121,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   useEffect(() => {
     if (!!operator && !sideSheetMode) {
       // this should only be set when the user is viewing this as a full page, not side sheet.
-      document.title = `${operator ? operator.name : 'Operator Details'
-        } | Aqueduct`;
+      document.title = `${
+        operator ? operator.name : 'Operator Details'
+      } | Aqueduct`;
     }
   }, [operator]);
 
@@ -154,7 +155,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -86,7 +86,9 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   ];
 
   useEffect(() => {
-    document.title = 'Operator Details | Aqueduct';
+    if (!sideSheetMode) {
+      document.title = 'Operator Details | Aqueduct';
+    }
 
     if (
       // Load workflow dag result if it's not cached
@@ -188,6 +190,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     workflowDagResultWithLoadingStatus.status.loading ===
     LoadingStatusEnum.Failed
   ) {
+    console.log("triggering this redirect to 404.")
     navigate('/404');
     return null;
   }

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -190,7 +190,6 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     workflowDagResultWithLoadingStatus.status.loading ===
     LoadingStatusEnum.Failed
   ) {
-    console.log("triggering this redirect to 404.")
     navigate('/404');
     return null;
   }
@@ -200,7 +199,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -178,7 +178,6 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
                 padding: 2,
                 textOverflow: 'wrap',
                 flex: 1,
-                // width: '100%',
               }}
             >
               <Typography
@@ -226,7 +225,6 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
                 >
                   {getTypeLabel(listItem.type)}
                 </Typography>
-
               </Box>
             </Box>
           </Box>

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -137,7 +137,9 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
   return (
     <Box
       sx={{
-        width: `${StatusBarWidthInPx}px`,
+        minWidth: `${StatusBarWidthInPx}px`,
+        width: 'fit-content',
+        maxWidth: '600px',
         maxHeight: `${MaxStatusBarListHeightInPx}px`,
         position: 'absolute',
         overflow: 'auto',
@@ -146,6 +148,7 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
         zIndex: 10,
         border: `1px solid`,
         borderColor: 'gray.500',
+        p: '4px',
       }}
     >
       {listItems.map((listItem, index) => {
@@ -166,12 +169,16 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
             <Box sx={{ marginLeft: '8px', marginTop: '16px' }}>
               {listItem ? workflowStatusIcons[listItem.level] : null}
             </Box>
+
             <Box
               sx={{
                 display: 'flex',
                 flexDirection: 'column',
-                verticalAlign: 'middle',
+                alignItems: 'start',
                 padding: 2,
+                textOverflow: 'wrap',
+                flex: 1,
+                // width: '100%',
               }}
             >
               <Typography
@@ -192,14 +199,16 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
               >
                 {listItem.title}
               </Typography>
+
               <Typography
                 sx={{
                   fontFamily: 'Monospace',
                   fontWeight: 'light',
                   marginTop: '2px',
                   fontSize: '12px',
-                  whiteSpace: 'pre-wrap',
+                  textOverflow: 'wrap',
                 }}
+                component="pre"
               >
                 {listItem.message}
               </Typography>
@@ -217,6 +226,7 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
                 >
                   {getTypeLabel(listItem.type)}
                 </Typography>
+
               </Box>
             </Box>
           </Box>
@@ -519,7 +529,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         if (!!opExecState.error) {
           newWorkflowStatusItem.title = (
             <>
-              Error executing <b>${operatorName}</b> ({operatorId})
+              Error executing <b>{operatorName}</b> ({operatorId})
             </>
           );
           const err = opExecState.error;
@@ -546,7 +556,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
       // add workflow status item to the list.
       normalizedWorkflowStatusItems.push(newWorkflowStatusItem);
 
-      // LEFT off here, see the normalize logs function and work from there :)
       if (opExecState && opExecState.user_logs) {
         const logs = opExecState?.user_logs;
         const stdoutLines = (logs.stdout ?? '').split('\n');

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -61,7 +61,8 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   const getContainerSize = () => {
     const container = document.getElementById(WorkflowPageContentId);
 
-    if(!container) { // The page hasn't fully rendered yet.
+    if (!container) {
+      // The page hasn't fully rendered yet.
       setContainerWidth(1000); // Just a default value.
     } else {
       setContainerWidth(container.clientWidth);

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -60,7 +60,12 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
 
   const getContainerSize = () => {
     const container = document.getElementById(WorkflowPageContentId);
-    setContainerWidth(container.clientWidth);
+
+    if(!container) { // The page hasn't fully rendered yet.
+      setContainerWidth(1000); // Just a default value.
+    } else {
+      setContainerWidth(container.clientWidth);
+    }
   };
 
   useEffect(getContainerSize, [currentNode]);

--- a/src/ui/common/src/handlers/getWorkflowDagResult.ts
+++ b/src/ui/common/src/handlers/getWorkflowDagResult.ts
@@ -36,7 +36,6 @@ export const handleGetWorkflowDagResult = createAsyncThunk<
     const body = await resp.json();
 
     if (!resp.ok) {
-      console.log('error body is', body);
       return thunkAPI.rejectWithValue(body.error);
     }
 

--- a/src/ui/common/src/handlers/getWorkflowDagResult.ts
+++ b/src/ui/common/src/handlers/getWorkflowDagResult.ts
@@ -36,6 +36,7 @@ export const handleGetWorkflowDagResult = createAsyncThunk<
     const body = await resp.json();
 
     if (!resp.ok) {
+      console.log('error body is', body);
       return thunkAPI.rejectWithValue(body.error);
     }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR fixes a bunch of small bugs in the way errors are surfaced in the UI redesign. 

For ENG-1833, this PR increases the maximum width of viewport of the status bar -- it doesn't just do `fit-content` because that makes it weirdly wide, but now a typical stack trace much easier to lead.

For ENG-1834, this PR shows the full stack trace under the log viewer component; if the user is at this point, they probably want to see the full set of details, so we don't condense the height at all -- instead, we set the height to `fit-content` of the stack trace. 

## Related issue number (if any)

ENG-1833, ENG-1834

## Loom demo (if any)

The expanded width of the workflow status bar when there's a stack trace. Note that there's still a minor bit of scroll -- I picked this width because it's still legible with the drawer open on a 13" MBP screen.
<img width="643" alt="image" src="https://user-images.githubusercontent.com/867892/195686999-1429fce0-4c98-4961-9f42-fd6a1ec35371.png">

When there's no information, the min width is still set to the previous viewport width:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/867892/195687326-c8f66ca0-78d7-4157-8251-720d5851c45e.png">

The reformatted error component on the log viewer: 
<img width="766" alt="image" src="https://user-images.githubusercontent.com/867892/195687730-29243601-c66d-41be-8e9b-fb5bb771e402.png">

The minorly reformatted component when there are no logs:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/867892/195687818-f19f5ddc-35a3-4a44-a1a3-0163795c67ef.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


