### PR TITLE
Move preview caching test to `no_concurrency` suite

### DIFF
--- a/integration_tests/no_concurrency/sdk/latency_sensitive_test.py
+++ b/integration_tests/no_concurrency/sdk/latency_sensitive_test.py
@@ -1,3 +1,7 @@
+from utils import SENTIMENT_SQL_QUERY, get_integration_name
+
+from aqueduct import op
+
 
 def test_preview_artifact_caching(client):
     db = client.integration(name=get_integration_name())
@@ -13,6 +17,8 @@ def test_preview_artifact_caching(client):
         return df
 
     # Check that the first run will take a while, but the second run will happen much faster.
+    import time
+
     start = time.time()
     slow_output = slow_fn(sql_artifact)
     first_duration = time.time() - start

--- a/integration_tests/no_concurrency/sdk/latency_sensitive_test.py
+++ b/integration_tests/no_concurrency/sdk/latency_sensitive_test.py
@@ -1,0 +1,23 @@
+
+def test_preview_artifact_caching(client):
+    db = client.integration(name=get_integration_name())
+    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+
+    @op
+    def slow_fn(df):
+        time.sleep(5)
+        return df
+
+    @op
+    def noop(df):
+        return df
+
+    # Check that the first run will take a while, but the second run will happen much faster.
+    start = time.time()
+    slow_output = slow_fn(sql_artifact)
+    first_duration = time.time() - start
+    assert first_duration > 5
+
+    start = time.time()
+    _ = noop(slow_output)
+    assert time.time() - start < first_duration

--- a/integration_tests/no_concurrency/sdk/requirements_test.py
+++ b/integration_tests/no_concurrency/sdk/requirements_test.py
@@ -4,18 +4,12 @@ import pandas as pd
 import pytest
 from aqueduct.error import AqueductError, InvalidUserArgumentException
 from transformers_model.model import sentiment_prediction_using_transformers
+from utils import SENTIMENT_SQL_QUERY, get_integration_name
 
 from aqueduct import infer_requirements, op
 
-# Parameters for the sentiment dataset.
-SENTIMENT_SQL_QUERY = "select * from hotel_reviews"
-
 INVALID_REQUIREMENTS_PATH = "~/random.txt"
 VALID_REQUIREMENTS_PATH = "transformers_model/requirements.txt"
-
-
-def _get_integration_name() -> str:
-    return "aqueduct_demo"
 
 
 def _transformers_package_exists():
@@ -74,7 +68,7 @@ def test_infer_requirements(client):
         _uninstall_transformers_package()
 
     # If no requirements are supplied, our inference will not pick up the transformers package.
-    db = client.integration(name=_get_integration_name())
+    db = client.integration(name=get_integration_name())
     table = db.sql(query=SENTIMENT_SQL_QUERY)
     with pytest.raises(AqueductError):
         sentiment_prediction_without_reqs_path(table)
@@ -108,7 +102,7 @@ def test_requirements_installation_from_path(client):
     if _transformers_package_exists():
         _uninstall_transformers_package()
 
-    db = client.integration(name=_get_integration_name())
+    db = client.integration(name=get_integration_name())
     table = db.sql(query=SENTIMENT_SQL_QUERY)
 
     # Check that no an invalid path fails.
@@ -132,7 +126,7 @@ def test_requirements_installation_from_strings(client):
     if _transformers_package_exists():
         _uninstall_transformers_package()
 
-    db = client.integration(name=_get_integration_name())
+    db = client.integration(name=get_integration_name())
     table = db.sql(query=SENTIMENT_SQL_QUERY)
     valid_path_table = sentiment_prediction_with_string_requirements(table)
     assert valid_path_table.get().shape[0] == 100
@@ -146,7 +140,7 @@ def test_default_requirements_installation(client):
     if _transformers_package_exists():
         _uninstall_transformers_package()
 
-    db = client.integration(name=_get_integration_name())
+    db = client.integration(name=get_integration_name())
     table = db.sql(query=SENTIMENT_SQL_QUERY)
     valid_path_table = sentiment_prediction_using_transformers(table)
     assert valid_path_table.get().shape[0] == 100

--- a/integration_tests/no_concurrency/sdk/utils.py
+++ b/integration_tests/no_concurrency/sdk/utils.py
@@ -1,0 +1,5 @@
+SENTIMENT_SQL_QUERY = "select * from hotel_reviews"
+
+
+def get_integration_name() -> str:
+    return "aqueduct_demo"

--- a/integration_tests/sdk/preview_test.py
+++ b/integration_tests/sdk/preview_test.py
@@ -105,30 +105,6 @@ def test_invalid_file_dependencies(client):
         model_with_out_of_package_file_dependency(sql_artifact)
 
 
-def test_preview_artifact_caching(client):
-    db = client.integration(name=get_integration_name())
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
-
-    @op
-    def slow_fn(df):
-        time.sleep(10)
-        return df
-
-    @op
-    def noop(df):
-        return df
-
-    # Check that the first run will take a while, but the second run will happen much faster.
-    start = time.time()
-    slow_output = slow_fn(sql_artifact)
-    duration = time.time() - start
-    assert duration > 10
-
-    start = time.time()
-    _ = noop(slow_output)
-    assert time.time() - start < duration
-
-
 def test_table_with_non_string_column_name(client):
     @op
     def bad_return():


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This test appears to fail transiently in GH actions. The theory is that the GH machines are quite underpowered and can leave certain flows hanging for some time under concurrency. As a first step, lets move this latency-sensitive test to the single-process suite.

Linked to in https://www.notion.so/aqueducthq/Transient-Automated-Test-Failures-76639acc78ec45d9a0a0df66f9a3799d

## Related issue number (if any)
ENG-1583

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


