### PR TITLE
[2/7] Implements server pause and restart

### DIFF
--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -298,3 +298,19 @@ func IndexHandler() func(w http.ResponseWriter, r *http.Request) {
 
 	return http.HandlerFunc(fn)
 }
+
+// Pause puts the server in system maintenance mode by blocking all new requests
+// and waits for all active requests to finish.
+// It is the responsibility of the caller to call s.Restart() to allow requests
+// to be processed again once the system maintenance is complete.
+func (s *AqServer) Pause() {
+	s.UnderMaintenance.Store(true)
+	s.RequestMutex.Lock()
+}
+
+// Restart restarts a server that was previously stopped via s.Pause().
+func (s *AqServer) Restart() {
+	// init again
+	s.RequestMutex.Unlock()
+	s.UnderMaintenance.Store(false)
+}

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -44,8 +44,9 @@ var uiDir = path.Join(os.Getenv("HOME"), ".aqueduct", "ui")
 
 type AqServer struct {
 	Router *chi.Mux
+	Name   string
 
-	Name          string
+	// Only the following group of fields will be reinitialized when the server is restarted
 	Database      database.Database
 	GithubManager github.Manager
 	// TODO ENG-1483: Move JobManager from Server to Handlers
@@ -65,87 +66,14 @@ type AqServer struct {
 
 func NewAqServer() *AqServer {
 	ctx := context.Background()
-	aqPath := config.AqueductPath()
-	db, err := database.NewSqliteDatabase(&database.SqliteConfig{
-		File: path.Join(aqPath, database.SqliteDatabasePath),
-	})
-	if err != nil {
-		log.Fatalf("Unable to connect to database: %v", err)
-	}
-
-	githubManager := github.NewUnimplementedManager()
-
-	jobManager, err := job.NewProcessJobManager(
-		&job.ProcessConfig{
-			BinaryDir:          path.Join(aqPath, job.BinaryDir),
-			OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
-		},
-	)
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to create job manager: ", err)
-	}
-
-	vault, err := vault.NewFileVault(&vault.FileConfig{
-		Directory:     path.Join(aqPath, vault.FileVaultDir),
-		EncryptionKey: config.EncryptionKey(),
-	})
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to start vault: ", err)
-	}
-
-	readers, err := CreateReaders(db.Config())
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to create readers: ", err)
-	}
-
-	writers, err := CreateWriters(db.Config())
-	if err != nil {
-		db.Close()
-		log.Fatal("Unable to create writers: ", err)
-	}
-
-	storageConfig := config.Storage()
-
-	previewCacheManager, err := preview_cache.NewInMemoryPreviewCacheManager(
-		&storageConfig,
-		previewCacheSize,
-	)
-	if err != nil {
-		log.Fatal("Unable to create preview artifact cache: ", err)
-	}
-
-	eng, err := engine.NewAqEngine(
-		db,
-		githubManager,
-		previewCacheManager,
-		vault,
-		aqPath,
-		GetEngineReaders(readers),
-		GetEngineWriters(writers),
-	)
-	if err != nil {
-		log.Fatal("Unable to create aqEngine: ", err)
-	}
-
 	s := &AqServer{
-		Router:        chi.NewRouter(),
-		Database:      db,
-		GithubManager: github.NewUnimplementedManager(),
-		JobManager:    jobManager,
-		Vault:         vault,
-		AqPath:        aqPath,
-		AqEngine:      eng,
-		Readers:       readers,
-		Writers:       writers,
+		Router:           chi.NewRouter(),
+		UnderMaintenance: atomic.Value{},
+		RequestMutex:     sync.RWMutex{},
 	}
-
 	s.UnderMaintenance.Store(false)
 
 	allowedOrigins := []string{"*"}
-
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
 		AllowedHeaders: GetAllHeaders(s),
@@ -153,17 +81,14 @@ func NewAqServer() *AqServer {
 	})
 	s.Router.Use(corsMiddleware.Handler)
 	s.Router.Use(middleware.Logger)
-	AddAllHandlers(s)
 
-	if err := collections.RequireSchemaVersion(
-		context.Background(),
-		RequiredSchemaVersion,
-		s.SchemaVersionReader,
-		db,
-	); err != nil {
-		db.Close()
-		log.Fatalf("Found incompatible database schema version: %v", err)
+	// Initialize the other server fields
+	if err := s.Init(); err != nil {
+		log.Fatalf("Unable to initialize server: %v", err)
 	}
+
+	// Register server handlers
+	AddAllHandlers(s)
 
 	log.Infof("Creating a user account and a builtin SQLite integration.")
 	testUser, err := CreateTestAccount(
@@ -176,20 +101,17 @@ func NewAqServer() *AqServer {
 		accountOrganizationId,
 	)
 	if err != nil {
-		db.Close()
 		log.Fatal(err)
 	}
 
 	demoConnected, err := CheckBuiltinIntegration(ctx, s, accountOrganizationId)
 	if err != nil {
-		db.Close()
 		log.Fatal(err)
 	}
 
 	if !demoConnected {
 		err = ConnectBuiltinIntegration(ctx, testUser, s.IntegrationWriter, s.Database, s.Vault)
 		if err != nil {
-			db.Close()
 			log.Fatal(err)
 		}
 	}
@@ -202,6 +124,96 @@ func NewAqServer() *AqServer {
 	}
 
 	return s
+}
+
+// Init sets all of the fields of this AqServer that depend on server configuration.
+func (s *AqServer) Init() error {
+	aqPath := config.AqueductPath()
+
+	db, err := database.NewSqliteDatabase(&database.SqliteConfig{
+		File: path.Join(aqPath, database.SqliteDatabasePath),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			db.Close()
+		}
+	}()
+
+	githubManager := github.NewUnimplementedManager()
+
+	jobManager, err := job.NewProcessJobManager(
+		&job.ProcessConfig{
+			BinaryDir:          path.Join(aqPath, job.BinaryDir),
+			OperatorStorageDir: path.Join(aqPath, job.OperatorStorageDir),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	vault, err := vault.NewFileVault(&vault.FileConfig{
+		Directory:     path.Join(aqPath, vault.FileVaultDir),
+		EncryptionKey: config.EncryptionKey(),
+	})
+	if err != nil {
+		return err
+	}
+
+	readers, err := CreateReaders(db.Config())
+	if err != nil {
+		return err
+	}
+
+	writers, err := CreateWriters(db.Config())
+	if err != nil {
+		return err
+	}
+
+	if err := collections.RequireSchemaVersion(
+		context.Background(),
+		RequiredSchemaVersion,
+		s.SchemaVersionReader,
+		db,
+	); err != nil {
+		return err
+	}
+
+	storageConfig := config.Storage()
+
+	previewCacheManager, err := preview_cache.NewInMemoryPreviewCacheManager(
+		&storageConfig,
+		previewCacheSize,
+	)
+	if err != nil {
+		return err
+	}
+
+	eng, err := engine.NewAqEngine(
+		db,
+		githubManager,
+		previewCacheManager,
+		vault,
+		aqPath,
+		GetEngineReaders(readers),
+		GetEngineWriters(writers),
+	)
+	if err != nil {
+		return err
+	}
+
+	s.Database = db
+	s.GithubManager = githubManager
+	s.JobManager = jobManager
+	s.Vault = vault
+	s.AqPath = aqPath
+	s.AqEngine = eng
+	s.Readers = readers
+	s.Writers = writers
+
+	return nil
 }
 
 func (s *AqServer) StartWorkflowRetentionJob(period string) error {
@@ -310,7 +322,9 @@ func (s *AqServer) Pause() {
 
 // Restart restarts a server that was previously stopped via s.Pause().
 func (s *AqServer) Restart() {
-	// init again
+	if err := s.Init(); err != nil {
+		log.Fatalf("Unable to restart server: %v", err)
+	}
 	s.RequestMutex.Unlock()
 	s.UnderMaintenance.Store(false)
 }

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -73,6 +73,11 @@ func NewAqServer() *AqServer {
 	}
 	s.UnderMaintenance.Store(false)
 
+	// Initialize the other server fields
+	if err := s.Init(); err != nil {
+		log.Fatalf("Unable to initialize server: %v", err)
+	}
+
 	allowedOrigins := []string{"*"}
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins: allowedOrigins,
@@ -81,11 +86,6 @@ func NewAqServer() *AqServer {
 	})
 	s.Router.Use(corsMiddleware.Handler)
 	s.Router.Use(middleware.Logger)
-
-	// Initialize the other server fields
-	if err := s.Init(); err != nil {
-		log.Fatalf("Unable to initialize server: %v", err)
-	}
 
 	// Register server handlers
 	AddAllHandlers(s)
@@ -175,7 +175,7 @@ func (s *AqServer) Init() error {
 	if err := collections.RequireSchemaVersion(
 		context.Background(),
 		RequiredSchemaVersion,
-		s.SchemaVersionReader,
+		readers.SchemaVersionReader,
 		db,
 	); err != nil {
 		return err


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This Pr allows for pausing and restarting the server. This is done by separating out the server field initialization from the server constructor. This allows us to ensure that the necessary fields are reinitialized after restart, such as the server vault. The important thing is that the `chi.Router` is not reinitialized as this needs to be the same in order for the HTTP server to continue running.

## Related issue number (if any)
ENG 1882

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


