### PR TITLE
Verified that the requirement detection hierarchy is already enforced

### DIFF
--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -290,6 +290,7 @@ def _package_files_and_requirements(
     # This is the absolute path to the requirements file we are sending to the backend.
     packaged_requirements_path = os.path.join(dir_path, REQUIREMENTS_FILE)
     if requirements is not None:
+        # The operator has a custom requirements specification.
         assert isinstance(requirements, str) or all(isinstance(req, str) for req in requirements)
 
         if isinstance(requirements, str):
@@ -305,16 +306,16 @@ def _package_files_and_requirements(
             with open(packaged_requirements_path, "x") as f:
                 f.write("\n".join(requirements))
 
-    # If there already exists a requirements.txt in the same directory as the function.
     elif os.path.exists(REQUIREMENTS_FILE):
+        # There exists a workflow-level requirements file (need to reside in the same directory as the function).
         logger().info(
             "%s: requirements.txt file detected in current directory %s, will not self-generate by inferring package dependencies."
-            % (os.getcwd(), func.__name__)
+            % (func.__name__, os.getcwd())
         )
-        shutil.copy(REQUIREMENTS_FILE, os.path.join(dir_path, REQUIREMENTS_FILE))
+        shutil.copy(REQUIREMENTS_FILE, packaged_requirements_path)
 
-    # No requirements have been provided, so we do our best to infer.
     else:
+        # No requirements have been provided, so we use `pip freeze` to infer.
         logger().info(
             "%s: No requirements.txt file detected, self-generating file by inferring package dependencies."
             % func.__name__


### PR DESCRIPTION
## Describe your changes and why you are making these changes
I verified that the proposed requirement detection rules are already enforced. This PR mainly tidies up some comments.

The only functionality change I made is to add client's cloudpickle version to the function's requirements file. This is useful when we aren't using `pip freeze`, because when the user manually specifies the requirements, they are unlikely to include the cloudpickle entry, but for us, we need to ensure that the server installs the same version of cloudpickle as the client, so adding this entry will prevent potential serialization bugs due to cloudpickle version mismatch.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


