### PR TITLE
Fix parameter triggering from the UI

### DIFF
--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -205,6 +205,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
       // 1) number 2) string 3) json.
       try {
         // All jsonable values are serialized as json.
+        JSON.parse(strVal)
         serializedParams[key] = {
           val: btoa(strVal),
           serialization_type: SerializationType.Json,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
I don't know how this line got lost, it was in the original PR. This should fix the parameter triggering bug when a string is inputted.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


