### PR TITLE
Fix extraneous request issue for kubernetes dialog.

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -29,7 +29,9 @@ export const KubernetesDialog: React.FC<Props> = ({
     if (!value?.use_same_cluster) {
       onUpdateField('use_same_cluster', 'false');
     }
+  }, [apiKey, onUpdateField, value?.use_same_cluster]);
 
+  useEffect(() => {
     const fetchEnvironment = async () => {
       const environmentResponse = await fetch(`${apiAddress}/api/environment`, {
         method: 'GET',
@@ -43,7 +45,7 @@ export const KubernetesDialog: React.FC<Props> = ({
     };
 
     fetchEnvironment().catch(console.error);
-  }, [apiKey, onUpdateField, value?.use_same_cluster]);
+  }, []);
 
   return (
     <Box sx={{ mt: 2 }}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes issue where a request is sent to fetch environment each time a key is pressed in the Kubernetes Add Integration Dialog

## Related issue number (if any)
ENG-1972

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


