### PR TITLE
Shows alert for in progress storage migration

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -127,25 +127,20 @@ const AddIntegrations: React.FC<Props> = ({
                     {`Successfully connected to ${service}!`}
                   </Alert>
                 </Snackbar>
-                <Snackbar
-                  anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-                  open={showMigrationDialog}
-                  onClose={() => {setShowMigrationDialog(false)}}
-                  key={'integrations-dialog-migration-snackbar'}
-                  autoHideDuration={6000}
-                >
-                  <Alert
-                    onClose={() => {setShowMigrationDialog(false)}}
-                    severity="info"
-                    sx={{ width: '100%' }}
-                  >
-                    {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
-                  </Alert>
-                </Snackbar>
+                
               </Grid>
             );
           })}
       </Grid>
+      { 
+        <Alert
+          onClose={() => {setShowMigrationDialog(false)}}
+          severity="info"
+          sx={{ width: '100%' }}
+        >
+          {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
+        </Alert>
+      }
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -34,6 +34,17 @@ const AddIntegrations: React.FC<Props> = ({
 
   return (
     <Box sx={{ maxWidth: '616px' }}>
+      {showMigrationDialog && (
+        <Alert
+          onClose={() => {
+            setShowMigrationDialog(false);
+          }}
+          severity="info"
+          sx={{ width: '100%' }}
+        >
+          {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
+        </Alert>
+      )}
       <Grid
         container
         spacing={1}
@@ -131,17 +142,6 @@ const AddIntegrations: React.FC<Props> = ({
             );
           })}
       </Grid>
-      {showMigrationDialog && (
-        <Alert
-          onClose={() => {
-            setShowMigrationDialog(false);
-          }}
-          severity="info"
-          sx={{ width: '100%' }}
-        >
-          {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
-        </Alert>
-      )}
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -127,20 +127,21 @@ const AddIntegrations: React.FC<Props> = ({
                     {`Successfully connected to ${service}!`}
                   </Alert>
                 </Snackbar>
-                
               </Grid>
             );
           })}
       </Grid>
-      { 
+      {showMigrationDialog && (
         <Alert
-          onClose={() => {setShowMigrationDialog(false)}}
+          onClose={() => {
+            setShowMigrationDialog(false);
+          }}
           severity="info"
           sx={{ width: '100%' }}
         >
           {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
         </Alert>
-      }
+      )}
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -30,6 +30,7 @@ const AddIntegrations: React.FC<Props> = ({
   const handleSuccessToastClose = () => {
     setShowSuccessToast(null);
   };
+  const [showMigrationDialog, setShowMigrationDialog] = useState(false);
 
   return (
     <Box sx={{ maxWidth: '616px' }}>
@@ -107,6 +108,7 @@ const AddIntegrations: React.FC<Props> = ({
                         setShowDialog(false);
                         dispatch(resetConnectNewStatus());
                       }}
+                      showMigrationDialog={() => setShowMigrationDialog(true)}
                     />
                   )}
                 </Box>
@@ -123,6 +125,21 @@ const AddIntegrations: React.FC<Props> = ({
                     sx={{ width: '100%' }}
                   >
                     {`Successfully connected to ${service}!`}
+                  </Alert>
+                </Snackbar>
+                <Snackbar
+                  anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+                  open={showMigrationDialog}
+                  onClose={() => {setShowMigrationDialog(false)}}
+                  key={'integrations-dialog-migration-snackbar'}
+                  autoHideDuration={6000}
+                >
+                  <Alert
+                    onClose={() => {setShowMigrationDialog(false)}}
+                    severity="info"
+                    sx={{ width: '100%' }}
+                  >
+                    {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
                   </Alert>
                 </Snackbar>
               </Grid>

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -61,6 +61,7 @@ type Props = {
   service: Service;
   onCloseDialog: () => void;
   onSuccess: () => void;
+  showMigrationDialog: () => void;
   integrationToEdit?: Integration;
 };
 
@@ -69,6 +70,7 @@ const IntegrationDialog: React.FC<Props> = ({
   service,
   onCloseDialog,
   onSuccess,
+  showMigrationDialog,
   integrationToEdit = undefined,
 }) => {
   const editMode = !!integrationToEdit;
@@ -106,6 +108,8 @@ const IntegrationDialog: React.FC<Props> = ({
     setConfig((config) => {
       return { ...config, [field]: value };
     });
+  
+  const [migrateStorage, setMigrateStorage] = useState(false);
 
   useEffect(() => {
     if (isSucceeded(connectStatus)) {
@@ -113,6 +117,9 @@ const IntegrationDialog: React.FC<Props> = ({
         handleLoadIntegrations({ apiKey: user.apiKey, forceLoad: true })
       );
       onSuccess();
+      if (migrateStorage) {
+        showMigrationDialog();
+      }
       onCloseDialog();
     }
   }, [connectStatus]);
@@ -201,12 +208,15 @@ const IntegrationDialog: React.FC<Props> = ({
           onUpdateField={setConfigField}
           value={config as S3Config}
           editMode={editMode}
+          setMigrateStorage={setMigrateStorage}
         />
       );
       break;
     case 'GCS':
       const gcsConfig = config as GCSConfig;
+      // GCS can only be used storage currently
       gcsConfig.use_as_storage = 'true';
+      setMigrateStorage(true);
       serviceDialog = (
         <GCSDialog
           onUpdateField={setConfigField}

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -108,7 +108,7 @@ const IntegrationDialog: React.FC<Props> = ({
     setConfig((config) => {
       return { ...config, [field]: value };
     });
-  
+
   const [migrateStorage, setMigrateStorage] = useState(false);
 
   useEffect(() => {

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -30,12 +30,14 @@ type Props = {
   onUpdateField: (field: keyof S3Config, value: string) => void;
   value?: S3Config;
   editMode: boolean;
+  setMigrateStorage: (value: boolean) => void;
 };
 
 export const S3Dialog: React.FC<Props> = ({
   onUpdateField,
   value,
   editMode,
+  setMigrateStorage,
 }) => {
   const [fileName, setFileName] = useState<string>(null);
 
@@ -216,12 +218,13 @@ export const S3Dialog: React.FC<Props> = ({
         control={
           <Checkbox
             checked={value?.use_as_storage === 'true'}
-            onChange={(event) =>
+            onChange={(event) => {
               onUpdateField(
                 'use_as_storage',
                 event.target.checked ? 'true' : 'false'
-              )
-            }
+              );
+              setMigrateStorage(event.target.checked);
+            }}
             disabled={editMode}
           />
         }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a snackbar alert once a storage integration is connected to indicate that a migration is in progress.

## Related issue number (if any)
ENG 1788

## Loom demo (if any)
https://www.loom.com/share/f2694548e8ed4d6e93c16efdaa08f529

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


