### PR TITLE
Invokes storage migration once storage integration is connected

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aqueducthq/aqueduct/config"
 	"github.com/aqueducthq/aqueduct/lib/airflow"
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact"
-	db_artifact "github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
@@ -60,7 +59,7 @@ type ConnectIntegrationHandler struct {
 	JobManager job.JobManager
 
 	WorkflowDagReader    workflow_dag.Reader
-	ArtifactReader       db_artifact.Reader
+	ArtifactReader       artifact.Reader
 	ArtifactResultReader artifact_result.Reader
 	OperatorReader       operator.Reader
 	IntegrationReader    integration.Reader

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -181,7 +181,7 @@ func (h *ConnectIntegrationHandler) Perform(ctx context.Context, interfaceArgs i
 			defer h.RestartServer()
 
 			if err := setIntegrationAsStorage(
-				ctx,
+				context.Background(),
 				args.Service,
 				args.Config,
 				args.OrganizationId,

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -21,8 +21,12 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			ArtifactReader:       s.ArtifactReader,
 			ArtifactResultReader: s.ArtifactResultReader,
 			OperatorReader:       s.OperatorReader,
+			IntegrationReader:    s.IntegrationReader,
 			WorkflowDagWriter:    s.WorkflowDagWriter,
 			IntegrationWriter:    s.IntegrationWriter,
+
+			PauseServer:   s.Pause,
+			RestartServer: s.Restart,
 		},
 		routes.DeleteIntegrationRoute: &handler.DeleteIntegrationHandler{
 			Database:          s.Database,

--- a/src/golang/cmd/server/server/vault.go
+++ b/src/golang/cmd/server/server/vault.go
@@ -44,7 +44,7 @@ func syncVaultWithStorage(
 		return err
 	}
 
-	if err := utils.MigrateVault(
+	if _, err := utils.MigrateVault(
 		context.Background(),
 		oldVault,
 		vaultObj,

--- a/src/golang/lib/vault/s3.go
+++ b/src/golang/lib/vault/s3.go
@@ -1,8 +1,6 @@
 package vault
 
 import (
-	"path"
-
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/storage"
 )
@@ -13,7 +11,15 @@ const (
 
 func newS3Vault(s3StoreConf shared.S3Config, key string) Vault {
 	// The S3 vault stores secrets under the ../vault path
-	s3StoreConf.Bucket = path.Join(s3StoreConf.Bucket, s3VaultDir)
+	// The S3 bucket is in the form of s3:// so we can't use path.Join, because
+	// it will clean the final filepath and change the prefix to s3:/
+	bucket := s3StoreConf.Bucket
+	if len(bucket) > 0 && bucket[len(bucket)-1] == '/' {
+		bucket += s3VaultDir
+	} else {
+		bucket += "/" + s3VaultDir
+	}
+	s3StoreConf.Bucket = bucket
 
 	store := storage.NewStorage(&shared.StorageConfig{
 		Type:     shared.S3StorageType,

--- a/src/golang/lib/workflow/utils/migrate.go
+++ b/src/golang/lib/workflow/utils/migrate.go
@@ -36,18 +36,6 @@ func MigrateStorageAndVault(
 	integrationReader integration.Reader,
 	db database.Database,
 ) error {
-	// Wait until there are no more workflow runs in progress
-	lock := NewExecutionLock()
-	if err := lock.Lock(); err != nil {
-		return err
-	}
-	defer func() {
-		unlockErr := lock.Unlock()
-		if unlockErr != nil {
-			log.Errorf("Unexpected error when unlocking workflow execution lock: %v", unlockErr)
-		}
-	}()
-
 	oldStore := storage.NewStorage(oldConf)
 	newStore := storage.NewStorage(newConf)
 

--- a/src/golang/lib/workflow/utils/migrate.go
+++ b/src/golang/lib/workflow/utils/migrate.go
@@ -67,7 +67,7 @@ func MigrateStorageAndVault(
 	}
 	defer database.TxnRollbackIgnoreErr(ctx, txn)
 
-	dags, err := dagReader.GetWorkflowDags(ctx, nil, txn)
+	dags, err := dagReader.ListWorkflowDags(ctx, txn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR puts together the final backend pieces of performing storage and vault migration.
The migration is invoked as an asynchronous goroutine once all other steps for connecting an integration have succeeded. These steps include validating the credentials of the integration.

The goroutine will do the following:
1. Stop all new requests to the server and respond with a server unavailable error code.
2. Wait for all active requests to complete.
3. Wait for all active workflow runs to complete.
4. Perform storage migration.
5. Perform vault migration.
6. Delete all storage and vault content from the old store and vault.
7. Update the storage config to the new config.
8. Unblock workflow runs.
9. Unblock server requests.

There are also a handful of various bug fixes. More details inline or in comments.

## Related issue number (if any)

## Loom demo (if any)
TEST: Tested a full storage migration from local to S3. Demo coming soon...

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


