### PR TITLE
Remove unnecessary requirements from `run_notebooks` readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,11 +11,3 @@ To run the notebook with a specific flow to wait for a successful run:
 To run the notebook with a specific server address, the address must be set in the notebook with the following format so the script can find and replace:
 `address = <server_address>`. Then the command becomes:
 `python3 run_notebook.py --path "churn_prediction/Quickstart Tutorial.ipynb --server_address=<...>`
-
-Requirements:
-1) The script will wait for one successful run of any flow published by the notebook. It will infer that flow from the stdout
-   of the notebook. Therefore, your notebook should do something akin to the following:
-```
-flow = client.publish_flow(...)
-print(flow.id())
-```


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This is unnecessary because we now print out the workflow url on every `publish_flow()`. The script is smart enough to find the UUID in this url and check that it has completed at least one run.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


