### PR TITLE
Enable function operators to run with Conda environments

### DIFF
--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -188,11 +188,23 @@ func (j *ProcessJobManager) mapJobTypeToCmd(jobName string, spec Spec) (*exec.Cm
 			return nil, err
 		}
 
-		cmd = exec.Command(
-			"bash",
-			filepath.Join(j.conf.BinaryDir, functionExecutorBashScript),
-			specStr,
-		)
+		if functionSpec.ExecEnv != nil {
+			cmd = exec.Command(
+				"conda",
+				"run",
+				"-n",
+				functionSpec.ExecEnv.Name(),
+				"bash",
+				filepath.Join(j.conf.BinaryDir, functionExecutorBashScript),
+				specStr,
+			)
+		} else {
+			cmd = exec.Command(
+				"bash",
+				filepath.Join(j.conf.BinaryDir, functionExecutorBashScript),
+				specStr,
+			)
+		}
 	} else if spec.Type() == ParamJobType {
 		specStr, err := EncodeSpec(spec, JsonSerializationType)
 		if err != nil {

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/param"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	exec_env "github.com/aqueducthq/aqueduct/lib/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
 	"github.com/dropbox/godropbox/errors"
@@ -141,6 +142,11 @@ type FunctionSpec struct {
 	OutputMetadataPaths         []string      `json:"output_metadata_paths"  yaml:"output_metadata_paths"`
 	ExpectedOutputArtifactTypes []string      `json:"expected_output_artifact_types" yaml:"expected_output_artifact_types"`
 	OperatorType                operator.Type `json:"operator_type" yaml:"operator_type"`
+	// We use this field as an indication of whether we should switch to certain environment before
+	// running a function.
+	// This field is not used by the Python side, so we use - to omit it during JSON serialization.
+	// Otherwise, Pydantic will complain about this extra field. It's good for performance reason as well.
+	ExecEnv *exec_env.ExecutionEnvironment `json:"-" yaml:"-"`
 
 	// Specific to the check operator. This is left unset by any other function type.
 	CheckSeverity *check.Level `json:"check_severity" yaml:"check_severity"`

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -49,9 +49,10 @@ type baseOperator struct {
 	execMode         ExecutionMode
 	execState        shared.ExecutionState
 
-	// TODO: This is public to avoid compiling error.
-	// We should change this to private once this attribute is used.
-	ExecEnv *exec_env.ExecutionEnvironment
+	// If set to nil, the job manager will run this operator in the server's default Python environment.
+	// Otherwise, it will switch to the approppriate Conda environment before running the operator.
+	// This only applies to operators running with the Aqueduct engine.
+	execEnv *exec_env.ExecutionEnvironment
 }
 
 func (bo *baseOperator) Type() operator.Type {
@@ -382,5 +383,6 @@ func (bfo *baseFunctionOperator) jobSpec(
 		ExpectedOutputArtifactTypes: expectedOutputTypes,
 		OperatorType:                bfo.Type(),
 		CheckSeverity:               checkSeverity,
+		ExecEnv:                     bfo.execEnv,
 	}
 }

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -139,7 +139,7 @@ func NewOperator(
 
 		// These fields may be set dynamically during orchestration.
 		resultsPersisted: false,
-		ExecEnv:          execEnv,
+		execEnv:          execEnv,
 	}
 
 	if dbOperator.Spec.IsFunction() {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds ExecEnv to the FunctionSpec and enables the job manager to run operators with non-nil ExecEnv field with their Conda environments. It also refines some code commenting.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


