### PR TITLE
Fix Run Notebook Fail Resulted From Python Setup

### DIFF
--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8.10'
+          python-version: '3.8'
 
       - name: Set up GOPATH variable
         run: echo "GOPATH=$(echo $HOME)" >> $GITHUB_ENV


### PR DESCRIPTION
## Describe your changes and why you are making these changes
After some digging, I think I get what’s going on. So we run notebooks on ubuntu-latest but now there is a migration that changes ubuntu-latest  version from 20.04 to 22.04. https://github.com/actions/runner-images/issues/6399. However, there is no python version of 3.8.10 of linux 22.04 which causes the failure.

One way we can make this work is to either hard coded the ubuntu version or we can change the python version that has linux 22.04 version.
## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


