### PR TITLE
Fix broken Lambda execution

### DIFF
--- a/src/dockerfiles/lambda/function/function.py
+++ b/src/dockerfiles/lambda/function/function.py
@@ -1,18 +1,14 @@
 import base64
-import os
 import subprocess
 import sys
 
 from aqueduct_executor.operators.function_executor import (
     execute,
     extract_function,
-    prune_requirements,
+    install_requirements,
 )
 from aqueduct_executor.operators.function_executor.spec import parse_spec
 
-
-def install_packages(requirements_path):
-    subprocess.run([sys.executable, "-m", "pip", "install", "-r", requirements_path, "--no-cache-dir"])
 
 def pip_freeze(local_deps_path):
     subprocess.run([sys.executable, "-m", "pip", "freeze", ">>", local_deps_path])
@@ -33,11 +29,10 @@ def handler(event, context):
     open(spec.function_extract_path + "op/local_deps.txt", 'w')
     open(spec.function_extract_path + "op/missing.txt", 'w')
     pip_freeze(spec.function_extract_path + "op/local_deps.txt")
-    prune_requirements.run(
+    install_requirements.run(
         spec.function_extract_path + "op/local_deps.txt",
         spec.function_extract_path + "op/requirements.txt",
         spec.function_extract_path + "op/missing.txt",
+        spec,
     )
-
-    install_packages(spec.function_extract_path + "op/requirements.txt")
     execute.run(spec)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Lambda execution is broken because it's still using `prune_requirements`. This updates it to use `install_requirements()`.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


