### PR TITLE
[7/7] Syncs vault with storage at server start

### DIFF
--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -193,8 +193,7 @@ func (s *AqServer) Init() error {
 		readers.IntegrationReader,
 		db,
 	); err != nil {
-		db.Close()
-		log.Fatalf("Unable to sync vault with storage: %v", err)
+		return err
 	}
 
 	eng, err := engine.NewAqEngine(

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -188,6 +188,15 @@ func (s *AqServer) Init() error {
 		return err
 	}
 
+	if err := syncVaultWithStorage(
+		vault,
+		readers.IntegrationReader,
+		db,
+	); err != nil {
+		db.Close()
+		log.Fatalf("Unable to sync vault with storage: %v", err)
+	}
+
 	eng, err := engine.NewAqEngine(
 		db,
 		githubManager,

--- a/src/golang/cmd/server/server/vault.go
+++ b/src/golang/cmd/server/server/vault.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path"
+
+	"github.com/aqueducthq/aqueduct/config"
+	"github.com/aqueducthq/aqueduct/lib/collections/integration"
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/vault"
+	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
+)
+
+// syncVaultWithStorage checks if this server's vault is out of sync
+// with its storage; if so, it will migrate the vault's contents into
+// storage. This operation will only need to happen once.
+func syncVaultWithStorage(
+	vaultObj vault.Vault,
+	integrationReader integration.Reader,
+	db database.Database,
+) error {
+	oldVaultPath := path.Join(config.AqueductPath(), "vault")
+	if _, err := os.Stat(oldVaultPath); err != nil {
+		if os.IsNotExist(err) {
+			// The old vault path does not exist, so the vault has already been synced
+			// with storage.
+			return nil
+		}
+		return err
+	}
+
+	oldVault, err := vault.NewVault(
+		&shared.StorageConfig{
+			Type: shared.FileStorageType,
+			FileConfig: &shared.FileConfig{
+				Directory: config.AqueductPath(),
+			},
+		},
+		config.EncryptionKey(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := utils.MigrateVault(
+		context.Background(),
+		oldVault,
+		vaultObj,
+		accountOrganizationId,
+		integrationReader,
+		db,
+	); err != nil {
+		return err
+	}
+
+	// Vault syncing was successful so we can delete `oldVaultPath`, so this operation
+	// is not repeated.
+	return os.RemoveAll(oldVaultPath)
+}

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 )
 
 const (
 	filePermissionCode = 0o664
+	dirPermissionCode  = 0o777
 )
 
 type fileStorage struct {
@@ -32,7 +34,19 @@ func (f *fileStorage) Get(ctx context.Context, key string) ([]byte, error) {
 }
 
 func (f *fileStorage) Put(ctx context.Context, key string, value []byte) error {
-	return os.WriteFile(f.getFullPath(key), value, filePermissionCode)
+	filePath := f.getFullPath(key)
+	dir := path.Dir(filePath)
+
+	if _, err := os.Stat(dir); errors.Is(err, os.ErrNotExist) {
+		// Directory does not exist, so we need to create it
+		if err := os.MkdirAll(dir, dirPermissionCode); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filePath, value, filePermissionCode)
 }
 
 func (f *fileStorage) Delete(ctx context.Context, key string) error {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR syncs the vault with storage by moving the vault into the current storage layer. This operation will only happen once at server start time if it has not happened in the past.

This is necessary because currently the vault is found in the local filesystem at `aqueduct_path/vault`, whereas storage can be either in a different directory locally or it could be set to cloud storage, i.e. S3 or GCS.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


