### PR TITLE
[1/7] Allows for blocking requests during system maintenance

### DIFF
--- a/src/golang/cmd/server/middleware/maintenance/maintenance.go
+++ b/src/golang/cmd/server/middleware/maintenance/maintenance.go
@@ -1,0 +1,23 @@
+package maintenance
+
+import (
+	"net/http"
+	"sync/atomic"
+
+	"github.com/aqueducthq/aqueduct/cmd/server/response"
+)
+
+// Check validates that the server is not currently under system maintenance.
+// If it is, it returns an error response to the client.
+func Check(underMaintenance *atomic.Bool) func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if underMaintenance.Load() {
+				// The server is currently under maintenance
+				response.SendErrorResponse(w, "The server is currently unavailable due to system maintenance.", http.StatusServiceUnavailable)
+			} else {
+				h.ServeHTTP(w, r)
+			}
+		})
+	}
+}

--- a/src/golang/cmd/server/middleware/maintenance/maintenance.go
+++ b/src/golang/cmd/server/middleware/maintenance/maintenance.go
@@ -9,10 +9,10 @@ import (
 
 // Check validates that the server is not currently under system maintenance.
 // If it is, it returns an error response to the client.
-func Check(underMaintenance *atomic.Bool) func(http.Handler) http.Handler {
+func Check(underMaintenance *atomic.Value) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if underMaintenance.Load() {
+			if underMaintenance.Load().(bool) {
 				// The server is currently under maintenance
 				response.SendErrorResponse(w, "The server is currently unavailable due to system maintenance.", http.StatusServiceUnavailable)
 			} else {

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -57,7 +57,7 @@ type AqServer struct {
 	*Writers
 
 	// UnderMaintenance indicates whether the server is currently down for system maintenance.
-	UnderMaintenance atomic.Bool
+	UnderMaintenance atomic.Value
 	// RequestMutex's read lock is acquired and released by each request to indicate when there
 	// are no more active requests.
 	RequestMutex sync.RWMutex

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -44,8 +44,9 @@ var uiDir = path.Join(os.Getenv("HOME"), ".aqueduct", "ui")
 
 type AqServer struct {
 	Router *chi.Mux
+	Name   string
 
-	Name          string
+	// Only the following group of fields will be reinitialized when the server is restarted
 	Database      database.Database
 	GithubManager github.Manager
 	// TODO ENG-1483: Move JobManager from Server to Handlers
@@ -65,87 +66,19 @@ type AqServer struct {
 
 func NewAqServer() *AqServer {
 	ctx := context.Background()
-	aqPath := config.AqueductPath()
-	db, err := database.NewSqliteDatabase(&database.SqliteConfig{
-		File: path.Join(aqPath, database.SqliteDatabasePath),
-	})
-	if err != nil {
-		log.Fatalf("Unable to connect to database: %v", err)
-	}
-
-	githubManager := github.NewUnimplementedManager()
-
-	jobManager, err := job.NewProcessJobManager(
-		&job.ProcessConfig{
-			BinaryDir:          path.Join(aqPath, job.BinaryDir),
-			OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
-		},
-	)
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to create job manager: ", err)
-	}
-
-	vault, err := vault.NewFileVault(&vault.FileConfig{
-		Directory:     path.Join(aqPath, vault.FileVaultDir),
-		EncryptionKey: config.EncryptionKey(),
-	})
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to start vault: ", err)
-	}
-
-	readers, err := CreateReaders(db.Config())
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to create readers: ", err)
-	}
-
-	writers, err := CreateWriters(db.Config())
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to create writers: ", err)
-	}
-
-	storageConfig := config.Storage()
-
-	previewCacheManager, err := preview_cache.NewInMemoryPreviewCacheManager(
-		&storageConfig,
-		previewCacheSize,
-	)
-	if err != nil {
-		log.Fatal("Unable to create preview artifact cache: ", err)
-	}
-
-	eng, err := engine.NewAqEngine(
-		db,
-		githubManager,
-		previewCacheManager,
-		vault,
-		aqPath,
-		GetEngineReaders(readers),
-		GetEngineWriters(writers),
-	)
-	if err != nil {
-		log.Fatal("Unable to create aqEngine: ", err)
-	}
-
 	s := &AqServer{
-		Router:        chi.NewRouter(),
-		Database:      db,
-		GithubManager: github.NewUnimplementedManager(),
-		JobManager:    jobManager,
-		Vault:         vault,
-		AqPath:        aqPath,
-		AqEngine:      eng,
-		Readers:       readers,
-		Writers:       writers,
+		Router:           chi.NewRouter(),
+		UnderMaintenance: atomic.Value{},
+		RequestMutex:     sync.RWMutex{},
 	}
-
 	s.UnderMaintenance.Store(false)
 
-	allowedOrigins := []string{"*"}
+	// Initialize the other server fields
+	if err := s.Init(); err != nil {
+		log.Fatalf("Unable to initialize server: %v", err)
+	}
 
+	allowedOrigins := []string{"*"}
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedHeaders: GetAllHeaders(s),
@@ -153,17 +86,9 @@ func NewAqServer() *AqServer {
 	})
 	s.Router.Use(corsMiddleware.Handler)
 	s.Router.Use(middleware.Logger)
-	AddAllHandlers(s)
 
-	if err := collections.RequireSchemaVersion(
-		context.Background(),
-		RequiredSchemaVersion,
-		s.SchemaVersionReader,
-		db,
-	); err != nil {
-		db.Close()
-		log.Fatalf("Found incompatible database schema version: %v", err)
-	}
+	// Register server handlers
+	AddAllHandlers(s)
 
 	log.Infof("Creating a user account and a builtin SQLite integration.")
 	testUser, err := CreateTestAccount(
@@ -176,20 +101,17 @@ func NewAqServer() *AqServer {
 		accountOrganizationId,
 	)
 	if err != nil {
-		db.Close()
 		log.Fatal(err)
 	}
 
 	demoConnected, err := CheckBuiltinIntegration(ctx, s, accountOrganizationId)
 	if err != nil {
-		db.Close()
 		log.Fatal(err)
 	}
 
 	if !demoConnected {
 		err = ConnectBuiltinIntegration(ctx, testUser, s.IntegrationWriter, s.Database, s.Vault)
 		if err != nil {
-			db.Close()
 			log.Fatal(err)
 		}
 	}
@@ -202,6 +124,96 @@ func NewAqServer() *AqServer {
 	}
 
 	return s
+}
+
+// Init sets all of the fields of this AqServer that depend on server configuration.
+func (s *AqServer) Init() error {
+	aqPath := config.AqueductPath()
+
+	db, err := database.NewSqliteDatabase(&database.SqliteConfig{
+		File: path.Join(aqPath, database.SqliteDatabasePath),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			db.Close()
+		}
+	}()
+
+	githubManager := github.NewUnimplementedManager()
+
+	jobManager, err := job.NewProcessJobManager(
+		&job.ProcessConfig{
+			BinaryDir:          path.Join(aqPath, job.BinaryDir),
+			OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	vault, err := vault.NewFileVault(&vault.FileConfig{
+		Directory:     path.Join(aqPath, vault.FileVaultDir),
+		EncryptionKey: config.EncryptionKey(),
+	})
+	if err != nil {
+		return err
+	}
+
+	readers, err := CreateReaders(db.Config())
+	if err != nil {
+		return err
+	}
+
+	writers, err := CreateWriters(db.Config())
+	if err != nil {
+		return err
+	}
+
+	if err := collections.RequireSchemaVersion(
+		context.Background(),
+		RequiredSchemaVersion,
+		readers.SchemaVersionReader,
+		db,
+	); err != nil {
+		return err
+	}
+
+	storageConfig := config.Storage()
+
+	previewCacheManager, err := preview_cache.NewInMemoryPreviewCacheManager(
+		&storageConfig,
+		previewCacheSize,
+	)
+	if err != nil {
+		return err
+	}
+
+	eng, err := engine.NewAqEngine(
+		db,
+		githubManager,
+		previewCacheManager,
+		vault,
+		aqPath,
+		GetEngineReaders(readers),
+		GetEngineWriters(writers),
+	)
+	if err != nil {
+		return err
+	}
+
+	s.Database = db
+	s.GithubManager = githubManager
+	s.JobManager = jobManager
+	s.Vault = vault
+	s.AqPath = aqPath
+	s.AqEngine = eng
+	s.Readers = readers
+	s.Writers = writers
+
+	return nil
 }
 
 func (s *AqServer) StartWorkflowRetentionJob(period string) error {
@@ -297,4 +309,22 @@ func IndexHandler() func(w http.ResponseWriter, r *http.Request) {
 	}
 
 	return http.HandlerFunc(fn)
+}
+
+// Pause puts the server in system maintenance mode by blocking all new requests
+// and waits for all active requests to finish.
+// It is the responsibility of the caller to call s.Restart() to allow requests
+// to be processed again once the system maintenance is complete.
+func (s *AqServer) Pause() {
+	s.UnderMaintenance.Store(true)
+	s.RequestMutex.Lock()
+}
+
+// Restart restarts a server that was previously stopped via s.Pause().
+func (s *AqServer) Restart() {
+	if err := s.Init(); err != nil {
+		log.Fatalf("Unable to restart server: %v", err)
+	}
+	s.RequestMutex.Unlock()
+	s.UnderMaintenance.Store(false)
 }

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -56,8 +56,11 @@ type AqServer struct {
 	*Readers
 	*Writers
 
+	// UnderMaintenance indicates whether the server is currently down for system maintenance.
 	UnderMaintenance atomic.Bool
-	RequestMutex     sync.RWMutex
+	// RequestMutex's read lock is acquired and released by each request to indicate when there
+	// are no more active requests.
+	RequestMutex sync.RWMutex
 }
 
 func NewAqServer() *AqServer {

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -318,6 +318,9 @@ func IndexHandler() func(w http.ResponseWriter, r *http.Request) {
 func (s *AqServer) Pause() {
 	s.UnderMaintenance.Store(true)
 	s.RequestMutex.Lock()
+
+	// Close the database because it will be reopened when s.Restart() is called
+	s.Database.Close()
 }
 
 // Restart restarts a server that was previously stopped via s.Pause().

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -230,12 +230,9 @@ func (s *AqServer) StartWorkflowRetentionJob(period string) error {
 }
 
 func (s *AqServer) AddHandler(route string, handlerObj handler.Handler) {
-	s.RequestMutex.RLock()
-	defer s.RequestMutex.RUnlock()
-
-	var middlewareChain alice.Chain
+	var middleware alice.Chain
 	if handlerObj.AuthMethod() == handler.ApiKeyAuthMethod {
-		middlewareChain = alice.New(
+		middleware = alice.New(
 			maintenance.Check(&s.UnderMaintenance),
 			request_id.WithRequestId(),
 			authentication.RequireApiKey(s.UserReader, s.Database),
@@ -247,7 +244,7 @@ func (s *AqServer) AddHandler(route string, handlerObj handler.Handler) {
 	s.Router.Method(
 		string(handlerObj.Method()),
 		route,
-		middlewareChain.ThenFunc(ExecuteHandler(s, handlerObj)),
+		middleware.ThenFunc(ExecuteHandler(s, handlerObj)),
 	)
 }
 

--- a/src/golang/cmd/server/server/execute_handler.go
+++ b/src/golang/cmd/server/server/execute_handler.go
@@ -48,8 +48,11 @@ func HandleSuccess(
 	handlerObj.SendResponse(w, resp)
 }
 
-func ExecuteHandler(server Server, handlerObj handler.Handler) func(w http.ResponseWriter, r *http.Request) {
+func ExecuteHandler(server *AqServer, handlerObj handler.Handler) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		server.RequestMutex.RLock()
+		defer server.RequestMutex.RUnlock()
+
 		args, statusCode, err := handlerObj.Prepare(r)
 		ctx := r.Context()
 		if err != nil {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a couple of different things to the server struct:
1. An `atomic` bool is added as a flag to indicate when the server should block all new requests. An example of this use case is when performing storage migration.
2. It is not sufficient to just block new requests, sometimes the system maintenance job can only be performed when we are certain that there are no more active requests. One approach is shown in this PR by having a mutex that should be acquired and released by every single request. Each request will acquire a read lock, so requests will not block other requests, but when a system maintenance job needs to performed it can simply acquire an exclusive lock and be confident that there are no more requests active in the server, as otherwise the lock acquisition would still be blocked.

## Related issue number (if any)
ENG 1871

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


