### PR TITLE
Eng 2011 Asynchronosly create conda env after integration connection

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -267,12 +267,20 @@ func ConnectIntegration(
 	}
 
 	if args.Service == integration.Conda {
-		go exec_env.InitializeConda(
-			context.Background(),
-			integrationObject.Id,
-			integrationWriter,
-			db,
-		)
+		go func() {
+			db, err = database.NewDatabase(db.Config())
+			if err != nil {
+				log.Errorf("Error creating DB in go routine: %v", err)
+				return
+			}
+
+			exec_env.InitializeConda(
+				context.Background(),
+				integrationObject.Id,
+				integrationWriter,
+				db,
+			)
+		}()
 	}
 
 	return http.StatusOK, nil

--- a/src/golang/cmd/server/handler/preview.go
+++ b/src/golang/cmd/server/handler/preview.go
@@ -238,7 +238,7 @@ func (h *PreviewHandler) setupExecEnv(
 ) (map[uuid.UUID]exec_env.ExecutionEnvironment, int, error) {
 	condaIntegration, err := exec_env.GetCondaIntegration(ctx, args.Id, h.IntegrationReader, h.Database)
 	if err != nil {
-		return nil, http.StatusInternalServerError, errors.Wrap(err, "error getting Conda integration.")
+		return nil, http.StatusInternalServerError, errors.Wrap(err, "error getting conda integration.")
 	}
 
 	// For now, do nothing if conda is not connected.
@@ -248,14 +248,14 @@ func (h *PreviewHandler) setupExecEnv(
 
 	condaConnectionState, err := exec_env.ExtractConnectionState(condaIntegration)
 	if err != nil {
-		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to retrieve Conda connection state.")
+		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to retrieve conda connection state.")
 	}
 
 	if condaConnectionState.Status == shared.FailedExecutionStatus {
-		errMsg := "Failed to create Conda environments."
+		errMsg := "Failed to create conda environments."
 		if condaConnectionState.Error != nil {
 			errMsg = fmt.Sprintf(
-				"Failed to create Conda environments: %s. %s.",
+				"Failed to create base conda environments: %s. %s.",
 				condaConnectionState.Error.Context,
 				condaConnectionState.Error.Tip,
 			)
@@ -266,7 +266,7 @@ func (h *PreviewHandler) setupExecEnv(
 
 	if condaConnectionState.Status != shared.SucceededExecutionStatus {
 		return nil, http.StatusBadRequest, errors.New(
-			"We are still creating Conda environments. This may take a few minutes.",
+			"We are still creating base conda environments. This may take a few minutes.",
 		)
 	}
 

--- a/src/golang/cmd/server/handler/preview.go
+++ b/src/golang/cmd/server/handler/preview.go
@@ -236,26 +236,26 @@ func (h *PreviewHandler) setupExecEnv(
 	ctx context.Context,
 	args *previewArgs,
 ) (map[uuid.UUID]exec_env.ExecutionEnvironment, int, error) {
-	condaIntegration, condaConnectionState, err := exec_env.CondaConnectionState(
-		ctx, args.Id, h.IntegrationReader, h.Database,
-	)
-
-	dagSummary := args.DagSummary
-
+	condaIntegration, err := exec_env.GetCondaIntegration(ctx, args.Id, h.IntegrationReader, h.Database)
 	if err != nil {
-		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to verify if conda is connected.")
+		return nil, http.StatusInternalServerError, errors.Wrap(err, "error getting Conda integration.")
 	}
 
 	// For now, do nothing if conda is not connected.
-	if condaConnectionState == nil {
+	if condaIntegration == nil {
 		return nil, http.StatusOK, nil
 	}
 
+	condaConnectionState, err := exec_env.ExtractConnectionState(condaIntegration)
+	if err != nil {
+		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to retrieve Conda connection state.")
+	}
+
 	if condaConnectionState.Status == shared.FailedExecutionStatus {
-		errMsg := "Failed to create conda environments."
+		errMsg := "Failed to create Conda environments."
 		if condaConnectionState.Error != nil {
 			errMsg = fmt.Sprintf(
-				"Failed to create conda environments: %s. %s.",
+				"Failed to create Conda environments: %s. %s.",
 				condaConnectionState.Error.Context,
 				condaConnectionState.Error.Tip,
 			)
@@ -266,10 +266,11 @@ func (h *PreviewHandler) setupExecEnv(
 
 	if condaConnectionState.Status != shared.SucceededExecutionStatus {
 		return nil, http.StatusBadRequest, errors.New(
-			"We are still creating conda environments. This may take a few minutes.",
+			"We are still creating Conda environments. This may take a few minutes.",
 		)
 	}
 
+	dagSummary := args.DagSummary
 	rawEnvByOperator := make(
 		map[uuid.UUID]exec_env.ExecutionEnvironment,
 		len(dagSummary.FileContentsByOperatorUUID),

--- a/src/golang/cmd/server/handler/preview.go
+++ b/src/golang/cmd/server/handler/preview.go
@@ -266,7 +266,7 @@ func (h *PreviewHandler) setupExecEnv(
 
 	if condaConnectionState.Status != shared.SucceededExecutionStatus {
 		return nil, http.StatusBadRequest, errors.New(
-			"We are still creating conda enviroments. This may take a few minutes.",
+			"We are still creating conda environments. This may take a few minutes.",
 		)
 	}
 

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	db_exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
-	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/google/uuid"
@@ -168,29 +167,6 @@ func GetExecEnvFromDB(
 	}
 
 	return newFromDBExecutionEnvironment(dbExecEnv), nil
-}
-
-func GetCondaIntegration(
-	ctx context.Context,
-	userId uuid.UUID,
-	integrationReader integration.Reader,
-	db database.Database,
-) (*integration.Integration, error) {
-	integrations, err := integrationReader.GetIntegrationsByServiceAndUser(
-		ctx,
-		integration.Conda,
-		userId,
-		db,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(integrations) == 0 {
-		return nil, nil
-	}
-
-	return &integrations[0], nil
 }
 
 // Best-effort to delete all envs and log any error

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -80,7 +80,7 @@ func (e *ExecutionEnvironment) Name() string {
 }
 
 func (e *ExecutionEnvironment) CreateEnv() error {
-	// First, we create a Conda env with the env object's Python version.
+	// First, we create a conda env with the env object's Python version.
 	createArgs := []string{
 		"create",
 		"-n",
@@ -95,7 +95,7 @@ func (e *ExecutionEnvironment) CreateEnv() error {
 		return err
 	}
 	duration := time.Since(start)
-	log.Infof("Conda creation took %d seconds", duration.Seconds())
+	log.Infof("conda creation took %d seconds", duration.Seconds())
 
 	forkEnvPath := fmt.Sprintf("%s/envs/aqueduct_python%s/lib/python%s/site-packages", e.CondaPath, e.PythonVersion, e.PythonVersion)
 	log.Infof("forkEnvPath is %s", forkEnvPath)
@@ -113,7 +113,7 @@ func (e *ExecutionEnvironment) CreateEnv() error {
 		return err
 	}
 	duration = time.Since(start)
-	log.Infof("Conda fork took %d seconds", duration.Seconds())
+	log.Infof("conda fork took %d seconds", duration.Seconds())
 
 	log.Info("Printing dependencies...")
 	for _, d := range e.Dependencies {
@@ -135,7 +135,7 @@ func (e *ExecutionEnvironment) CreateEnv() error {
 		return err
 	}
 	duration = time.Since(start)
-	log.Infof("Conda dep install took %d seconds", duration.Seconds())
+	log.Infof("conda dep install took %d seconds", duration.Seconds())
 
 	return nil
 }

--- a/src/golang/lib/execution_environment/integration.go
+++ b/src/golang/lib/execution_environment/integration.go
@@ -1,0 +1,298 @@
+package execution_environment
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aqueducthq/aqueduct/lib"
+	"github.com/aqueducthq/aqueduct/lib/collections/integration"
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	collection_utils "github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/lib_utils"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	CondaPathKey = "conda_path"
+	ExecStateKey = "exec_state"
+)
+
+func serializeExecStateAndLogFailure(execState *shared.ExecutionState) string {
+	serializedState, err := json.Marshal(execState)
+	if err != nil {
+		// We should never hit this
+		log.Errorf("Error marshalling serialized state: %v", err)
+		return ""
+	}
+
+	return string(serializedState)
+}
+
+func serializedFailure(
+	outputs string,
+	msg string,
+	runningAt *time.Time,
+) string {
+	failureType := shared.SystemFailure
+	now := time.Now()
+	execState := &shared.ExecutionState{
+		Status:      shared.FailedExecutionStatus,
+		FailureType: &failureType,
+		UserLogs: &shared.Logs{
+			Stdout: outputs,
+		},
+		Error: &shared.Error{
+			Context: msg,
+			Tip:     shared.TipUnknownInternalError,
+		},
+		Timestamps: &shared.ExecutionTimestamps{
+			RunningAt:  runningAt,
+			FinishedAt: &now,
+		},
+	}
+
+	return serializeExecStateAndLogFailure(execState)
+}
+
+func serializedRunning(runningAt *time.Time) string {
+	execState := &shared.ExecutionState{
+		Status: shared.SucceededExecutionStatus,
+		Timestamps: &shared.ExecutionTimestamps{
+			RunningAt: runningAt,
+		},
+	}
+
+	return serializeExecStateAndLogFailure(execState)
+}
+
+func serializedSuccess(runningAt *time.Time) string {
+	now := time.Now()
+	execState := &shared.ExecutionState{
+		Status: shared.SucceededExecutionStatus,
+		Timestamps: &shared.ExecutionTimestamps{
+			RunningAt:  runningAt,
+			FinishedAt: &now,
+		},
+	}
+
+	return serializeExecStateAndLogFailure(execState)
+}
+
+func updateFailure(
+	ctx context.Context,
+	outputs string,
+	msg string,
+	condaPath string,
+	runningAt *time.Time,
+	integrationID uuid.UUID,
+	integrationWriter integration.Writer,
+	db database.Database,
+) {
+	_, err := integrationWriter.UpdateIntegration(
+		ctx,
+		integrationID,
+		map[string]interface{}{
+			"config": (*collection_utils.Config)(&map[string]string{
+				CondaPathKey: condaPath,
+				ExecStateKey: serializedFailure(outputs, msg, runningAt),
+			}),
+		},
+		db,
+	)
+	if err != nil {
+		log.Errorf("Failed to update conda integration: %v", err)
+	}
+
+	return
+}
+
+func InitializeConda(
+	ctx context.Context,
+	integrationID uuid.UUID,
+	integrationWriter integration.Writer,
+	db database.Database,
+) {
+	now := time.Now()
+	_, err := integrationWriter.UpdateIntegration(
+		ctx,
+		integrationID,
+		map[string]interface{}{
+			"config": (*collection_utils.Config)(&map[string]string{
+				ExecStateKey: serializedRunning(&now),
+			}),
+		},
+		db,
+	)
+	if err != nil {
+		log.Errorf("Failed to update conda integration: %v", err)
+		return
+	}
+
+	out, _, err := lib_utils.RunCmd(CondaCmdPrefix, "info", "--base")
+	if err != nil {
+		updateFailure(
+			ctx,
+			out,
+			err.Error(),
+			"", /* condaPath */
+			&now,
+			integrationID,
+			integrationWriter,
+			db,
+		)
+
+		return
+	}
+
+	condaPath := strings.TrimSpace(out)
+	log.Infof("Conda base path is %s", condaPath)
+
+	pythonVersions := []string{"3.7", "3.8", "3.9", "3.10"}
+	for _, pythonVersion := range pythonVersions {
+		args := []string{
+			"create",
+			"-n",
+			fmt.Sprintf("aqueduct_python%s", pythonVersion),
+			fmt.Sprintf("python==%s", pythonVersion),
+			"-y",
+		}
+		_, _, err := lib_utils.RunCmd(CondaCmdPrefix, args...)
+		if err != nil {
+			updateFailure(
+				ctx,
+				out,
+				err.Error(),
+				condaPath,
+				&now,
+				integrationID,
+				integrationWriter,
+				db,
+			)
+
+			return
+		}
+
+		args = []string{
+			"run",
+			"-n",
+			fmt.Sprintf("aqueduct_python%s", pythonVersion),
+			"pip3",
+			"install",
+			fmt.Sprintf("aqueduct-ml==%s", lib.ServerVersionNumber),
+		}
+		_, _, err = lib_utils.RunCmd(CondaCmdPrefix, args...)
+		if err != nil {
+			updateFailure(
+				ctx,
+				out,
+				err.Error(),
+				condaPath,
+				&now,
+				integrationID,
+				integrationWriter,
+				db,
+			)
+
+			return
+		}
+	}
+
+	// This is to ensure we can use `conda develop` to update the python path later on.
+	args := []string{
+		"install",
+		"conda-build",
+		"-y",
+	}
+	_, _, err = lib_utils.RunCmd(CondaCmdPrefix, args...)
+	if err != nil {
+		updateFailure(
+			ctx,
+			out,
+			err.Error(),
+			condaPath,
+			&now,
+			integrationID,
+			integrationWriter,
+			db,
+		)
+
+		return
+	}
+
+	_, err = integrationWriter.UpdateIntegration(
+		ctx,
+		integrationID,
+		map[string]interface{}{
+			"config": (*collection_utils.Config)(&map[string]string{
+				CondaPathKey: condaPath,
+				ExecStateKey: serializedSuccess(&now),
+			}),
+		},
+		db,
+	)
+
+	if err != nil {
+		log.Errorf("Failed to update conda integration: ")
+	}
+}
+
+func getCondaIntegration(
+	ctx context.Context,
+	userId uuid.UUID,
+	integrationReader integration.Reader,
+	db database.Database,
+) (*integration.Integration, error) {
+	integrations, err := integrationReader.GetIntegrationsByServiceAndUser(
+		ctx,
+		integration.Conda,
+		userId,
+		db,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(integrations) == 0 {
+		return nil, nil
+	}
+
+	return &integrations[0], nil
+}
+
+// CondaConnectionState shows the current conda connection status
+// if the user is connected to conda. Otherwise, it returns nil.
+func CondaConnectionState(
+	ctx context.Context,
+	userId uuid.UUID,
+	integrationReader integration.Reader,
+	db database.Database,
+) (*integration.Integration, *shared.ExecutionState, error) {
+	integration, err := getCondaIntegration(ctx, userId, integrationReader, db)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if integration == nil {
+		return nil, nil, nil
+	}
+
+	stateSerialized, ok := integration.Config[ExecStateKey]
+	if !ok {
+		return integration, &shared.ExecutionState{
+			Status: shared.PendingExecutionStatus,
+		}, nil
+	}
+
+	var state shared.ExecutionState
+	err = json.Unmarshal([]byte(stateSerialized), &state)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return integration, &state, nil
+}

--- a/src/golang/lib/execution_environment/integration.go
+++ b/src/golang/lib/execution_environment/integration.go
@@ -107,8 +107,6 @@ func updateFailure(
 	if err != nil {
 		log.Errorf("Failed to update conda integration: %v", err)
 	}
-
-	return
 }
 
 func InitializeConda(

--- a/src/golang/lib/execution_environment/integration.go
+++ b/src/golang/lib/execution_environment/integration.go
@@ -44,7 +44,7 @@ func serializedFailure(
 		Status:      shared.FailedExecutionStatus,
 		FailureType: &failureType,
 		UserLogs: &shared.Logs{
-			Stdout: outputs,
+			StdErr: outputs,
 		},
 		Error: &shared.Error{
 			Context: msg,
@@ -83,7 +83,7 @@ func serializedSuccess(runningAt *time.Time) string {
 	return serializeExecStateAndLogFailure(execState)
 }
 
-func updateFailure(
+func updateOnFailure(
 	ctx context.Context,
 	outputs string,
 	msg string,
@@ -105,7 +105,7 @@ func updateFailure(
 		db,
 	)
 	if err != nil {
-		log.Errorf("Failed to update conda integration: %v", err)
+		log.Errorf("Failed to update Conda integration: %v", err)
 	}
 }
 
@@ -127,13 +127,13 @@ func InitializeConda(
 		db,
 	)
 	if err != nil {
-		log.Errorf("Failed to update conda integration: %v", err)
+		log.Errorf("Failed to update Conda integration: %v", err)
 		return
 	}
 
 	out, _, err := lib_utils.RunCmd(CondaCmdPrefix, "info", "--base")
 	if err != nil {
-		updateFailure(
+		updateOnFailure(
 			ctx,
 			out,
 			err.Error(),
@@ -148,7 +148,6 @@ func InitializeConda(
 	}
 
 	condaPath := strings.TrimSpace(out)
-	log.Infof("Conda base path is %s", condaPath)
 
 	pythonVersions := []string{"3.7", "3.8", "3.9", "3.10"}
 	for _, pythonVersion := range pythonVersions {
@@ -161,7 +160,7 @@ func InitializeConda(
 		}
 		_, _, err := lib_utils.RunCmd(CondaCmdPrefix, args...)
 		if err != nil {
-			updateFailure(
+			updateOnFailure(
 				ctx,
 				out,
 				err.Error(),
@@ -185,7 +184,7 @@ func InitializeConda(
 		}
 		_, _, err = lib_utils.RunCmd(CondaCmdPrefix, args...)
 		if err != nil {
-			updateFailure(
+			updateOnFailure(
 				ctx,
 				out,
 				err.Error(),
@@ -208,7 +207,7 @@ func InitializeConda(
 	}
 	_, _, err = lib_utils.RunCmd(CondaCmdPrefix, args...)
 	if err != nil {
-		updateFailure(
+		updateOnFailure(
 			ctx,
 			out,
 			err.Error(),
@@ -235,11 +234,11 @@ func InitializeConda(
 	)
 
 	if err != nil {
-		log.Errorf("Failed to update conda integration: ")
+		log.Errorf("Failed to update Conda integration: ")
 	}
 }
 
-func getCondaIntegration(
+func GetCondaIntegration(
 	ctx context.Context,
 	userId uuid.UUID,
 	integrationReader integration.Reader,
@@ -262,35 +261,31 @@ func getCondaIntegration(
 	return &integrations[0], nil
 }
 
-// CondaConnectionState shows the current conda connection status
-// if the user is connected to conda. Otherwise, it returns nil.
-func CondaConnectionState(
-	ctx context.Context,
-	userId uuid.UUID,
-	integrationReader integration.Reader,
-	db database.Database,
-) (*integration.Integration, *shared.ExecutionState, error) {
-	integration, err := getCondaIntegration(ctx, userId, integrationReader, db)
-	if err != nil {
-		return nil, nil, err
+// ExtractConnectionState retrieves the current connection state from
+// the given integration object.
+// For non-conda integration, we assume they are always successfully connected
+// since they are created in-sync in `connectIntegration` handler.
+func ExtractConnectionState(
+	integrationObject *integration.Integration,
+) (*shared.ExecutionState, error) {
+	if integrationObject.Service != integration.Conda {
+		return &shared.ExecutionState{
+			Status: shared.SucceededExecutionStatus,
+		}, nil
 	}
 
-	if integration == nil {
-		return nil, nil, nil
-	}
-
-	stateSerialized, ok := integration.Config[ExecStateKey]
+	stateSerialized, ok := integrationObject.Config[ExecStateKey]
 	if !ok {
-		return integration, &shared.ExecutionState{
+		return &shared.ExecutionState{
 			Status: shared.PendingExecutionStatus,
 		}, nil
 	}
 
 	var state shared.ExecutionState
-	err = json.Unmarshal([]byte(stateSerialized), &state)
+	err := json.Unmarshal([]byte(stateSerialized), &state)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return integration, &state, nil
+	return &state, nil
 }

--- a/src/golang/lib/execution_environment/integration.go
+++ b/src/golang/lib/execution_environment/integration.go
@@ -105,7 +105,7 @@ func updateOnFailure(
 		db,
 	)
 	if err != nil {
-		log.Errorf("Failed to update Conda integration: %v", err)
+		log.Errorf("Failed to update conda integration: %v", err)
 	}
 }
 
@@ -127,7 +127,7 @@ func InitializeConda(
 		db,
 	)
 	if err != nil {
-		log.Errorf("Failed to update Conda integration: %v", err)
+		log.Errorf("Failed to update conda integration: %v", err)
 		return
 	}
 
@@ -234,7 +234,7 @@ func InitializeConda(
 	)
 
 	if err != nil {
-		log.Errorf("Failed to update Conda integration: ")
+		log.Errorf("Failed to update conda integration: ")
 	}
 }
 

--- a/src/golang/lib/execution_environment/integration.go
+++ b/src/golang/lib/execution_environment/integration.go
@@ -61,7 +61,7 @@ func serializedFailure(
 
 func serializedRunning(runningAt *time.Time) string {
 	execState := &shared.ExecutionState{
-		Status: shared.SucceededExecutionStatus,
+		Status: shared.RunningExecutionStatus,
 		Timestamps: &shared.ExecutionTimestamps{
 			RunningAt: runningAt,
 		},


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR moves conda base env creation to an async go routine. We also made changes to update the integration object properly.

Specifically, we use `config` field to track a serialized `ExecState` object so that the user / backend is informed about the exec state.

We also modified 'preview' such that it will block execution if the env creation is still in progress.

Note: UI change only set up basics to handle exec state. We will make improvements so that it renders more details about the exec state.

## Related issue number (if any)
ENG-2011

## Loom demo (if any)
https://www.loom.com/share/1dc0308ebeb3416d92cc229f45eaf2c3

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


