### PR TITLE
Add ability for tests to run against multiple backing engines

### DIFF
--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -68,6 +68,7 @@ def test_check_on_multiple_mixed_inputs(client, data_integration, engine):
 
     run_flow_test(client, artifacts=[check_artifact], engine=engine)
 
+
 def test_edit_check(client, data_integration):
     """Test that checks can be edited by replacing with the same name."""
     db = client.integration(data_integration)

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -32,17 +32,17 @@ def success_on_multiple_mixed_inputs(metric, df):
     return True
 
 
-def test_check_on_table(client, data_integration):
+def test_check_on_table(client, data_integration, engine):
     """Test check on a function operator."""
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     check_artifact = success_on_single_table_input(sql_artifact)
     assert check_artifact.get()
 
-    run_flow_test(client, artifacts=[check_artifact])
+    run_flow_test(client, artifacts=[check_artifact], engine=engine)
 
 
-def test_check_on_metric(client, data_integration):
+def test_check_on_metric(client, data_integration, engine):
     """Test check on a metric operator."""
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
@@ -51,10 +51,10 @@ def test_check_on_metric(client, data_integration):
     check_artifact = success_on_single_metric_input(metric)
     assert check_artifact.get()
 
-    run_flow_test(client, artifacts=[check_artifact])
+    run_flow_test(client, artifacts=[check_artifact], engine=engine)
 
 
-def test_check_on_multiple_mixed_inputs(client, data_integration):
+def test_check_on_multiple_mixed_inputs(client, data_integration, engine):
     """Test check on multiple tables and metrics."""
     db = client.integration(data_integration)
     sql_artifact1 = db.sql(query=SENTIMENT_SQL_QUERY)
@@ -66,8 +66,7 @@ def test_check_on_multiple_mixed_inputs(client, data_integration):
     check_artifact = success_on_multiple_mixed_inputs(metric, table)
     assert check_artifact.get()
 
-    run_flow_test(client, artifacts=[check_artifact])
-
+    run_flow_test(client, artifacts=[check_artifact], engine=engine)
 
 def test_edit_check(client, data_integration):
     """Test that checks can be edited by replacing with the same name."""
@@ -151,7 +150,7 @@ def test_check_with_numpy_bool_output(client, data_integration):
     assert check_artifact.get()
 
 
-def test_check_with_series_output(client, data_integration):
+def test_check_with_series_output(client, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
 
@@ -169,10 +168,10 @@ def test_check_with_series_output(client, data_integration):
     failed = failure_check_return_series_of_booleans(sql_artifact)
     assert not failed.get()
 
-    run_flow_test(client, artifacts=[sql_artifact, passed, failed])
+    run_flow_test(client, artifacts=[sql_artifact, passed, failed], engine=engine)
 
 
-def test_check_failure_with_varying_severity(client, data_integration):
+def test_check_failure_with_varying_severity(client, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
 
@@ -186,7 +185,7 @@ def test_check_failure_with_varying_severity(client, data_integration):
         return False
 
     nonblocking_check = failure_nonblocking_check(sql_artifact)
-    run_flow_test(client, artifacts=[sql_artifact, nonblocking_check])
+    run_flow_test(client, artifacts=[sql_artifact, nonblocking_check], engine=engine)
 
     # In eager execution, this check should fail before we can publish the flow.
     with pytest.raises(AqueductError):

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -11,7 +11,6 @@ import aqueduct
 # The option variable can be accessed through utils.flags during tests.
 # One can also mark test to be triggered only when `--{flag}` is turned on through
 # @pytest.mark.<flag_name>
-from sdk.constants import AQUEDUCT_ENGINE
 
 FLAGS = []
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -2,33 +2,17 @@ import os
 from typing import List
 
 import pytest
-import utils
 from aqueduct.dag import DAG, Metadata
 
 import aqueduct
 
-# Usage: add a <flag> in FLAGS which will enable `--{flag}` in test cmd options.
-# The option variable can be accessed through utils.flags during tests.
-# One can also mark test to be triggered only when `--{flag}` is turned on through
-# @pytest.mark.<flag_name>
-
-FLAGS = []
-
-
 def pytest_addoption(parser):
-    for flag in FLAGS:
-        parser.addoption(f"--{flag}", action="store_true", default=False)
+    # We currently only support a single engine backend at a time.
+    parser.addoption(f"--engine", action="store", default=None)
 
 
 API_KEY_ENV_NAME = "API_KEY"
 SERVER_ADDR_ENV_NAME = "SERVER_ADDRESS"
-
-
-@pytest.fixture(autouse=True)
-def fetch_flags(pytestconfig):
-    for flag in FLAGS:
-        utils.flags[flag] = pytestconfig.getoption(flag)
-    yield
 
 
 def all_data_integration_names() -> List[str]:
@@ -41,13 +25,9 @@ def data_integration(request):
     return request.param
 
 
-def all_engine_integrations():
-    return [None]
-
-
-@pytest.fixture(scope="session", params=all_engine_integrations())
-def engine(request):
-    return request.param
+@pytest.fixture(scope="session")
+def engine(pytestconfig):
+    return pytestconfig.getoption("engine")
 
 
 @pytest.fixture(scope="function")
@@ -63,19 +43,3 @@ def client(pytestconfig):
         )
 
     return aqueduct.Client(api_key, server_address)
-
-
-def pytest_configure(config):
-    for flag in FLAGS:
-        config.addinivalue_line(
-            "markers",
-            f"{flag}: mark test to only run if --{flag} command line flag is supplied",
-        )
-
-
-# This allows us to skip tests that depend on command line flags, because pytest.mark.skipif() is evaluated
-# before our fixtures are, so we cannot reference fixtures in our test skip condition.
-def pytest_runtest_setup(item):
-    for flag in FLAGS:
-        if flag in item.keywords and not item.config.getoption(f"--{flag}"):
-            pytest.skip(f"need --{flag} option to run this test")

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -6,6 +6,7 @@ from aqueduct.dag import DAG, Metadata
 
 import aqueduct
 
+
 def pytest_addoption(parser):
     # We currently only support a single engine backend at a time.
     parser.addoption(f"--engine", action="store", default=None)

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -11,6 +11,8 @@ import aqueduct
 # The option variable can be accessed through utils.flags during tests.
 # One can also mark test to be triggered only when `--{flag}` is turned on through
 # @pytest.mark.<flag_name>
+from sdk.constants import AQUEDUCT_ENGINE
+
 FLAGS = []
 
 
@@ -37,6 +39,15 @@ def all_data_integration_names() -> List[str]:
 
 @pytest.fixture(scope="session", params=all_data_integration_names())
 def data_integration(request):
+    return request.param
+
+
+def all_engine_integrations():
+    return [None]
+
+
+@pytest.fixture(scope="session", params=all_engine_integrations())
+def engine(request):
     return request.param
 
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -8,7 +8,8 @@ import aqueduct
 
 
 def pytest_addoption(parser):
-    # We currently only support a single engine backend at a time.
+    # We currently only support a single data integration and compute engine per test suite run.
+    parser.addoption(f"--data", action="store", default="aqueduct_demo")
     parser.addoption(f"--engine", action="store", default=None)
 
 
@@ -16,14 +17,9 @@ API_KEY_ENV_NAME = "API_KEY"
 SERVER_ADDR_ENV_NAME = "SERVER_ADDRESS"
 
 
-def all_data_integration_names() -> List[str]:
-    """We currently only support the demo database, but this can eventually be configured arbitrarily."""
-    return ["aqueduct_demo"]
-
-
-@pytest.fixture(scope="session", params=all_data_integration_names())
-def data_integration(request):
-    return request.param
+@pytest.fixture(scope="session")
+def data_integration(pytestconfig):
+    return pytestconfig.getoption("data")
 
 
 @pytest.fixture(scope="session")

--- a/integration_tests/sdk/constants.py
+++ b/integration_tests/sdk/constants.py
@@ -7,6 +7,3 @@ SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
 CHURN_SQL_QUERY = "select * from customer_activity"
 
 WINE_SQL_QUERY = "select * from wine"
-
-# For using the Aqueduct engine.
-AQUEDUCT_ENGINE = "aqueduct_engine"

--- a/integration_tests/sdk/constants.py
+++ b/integration_tests/sdk/constants.py
@@ -7,3 +7,6 @@ SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
 CHURN_SQL_QUERY = "select * from customer_activity"
 
 WINE_SQL_QUERY = "select * from wine"
+
+# For using the Aqueduct engine.
+AQUEDUCT_ENGINE = "aqueduct_engine"

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -129,14 +129,18 @@ def test_delete_workflow_saved_objects_twice(client, data_integration, engine):
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
     # Workflow 1's name not specified, so given a random workflow name.
-    flow_ids_to_delete.add(run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id())
+    flow_ids_to_delete.add(
+        run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id()
+    )
 
     ###
 
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
 
     # Workflow 2's name not specified, so given a random workflow name.
-    flow_ids_to_delete.add(run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id())
+    flow_ids_to_delete.add(
+        run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id()
+    )
 
     ###
 

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -13,7 +13,7 @@ from utils import (
 from aqueduct import LoadUpdateMode
 
 
-def test_delete_workflow_invalid_saved_objects(client, data_integration):
+def test_delete_workflow_invalid_saved_objects(client, data_integration, engine):
     """Check the flow cannot delete an object it had not saved."""
     integration = client.integration(data_integration)
     name = generate_new_flow_name()
@@ -26,7 +26,14 @@ def test_delete_workflow_invalid_saved_objects(client, data_integration):
 
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
-    flow_id = run_flow_test(client, [table], name=name, num_runs=1, delete_flow_after=False).id()
+    flow_id = run_flow_test(
+        client,
+        [table],
+        engine,
+        name=name,
+        num_runs=1,
+        delete_flow_after=False,
+    ).id()
 
     ###
 
@@ -45,7 +52,7 @@ def test_delete_workflow_invalid_saved_objects(client, data_integration):
         delete_flow(client, flow_id)
 
 
-def test_delete_workflow_saved_objects(client, data_integration):
+def test_delete_workflow_saved_objects(client, data_integration, engine):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     integration = client.integration(data_integration)
     name = generate_new_flow_name()
@@ -59,7 +66,7 @@ def test_delete_workflow_saved_objects(client, data_integration):
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
     flow_ids_to_delete.add(
-        run_flow_test(client, [table], name=name, num_runs=1, delete_flow_after=False).id()
+        run_flow_test(client, [table], engine, name=name, num_runs=1, delete_flow_after=False).id()
     )
 
     ###
@@ -67,7 +74,7 @@ def test_delete_workflow_saved_objects(client, data_integration):
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
 
     flow_ids_to_delete.add(
-        run_flow_test(client, [table], name=name, num_runs=2, delete_flow_after=False).id()
+        run_flow_test(client, [table], engine, name=name, num_runs=2, delete_flow_after=False).id()
     )
 
     ###
@@ -104,7 +111,7 @@ def test_delete_workflow_saved_objects(client, data_integration):
             delete_flow(client, flow_id)
 
 
-def test_delete_workflow_saved_objects_twice(client, data_integration):
+def test_delete_workflow_saved_objects_twice(client, data_integration, engine):
     """Checking the successful deletion case and unsuccessful deletion case works as expected.
     To test this, I have two workflows that write to the same table. When I delete the table in the first workflow,
     it is successful but when I delete it in the second workflow, it is unsuccessful because the table has already
@@ -122,14 +129,14 @@ def test_delete_workflow_saved_objects_twice(client, data_integration):
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
     # Workflow 1's name not specified, so given a random workflow name.
-    flow_ids_to_delete.add(run_flow_test(client, [table], num_runs=1, delete_flow_after=False).id())
+    flow_ids_to_delete.add(run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id())
 
     ###
 
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
 
     # Workflow 2's name not specified, so given a random workflow name.
-    flow_ids_to_delete.add(run_flow_test(client, [table], num_runs=1, delete_flow_after=False).id())
+    flow_ids_to_delete.add(run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id())
 
     ###
 

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -356,7 +356,12 @@ def test_fetching_historical_flows_uses_old_data(client, data_integration, engin
         table = generate_new_table()
         table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
         run_flow_test(
-            client, name=setup_flow_name, artifacts=[table], engine=engine, num_runs=2, delete_flow_after=False
+            client,
+            name=setup_flow_name,
+            artifacts=[table],
+            engine=engine,
+            num_runs=2,
+            delete_flow_after=False,
         )
 
         # Fetching the historical flow and materializing the data will not use the new data

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -15,25 +15,33 @@ def test_list_saved_objects(client, data_integration, engine):
 
         # This will create the table.
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, engine=engine, num_runs=1, delete_flow_after=False).id()
+            run_flow_test(
+                client, [table], name=name, engine=engine, num_runs=1, delete_flow_after=False
+            ).id()
         )
 
         # Change to append mode.
         table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, engine=engine, num_runs=2, delete_flow_after=False).id()
+            run_flow_test(
+                client, [table], name=name, engine=engine, num_runs=2, delete_flow_after=False
+            ).id()
         )
 
         # Redundant append mode change.
         table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, engine=engine, num_runs=3, delete_flow_after=False).id()
+            run_flow_test(
+                client, [table], name=name, engine=engine, num_runs=3, delete_flow_after=False
+            ).id()
         )
 
         # Create a different table from the same artifact.
         table.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, engine=engine, num_runs=4, delete_flow_after=False).id()
+            run_flow_test(
+                client, [table], name=name, engine=engine, num_runs=4, delete_flow_after=False
+            ).id()
         )
 
         ###
@@ -75,7 +83,9 @@ def test_multiple_artifacts_saved_to_same_integration(client, data_integration, 
     table_2 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
     table_2.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
 
-    flow = run_flow_test(client, artifacts=[table_1, table_2], engine=engine, delete_flow_after=False)
+    flow = run_flow_test(
+        client, artifacts=[table_1, table_2], engine=engine, delete_flow_after=False
+    )
     try:
         data = client.flow(flow.id()).list_saved_objects()
 

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -4,7 +4,7 @@ from utils import delete_flow, generate_new_flow_name, run_flow_test
 from aqueduct import LoadUpdateMode, op
 
 
-def test_list_saved_objects(client, data_integration):
+def test_list_saved_objects(client, data_integration, engine):
     integration = client.integration(name=data_integration)
     name = generate_new_flow_name()
     flow_ids_to_delete = set()
@@ -15,25 +15,25 @@ def test_list_saved_objects(client, data_integration):
 
         # This will create the table.
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, num_runs=1, delete_flow_after=False).id()
+            run_flow_test(client, [table], name=name, engine=engine, num_runs=1, delete_flow_after=False).id()
         )
 
         # Change to append mode.
         table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, num_runs=2, delete_flow_after=False).id()
+            run_flow_test(client, [table], name=name, engine=engine, num_runs=2, delete_flow_after=False).id()
         )
 
         # Redundant append mode change.
         table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, num_runs=3, delete_flow_after=False).id()
+            run_flow_test(client, [table], name=name, engine=engine, num_runs=3, delete_flow_after=False).id()
         )
 
         # Create a different table from the same artifact.
         table.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
         flow_ids_to_delete.add(
-            run_flow_test(client, [table], name=name, num_runs=4, delete_flow_after=False).id()
+            run_flow_test(client, [table], name=name, engine=engine, num_runs=4, delete_flow_after=False).id()
         )
 
         ###
@@ -67,7 +67,7 @@ def test_list_saved_objects(client, data_integration):
             delete_flow(client, flow_id)
 
 
-def test_multiple_artifacts_saved_to_same_integration(client, data_integration):
+def test_multiple_artifacts_saved_to_same_integration(client, data_integration, engine):
     integration = client.integration(name=data_integration)
 
     table_1 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
@@ -75,7 +75,7 @@ def test_multiple_artifacts_saved_to_same_integration(client, data_integration):
     table_2 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
     table_2.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
 
-    flow = run_flow_test(client, artifacts=[table_1, table_2], delete_flow_after=False)
+    flow = run_flow_test(client, artifacts=[table_1, table_2], engine=engine, delete_flow_after=False)
     try:
         data = client.flow(flow.id()).list_saved_objects()
 
@@ -96,7 +96,7 @@ def test_multiple_artifacts_saved_to_same_integration(client, data_integration):
         delete_flow(client, flow.id())
 
 
-def test_lazy_artifact_with_save(client, data_integration):
+def test_lazy_artifact_with_save(client, data_integration, engine):
     db = client.integration(data_integration)
     reviews = db.sql(SHORT_SENTIMENT_SQL_QUERY)
 
@@ -110,4 +110,4 @@ def test_lazy_artifact_with_save(client, data_integration):
         config=db.config(table="test_timestamp_succeeded", update_mode=LoadUpdateMode.REPLACE)
     )
 
-    run_flow_test(client, artifacts=[review_copied])
+    run_flow_test(client, artifacts=[review_copied], engine=engine)

--- a/integration_tests/sdk/metrics_test.py
+++ b/integration_tests/sdk/metrics_test.py
@@ -40,11 +40,11 @@ def test_metric_bound(client, data_integration):
     assert not check_artifact.get()
 
 
-def test_register_metric(client, data_integration):
+def test_register_metric(client, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     metric_artifact = constant_metric(sql_artifact)
-    run_flow_test(client, artifacts=[sql_artifact, metric_artifact])
+    run_flow_test(client, artifacts=[sql_artifact, metric_artifact], engine=engine)
 
 
 @metric()
@@ -59,7 +59,7 @@ def metric_with_multiple_inputs(df1, m, df2):
     return m + 10
 
 
-def test_metric_mixed_inputs(client, data_integration):
+def test_metric_mixed_inputs(client, data_integration, engine):
     db = client.integration(data_integration)
     sql1 = db.sql(query=SENTIMENT_SQL_QUERY)
     sql2 = db.sql(query=SENTIMENT_SQL_QUERY)
@@ -68,4 +68,4 @@ def test_metric_mixed_inputs(client, data_integration):
     metric_output = metric_with_multiple_inputs(sql1, metric_input, sql2)
     assert metric_output.get() == 27.5
 
-    run_flow_test(client, artifacts=[metric_output])
+    run_flow_test(client, artifacts=[metric_output], engine=engine)

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -27,7 +27,9 @@ def test_multiple_outputs(client, engine):
     assert str_output.get() == "hello world."
     assert int_output.get() == 2468
 
-    run_flow_test(client, artifacts=[str_output, int_output], engine=engine, delete_flow_after=False)
+    run_flow_test(
+        client, artifacts=[str_output, int_output], engine=engine, delete_flow_after=False
+    )
 
 
 def test_multiple_outputs_user_failure(client):

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -5,7 +5,7 @@ from utils import run_flow_test
 from aqueduct import op
 
 
-def test_multiple_outputs(client):
+def test_multiple_outputs(client, engine):
     @op(num_outputs=2)
     def generate_two_outputs():
         return "hello", 1234
@@ -27,7 +27,7 @@ def test_multiple_outputs(client):
     assert str_output.get() == "hello world."
     assert int_output.get() == 2468
 
-    run_flow_test(client, artifacts=[str_output, int_output], delete_flow_after=False)
+    run_flow_test(client, artifacts=[str_output, int_output], engine=engine, delete_flow_after=False)
 
 
 def test_multiple_outputs_user_failure(client):

--- a/integration_tests/sdk/no_return_test.py
+++ b/integration_tests/sdk/no_return_test.py
@@ -1,4 +1,3 @@
-import pytest
 from utils import run_flow_test
 
 from aqueduct import op
@@ -9,11 +8,11 @@ def no_return() -> None:
     return None
 
 
-def test_operator_with_no_return(client):
+def test_operator_with_no_return(client, engine):
     result = no_return()
     assert result.get() is None
     try:
-        flow = run_flow_test(client, artifacts=[result], delete_flow_after=False)
+        flow = run_flow_test(client, artifacts=[result], engine=engine, delete_flow_after=False)
         artifact_return = flow.latest().artifact("no_return artifact")
         assert artifact_return.get() is None
     finally:

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -133,7 +133,9 @@ def test_edit_param_for_flow(client, data_integration, engine):
 
     flow_id = None
     try:
-        flow = run_flow_test(client, artifacts=[output], name=flow_name, engine=engine, delete_flow_after=False)
+        flow = run_flow_test(
+            client, artifacts=[output], name=flow_name, engine=engine, delete_flow_after=False
+        )
         flow_id = flow.id()
 
         # Edit the flow with a different row to append and re-publish
@@ -144,7 +146,12 @@ def test_edit_param_for_flow(client, data_integration, engine):
         # Wait for the first run, then refresh the workflow and verify that it runs at least
         # one more time (two runs total, since the original was manually triggered).
         flow = run_flow_test(
-            client, artifacts=[output], name=flow_name, engine=engine, num_runs=2, delete_flow_after=False
+            client,
+            artifacts=[output],
+            name=flow_name,
+            engine=engine,
+            num_runs=2,
+            delete_flow_after=False,
         )
 
         # Verify that the parameters were edited as expected.
@@ -183,7 +190,9 @@ def test_trigger_flow_with_different_param(client, data_integration, engine):
     output = add_numbers(sql_artifact, num1, num2)
 
     flow_name = generate_new_flow_name()
-    flow = run_flow_test(client, artifacts=[output], engine=engine, name=flow_name, delete_flow_after=False)
+    flow = run_flow_test(
+        client, artifacts=[output], engine=engine, name=flow_name, delete_flow_after=False
+    )
 
     # First, check that triggering the flow with a non-existant parameter will error.
     with pytest.raises(InvalidUserArgumentException):

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -75,7 +75,7 @@ def test_sql_query_with_parameter(client, data_integration):
         _ = sql_artifact.get(parameters={"non-existant parameter": "blah"})
 
 
-def test_sql_query_with_multiple_parameters(client, data_integration):
+def test_sql_query_with_multiple_parameters(client, data_integration, engine):
     db = client.integration(data_integration)
 
     _ = client.create_param("table_name", default="hotel_reviews")
@@ -105,7 +105,7 @@ def test_sql_query_with_multiple_parameters(client, data_integration):
     assert result.get() == len(nationality.get())
     assert result.get(parameters={"reviewer-nationality": "Australia"}) == len("Australia")
 
-    run_flow_test(client, artifacts=[result])
+    run_flow_test(client, artifacts=[result], engine=engine)
 
 
 def test_sql_query_user_vs_builtin_precedence(client, data_integration):

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -15,11 +15,11 @@ def output_different_types(should_return_num: bool) -> Union[str, int]:
     return "not a number"
 
 
-def test_flow_fails_on_unexpected_type_output(client):
+def test_flow_fails_on_unexpected_type_output(client, engine):
     type_toggle = client.create_param("output_type_toggle", True)
     output = output_different_types(type_toggle)
 
-    flow = run_flow_test(client, artifacts=[output], delete_flow_after=False)
+    flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
 
     try:
         client.trigger(flow.id(), parameters={"output_type_toggle": False})
@@ -32,13 +32,13 @@ def test_flow_fails_on_unexpected_type_output(client):
         client.delete_flow(flow.id())
 
 
-def test_flow_fails_on_unexpected_type_output_for_lazy(client):
+def test_flow_fails_on_unexpected_type_output_for_lazy(client, engine):
     type_toggle = client.create_param("output_type_toggle", True)
     output = output_different_types.lazy(type_toggle)
 
     # The flow will first be lazily executed, and the new type information
     # will be persisted to the database.
-    flow = run_flow_test(client, artifacts=[output], delete_flow_after=False)
+    flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
 
     try:
         # Because we are violating our inferred types, this will fail!

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -11,15 +11,6 @@ from aqueduct import Flow
 flags: Dict[str, bool] = {}
 
 
-def publish_flow(
-    client: aqueduct.Client,
-    engine: str,
-) -> Flow:
-    client.publish_flow(
-
-    )
-
-
 def generate_new_flow_name() -> str:
     return "test_" + uuid.uuid4().hex
 

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -11,6 +11,15 @@ from aqueduct import Flow
 flags: Dict[str, bool] = {}
 
 
+def publish_flow(
+    client: aqueduct.Client,
+    engine: str,
+) -> Flow:
+    client.publish_flow(
+
+    )
+
+
 def generate_new_flow_name() -> str:
     return "test_" + uuid.uuid4().hex
 
@@ -22,6 +31,7 @@ def generate_table_name() -> str:
 def run_flow_test(
     client: aqueduct.Client,
     artifacts: List[BaseArtifact],
+    engine: Optional[str],
     metrics: Optional[List[BaseArtifact]] = None,
     checks: Optional[List[BaseArtifact]] = None,
     name: str = "",
@@ -40,6 +50,7 @@ def run_flow_test(
     flow = client.publish_flow(
         name=name,
         artifacts=artifacts,
+        engine=engine,
         metrics=metrics,
         checks=checks,
         schedule=schedule,

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -8,9 +8,6 @@ from aqueduct.enums import ExecutionStatus
 import aqueduct
 from aqueduct import Flow
 
-flags: Dict[str, bool] = {}
-
-
 def generate_new_flow_name() -> str:
     return "test_" + uuid.uuid4().hex
 

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -8,6 +8,7 @@ from aqueduct.enums import ExecutionStatus
 import aqueduct
 from aqueduct import Flow
 
+
 def generate_new_flow_name() -> str:
     return "test_" + uuid.uuid4().hex
 

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -460,7 +460,7 @@ class Client:
         else:
             if engine not in self._connected_integrations.keys():
                 raise InvalidIntegrationException(
-                    "Not connected to compute integration %s!" % engine
+                    "Not connected to compute integration `%s`!" % engine
                 )
             engine_config = generate_engine_config(self._connected_integrations[engine])
 

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -428,6 +428,8 @@ class Client:
         if k_latest_runs is None:
             retention_policy = retention_policy_from_latest_runs(-1)
         else:
+            if not isinstance(k_latest_runs, int):
+                raise InvalidUserArgumentException("`k_latest_runs` parameter must be an int, got %s" % type(k_latest_runs))
             retention_policy = retention_policy_from_latest_runs(k_latest_runs)
 
         # Set's the execution `engine` if one was provided.
@@ -457,6 +459,9 @@ class Client:
         if engine is None:
             engine_config = EngineConfig()
         else:
+            if not isinstance(engine, str):
+                raise InvalidUserArgumentException("`engine` parameter must be a string, got %s." % type(engine))
+
             if engine not in self._connected_integrations.keys():
                 raise InvalidIntegrationException(
                     "Not connected to compute integration `%s`!" % engine

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -429,7 +429,9 @@ class Client:
             retention_policy = retention_policy_from_latest_runs(-1)
         else:
             if not isinstance(k_latest_runs, int):
-                raise InvalidUserArgumentException("`k_latest_runs` parameter must be an int, got %s" % type(k_latest_runs))
+                raise InvalidUserArgumentException(
+                    "`k_latest_runs` parameter must be an int, got %s" % type(k_latest_runs)
+                )
             retention_policy = retention_policy_from_latest_runs(k_latest_runs)
 
         # Set's the execution `engine` if one was provided.
@@ -460,7 +462,9 @@ class Client:
             engine_config = EngineConfig()
         else:
             if not isinstance(engine, str):
-                raise InvalidUserArgumentException("`engine` parameter must be a string, got %s." % type(engine))
+                raise InvalidUserArgumentException(
+                    "`engine` parameter must be a string, got %s." % type(engine)
+                )
 
             if engine not in self._connected_integrations.keys():
                 raise InvalidIntegrationException(

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -327,11 +327,10 @@ class Client:
 
         The default execution engine of the flow is Aqueduct. In order to specify which
         execution engine the flow will be running on, use "config" parameter. Eg:
-        >>> k8s_integration = client.integration("k8s_integration")
         >>> flow = client.publish_flow(
-        >>>     name = "k8s_example",
-        >>>     artifacts = [output],
-        >>>     config = FlowConfig(engine=k8s_integration),
+        >>>     name="k8s_example",
+        >>>     artifacts=[output],
+        >>>     engine="k8s_integration",
         >>> )
 
         Args:


### PR DESCRIPTION
@hsubbaraj-spiral  as primary reviewer. @Fanjia-Yan this should help you test out your changes in a more automated fashion.

## Describe your changes and why you are making these changes
Adds an `engine` fixture to our SDK integration test suite. This value can be requested by any test:
```
def test_something(client, engine):
      ...
      client.publish_flow(..., engine=engine)
```

This `engine` value can be configured through the command line, and corresponds to the name of the compute integration we want to run the test suite against!

For example, if our server has connected to a K8s integration called "my_k8s_integration", I could run the test suite with:
```
 API_KEY=Q96DTSL0MNRCVO3YF2IJX1WAKPEH8U45 SERVER_ADDRESS=localhost:8080 pytest . -rP -vv --engine "my_k8s_integration" -n 8
```
And it will run all relevant tests agains the K8s compute backend.

If `--engine` cmd line arg is not supplied, we will default to `aqueduct_demo`.

## Testing
Tested that this works normally when `--engine` is not supplied. Tested that supplying the wrong integration name to `engine` will cause the tests to fail at publish time.

The next step in my work is to test the suite against the K8s integration, which will set the groundwork for testing CPU and Memory limits.

## Related issue number (if any)
ENG-1952

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)
