### PR TITLE
Fixes vault encryption bug

### DIFF
--- a/src/golang/lib/vault/crypto.go
+++ b/src/golang/lib/vault/crypto.go
@@ -29,15 +29,12 @@ func encrypt(secrets map[string]string, key string) ([]byte, error) {
 		return nil, err
 	}
 
-	// allocate a byte array for encrypted value
-	dst := make([]byte, len(nonce))
-
 	serialized, err := json.Marshal(secrets)
 	if err != nil {
 		return nil, err
 	}
 
-	encrypted := gcm.Seal(dst, nonce, serialized, nil /* additionalData */)
+	encrypted := gcm.Seal(nonce, nonce, serialized, nil /* additionalData */)
 	return encrypted, nil
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a vault encryption bug where the arguments to `gcm.Seal` were modified.

I confirmed this works by connecting a Snowflake integration and issuing a preview request, which goes thru the vault to access the credentials.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


