### PR TITLE
ENG-1899 Fix bug where the text in the "view operator details" box overflows

### DIFF
--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -35977,6 +35977,11 @@
       "requires": {
         "@types/mdx": "^2.0.0",
         "@types/react": "^18.0.8"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "^18.0.8"
+        }
       }
     },
     "@mdx-js/util": {
@@ -42925,6 +42930,11 @@
       "requires": {
         "@types/react": "^18.0.8",
         "hoist-non-react-statics": "^3.3.0"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "^18.0.8"
+        }
       }
     },
     "@types/html-minifier-terser": {
@@ -43074,6 +43084,11 @@
       "devOptional": true,
       "requires": {
         "@types/react": "^18.0.8"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "^18.0.8"
+        }
       }
     },
     "@types/react-is": {
@@ -43083,6 +43098,11 @@
       "peer": true,
       "requires": {
         "@types/react": "^18.0.8"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "^18.0.8"
+        }
       }
     },
     "@types/react-transition-group": {
@@ -43092,6 +43112,11 @@
       "peer": true,
       "requires": {
         "@types/react": "^18.0.8"
+      },
+      "dependencies": {
+        "@types/react": {
+          "version": "^18.0.8"
+        }
       }
     },
     "@types/resize-observer-browser": {

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -335,7 +335,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
     const operator = (workflow.selectedDag?.operators ?? {})[currentNode.id];
     const exportOpButton = (
       <Button
-        style={buttonStyle}
+        style={{ ...buttonStyle, maxWidth: '300px' }}
         onClick={async () => {
           await handleExportFunction(
             user,
@@ -346,9 +346,9 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         color="primary"
       >
         <FontAwesomeIcon icon={faCircleDown} />
-        <Typography sx={{ ml: 1 }}>{`${
-          operator?.name ?? 'function'
-        }.zip`}</Typography>
+        <Typography
+          sx={{ ml: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}
+        >{`${operator?.name ?? 'function'}.zip`}</Typography>
       </Button>
     );
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where there is an overflow in the "View operator details" button when the contents of the button next to it are too long.

To remedy this issue, I added a max width to the .zip file button and set it's text overflow to be ellipsis.

## Related issue number (if any)
ENG-1899

## Loom demo (if any)
Screenshot:
<img width="406" alt="image" src="https://user-images.githubusercontent.com/1031759/199331819-7d23b783-424a-4f93-8b7c-585785bd3dee.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


