### PR TITLE
ENG-1936: Dividers Too Wide

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -193,7 +193,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
       </Box>
 
       <Box style={menuSidebarFooter}>
-        <Divider sx={{ width: '100%', backgroundColor: 'white' }} />
+        <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
         <Box sx={{ my: 2 }}>
           <Tooltip title="Documentation" placement="right" arrow>
             <Link href="https://docs.aqueducthq.com" underline="none">
@@ -204,7 +204,7 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
             </Link>
           </Tooltip>
         </Box>
-        <Divider sx={{ width: '100%', backgroundColor: 'white' }} />
+        <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
         <Box sx={{ my: 2 }}>
           <Tooltip title="Report Issue" placement="right" arrow>
             <Link href="mailto:support@aqueducthq.com" underline="none">


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes issue where dividers take up more than the width of the menu sidebar.

## Related issue number (if any)
ENG-1936

## Loom demo (if any)
Screenshot: 
<img width="1886" alt="image" src="https://user-images.githubusercontent.com/1031759/200685274-b35a0892-1ef3-4bb8-a52a-945f19fb5bbe.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


