### PR TITLE
ENG-1974 Properly Show Operator Name in SideSheet

### DIFF
--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aqueducthq/common",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aqueducthq/common",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "devDependencies": {
         "@babel/core": "^7.19.3",

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -104,8 +104,6 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   ];
 
   useEffect(() => {
-    document.title = 'Artifact Details | Aqueduct';
-
     // Load workflow dag result if it's not cached
     if (
       !workflowDagResultWithLoadingStatus ||

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -80,8 +80,6 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
   ];
 
   useEffect(() => {
-    document.title = 'Operator Details | Aqueduct';
-
     if (
       // Load workflow dag result if it's not cached
       !workflowDagResultWithLoadingStatus ||

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -313,7 +313,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -360,7 +361,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -379,7 +381,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -398,7 +401,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -282,7 +282,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
       }
       return 'Artifact Node';
     } else {
-      if (selectedDag.artifacts[currentNode.id]) {
+      if (selectedDag.operators[currentNode.id]) {
         return selectedDag.operators[currentNode.id].name;
       }
       return 'Operator Node';
@@ -313,8 +313,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -361,8 +360,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -381,8 +379,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -401,8 +398,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes bug where operator sidesheet names showed as operator node

## Related issue number (if any)
ENG-1974

## Loom demo (if any)
Screenshot:
<img width="1888" alt="image" src="https://user-images.githubusercontent.com/1031759/200683959-cedd47fd-f665-43f9-bce0-9c6edd442eee.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


