### PR TITLE
[SDK] Simplify supplying the engine integration

### DIFF
--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -1,9 +1,12 @@
+import uuid
 from datetime import datetime, timedelta
 
 import pandas as pd
 import pytest
-from aqueduct.enums import ExecutionStatus
+from aqueduct.enums import ExecutionStatus, ServiceType
 from aqueduct.error import InvalidUserArgumentException
+from aqueduct.integrations.airflow_integration import AirflowIntegration
+from aqueduct.integrations.integration import IntegrationInfo
 from constants import SENTIMENT_SQL_QUERY
 from test_functions.sentiment.model import sentiment_model
 from test_functions.simple.model import (
@@ -21,7 +24,7 @@ from utils import (
 )
 
 import aqueduct
-from aqueduct import LoadUpdateMode, check, metric, op
+from aqueduct import FlowConfig, LoadUpdateMode, check, metric, op
 
 
 def test_basic_flow(client, data_integration):
@@ -379,3 +382,37 @@ def test_flow_with_args(client):
     # Implicit parameter creation is disallowed for variable-length parameters.
     with pytest.raises(InvalidUserArgumentException):
         foo_with_args(*[str_val, num_val])
+
+
+def test_publish_with_redundant_config_fields(client):
+    """Once the user-facing `FlowConfig` struct is deprecated, we can get rid of this test."""
+    @op
+    def noop():
+        return 123
+
+    output = noop()
+
+    # Test redundant engine field.
+    dummy_integration_info = IntegrationInfo(
+        id=uuid.uuid4(),
+        name="dummy",
+        service=ServiceType.LAMBDA,
+        createdAt=123,
+        validated=True,
+    )
+    with pytest.raises(InvalidUserArgumentException):
+        client.publish_flow(
+            generate_new_flow_name(),
+            artifacts=[output],
+            engine="something",
+            config=FlowConfig(engine=AirflowIntegration(dummy_integration_info)),
+        )
+
+    # Test redundant `k_latest_runs` field.
+    with pytest.raises(InvalidUserArgumentException):
+        client.publish_flow(
+            generate_new_flow_name(),
+            artifacts=[output],
+            k_latest_runs=10,
+            config=FlowConfig(k_latest_runs=123),
+        )

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -386,6 +386,7 @@ def test_flow_with_args(client):
 
 def test_publish_with_redundant_config_fields(client):
     """Once the user-facing `FlowConfig` struct is deprecated, we can get rid of this test."""
+
     @op
     def noop():
         return 123

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -373,6 +373,9 @@ class Client:
         Returns:
             A flow object handle to be used to fetch information about this productionized flow.
         """
+        if config is not None:
+            logger().warning("`config` is deprecated, please use the `engine` or `k_latest_runs` fields directly.")
+
         if artifacts is None or artifacts == []:
             raise InvalidUserArgumentException(
                 "Must supply at least one artifact to compute when creating a flow."

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -9,7 +9,7 @@ import __main__ as main
 import yaml
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
-from aqueduct.config import FlowConfig
+from aqueduct.config import EngineConfig, FlowConfig
 from aqueduct.parameter_utils import create_param
 
 from aqueduct import dag, globals
@@ -54,6 +54,14 @@ def global_config(config_dict: Dict[str, Any]) -> None:
         if not isinstance(lazy_val, bool):
             raise InvalidUserArgumentException("Must supply a boolean for the lazy key.")
         globals.__GLOBAL_CONFIG__.lazy = lazy_val
+
+    if globals.GLOBAL_ENGINE_KEY in config_dict:
+        engine_name = config_dict[globals.GLOBAL_ENGINE_KEY]
+        if not isinstance(engine_name, str):
+            raise InvalidUserArgumentException(
+                "Engine should be the string name of your compute integration."
+            )
+        globals.__GLOBAL_CONFIG__.engine = engine_name
 
 
 def get_apikey() -> str:
@@ -298,9 +306,11 @@ class Client:
         name: str,
         description: str = "",
         schedule: str = "",
+        engine: str = "",
         artifacts: Optional[Union[BaseArtifact, List[BaseArtifact]]] = None,
         metrics: Optional[List[NumericArtifact]] = None,
         checks: Optional[List[BoolArtifact]] = None,
+        k_latest_runs: Optional[int] = None,
         config: Optional[FlowConfig] = None,
     ) -> Flow:
         """Uploads and kicks off the given flow in the system.
@@ -320,6 +330,17 @@ class Client:
         Args:
             name:
                 The name of the newly created flow.
+            description:
+                A description for the new flow.
+            schedule:
+                A cron expression specifying the cadence that this flow
+                will run on. If empty, the flow will only execute manually.
+                For example, to run at the top of every hour:
+
+                >> schedule = aqueduct.hourly(minute: 0)
+            engine:
+                The name of the compute integration (eg. "my_lambda_integration") this the flow will
+                be computed on.
             artifacts:
                 All the artifacts that you care about computing. These artifacts are guaranteed
                 to be computed. Additional artifacts may also be computed if they are upstream
@@ -330,20 +351,16 @@ class Client:
             checks:
                 All the checks that you would like to compute. If not supplied, we will implicitly
                 include all checks computed on artifacts in the flow.
-            description:
-                A description for the new flow.
-            schedule: A cron expression specifying the cadence that this flow
-                will run on. If empty, the flow will only execute manually.
-                For example, to run at the top of every hour:
-
-                >> schedule = aqueduct.hourly(minute: 0)
-
+            k_latest_runs:
+                Number of most-recent runs of this flow that Aqueduct should keep. Runs outside of
+                this bound are garbage collected. Defaults to persisting all runs.
             config:
+                This field will be deprecated. Please use `engine` and `k_latest_runs` instead.
+
                 An optional set of config fields for this flow.
                 - engine: Specify where this flow should run with one of your connected integrations.
                 - k_latest_runs: Number of most-recent runs of this flow that Aqueduct should store.
                     Runs outside of this bound are deleted. Defaults to persisting all runs.
-                We currently support Airflow.
 
         Raises:
             InvalidUserArgumentException:
@@ -388,10 +405,44 @@ class Client:
             implicitly_include_checks = False
 
         cron_schedule = schedule_from_cron_string(schedule)
-        if not (config and config.k_latest_runs):
+
+        k_latest_runs_from_flow_config = config.k_latest_runs if config else None
+        if k_latest_runs and k_latest_runs_from_flow_config:
+            raise InvalidUserArgumentException(
+                "Cannot set `k_latest_runs` in two places, pick one. Note that use of `FlowConfig` will be deprecated soon."
+            )
+        if k_latest_runs is None and k_latest_runs_from_flow_config:
+            k_latest_runs = k_latest_runs_from_flow_config
+
+        if k_latest_runs is None:
             retention_policy = retention_policy_from_latest_runs(-1)
         else:
-            retention_policy = retention_policy_from_latest_runs(config.k_latest_runs)
+            retention_policy = retention_policy_from_latest_runs(k_latest_runs)
+
+        engine_defined_on_config = config and config.engine
+        if engine or engine_defined_on_config:
+            if engine and engine_defined_on_config:
+                raise InvalidUserArgumentException(
+                    "Cannot set compute engine in two places, pick one. Note that use of `FlowConfig` will be deprecated soon."
+                )
+
+            self._connected_integrations = globals.__GLOBAL_API_CLIENT__.list_integrations()
+            if engine:
+                if engine not in self._connected_integrations.keys():
+                    raise InvalidIntegrationException(
+                        "Not connected to compute integration %s!" % name
+                    )
+            else:
+                assert config and config.engine
+                for integration in self._connected_integrations.values():
+                    if integration.id == config.engine._metadata.id:
+                        engine = integration.name
+                        break
+
+                if engine is None:
+                    raise InvalidIntegrationException(
+                        "Not connected to the given compute integration!"
+                    )
 
         dag = apply_deltas_to_dag(
             self._dag,
@@ -411,7 +462,11 @@ class Client:
             schedule=cron_schedule,
             retention_policy=retention_policy,
         )
-        dag.engine_config = generate_engine_config(config)
+
+        if engine is None:
+            dag.engine_config = EngineConfig()
+        else:
+            dag.engine_config = generate_engine_config(self._connected_integrations[engine])
 
         if dag.engine_config.type == RuntimeType.AIRFLOW:
             # This is an Airflow workflow

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -306,7 +306,7 @@ class Client:
         name: str,
         description: str = "",
         schedule: str = "",
-        engine: str = "",
+        engine: Optional[str] = None,
         artifacts: Optional[Union[BaseArtifact, List[BaseArtifact]]] = None,
         metrics: Optional[List[NumericArtifact]] = None,
         checks: Optional[List[BoolArtifact]] = None,
@@ -374,7 +374,9 @@ class Client:
             A flow object handle to be used to fetch information about this productionized flow.
         """
         if config is not None:
-            logger().warning("`config` is deprecated, please use the `engine` or `k_latest_runs` fields directly.")
+            logger().warning(
+                "`config` is deprecated, please use the `engine` or `k_latest_runs` fields directly."
+            )
 
         if artifacts is None or artifacts == []:
             raise InvalidUserArgumentException(
@@ -450,7 +452,9 @@ class Client:
             engine_config = EngineConfig()
         else:
             if engine not in self._connected_integrations.keys():
-                raise InvalidIntegrationException("Not connected to compute integration %s!" % name)
+                raise InvalidIntegrationException(
+                    "Not connected to compute integration %s!" % engine
+                )
             engine_config = generate_engine_config(self._connected_integrations[engine])
 
         dag = apply_deltas_to_dag(

--- a/sdk/aqueduct/config.py
+++ b/sdk/aqueduct/config.py
@@ -34,7 +34,9 @@ class EngineConfig(BaseModel):
     lambda_config: Optional[LambdaEngineConfig]
 
 
+# TODO(...): this is deprecated.
 class FlowConfig(BaseModel):
+
     engine: Optional[Union[AirflowIntegration, K8sIntegration, LambdaIntegration]]
     k_latest_runs: int = -1
 

--- a/sdk/aqueduct/globals.py
+++ b/sdk/aqueduct/globals.py
@@ -15,5 +15,5 @@ GLOBAL_LAZY_KEY = "lazy"
 GLOBAL_ENGINE_KEY = "engine"
 __GLOBAL_CONFIG__ = GlobalConfig(lazy=False)
 
-# Initialize a unconfigured api client. It will be configured when the user construct an Aqueduct client.
+# Initialize an unconfigured api client. It will be configured when the user construct an Aqueduct client.
 __GLOBAL_API_CLIENT__ = APIClient()

--- a/sdk/aqueduct/globals.py
+++ b/sdk/aqueduct/globals.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from aqueduct.api_client import APIClient
 from pydantic import BaseModel
 
@@ -6,9 +8,11 @@ class GlobalConfig(BaseModel):
     """Defines the fields that are globally configurable with `aq.global_config()`."""
 
     lazy: bool
+    engine: Optional[str]
 
 
 GLOBAL_LAZY_KEY = "lazy"
+GLOBAL_ENGINE_KEY = "engine"
 __GLOBAL_CONFIG__ = GlobalConfig(lazy=False)
 
 # Initialize a unconfigured api client. It will be configured when the user construct an Aqueduct client.

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -22,9 +22,10 @@ from aqueduct.config import (
     LambdaEngineConfig,
 )
 from aqueduct.dag import DAG, RetentionPolicy, Schedule
-from aqueduct.enums import ArtifactType, OperatorType, RuntimeType, TriggerType
+from aqueduct.enums import ArtifactType, OperatorType, RuntimeType, ServiceType, TriggerType
 from aqueduct.error import *
 from aqueduct.integrations.airflow_integration import AirflowIntegration
+from aqueduct.integrations.integration import IntegrationInfo
 from aqueduct.integrations.k8s_integration import K8sIntegration
 from aqueduct.integrations.lambda_integration import LambdaIntegration
 from aqueduct.logger import logger
@@ -579,29 +580,27 @@ def parse_artifact_result_response(response: requests.Response) -> Dict[str, Any
     return result
 
 
-def generate_engine_config(config: Optional[FlowConfig]) -> EngineConfig:
-    """Generates an EngineConfig from the user provided configuration."""
-    if not (config and config.engine):
-        return EngineConfig()
-    elif isinstance(config.engine, AirflowIntegration):
+def generate_engine_config(integration: IntegrationInfo) -> EngineConfig:
+    """Generates an EngineConfig from an integration info object."""
+    if integration.service == ServiceType.AIRFLOW:
         return EngineConfig(
             type=RuntimeType.AIRFLOW,
             airflow_config=AirflowEngineConfig(
-                integration_id=config.engine._metadata.id,
+                integration_id=integration.id,
             ),
         )
-    elif isinstance(config.engine, K8sIntegration):
+    elif integration.service == ServiceType.K8S:
         return EngineConfig(
             type=RuntimeType.K8S,
             k8s_config=K8sEngineConfig(
-                integration_id=config.engine._metadata.id,
+                integration_id=integration.id,
             ),
         )
-    elif isinstance(config.engine, LambdaIntegration):
+    elif integration.service == ServiceType.LAMBDA:
         return EngineConfig(
             type=RuntimeType.LAMBDA,
             lambda_config=LambdaEngineConfig(
-                integration_id=config.engine._metadata.id,
+                integration_id=integration.id,
             ),
         )
     else:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR does two things:
1) Adds the `engine` key to `aq.global_config()`. Once this merges, the client can define a global engine backend to run against. `publish_flow()` will respect this global config if none is set.
```
aq.global_config({"engine": "my_lambda_integration"})

# Uses the lambda integration
client.publish_flow(...)

# Uses the k8s integration
client.publish_flow(engine="my_k8s_integration")
```
@Fanjia-Yan, you can use this global config in your preview change.

2) Adds the `engine` and `k_latest_runs` arguments directly to `publish_flow()`. We will keep the old `FlowConfig()` way around for backwards compatability, but with a deprecation message if it is used.
```
client.publish_flow(..., engine="my_compute_integration", k_latest_runs=10)
```

You cannot set these fields redundantly, you'll get the following:
<img width="1211" alt="Screen Shot 2022-11-03 at 4 13 15 PM" src="https://user-images.githubusercontent.com/6466121/199854137-4029e22b-e792-4ed0-ae99-48e8093ca968.png">


Testing:
- This is somewhat challenging since we don't have any guide for running the suite against a different compute backend. I'll be working getting this done in a more automated fashion next.

## Related issue number (if any)
ENG-1950

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


