### PR TITLE
ENG-1968: Close Add Integration Dialog After Successfully Connecting

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -143,6 +143,7 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
             user={user}
             service={service}
             onSuccess={() => {
+              setShowDialog(false);
               setShowSuccessToast(service);
             }}
             onCloseDialog={() => {

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -10,7 +10,7 @@ import {
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
@@ -114,7 +114,7 @@ const IntegrationDialog: React.FC<Props> = ({
 
   const [migrateStorage, setMigrateStorage] = useState(false);
 
-  useCallback(() => {
+  useEffect(() => {
     if (isSucceeded(connectStatus)) {
       dispatch(
         handleLoadIntegrations({ apiKey: user.apiKey, forceLoad: true })


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the add integrations dialog does not close after successfully connecting.

## Related issue number (if any)
ENG-1968

## Loom demo (if any)
https://www.loom.com/share/72d09ed3ca1840b581598078bf20da45

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


