### PR TITLE
Fixes react-hooks/exhaustive-deps warning in kubernetesDialog.

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -45,7 +45,7 @@ export const KubernetesDialog: React.FC<Props> = ({
     };
 
     fetchEnvironment().catch(console.error);
-  }, []);
+  }, [apiKey]);
 
   return (
     <Box sx={{ mt: 2 }}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a lint warning in the kubernetes dialog related to not using exhaustive dependencies.

## Related issue number (if any)
NA

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


