### PR TITLE
Fixes lint warning on version_selector component

### DIFF
--- a/src/ui/common/src/components/workflows/version_selector.tsx
+++ b/src/ui/common/src/components/workflows/version_selector.tsx
@@ -81,11 +81,6 @@ export const VersionSelector: React.FC = () => {
     });
   };
 
-  let menuItems = getMenuItems();
-  useEffect(() => {
-    menuItems = getMenuItems();
-  }, [results]);
-
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
       <FormControl sx={{ minWidth: 120 }} size="small">
@@ -95,7 +90,7 @@ export const VersionSelector: React.FC = () => {
           autoWidth
           value={selectedResultIdx}
         >
-          {menuItems}
+          {getMenuItems()}
         </Select>
       </FormControl>
     </Box>

--- a/src/ui/common/src/components/workflows/version_selector.tsx
+++ b/src/ui/common/src/components/workflows/version_selector.tsx
@@ -9,7 +9,7 @@ import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import Typography from '@mui/material/Typography';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a lint error in the version_selector component:
```
/Users/andre/Documents/Code/aqueduct/src/ui/common/src/components/workflows/version_selector.tsx

║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║
╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢
║ 86       │ 17       │ warning  │ Assignments to the 'menuItems' variable from           │ react-hooks/         ║
║          │          │          │ inside React Hook useEffect will be lost after         │ exhaustive-deps      ║
║          │          │          │ each render. To preserve the value over time,          │                      ║
║          │          │          │ store it in a useRef Hook and keep the mutable         │                      ║
║          │          │          │ value in the '.current' property. Otherwise, you       │                      ║
║          │          │          │ can move this variable directly inside useEffect.      │                      ║
```

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


