### PR TITLE
Add tfrs.Model type support

### DIFF
--- a/sdk/aqueduct/enums.py
+++ b/sdk/aqueduct/enums.py
@@ -151,6 +151,7 @@ class ArtifactType(str, Enum, metaclass=MetaEnum):
     BYTES = "bytes"
     IMAGE = "image"  # corresponds to PIL.Image.Image type
     PICKLABLE = "picklable"
+    TF_KERAS = "tensorflow-keras-model"
 
 
 class SerializationType(str, Enum, metaclass=MetaEnum):
@@ -160,6 +161,7 @@ class SerializationType(str, Enum, metaclass=MetaEnum):
     IMAGE = "image"
     STRING = "string"
     BYTES = "bytes"
+    TF_KERAS = "tensorflow-keras-model"
 
 
 class ExecutionMode(str, Enum, metaclass=MetaEnum):

--- a/sdk/aqueduct/serialization.py
+++ b/sdk/aqueduct/serialization.py
@@ -78,6 +78,7 @@ def _read_tf_keras_model(content: bytes) -> Any:
             f.write(content)
 
         from tensorflow import keras
+
         return keras.load_model(model_file_path)
     finally:
         if temp_model_dir is not None and os.path.exists(temp_model_dir):

--- a/sdk/aqueduct/serialization.py
+++ b/sdk/aqueduct/serialization.py
@@ -78,7 +78,6 @@ def _read_tf_keras_model(content: bytes) -> Any:
             f.write(content)
 
         from tensorflow import keras
-
         return keras.load_model(model_file_path)
     finally:
         if temp_model_dir is not None and os.path.exists(temp_model_dir):

--- a/sdk/aqueduct/serialization.py
+++ b/sdk/aqueduct/serialization.py
@@ -147,7 +147,7 @@ def _write_tf_keras_model(output: Any) -> bytes:
         temp_model_dir = make_temp_dir()
         model_file_path = os.path.join(temp_model_dir, _TEMP_KERAS_MODEL_NAME)
 
-        output.save_model(model_file_path)
+        output.save(model_file_path)
         return open(model_file_path, "rb").read()
     finally:
         if temp_model_dir is not None and os.path.exists(temp_model_dir):

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -523,7 +523,6 @@ def infer_artifact_type(value: Any) -> ArtifactType:
         try:
             # Keras models cannot be pickled.
             from tensorflow import keras
-
             if isinstance(value, keras.Model):
                 return ArtifactType.TF_KERAS
         except:

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -523,6 +523,7 @@ def infer_artifact_type(value: Any) -> ArtifactType:
         try:
             # tf.keras.Model's can be pickled, but some classes that inherit from it cannot (eg. `tfrs.Model`)
             from tensorflow import keras
+
             if isinstance(value, keras.Model):
                 return ArtifactType.TF_KERAS
         except:

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -4,7 +4,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -31,6 +30,7 @@ from aqueduct.logger import logger
 from aqueduct.operators import Operator, ParamSpec
 from aqueduct.serialization import (
     artifact_type_to_serialization_type,
+    make_temp_dir,
     serialization_function_mapping,
     serialize_val,
 )
@@ -160,22 +160,6 @@ def delete_zip_folder_and_file(dir_name: str) -> None:
         shutil.rmtree(dir_name)
 
 
-def make_zip_dir() -> str:
-    """
-    Given a base path, creates an unique directory and returns the path.
-    """
-    created = False
-    # Try to create the directory. If it already exists, try again with a new name.
-    while not created:
-        dir_path = Path(tempfile.gettempdir()) / str(uuid.uuid4())
-        try:
-            os.mkdir(dir_path)
-            created = True
-        except FileExistsError:
-            pass
-    return str(dir_path)
-
-
 def serialize_function(
     func: Union[UserFunction, MetricFunction, CheckFunction],
     op_name: str,
@@ -205,7 +189,7 @@ def serialize_function(
     """
     dir_path = None
     try:
-        dir_path = make_zip_dir()
+        dir_path = make_temp_dir()
         _package_files_and_requirements(
             func, os.path.join(os.getcwd(), dir_path), file_dependencies, requirements
         )
@@ -534,7 +518,18 @@ def infer_artifact_type(value: Any) -> ArtifactType:
             pickle.dumps(value)
             return ArtifactType.PICKLABLE
         except:
-            raise Exception("Failed to map type %s to supported artifact type." % type(value))
+            pass
+
+        try:
+            # Keras models cannot be pickled.
+            from tensorflow import keras
+
+            if isinstance(value, keras.Model):
+                return ArtifactType.TF_KERAS
+        except:
+            pass
+
+        raise Exception("Failed to map type %s to supported artifact type." % type(value))
 
 
 def construct_param_spec(val: Any, artifact_type: ArtifactType) -> ParamSpec:

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -521,7 +521,7 @@ def infer_artifact_type(value: Any) -> ArtifactType:
             pass
 
         try:
-            # Keras models cannot be pickled.
+            # tf.keras.Model's can be pickled, but some classes that inherit from it cannot (eg. `tfrs.Model`)
             from tensorflow import keras
             if isinstance(value, keras.Model):
                 return ArtifactType.TF_KERAS

--- a/src/python/aqueduct_executor/migrators/parameter_val_type_inference_000019/serialize.py
+++ b/src/python/aqueduct_executor/migrators/parameter_val_type_inference_000019/serialize.py
@@ -97,20 +97,6 @@ def _bytes_to_base64_string(content: bytes) -> str:
     return base64.b64encode(content).decode(_DEFAULT_ENCODING)
 
 
-artifact_to_serialization = {
-    ArtifactType.STRING: [SerializationType.STRING],
-    ArtifactType.BOOL: [SerializationType.JSON],
-    ArtifactType.NUMERIC: [SerializationType.JSON],
-    ArtifactType.DICT: [SerializationType.JSON, SerializationType.PICKLE],
-    ArtifactType.TUPLE: [SerializationType.JSON, SerializationType.PICKLE],
-    ArtifactType.TABLE: [SerializationType.TABLE],
-    ArtifactType.JSON: [SerializationType.STRING],
-    ArtifactType.BYTES: [SerializationType.BYTES],
-    ArtifactType.IMAGE: [SerializationType.IMAGE],
-    ArtifactType.PICKLABLE: [SerializationType.PICKLE],
-}
-
-
 def artifact_type_to_serialization_type(
     artifact_type: ArtifactType, content: Any
 ) -> SerializationType:
@@ -136,7 +122,5 @@ def artifact_type_to_serialization_type(
     else:
         raise Exception("Unsupported artifact type %s" % artifact_type)
 
-    assert serialization_type is not None and (
-        serialization_type in artifact_to_serialization[artifact_type]
-    )
+    assert serialization_type is not None
     return serialization_type

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -136,7 +136,6 @@ def _execute_function(
         results = [results]
 
     inferred_result_types = [infer_artifact_type(res) for res in results]
-    print("HELLO: inferred result types: ", inferred_result_types)
 
     elapsedTime = timer.stop()
     _, peak = tracemalloc.get_traced_memory()

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -136,6 +136,7 @@ def _execute_function(
         results = [results]
 
     inferred_result_types = [infer_artifact_type(res) for res in results]
+    print("HELLO: inferred result types: ", inferred_result_types)
 
     elapsedTime = timer.stop()
     _, peak = tracemalloc.get_traced_memory()

--- a/src/python/aqueduct_executor/operators/param_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/param_executor/execute.py
@@ -30,8 +30,11 @@ def run(spec: ParamSpec) -> None:
     storage = parse_storage(spec.storage_config)
 
     try:
-        val_bytes = storage.get(spec.output_content_path)
-        val = deserialize(spec.serialization_type, spec.expected_type, val_bytes)
+        val = deserialize(
+            spec.serialization_type,
+            spec.expected_type,
+            storage.get(spec.output_content_path),
+        )
 
         # This does not write to the output artifact's content path as a performance optimization.
         # That has already been written by the Golang Orchestrator.

--- a/src/python/aqueduct_executor/operators/utils/enums.py
+++ b/src/python/aqueduct_executor/operators/utils/enums.py
@@ -69,6 +69,7 @@ class ArtifactType(str, Enum, metaclass=MetaEnum):
     BYTES = "bytes"
     IMAGE = "image"
     PICKLABLE = "picklable"
+    TF_KERAS = "tensorflow-keras-model"
 
 
 class SerializationType(str, Enum, metaclass=MetaEnum):
@@ -78,17 +79,4 @@ class SerializationType(str, Enum, metaclass=MetaEnum):
     IMAGE = "image"
     STRING = "string"
     BYTES = "bytes"
-
-
-artifact_to_serialization = {
-    ArtifactType.STRING: [SerializationType.STRING],
-    ArtifactType.BOOL: [SerializationType.JSON],
-    ArtifactType.NUMERIC: [SerializationType.JSON],
-    ArtifactType.DICT: [SerializationType.JSON, SerializationType.PICKLE],
-    ArtifactType.TUPLE: [SerializationType.JSON, SerializationType.PICKLE],
-    ArtifactType.TABLE: [SerializationType.TABLE],
-    ArtifactType.JSON: [SerializationType.STRING],
-    ArtifactType.BYTES: [SerializationType.BYTES],
-    ArtifactType.IMAGE: [SerializationType.IMAGE],
-    ArtifactType.PICKLABLE: [SerializationType.PICKLE],
-}
+    TF_KERAS = "tensorflow-keras-model"

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -103,6 +103,7 @@ def _read_tf_keras_model(input_bytes: bytes) -> Any:
             f.write(input_bytes)
 
         from tensorflow import keras
+
         return keras.load_model(model_file_path)
     finally:
         if temp_model_dir is not None and os.path.exists(temp_model_dir):
@@ -439,6 +440,7 @@ def infer_artifact_type(value: Any) -> ArtifactType:
         try:
             # tf.keras.Model's can be pickled, but some classes that inherit from it cannot (eg. `tfrs.Model`)
             from tensorflow import keras
+
             if isinstance(value, keras.Model):
                 return ArtifactType.TF_KERAS
         except:

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -440,8 +440,6 @@ def infer_artifact_type(value: Any) -> ArtifactType:
             # Keras models cannot be pickled.
             from tensorflow import keras
             if isinstance(value, keras.Model):
-                print("Keras Model Value has type ", type(value))
-
                 return ArtifactType.TF_KERAS
         except:
             pass

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -103,7 +103,6 @@ def _read_tf_keras_model(input_bytes: bytes) -> Any:
             f.write(input_bytes)
 
         from tensorflow import keras
-
         return keras.load_model(model_file_path)
     finally:
         if temp_model_dir is not None and os.path.exists(temp_model_dir):
@@ -269,7 +268,7 @@ def _write_tf_keras_model(
         temp_model_dir = _make_temp_dir()
         model_file_path = os.path.join(temp_model_dir, _TEMP_KERAS_MODEL_NAME)
 
-        output.save_model(model_file_path)
+        output.save(model_file_path)
         storage.put(output_path, open(model_file_path, "rb").read())
     finally:
         if temp_model_dir is not None and os.path.exists(temp_model_dir):
@@ -440,8 +439,9 @@ def infer_artifact_type(value: Any) -> ArtifactType:
         try:
             # Keras models cannot be pickled.
             from tensorflow import keras
-
             if isinstance(value, keras.Model):
+                print("Keras Model Value has type ", type(value))
+
                 return ArtifactType.TF_KERAS
         except:
             pass

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -437,7 +437,7 @@ def infer_artifact_type(value: Any) -> ArtifactType:
             pass
 
         try:
-            # Keras models cannot be pickled.
+            # tf.keras.Model's can be pickled, but some classes that inherit from it cannot (eg. `tfrs.Model`)
             from tensorflow import keras
             if isinstance(value, keras.Model):
                 return ArtifactType.TF_KERAS


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds type support for any non-pickleable classes that inherit from tf.keras.Model. `tf.keras.Model` objects themselves are actually picklable, and so are already supported by our typing system.

In the example notebook torn pulled from https://www.tensorflow.org/recommenders, we can actually get it working with the existing system if `train_model` returns the user and movie models directly, instead of the `MoveLensModel`, which is a `tfrs.Model` (which inherits from `tf.keras.Model`).

If `train_model()` returns a `MovieLensModel`, we get the following error:
```
ValueError: Model <__main__.train_model.<locals>.MovieLensModel object at 0x7f1f20436100> cannot be saved either because the input shape is not available or because the forward pass of the model is not defined.To define a forward pass, please override `Model.call()`. To specify an input shape, either call `build(input_shape)` directly, or call the model on actual data using `Model()`, `Model.fit()`, or `Model.predict()`. If you have a custom training step, please make sure to invoke the forward pass in train step through `Model.__call__`, i.e. `model(inputs)`, as opposed to `model.call()`.
```
I'm not sure I have the context to fix this before asking ya'll. Googling around, I see a lot of people saying you have to call `model.fit()` beforehand, but we're doing exactly that in this notebook...

## Related issue number (if any)
ENG-1822

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


