### PR TITLE
Add positional, variable-length support for all functions

### DIFF
--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -354,7 +354,7 @@ def test_fetching_historical_flows_uses_old_data(client):
             delete_flow(client, flow_id)
 
 
-def test_flow_with_args_and_kwargs(client):
+def test_flow_with_args(client):
     str_val = "this is a string"
     num_val = 1234
 
@@ -378,8 +378,3 @@ def test_flow_with_args_and_kwargs(client):
     # Implicit parameter creation is disallowed for variable-length parameters.
     with pytest.raises(InvalidUserArgumentException):
         foo_with_args(*[str_val, num_val])
-
-
-# TODO: get the above to work  (or at least throw an error) with implicit parameters
-# output = foo_with_args(str_val, num_val)
-# print(output.get())

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -352,3 +352,34 @@ def test_fetching_historical_flows_uses_old_data(client):
     finally:
         for flow_id in flows_to_delete:
             delete_flow(client, flow_id)
+
+
+def test_flow_with_args_and_kwargs(client):
+    str_val = "this is a string"
+    num_val = 1234
+
+    @op
+    def foo_with_args(*args):
+        args_list = list(args)
+        assert args_list == [str_val, num_val]
+        return args_list
+
+    @op
+    def generate_str():
+        return str_val
+
+    @op
+    def generate_num():
+        return num_val
+
+    output = foo_with_args(generate_str(), generate_num())
+    assert output.get() == [str_val, num_val]
+
+    # Implicit parameter creation is disallowed for variable-length parameters.
+    with pytest.raises(InvalidUserArgumentException):
+        foo_with_args(*[str_val, num_val])
+
+
+# TODO: get the above to work  (or at least throw an error) with implicit parameters
+# output = foo_with_args(str_val, num_val)
+# print(output.get())

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -234,7 +234,7 @@ def _convert_input_arguments_to_parameters(
         if not isinstance(artifact, BaseArtifact):
             if implicit_params_disallowed:
                 raise InvalidUserArgumentException(
-                    """Input %d to function is not an artifact. Creating an Aqueduct parameter implicitly for a """
+                    """Input at index %d to function is not an artifact. Creating an Aqueduct parameter implicitly for a """
                     """function that takes in variable-length parameters (eg. *args or **kwargs) is currently unsupported."""
                     % idx
                 )

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -221,6 +221,8 @@ def _convert_input_arguments_to_parameters(
     """
     # KEYWORD_ONLY parameters are allowed, since they are guaranteed to have a name.
     # Note that we only accept them after "*" arguments, since we error out on VAR_POSITIONAL (eg. *args).
+    # For example, `foo(*, positional_arg)` is allowed, but `foo(*args, positional_arg)` is not.
+    # See https://peps.python.org/pep-0362/#parameter-object for a description of each parameter kind.
     disallowed_kinds = [inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD]
     implicit_params_disallowed = any(
         param.kind in disallowed_kinds for param in func_params.values()

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Any, Callable, List, Optional, Union, cast, Mapping
+from typing import Any, Callable, List, Mapping, Optional, Union, cast
 
 import numpy as np
 from aqueduct.artifacts import utils as artifact_utils
@@ -234,7 +234,7 @@ def _convert_input_arguments_to_parameters(
         if not isinstance(artifact, BaseArtifact):
             if implicit_params_disallowed:
                 raise InvalidUserArgumentException(
-                    """Input %d to function is not an artifact. Creating an Aqueduct parameter implicitly for a """ 
+                    """Input %d to function is not an artifact. Creating an Aqueduct parameter implicitly for a """
                     """function that takes in variable-length parameters (eg. *args or **kwargs) is currently unsupported."""
                     % idx
                 )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
While looking at the task for adding **kwargs support, I noticed that we didn't consider all the possibilities for *args support.

This PR allows us to support user functions that are defined with variable-length parameters:
```
def foo(*args):
    ...
```
This involves disallowing implicit parameters in such cases. For now, it's easier to make this an unsupported case, since we don't really know what name to assign such parameters. If they want to use parameters for such functions, they should create them explicitly.

Here is the error message:

<img width="1119" alt="Screen Shot 2022-10-24 at 1 49 39 PM" src="https://user-images.githubusercontent.com/6466121/197630157-80d069fb-2c58-4ce6-b587-7c2994f3f4c8.png">

NOTE: supporting **kwargs is actually a bit more involved than originally intended, as we have to do some stuff on both the sdk and backend side.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


