### PR TITLE
ENG-1827: Fix for SQL queries not showing on extract operators. Fix for app crashing when loading extract operator from link

### DIFF
--- a/src/ui/common/src/components/CodeBlock/index.tsx
+++ b/src/ui/common/src/components/CodeBlock/index.tsx
@@ -8,7 +8,6 @@ type Props = {
 };
 
 export const CodeBlock: React.FC<Props> = ({ language, children }) => {
-  console.log('codeblock children: ', children);
   return (
     <SyntaxHighlighter
       language={language}

--- a/src/ui/common/src/components/CodeBlock/index.tsx
+++ b/src/ui/common/src/components/CodeBlock/index.tsx
@@ -8,6 +8,7 @@ type Props = {
 };
 
 export const CodeBlock: React.FC<Props> = ({ language, children }) => {
+  console.log('codeblock children: ', children);
   return (
     <SyntaxHighlighter
       language={language}

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -17,10 +17,10 @@ import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { exportFunction } from '../../../../utils/operators';
 import { LoadingStatusEnum } from '../../../../utils/shared';
 import { isInitial, isLoading } from '../../../../utils/shared';
+import { CodeBlock } from '../../../CodeBlock';
 import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
-import { CodeBlock } from '../../../CodeBlock';
 
 type OperatorDetailsPageProps = {
   user: UserProfile;
@@ -85,7 +85,10 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(workflowLink, workflow?.selectedDag?.metadata?.name || ''),
+    new BreadcrumbLink(
+      workflowLink,
+      workflow?.selectedDag?.metadata?.name || ''
+    ),
     new BreadcrumbLink(path, operator?.name || 'Operator'),
   ];
 
@@ -173,9 +176,12 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       }
     }
 
-
     // TODO: only call this when we are inside a function operator. not an extract or load operator.
-    if (operator && operator?.spec?.type !== "extract" && operator?.spec?.type !== "load") {
+    if (
+      operator &&
+      operator?.spec?.type !== 'extract' &&
+      operator?.spec?.type !== 'load'
+    ) {
       getFilesBlob();
     } else if (operator) {
       if (operator?.spec?.type === 'extract') {
@@ -211,7 +217,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -225,12 +231,9 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
           <Typography variant="h6" fontWeight="normal" mb={1}>
             Code Preview
           </Typography>
-          <MultiFileViewer
-            files={files}
-            defaultFile={operator.name || ''}
-          />
+          <MultiFileViewer files={files} defaultFile={operator.name || ''} />
         </Box>
-      )
+      );
     }
 
     return (
@@ -240,9 +243,8 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
         </Typography>
         <CodeBlock language="sql">{fileContent}</CodeBlock>
       </Box>
-    )
-  }
-
+    );
+  };
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
@@ -289,7 +291,6 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
 
           <Divider sx={{ my: '32px' }} />
           {operatorPreview()}
-
         </Box>
       </Box>
     </Layout>

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -176,10 +176,8 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
 
     // TODO: only call this when we are inside a function operator. not an extract or load operator.
     if (operator && operator?.spec?.type !== "extract" && operator?.spec?.type !== "load") {
-      console.log('getting files blob');
       getFilesBlob();
     } else if (operator) {
-      console.log('getting sql statement from operator');
       if (operator?.spec?.type === 'extract') {
         setFileContent(operator.spec.extract.parameters.query);
         setIsExtractOperator(true);

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -71,6 +71,7 @@ export type RelationalDBExtractParams = {
 };
 
 export type GoogleSheetsExtractParams = {
+  query?: string;
   spreadsheet_id: string;
   github_metadata?: GithubMetadata;
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes two things: 
-Fixes crash which happened when loading operator details page from it's link
-Fixes issue where extract operators did not show SQL query in file viewer. These queries are now rendered using the code block component since there are no files associated with the extract operator.

## Related issue number (if any)
ENG-1827

## Loom demo (if any)
https://www.loom.com/share/29ce87e2d2b94a439f62c728cb0b6218

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


