### PR TITLE
Disable Conda from UI and remove Conda install option

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -362,20 +362,14 @@ def install_mongodb():
 def install_postgres():
     execute_command([sys.executable, "-m", "pip", "install", "psycopg2-binary"])
 
-
 def install_bigquery():
     execute_command([sys.executable, "-m", "pip", "install", "google-cloud-bigquery"])
-
 
 def install_snowflake():
     execute_command([sys.executable, "-m", "pip", "install", "snowflake-sqlalchemy"])
 
-
 def install_s3():
     execute_command([sys.executable, "-m", "pip", "install", "pyarrow"])
-
-def install_conda():
-    execute_command([sys.executable, "-m", "pip", "install", "conda"])
 
 def install_athena():
     execute_command([sys.executable, "-m", "pip", "install", "awswrangler"])
@@ -459,8 +453,6 @@ def install(system):
         install_sqlserver()
     elif system == "mongodb":
         install_mongodb()
-    elif system == "conda":
-        install_conda()
     else:
         raise Exception("Unsupported system: %s" % system)
 

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -351,11 +351,14 @@ export const SupportedIntegrations: ServiceInfoMap = {
     activated: true,
     category: 'data',
   },
+  // TODO: enable this once we release conda
+  /*
   ['Conda']: {
     logo: 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations/conda.png',
     activated: true,
     category: 'compute',
   },
+  */
 };
 
 // Helper function to format integration service


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We will re-enable the Conda integration option once we finish the backend implementation.
The Conda install option needs to be removed anyway. This should have been done in the previous PR but we forgot to remove it.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


