### PR TITLE
Fix start-function-executor mismatch bug between aqueduct_executor and dockerfiles

### DIFF
--- a/src/dockerfiles/function/start-function-executor.sh
+++ b/src/dockerfiles/function/start-function-executor.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#!/bin/bash
-echo $JOB_SPEC
+JOB_SPEC=$1
 FUNCTION_EXTRACT_PATH=$(python3 -m aqueduct_executor.operators.function_executor.get_extract_path --spec "$JOB_SPEC")
 EXIT_CODE=$?
 if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
@@ -11,14 +10,10 @@ if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
 
 if test -f "$FUNCTION_EXTRACT_PATH/op/requirements.txt"
 then
-      pip freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
-      python3 -m aqueduct_executor.operators.function_executor.prune_requirements --local_path="$FUNCTION_EXTRACT_PATH/op/local_deps.txt" --requirements_path="$FUNCTION_EXTRACT_PATH/op/requirements.txt" --missing_path="$FUNCTION_EXTRACT_PATH/op/missing.txt"
+      python3 -m pip freeze >> "$FUNCTION_EXTRACT_PATH/op/local_deps.txt"
+      python3 -m aqueduct_executor.operators.function_executor.install_requirements --local_path="$FUNCTION_EXTRACT_PATH/op/local_deps.txt" --requirements_path="$FUNCTION_EXTRACT_PATH/op/requirements.txt" --missing_path="$FUNCTION_EXTRACT_PATH/op/missing.txt" --spec "$JOB_SPEC"
       EXIT_CODE=$?
       if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi
-      if test -f "$FUNCTION_EXTRACT_PATH/op/missing.txt"
-      then
-            pip3 install -r "$FUNCTION_EXTRACT_PATH/op/missing.txt" --no-cache-dir
-      fi
 fi
 
 python3 -m aqueduct_executor.operators.function_executor.main --spec "$JOB_SPEC"

--- a/src/dockerfiles/function/start-function-executor.sh
+++ b/src/dockerfiles/function/start-function-executor.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# NOTE: Keep this in sync with the `start-function-executor.sh` in `/src/dockerfiles/function`.
+
 FUNCTION_EXTRACT_PATH=$(python3 -m aqueduct_executor.operators.function_executor.get_extract_path --spec "$JOB_SPEC")
 EXIT_CODE=$?
 if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi

--- a/src/dockerfiles/function/start-function-executor.sh
+++ b/src/dockerfiles/function/start-function-executor.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-JOB_SPEC=$1
 FUNCTION_EXTRACT_PATH=$(python3 -m aqueduct_executor.operators.function_executor.get_extract_path --spec "$JOB_SPEC")
 EXIT_CODE=$?
 if [ $EXIT_CODE != "0" ]; then exit $(($EXIT_CODE)); fi

--- a/src/python/aqueduct_executor/start-function-executor.sh
+++ b/src/python/aqueduct_executor/start-function-executor.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# NOTE: Keep this in sync with the `start-function-executor.sh` in `/src/python/aqueduct_executor`.
+
 JOB_SPEC=$1
 FUNCTION_EXTRACT_PATH=$(python3 -m aqueduct_executor.operators.function_executor.get_extract_path --spec "$JOB_SPEC")
 EXIT_CODE=$?


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Couple questions here:
1) Why didn't this fail before? This was changed 6 days. Is it because we didn't update the dockerhub image for 3.8? @cw75 
2) Why are these two dockerfiles separate at all?


## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


