### PR TITLE
WIP: ENG-1904 Set up Vite build on app

### DIFF
--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -3,6 +3,9 @@
   "author": "Aqueduct, Inc. <hello@aqueducthq.com>",
   "version": "0.1.2",
   "scripts": {
+    "start:vite": "vite",
+    "build:vite": "vite build",
+    "preview": "vite preview",
     "start": "parcel --no-cache index.html",
     "build": "parcel build --public-url /dist --dist-dir dist/default index.html",
     "build-sagemaker": "parcel build --public-url /proxy/8080/dist --dist-dir dist/sagemaker index.html",
@@ -46,6 +49,7 @@
     "@types/react-dom": "^18.0.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
+    "@vitejs/plugin-react": "^2.1.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
@@ -57,6 +61,8 @@
     "parcel-resolver-ignore": "^2.1.3",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
-    "typescript": "^3.9.10"
+    "typescript": "^3.9.10",
+    "vite": "^3.1.0",
+    "vite-plugin-externalize-deps": "^0.4.0"
   }
 }

--- a/src/ui/app/tsconfig.json
+++ b/src/ui/app/tsconfig.json
@@ -4,6 +4,9 @@
     "src",
     "types"
   ],
+  "exclude": [
+    "node_modules"
+  ],
   "compilerOptions": {
     "target": "es5",
     "lib": [
@@ -38,7 +41,6 @@
     // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",
     "incremental": true,
-
     // linter checks for common issues
     //"noImplicitReturns": true,
     //"noFallthroughCasesInSwitch": true,

--- a/src/ui/app/vite.config.ts
+++ b/src/ui/app/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [react()],
+    define: {
+        'process.env': {}
+    },
+    build: {
+        sourcemap: true,
+        minify: false,
+    }
+})


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR sets up vite to build the app project.

Currently, we're blocked by an issue building react-virtualized:
```
➜  app git:(eng-1904-vite-app-build) ✗ npm run start:vite

> @aqueducthq/ui@0.1.2 start:vite
> vite


  VITE v3.2.2  ready in 230 ms

  ➜  Local:   http://127.0.0.1:5173/
  ➜  Network: use --host to expose
✘ [ERROR] No matching export in "../common/node_modules/react-virtualized/dist/es/WindowScroller/WindowScroller.js" for import "bpfrpt_proptype_WindowScroller"

    ../common/node_modules/react-virtualized/dist/es/WindowScroller/utils/onScroll.js:74:9:
      74 │ import { bpfrpt_proptype_WindowScroller } from "../WindowScroller.js";
         ╵          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:1566
  let error = new Error(`${text}${summary}`);
              ^

Error: Build failed with 1 error:
../common/node_modules/react-virtualized/dist/es/WindowScroller/utils/onScroll.js:74:9: ERROR: No matching export in "../common/node_modules/react-virtualized/dist/es/WindowScroller/WindowScroller.js" for import "bpfrpt_proptype_WindowScroller"
    at failureErrorWithLog (/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:1566:15)
    at /Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:1024:28
    at runOnEndCallbacks (/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:1438:61)
    at buildResponseToResult (/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:1022:7)
    at /Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:1134:14
    at responseCallbacks.<computed> (/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:671:9)
    at handleIncomingPacket (/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:726:9)
    at Socket.readFromStdout (/Users/andre/Documents/Code/aqueduct/src/ui/app/node_modules/esbuild/lib/main.js:647:7)
    at Socket.emit (node:events:526:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
  errors: [
    {
      detail: undefined,
      id: '',
      location: {
        column: 9,
        file: '../common/node_modules/react-virtualized/dist/es/WindowScroller/utils/onScroll.js',
        length: 30,
        line: 74,
        lineText: 'import { bpfrpt_proptype_WindowScroller } from "../WindowScroller.js";',
        namespace: '',
        suggestion: ''
      },
      notes: [],
      pluginName: '',
      text: 'No matching export in "../common/node_modules/react-virtualized/dist/es/WindowScroller/WindowScroller.js" for import "bpfrpt_proptype_WindowScroller"'
    }
  ],
  warnings: []
}
```

I'm sure there's some workaround or configs that we can adjust to get around this, need to do some more research on it.

**Other Virtualized Libraries to explore:**
react-window: https://github.com/bvaughn/react-window
This one is written by the same author of react-virtualized, but is a successor to react-virtualized. I do not know if it still suffers from the same issue, but this could be worth looking into.

Tanstack Virtual: https://tanstack.com/virtual/v3
This library uses vite in their examples, and is probably one of our best bets. Should we choose to use it, it will probably take a bit more refactoring than react-window (since both react-window and react-virtualized follow a similar pattern), but we know for a fact that this library will work with our build tooling.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


