### PR TITLE
Adds ability to configure memory for Lambda-backed operators

### DIFF
--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -48,7 +48,7 @@ def enable_by_engine_type(request, client, engine):
     """When a test is marked with this, it is enabled for a particular ServiceType!
 
     Eg.
-    @pytest.mark.enable_only_for_engine("Kubernetes")
+    @pytest.mark.enable_only_for_engine(ServiceType.LAMBDA, ServiceType.K8s)
     def test_k8s(engine):
         ...
     """

--- a/integration_tests/sdk/preview_test.py
+++ b/integration_tests/sdk/preview_test.py
@@ -1,8 +1,7 @@
 import pandas as pd
 import pytest
+from aqueduct.enums import RuntimeType, ServiceType
 from aqueduct.error import AqueductError, InvalidDependencyFilePath, InvalidFunctionException
-from aqueduct.enums import ServiceType, RuntimeType
-from aqueduct import global_config
 from constants import SENTIMENT_SQL_QUERY
 from test_functions.simple.file_dependency_model import (
     model_with_file_dependency,
@@ -17,7 +16,7 @@ from test_functions.simple.model import (
     dummy_sentiment_model_multiple_input,
 )
 
-from aqueduct import op
+from aqueduct import global_config, op
 
 
 def test_basic_get(client, data_integration):

--- a/integration_tests/sdk/resources_test.py
+++ b/integration_tests/sdk/resources_test.py
@@ -1,12 +1,11 @@
 from os import cpu_count
 
 import pytest
-from aqueduct import global_config
 from aqueduct.enums import ServiceType
 from aqueduct.error import AqueductError, InvalidUserArgumentException
 from utils import generate_new_flow_name, run_flow_test
 
-from aqueduct import op
+from aqueduct import global_config, op
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
@@ -169,9 +168,6 @@ def test_too_much_memory_requested_lambda(client, engine):
 
     with pytest.raises(InvalidUserArgumentException):
         run_flow_test(client, [output], engine=engine)
-
-
-# TODO: pause EC2
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)

--- a/integration_tests/sdk/resources_test.py
+++ b/integration_tests/sdk/resources_test.py
@@ -3,6 +3,7 @@ from os import cpu_count
 import pytest
 from aqueduct import global_config
 from aqueduct.enums import ServiceType
+from aqueduct.error import AqueductError, InvalidUserArgumentException
 from utils import generate_new_flow_name, run_flow_test
 
 from aqueduct import op
@@ -29,12 +30,14 @@ def test_custom_num_cpus(client, engine):
         return cpus
 
     global_config({"engine": engine})
+
     # Returns the default number of CPUs of the K8s cluster. (Currently 2)
     @op(requirements=[])
     def count_default_available_cpus():
         return _count_available_cpus()
 
     num_default_available_cpus = count_default_available_cpus()
+    assert num_default_available_cpus.get() == 2
 
     # Returns 4, the custom number of CPUs on the K8s cluster.
     @op(requirements=[], resources={"num_cpus": 4})
@@ -42,6 +45,7 @@ def test_custom_num_cpus(client, engine):
         return _count_available_cpus()
 
     num_count_available_cpus = count_with_custom_available_cpus()
+    assert num_count_available_cpus.get() == 4
 
     flows = []
     try:
@@ -85,11 +89,14 @@ def test_too_many_cpus_requested(client, engine):
     def too_many_cpus():
         return 123
 
-    output = too_many_cpus()
+    with pytest.raises(AqueductError):
+        too_many_cpus()
+    output = too_many_cpus.lazy()
+
     run_flow_test(client, [output], engine=engine, expect_success=False)
 
 
-@pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
+@pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
 def test_custom_memory(client, engine):
     """Assumption: nodes in the K8s cluster have more than 200MB of capacity.
 
@@ -110,7 +117,9 @@ def test_custom_memory(client, engine):
         output = bytearray(1000 * 1000 * 100 * 4)
         return output
 
-    failure_output = fn_expect_failure()
+    with pytest.raises(AqueductError):
+        fn_expect_failure()
+    failure_output = fn_expect_failure.lazy()
 
     run_flow_test(
         client,
@@ -129,17 +138,40 @@ def test_custom_memory(client, engine):
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_too_much_memory_requested(client, engine):
+def test_too_much_memory_requested_K8s(client, engine):
     """Assumption: nodes in the k8s cluster have less then 100GB of memory."""
-
     global_config({"engine": engine})
 
     @op(requirements=[], resources={"memory": "100GB"})
     def too_much_memory():
         return 123
 
-    output = too_much_memory()
+    with pytest.raises(AqueductError):
+        _ = too_much_memory()
+    output = too_much_memory.lazy()
+
     run_flow_test(client, [output], engine=engine, expect_success=False)
+
+
+@pytest.mark.enable_only_for_engine_type(ServiceType.LAMBDA)
+def test_too_much_memory_requested_lambda(client, engine):
+    """Lambda does not allow you to allocate more than 10,240MB of memory."""
+    global_config({"engine": engine})
+
+    @op(requirements=[], resources={"memory": 11000})
+    def too_much_memory():
+        return 123
+
+    with pytest.raises(InvalidUserArgumentException):
+        _ = too_much_memory()
+
+    output = too_much_memory.lazy()
+
+    with pytest.raises(InvalidUserArgumentException):
+        run_flow_test(client, [output], engine=engine)
+
+
+# TODO: pause EC2
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
@@ -187,8 +219,8 @@ def test_custom_gpus(client, engine):
         )
         flows.append(gpu_flow)
 
-        assert no_gpu_flow.latest().artifact("gpu_is_not_available artifact").get() == False
-        assert gpu_flow.latest().artifact("gpu_is_available artifact").get() == True
+        assert not no_gpu_flow.latest().artifact("gpu_is_not_available artifact").get()
+        assert gpu_flow.latest().artifact("gpu_is_available artifact").get()
 
     finally:
         for flow in flows:

--- a/sdk/aqueduct/artifacts/utils.py
+++ b/sdk/aqueduct/artifacts/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from aqueduct.artifacts import bool_artifact, generic_artifact, numeric_artifact, table_artifact
 from aqueduct.artifacts.base_artifact import BaseArtifact

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -72,6 +72,8 @@ class DAG(BaseModel):
                 "memory": True,
                 "gpu_resource_name": True,
             }
+        elif engine_config.type == RuntimeType.LAMBDA:
+            allowed_customizable_resources["memory"] = True
 
         for op in self.operators.values():
             if op.spec.resources is not None:

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -10,10 +10,12 @@ from aqueduct.error import (
     InvalidUserArgumentException,
 )
 from aqueduct.operators import (
+    LAMBDA_MAX_MEMORY_MB,
+    LAMBDA_MIN_MEMORY_MB,
     Operator,
     OperatorSpec,
     get_operator_type,
-    get_operator_type_from_spec, LAMBDA_MIN_MEMORY_MB, LAMBDA_MAX_MEMORY_MB,
+    get_operator_type_from_spec,
 )
 from pydantic import BaseModel
 

--- a/sdk/aqueduct/dag.py
+++ b/sdk/aqueduct/dag.py
@@ -9,6 +9,7 @@ from aqueduct.error import (
     InternalAqueductError,
     InvalidUserArgumentException,
 )
+from aqueduct.logger import logger
 from aqueduct.operators import (
     LAMBDA_MAX_MEMORY_MB,
     LAMBDA_MIN_MEMORY_MB,
@@ -102,6 +103,9 @@ class DAG(BaseModel):
                             "AWS Lambda method must be configured with at most %d MB of memory, but got a request for %d."
                             % (LAMBDA_MIN_MEMORY_MB, op.spec.resources.memory_mb)
                         )
+                    logger().warning(
+                        "Customizing memory for a AWS Lambda operator will add about a minute to its runtime, per operator."
+                    )
 
                 if (
                     not allowed_customizable_resources["gpu_resource_name"]

--- a/sdk/aqueduct/operators.py
+++ b/sdk/aqueduct/operators.py
@@ -173,6 +173,11 @@ class ParamSpec(BaseModel):
     serialization_type: SerializationType
 
 
+# https://docs.aws.amazon.com/lambda/latest/operatorguide/computing-power.html
+LAMBDA_MIN_MEMORY_MB = 128
+LAMBDA_MAX_MEMORY_MB = 10240
+
+
 class ResourceConfig(BaseModel):
     # These resources are configured exactly. The user is not given any more
     # or any less. If the requested resources exceeds capacity, an error

--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -69,16 +69,15 @@ func (j *k8sJobManager) Launch(ctx context.Context, name string, spec Spec) erro
 		if !ok {
 			return ErrInvalidJobSpec
 		}
+
+		functionSpec.FunctionExtractPath = defaultFunctionExtractPath
+
 		if functionSpec.Resources != nil {
 			if functionSpec.Resources.GPUResourceName != nil {
 				resourceRequest[k8s.GPUResourceName] = *functionSpec.Resources.GPUResourceName
 				launchGpu = true
 			}
-		}
 
-		functionSpec.FunctionExtractPath = defaultFunctionExtractPath
-
-		if functionSpec.Resources != nil {
 			if functionSpec.Resources.NumCPU != nil {
 				resourceRequest[k8s.PodResourceCPUKey] = strconv.Itoa(*functionSpec.Resources.NumCPU)
 			}

--- a/src/golang/lib/job/lambda.go
+++ b/src/golang/lib/job/lambda.go
@@ -40,6 +40,9 @@ func (j *lambdaJobManager) Config() Config {
 }
 
 func (j *lambdaJobManager) Launch(ctx context.Context, name string, spec Spec) error {
+	j.lambdaService.UpdateFunctionConfiguration()
+	j.lambdaService.GetFunctionConfiguration()
+
 	if spec.Type() == FunctionJobType {
 		functionSpec, ok := spec.(*FunctionSpec)
 		if !ok {
@@ -79,7 +82,7 @@ func (j *lambdaJobManager) Launch(ctx context.Context, name string, spec Spec) e
 		Payload:        payload,
 	}
 
-	_, err = j.lambdaService.Invoke(invokeInput)
+	_, err = j.lambdaService.InvokeWithContext(ctx, invokeInput)
 	if err != nil {
 		return errors.Wrap(err, "Unable to invoke lambda function.")
 	}

--- a/src/golang/lib/job/lambda_test.go
+++ b/src/golang/lib/job/lambda_test.go
@@ -1,0 +1,31 @@
+package job
+
+import (
+	"context"
+	"fmt"
+	lambda_utils "github.com/aqueducthq/aqueduct/lib/lambda"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestLambdaAPI(t *testing.T) {
+	//t.Skip( " ERROR MESSAGE" ) // TODO:
+
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+	lambdaSvc := lambda.New(sess)
+
+	functionName := lambda_utils.FunctionLambdaFunction38
+
+	jobManager := &lambdaJobManager{
+		lambdaService: lambdaSvc,
+	}
+
+	newMemory := int64(300)
+	oldMemory, err := jobManager.updateFunctionMemory(context.Background(), functionName, &newMemory)
+	require.Nil(t, err)
+	fmt.Println("OLD MEMORY: ", *oldMemory)
+}

--- a/src/golang/lib/job/lambda_test.go
+++ b/src/golang/lib/job/lambda_test.go
@@ -26,6 +26,7 @@ func TestLambdaAPI(t *testing.T) {
 
 	newMemory := int64(300)
 	oldMemory, err := jobManager.updateFunctionMemory(context.Background(), functionName, &newMemory)
+	fmt.Println(err)
 	require.Nil(t, err)
 
 	fmt.Println("OLD MEMORY: ", *oldMemory)

--- a/src/golang/lib/job/lambda_test.go
+++ b/src/golang/lib/job/lambda_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLambdaAPI(t *testing.T) {
-	//t.Skip( " ERROR MESSAGE" ) // TODO:
+	t.Skip("This is not really a unit test since it relies on AWS Lambda. Can be manually unskipped.")
 
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
@@ -27,5 +27,6 @@ func TestLambdaAPI(t *testing.T) {
 	newMemory := int64(300)
 	oldMemory, err := jobManager.updateFunctionMemory(context.Background(), functionName, &newMemory)
 	require.Nil(t, err)
+
 	fmt.Println("OLD MEMORY: ", *oldMemory)
 }

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -105,6 +105,7 @@ func (bo *baseOperator) launch(ctx context.Context, spec job.Spec) error {
 	}
 
 	bo.updateExecState(&shared.ExecutionState{Status: shared.RunningExecutionStatus})
+
 	// Check if this operator can use previously cached results instead of computing for scratch.
 	if bo.previewCacheManager != nil {
 		outputArtifactSignatures := make([]uuid.UUID, 0, len(bo.outputs))


### PR DESCRIPTION
@hsubbaraj-spiral as lead reviewer.

## Describe your changes and why you are making these changes
Configuring memory for a lambda-backed operator adds about a minute of latency to the operator, since it takes about 25-30 seconds for the update to be properly registered, and we have to make two updates, one to set to the new memory, one to reset to the previous one at the end of the operator. Also, the operator has to run synchronously in such cases now.

This PR doesn't provide full memory config isolation. It is possible that operators scheduled beforehand will race with our custom memory config request to the Lambda function. I made a task (https://linear.app/aqueducthq/issue/ENG-2030/decide-what-level-of-memory-configuration-isolation-to-provide-for) to decide whether we want full isolation. The reason I didn't do it here is that it seemed like a bit of non-trivial refactor work, and didn't want to jump into it without advice from product as to whether this would be worth building.

## Related issue number (if any)
ENG-1953

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


