### PR TITLE
Allow data integration to be configured from command line in the integration tests

### DIFF
--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -8,7 +8,8 @@ import aqueduct
 
 
 def pytest_addoption(parser):
-    # We currently only support a single engine backend at a time.
+    # We currently only support a single data integration and compute engine per test suite run.
+    parser.addoption(f"--data", action="store", default="aqueduct_demo")
     parser.addoption(f"--engine", action="store", default=None)
 
 
@@ -16,14 +17,9 @@ API_KEY_ENV_NAME = "API_KEY"
 SERVER_ADDR_ENV_NAME = "SERVER_ADDRESS"
 
 
-def all_data_integration_names() -> List[str]:
-    """We currently only support the demo database, but this can eventually be configured arbitrarily."""
-    return ["aqueduct_demo"]
-
-
-@pytest.fixture(scope="session", params=all_data_integration_names())
-def data_integration(request):
-    return request.param
+@pytest.fixture(scope="session")
+def data_integration(pytestconfig):
+    return pytestconfig.getoption("data")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds the `--data` flag, which is the same as the `--engine` flag but specifies that we will only extract and load to/from a certain data integration. 

Moves away from parameterizing the test suite across all integrations for now. After this lands, the user will have full control over what data integration and engine they want to run their tests against.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


