### PR TITLE
ENG-1860: Parameter Status Bar Label and add Parameter Icon

### DIFF
--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aqueducthq/common",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aqueducthq/common",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "devDependencies": {
         "@babel/preset-react": "^7.17.12",

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -66,7 +66,6 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
       state.workflowDagResultsReducer.results[workflowDagResultId]
   );
 
-  const workflow = useSelector((state: RootState) => state.workflowReducer);
   const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
     {})[checkOperatorId];
 

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -460,7 +460,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         newWorkflowStatusItem.level = WorkflowStatusTabs.Errors;
         newWorkflowStatusItem.title = (
           <>
-            Error creating <b>${artifactName}.</b>
+            Error creating <b>{artifactName}.</b>
           </>
         );
         newWorkflowStatusItem.message = `Unable to create artifact ${artifactName} (${artifactId}).`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -124,7 +124,6 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
   };
 
   const getTypeLabel = (nodeType: string) => {
-    console.log('getTypeLabel nodeType: ', nodeType);
     const label = nodeTypeToStringLabel[nodeType];
 
     // Return catch all operator / artifact label if not found in lookup table.
@@ -539,9 +538,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -19,6 +19,7 @@ import React, {
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
+  ArtifactTypeToNodeTypeMap,
   NodeType,
   OperatorTypeToNodeTypeMap,
   selectNode,
@@ -434,11 +435,15 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         ),
         message: '',
         nodeId: artifactId,
-        type: 'tableArtifact',
+        type: 'Artifact',
       };
 
       const artifactStatus: ExecutionStatus = artifactResult.result?.status;
       const artifactExecState: ExecState = artifactResult.result?.exec_state;
+      const artifactType: string = artifactResult.result?.artifact_type;
+
+      const artifactNodeType: string = ArtifactTypeToNodeTypeMap[artifactType];
+      newWorkflowStatusItem.type = artifactNodeType;
 
       if (
         artifactStatus === ExecutionStatus.Failed &&
@@ -538,8 +543,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -124,6 +124,7 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
   };
 
   const getTypeLabel = (nodeType: string) => {
+    console.log('getTypeLabel nodeType: ', nodeType);
     const label = nodeTypeToStringLabel[nodeType];
 
     // Return catch all operator / artifact label if not found in lookup table.

--- a/src/ui/common/src/components/workflows/nodes/ParameterOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/ParameterOperatorNode.tsx
@@ -1,0 +1,25 @@
+import { faSliders } from '@fortawesome/free-solid-svg-icons';
+import React, { memo } from 'react';
+
+import { ReactFlowNodeData } from '../../../utils/reactflow';
+import Node from './Node';
+
+type Props = {
+  data: ReactFlowNodeData;
+  isConnectable: boolean;
+};
+
+export const paramOperatorNodeIcon = faSliders;
+
+const ParameterOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
+  return (
+    <Node
+      icon={paramOperatorNodeIcon}
+      data={data}
+      isConnectable={isConnectable}
+      defaultLabel="Parameter"
+    />
+  );
+};
+
+export default memo(ParameterOperatorNode);

--- a/src/ui/common/src/components/workflows/nodes/nodeTypes.tsx
+++ b/src/ui/common/src/components/workflows/nodes/nodeTypes.tsx
@@ -16,6 +16,9 @@ import { metricOperatorNodeIcon } from './MetricOperatorNode';
 import NumericArtifactNode, {
   numericArtifactNodeIcon,
 } from './NumericArtifactNode';
+import ParameterOperatorNode, {
+  paramOperatorNodeIcon,
+} from './ParameterOperatorNode';
 import StringArtifactNode, {
   stringArtifactNodeIcon,
 } from './StringArtifactNode';
@@ -39,6 +42,7 @@ export const nodeTypes = {
   loadOp: DatabaseNode,
   metricOp: MetricOperatorNode,
   checkOp: CheckOperatorNode,
+  paramOp: ParameterOperatorNode,
 };
 
 export const nodeTypeToStringLabel = {
@@ -57,6 +61,7 @@ export const nodeTypeToStringLabel = {
   loadOp: 'Load Operator',
   metricOp: 'Metric Operator',
   checkOp: 'Check Operator',
+  paramOp: 'Parameter Operator',
 };
 
 export const artifactTypeToIconMapping = {
@@ -76,6 +81,7 @@ export const artifactTypeToIconMapping = {
 };
 
 export const operatorTypeToIconMapping = {
+  [OperatorType.Param]: paramOperatorNodeIcon,
   [OperatorType.Function]: functionOperatorNodeIcon,
   [OperatorType.Extract]: databaseNodeIcon,
   [OperatorType.Load]: databaseNodeIcon,

--- a/src/ui/common/src/components/workflows/nodes/nodeTypes.tsx
+++ b/src/ui/common/src/components/workflows/nodes/nodeTypes.tsx
@@ -61,7 +61,7 @@ export const nodeTypeToStringLabel = {
   loadOp: 'Load Operator',
   metricOp: 'Metric Operator',
   checkOp: 'Check Operator',
-  paramOp: 'Parameter Operator',
+  paramOp: 'Parameter',
 };
 
 export const artifactTypeToIconMapping = {

--- a/src/ui/common/src/index.tsx
+++ b/src/ui/common/src/index.tsx
@@ -74,6 +74,7 @@ import MetricOperatorNode from './components/workflows/nodes/MetricOperatorNode'
 import Node from './components/workflows/nodes/Node';
 import nodeTypes from './components/workflows/nodes/nodeTypes';
 import NumericArtifactNode from './components/workflows/nodes/NumericArtifactNode';
+import ParameterOperatorNode from './components/workflows/nodes/ParameterOperatorNode';
 import TableArtifactNode from './components/workflows/nodes/TableArtifactNode';
 import ReactFlowCanvas from './components/workflows/ReactFlowCanvas';
 import DataPreviewSideSheet from './components/workflows/SideSheets/DataPreviewSideSheet';
@@ -345,6 +346,7 @@ export {
   OperatorType,
   OperatorTypeToNodeTypeMap,
   PaginatedTable,
+  ParameterOperatorNode,
   PeriodUnit,
   PostgresCard,
   PostgresDialog,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR gives parameters label in status bar output. Adds icon and node type to use for rendering parameters should we choose to render them in the future.

## Related issue number (if any)
ENG-1860

## Loom demo (if any)

Updated loom demo:
https://www.loom.com/share/f6d8e0e722084134bd80641fe324591d


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


