### PR TITLE
ENG-1881 Fix bug where data page search suggestions did not appear.

### DIFF
--- a/src/ui/common/src/components/Search/index.tsx
+++ b/src/ui/common/src/components/Search/index.tsx
@@ -18,7 +18,7 @@ type Props = {
   setSearchTerm: (v: string) => void;
 };
 
-export const SearchBar: React.FC<Props> = ({ options, setSearchTerm }) => {
+export const SearchBar: React.FC<Props> = ({ options, setSearchTerm, getOptionLabel }) => {
   return (
     <Autocomplete
       sx={{ width: 300 }}
@@ -32,7 +32,14 @@ export const SearchBar: React.FC<Props> = ({ options, setSearchTerm }) => {
         setSearchTerm(val);
       }}
       freeSolo
-      getOptionLabel={(option) => option.name || ''}
+      getOptionLabel={(option) => {
+        if (getOptionLabel) {
+          return getOptionLabel(option);
+        }
+
+        // default case, just return .name if no function provided.
+        return option.name || ''
+      }}
       renderInput={(params) => {
         params['InputProps']['startAdornment'] = (
           <InputAdornment position="start">

--- a/src/ui/common/src/components/Search/index.tsx
+++ b/src/ui/common/src/components/Search/index.tsx
@@ -18,7 +18,11 @@ type Props = {
   setSearchTerm: (v: string) => void;
 };
 
-export const SearchBar: React.FC<Props> = ({ options, setSearchTerm, getOptionLabel }) => {
+export const SearchBar: React.FC<Props> = ({
+  options,
+  setSearchTerm,
+  getOptionLabel,
+}) => {
   return (
     <Autocomplete
       sx={{ width: 300 }}
@@ -38,7 +42,7 @@ export const SearchBar: React.FC<Props> = ({ options, setSearchTerm, getOptionLa
         }
 
         // default case, just return .name if no function provided.
-        return option.name || ''
+        return option.name || '';
       }}
       renderInput={(params) => {
         params['InputProps']['startAdornment'] = (


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the search bar on data page did not show suggestions.

## Related issue number (if any)
ENG-1881

## Loom demo (if any)
Screenshot:
<img width="1513" alt="image" src="https://user-images.githubusercontent.com/1031759/197243254-4447f2d8-bc4e-40bc-963a-66ef8124e37a.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


