### PR TITLE
Eng 1864 Fix UI bugs on showing nodes and render breadcrumb links

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -97,7 +97,10 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(workflowLink, workflow.selectedDag.metadata.name),
+    new BreadcrumbLink(
+      workflowLink,
+      workflowDagResultWithLoadingStatus?.result?.name ?? 'Workflow'
+    ),
     new BreadcrumbLink(path, artifact ? artifact.name : 'Artifact'),
   ];
 

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -87,7 +87,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
     BreadcrumbLink.WORKFLOWS,
     new BreadcrumbLink(
       workflowLink,
-      workflow?.selectedDag?.metadata?.name || ''
+      workflowDagResultWithLoadingStatus?.result?.name ?? 'Workflow'
     ),
     new BreadcrumbLink(path, operator?.name || 'Operator'),
   ];

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -61,6 +61,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   const navigate = useNavigate();
   const dispatch: AppDispatch = useDispatch();
   const workflowId = useParams().id;
+  const urlSearchParams = parse(window.location.search);
   const path = useLocation().pathname;
 
   const currentNode = useSelector(
@@ -81,14 +82,13 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   }, [workflow.selectedDag]);
 
   useEffect(() => {
-    const urlSearchParams = parse(window.location.search);
     if (
       workflow.selectedResult !== undefined &&
       !urlSearchParams.workflowDagResultId
     ) {
       navigate(`?workflowDagResultId=${encodeURI(workflow.selectedResult.id)}`);
     }
-  }, [workflow.selectedResult]);
+  }, [workflow.selectedResult, urlSearchParams]);
 
   useEffect(() => {
     dispatch(handleGetWorkflow({ apiKey: user.apiKey, workflowId }));
@@ -98,7 +98,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   useEffect(() => {
     if (workflow.dagResults && workflow.dagResults.length > 0) {
       let workflowDagResultIndex = 0;
-      const { workflowDagResultId } = parse(window.location.search);
+      const { workflowDagResultId } = urlSearchParams;
       for (let i = 0; i < workflow.dagResults.length; i++) {
         if (workflow.dagResults[i].id === workflowDagResultId) {
           workflowDagResultIndex = i;
@@ -109,7 +109,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         dispatch(selectResultIdx(workflowDagResultIndex));
       }
     }
-  }, [workflow.dagResults, window.location.search]);
+  }, [workflow.dagResults, urlSearchParams]);
 
   useEffect(() => {
     if (workflow.selectedDag) {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the following bugs:
* extra nodes don't get collapsed when clicking around UI. This is caused by the collapsing state depends on artfResults store, which sometimes is not available when we are trying to collapse. This PR changes the collapsing logic by not assuming artfResults exist, but we rather refill those results to collapsed nodes once they become available.
* artifact status appears to be wrong when refreshing workflow. We verified refreshing workflow does bring the state to latest.
* page crashes when trying to refresh artf / op detail pages. This is caused by these pages relying on wrong reducer. We fixed by using the new reducer.
## Related issue number (if any)
ENG-1864

## Loom demo (if any)
https://www.loom.com/share/f439a019169f4617b4dcfdb845d42e62

Verified everything works in two browsers (chrome and safari).

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


