### PR TITLE
Increases margin between notifications and setting button in header

### DIFF
--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -165,7 +165,7 @@ const NavBar: React.FC<{
           />
         </Box>
 
-        <Box sx={{ cursor: 'pointer', marginLeft: '8px' }}>
+        <Box sx={{ cursor: 'pointer', marginLeft: '16px' }}>
           <FontAwesomeIcon
             className={styles['navbar-icon']}
             icon={faGear}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds more space between the notifications and settings button.


<img width="74" alt="Screen Shot 2022-10-31 at 2 00 57 PM" src="https://user-images.githubusercontent.com/10413474/199109890-0c5b6ade-8a83-4f78-bbdf-f3b9d6a2bcad.png">

## Related issue number (if any)
ENG 1854

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


