### PR TITLE
Fix run_notebook action

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -3,17 +3,17 @@ name: Run Notebooks
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
-    paths:
-      - 'src/golang/**'
-      - 'src/python/**'
-      - 'sdk/aqueduct/**'
-  pull_request:
-    paths:
-      - '.github/workflows/run-notebooks.yml'
-      - "examples/churn_prediction/Customer Churn Tutorial.ipynb"
-      - "examples/sentiment_analysis/Sentiment Model.ipynb"
-      - "integration_tests/notebook/imported_function.ipynb"
+    branches: [ debug_notebook_action ]
+#    paths:
+#      - 'src/golang/**'
+#      - 'src/python/**'
+#      - 'sdk/aqueduct/**'
+#  pull_request:
+#    paths:
+#      - '.github/workflows/run-notebooks.yml'
+#      - "examples/churn_prediction/Customer Churn Tutorial.ipynb"
+#      - "examples/sentiment_analysis/Sentiment Model.ipynb"
+#      - "integration_tests/notebook/imported_function.ipynb"
 
 jobs:
   run-notebooks:
@@ -60,7 +60,7 @@ jobs:
         run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install Packages needed by the notebooks
-        run: python3 -m pip install sklearn transformers torch
+        run: python3 -m pip install scikit-learn transformers torch
 
       - name: Wait for server again
         timeout-minutes: 1

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -3,17 +3,22 @@ name: Run Notebooks
 on:
   workflow_dispatch:
   push:
-    branches: [ debug_notebook_action ]
-#    paths:
-#      - 'src/golang/**'
-#      - 'src/python/**'
-#      - 'sdk/aqueduct/**'
-#  pull_request:
-#    paths:
-#      - '.github/workflows/run-notebooks.yml'
-#      - "examples/churn_prediction/Customer Churn Tutorial.ipynb"
-#      - "examples/sentiment_analysis/Sentiment Model.ipynb"
-#      - "integration_tests/notebook/imported_function.ipynb"
+    branches: [ main ]
+    paths:
+      - 'src/golang/**'
+      - 'src/python/**'
+      - 'sdk/aqueduct/**'
+  pull_request:
+    paths:
+      - '.github/workflows/run-notebooks.yml'
+      - "examples/churn_prediction/Customer Churn Tutorial.ipynb"
+      - "examples/sentiment_analysis/Sentiment Model.ipynb"
+      - "examples/diabetes-classifier/Classifying Diabetes Risk.ipynb"
+      - "examples/house-price-prediction/House Price Prediction.ipynb"
+      - "examples/mpg-regressor/Predicting MPG.ipynb"
+      - "examples/tutorials/Parameters Tutorial.ipynb"
+      - "examples/tutorials/Quickstart Tutorial.ipynb"
+      - "integration_tests/notebook/imported_function.ipynb"
 
 jobs:
   run-notebooks:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We were installing a wrong pip package for sklearn, which caused the module import to fail. The PR also includes all example notebooks into the action triggering condition.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


