### PR TITLE
Builds many improvements into SDK integration test suite

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      # For now, we want to always perform inference in our periodic tests for additional coverage.
+      - name: Remove the requirements.txt file.
+      - working-directory: integration_tests/sdk
+      - run: rm requirements.txt
+
       - name: Create the logs directory
         run: mkdir -p logs
 

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -4,7 +4,7 @@ from aqueduct.error import AqueductError, ArtifactNotFoundException, InvalidUser
 from constants import CHURN_SQL_QUERY, SENTIMENT_SQL_QUERY
 from test_functions.simple.model import dummy_sentiment_model
 from test_metrics.constant.model import constant_metric
-from utils import run_flow_test
+from utils import run_flow_test, publish_flow_test
 
 from aqueduct import CheckSeverity, check
 
@@ -32,17 +32,22 @@ def success_on_multiple_mixed_inputs(metric, df):
     return True
 
 
-def test_check_on_table(client, data_integration, engine):
+def test_check_on_table(client, flow_name, data_integration, engine):
     """Test check on a function operator."""
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     check_artifact = success_on_single_table_input(sql_artifact)
     assert check_artifact.get()
 
-    run_flow_test(client, artifacts=[check_artifact], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        check_artifact,
+        engine=engine,
+    )
 
 
-def test_check_on_metric(client, data_integration, engine):
+def test_check_on_metric(client, flow_name, data_integration, engine):
     """Test check on a metric operator."""
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
@@ -51,10 +56,15 @@ def test_check_on_metric(client, data_integration, engine):
     check_artifact = success_on_single_metric_input(metric)
     assert check_artifact.get()
 
-    run_flow_test(client, artifacts=[check_artifact], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        check_artifact,
+        engine=engine,
+    )
 
 
-def test_check_on_multiple_mixed_inputs(client, data_integration, engine):
+def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, engine):
     """Test check on multiple tables and metrics."""
     db = client.integration(data_integration)
     sql_artifact1 = db.sql(query=SENTIMENT_SQL_QUERY)
@@ -66,7 +76,12 @@ def test_check_on_multiple_mixed_inputs(client, data_integration, engine):
     check_artifact = success_on_multiple_mixed_inputs(metric, table)
     assert check_artifact.get()
 
-    run_flow_test(client, artifacts=[check_artifact], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        check_artifact,
+        engine=engine,
+    )
 
 
 def test_edit_check(client, data_integration):
@@ -151,7 +166,7 @@ def test_check_with_numpy_bool_output(client, data_integration):
     assert check_artifact.get()
 
 
-def test_check_with_series_output(client, data_integration, engine):
+def test_check_with_series_output(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
 
@@ -169,10 +184,15 @@ def test_check_with_series_output(client, data_integration, engine):
     failed = failure_check_return_series_of_booleans(sql_artifact)
     assert not failed.get()
 
-    run_flow_test(client, artifacts=[sql_artifact, passed, failed], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        [sql_artifact, passed, failed],
+        engine=engine,
+    )
 
 
-def test_check_failure_with_varying_severity(client, data_integration, engine):
+def test_check_failure_with_varying_severity(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
 
@@ -186,7 +206,13 @@ def test_check_failure_with_varying_severity(client, data_integration, engine):
         return False
 
     nonblocking_check = failure_nonblocking_check(sql_artifact)
-    run_flow_test(client, artifacts=[sql_artifact, nonblocking_check], engine=engine)
+
+    publish_flow_test(
+        client,
+        flow_name(),
+        artifacts=[sql_artifact, nonblocking_check],
+        engine=engine,
+    )
 
     # In eager execution, this check should fail before we can publish the flow.
     with pytest.raises(AqueductError):

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -4,7 +4,7 @@ from aqueduct.error import AqueductError, ArtifactNotFoundException, InvalidUser
 from constants import CHURN_SQL_QUERY, SENTIMENT_SQL_QUERY
 from test_functions.simple.model import dummy_sentiment_model
 from test_metrics.constant.model import constant_metric
-from utils import run_flow_test, publish_flow_test
+from utils import publish_flow_test
 
 from aqueduct import CheckSeverity, check
 

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -41,8 +41,8 @@ def test_check_on_table(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
         check_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -58,8 +58,8 @@ def test_check_on_metric(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
         check_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -78,8 +78,8 @@ def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, eng
 
     publish_flow_test(
         client,
-        flow_name(),
         check_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -186,8 +186,8 @@ def test_check_with_series_output(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
-        [sql_artifact, passed, failed],
+        name=flow_name(),
+        artifacts=[sql_artifact, passed, failed],
         engine=engine,
     )
 
@@ -209,7 +209,7 @@ def test_check_failure_with_varying_severity(client, flow_name, data_integration
 
     publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=[sql_artifact, nonblocking_check],
         engine=engine,
     )

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
     # We currently only support a single data integration and compute engine per test suite run.
     parser.addoption(f"--data", action="store", default="aqueduct_demo")
     parser.addoption(f"--engine", action="store", default=None)
-    parser.addoption(f"--keep_flows", action="store_true", default=False)
+    parser.addoption(f"--keep-flows", action="store_true", default=False)
 
 
 def pytest_configure(config):

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -1,11 +1,10 @@
 import os
-import uuid
 
 import pytest
 from aqueduct.dag import DAG, Metadata
+from utils import delete_flow, flow_name_to_id, generate_new_flow_name
 
 import aqueduct
-from utils import delete_flow, flow_name_to_id
 
 
 def pytest_addoption(parser):
@@ -45,7 +44,7 @@ def client(pytestconfig):
     server_address = os.getenv(SERVER_ADDR_ENV_NAME)
     if api_key is None or server_address is None:
         raise Exception(
-            "Test Setup Error: api_key and server_address must be set as environmental variables."
+            "Test Setup Error: api_key and server_address must bbe set as environmental variables."
         )
 
     return aqueduct.Client(api_key, server_address)
@@ -84,11 +83,19 @@ def enable_by_engine_type(request, client, engine):
 
 @pytest.fixture(scope="function")
 def flow_name(client, request, pytestconfig):
-    """TODO: handles the registration and teardown of flow objects."""
+    """Any flows created by this fixture will be automatically cleaned up at test teardown.
+
+    Note that it returns a method, so it must be used like:
+
+    ```
+    def test_foo(flow_name):
+        publish_flow(name=flow_name(), ...)
+    ```
+    """
     flow_names = []
 
     def get_new_flow_name():
-        flow_name = "test_" + uuid.uuid4().hex
+        flow_name = generate_new_flow_name()
         flow_names.append(flow_name)
         return flow_name
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -45,7 +45,7 @@ def client(pytestconfig):
 # Pulled from: https://stackoverflow.com/questions/28179026/how-to-skip-a-pytest-using-an-external-fixture
 @pytest.fixture(autouse=True)
 def enable_by_engine_type(request, client, engine):
-    """When a test is marked with this, it is enabled for a particular ServiceType!
+    """When a test is marked with this, it is enabled for particular ServiceType(s)!
 
     Eg.
     @pytest.mark.enable_only_for_engine(ServiceType.LAMBDA, ServiceType.K8s)
@@ -71,3 +71,15 @@ def enable_by_engine_type(request, client, engine):
                 "Skipped on engine `%s`, since it is not of type `%s`."
                 % (engine, ",".join(enabled_engine_types))
             )
+
+
+# TODO: describe
+flow_names_by_test = {}
+
+
+@pytest.fixture(autouse=True)
+def flow_cleanup(request):
+    yield
+
+    test_name = (request.node.name)
+    flow_id = flow_name_by_test.get(test_name)

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -44,7 +44,7 @@ def client(pytestconfig):
     server_address = os.getenv(SERVER_ADDR_ENV_NAME)
     if api_key is None or server_address is None:
         raise Exception(
-            "Test Setup Error: api_key and server_address must bbe set as environmental variables."
+            "Test Setup Error: api_key and server_address must be set as environmental variables."
         )
 
     return aqueduct.Client(api_key, server_address)

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -5,9 +5,7 @@ from utils import (
     check_flow_doesnt_exist,
     check_table_doesnt_exist,
     check_table_exists,
-    delete_flow,
-    generate_new_flow_name,
-    run_flow_test, generate_table_name, publish_flow_test,
+    generate_table_name, publish_flow_test,
 )
 
 from aqueduct import LoadUpdateMode
@@ -23,8 +21,8 @@ def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integrati
 
     flow = publish_flow_test(
         client,
-        flow_name(),
         table,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -43,22 +41,20 @@ def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integrati
 def test_delete_workflow_saved_objects(client, flow_name, data_integration, engine):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     integration = client.integration(data_integration)
-    name = flow_name()
     table_name = generate_table_name()
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
     flow = publish_flow_test(
         client,
-        name,
         table,
+        name=flow_name(),
         engine=engine,
     )
 
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
     flow = publish_flow_test(
         client,
-        name,
         table,
         engine=engine,
         existing_flow=flow,
@@ -101,8 +97,8 @@ def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration
     # Workflow 1's name not specified, so given a random workflow name.
     flow1 = publish_flow_test(
         client,
-        flow_name(),
         table,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -110,8 +106,8 @@ def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
     flow2 = publish_flow_test(
         client,
-        flow_name(),
         table,
+        name=flow_name(),
         engine=engine,
     )
 

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -5,7 +5,8 @@ from utils import (
     check_flow_doesnt_exist,
     check_table_doesnt_exist,
     check_table_exists,
-    generate_table_name, publish_flow_test,
+    generate_table_name,
+    publish_flow_test,
 )
 
 from aqueduct import LoadUpdateMode

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -7,181 +7,137 @@ from utils import (
     check_table_exists,
     delete_flow,
     generate_new_flow_name,
-    run_flow_test,
+    run_flow_test, generate_table_name, publish_flow_test,
 )
 
 from aqueduct import LoadUpdateMode
 
 
-def test_delete_workflow_invalid_saved_objects(client, data_integration, engine):
+def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integration, engine):
     """Check the flow cannot delete an object it had not saved."""
     integration = client.integration(data_integration)
-    name = generate_new_flow_name()
-    table_name = generate_new_flow_name()
-    flow_id = None
-
-    ###
+    table_name = generate_table_name()
 
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
-    flow_id = run_flow_test(
+    flow = publish_flow_test(
         client,
-        [table],
-        engine,
-        name=name,
-        num_runs=1,
-        delete_flow_after=False,
-    ).id()
+        flow_name(),
+        table,
+        engine=engine,
+    )
 
-    ###
+    tables = client.flow(flow.id()).list_saved_objects()
+    tables[data_integration][0].object_name = "I_DON_T_EXIST"
+    tables[data_integration] = [tables[data_integration][0]]
 
-    try:
-        tables = client.flow(flow_id).list_saved_objects()
-        tables[data_integration][0].object_name = "I_DON_T_EXIST"
-        tables[data_integration] = [tables[data_integration][0]]
+    # Cannot delete a flow if the saved objects specified had not been saved by the flow.
+    with pytest.raises(InvalidRequestError):
+        _ = client.delete_flow(flow.id(), saved_objects_to_delete=tables, force=True)
 
-        # Cannot delete a flow if the saved objects specified had not been saved by the flow.
-        with pytest.raises(InvalidRequestError):
-            data = client.delete_flow(flow_id, saved_objects_to_delete=tables, force=True)
-
-        # Check flow exists.
-        client.flow(flow_id)
-    finally:
-        delete_flow(client, flow_id)
+    # Check flow exists.
+    client.flow(flow.id())
 
 
-def test_delete_workflow_saved_objects(client, data_integration, engine):
+def test_delete_workflow_saved_objects(client, flow_name, data_integration, engine):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     integration = client.integration(data_integration)
-    name = generate_new_flow_name()
-    table_name = generate_new_flow_name()
-    flow_ids_to_delete = set()
-
-    ###
-
+    name = flow_name()
+    table_name = generate_table_name()
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
-    flow_ids_to_delete.add(
-        run_flow_test(client, [table], engine, name=name, num_runs=1, delete_flow_after=False).id()
+    flow = publish_flow_test(
+        client,
+        name,
+        table,
+        engine=engine,
     )
-
-    ###
 
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
-
-    flow_ids_to_delete.add(
-        run_flow_test(client, [table], engine, name=name, num_runs=2, delete_flow_after=False).id()
+    flow = publish_flow_test(
+        client,
+        name,
+        table,
+        engine=engine,
+        existing_flow=flow,
     )
 
-    ###
+    tables = client.flow(flow.id()).list_saved_objects()
+    assert table_name in [item.object_name for item in tables[data_integration]]
 
-    try:
-        assert len(flow_ids_to_delete) == 1
-        flow_id = list(flow_ids_to_delete)[0]
-        tables = client.flow(flow_id).list_saved_objects()
+    # Check table is properly created at the integration.
+    # Need to poll initially in case still writing table.
+    check_table_exists(integration, table_name)
 
-        assert table_name in [item.object_name for item in tables[data_integration]]
+    # Doesn't work if don't force because it is created in append mode.
+    with pytest.raises(InvalidRequestError):
+        client.delete_flow(flow.id(), saved_objects_to_delete=tables, force=False)
 
-        # Check table is properly created at the integration.
-        # Need to poll initially in case still writing table.
-        check_table_exists(integration, table_name)
+    # Check table is properly created at the integration.
+    integration.sql(f"SELECT * FROM {table_name}").get()
 
-        # Doesn't work if don't force because it is created in append mode.
-        with pytest.raises(InvalidRequestError):
-            client.delete_flow(flow_id, saved_objects_to_delete=tables, force=False)
+    # Actually delete the flow.
+    client.delete_flow(flow.id(), saved_objects_to_delete=tables, force=True)
+    check_flow_doesnt_exist(client, flow.id())
 
-        # Check table is properly created at the integration.
-        integration.sql(f"SELECT * FROM {table_name}").get()
-
-        client.delete_flow(flow_id, saved_objects_to_delete=tables, force=True)
-
-        # Check flow indeed deleted
-        check_flow_doesnt_exist(client, flow_id)
-        flow_ids_to_delete.remove(flow_id)
-
-        # Check table no longer exists
-        check_table_doesnt_exist(integration, table_name)
-
-    finally:
-        for flow_id in flow_ids_to_delete:
-            delete_flow(client, flow_id)
+    # Check table no longer exists
+    check_table_doesnt_exist(integration, table_name)
 
 
-def test_delete_workflow_saved_objects_twice(client, data_integration, engine):
+def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration, engine):
     """Checking the successful deletion case and unsuccessful deletion case works as expected.
     To test this, I have two workflows that write to the same table. When I delete the table in the first workflow,
     it is successful but when I delete it in the second workflow, it is unsuccessful because the table has already
     been deleted.
     """
     integration = client.integration(data_integration)
-    generate_new_flow_name()
-    table_name = generate_new_flow_name()
-    flow_ids_to_delete = set()
-
-    ###
+    table_name = generate_table_name()
 
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-
     table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
 
     # Workflow 1's name not specified, so given a random workflow name.
-    flow_ids_to_delete.add(
-        run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id()
+    flow1 = publish_flow_test(
+        client,
+        flow_name(),
+        table,
+        engine=engine,
     )
-
-    ###
-
-    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
 
     # Workflow 2's name not specified, so given a random workflow name.
-    flow_ids_to_delete.add(
-        run_flow_test(client, [table], engine, num_runs=1, delete_flow_after=False).id()
+    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
+    flow2 = publish_flow_test(
+        client,
+        flow_name(),
+        table,
+        engine=engine,
     )
 
-    ###
+    # Check table is properly created at the integration.
+    # Need to poll initially in case still writing table.
+    check_table_exists(integration, table_name)
 
-    try:
-        assert len(flow_ids_to_delete) == 2
-        flow_list = list(flow_ids_to_delete)
-        flow_1_id = flow_list[0]
-        flow_2_id = flow_list[1]
+    tables = client.flow(flow1.id()).list_saved_objects()
+    tables_1 = set([item.object_name for item in tables[data_integration]])
+    assert table_name in tables_1
 
-        # Check table is properly created at the integration.
-        # Need to poll initially in case still writing table.
-        check_table_exists(integration, table_name)
+    tables = client.flow(flow2.id()).list_saved_objects()
+    tables_2 = set([item.object_name for item in tables[data_integration]])
+    assert table_name in tables_2
 
-        tables = client.flow(flow_1_id).list_saved_objects()
-        tables_1 = set([item.object_name for item in tables[data_integration]])
-        assert table_name in tables_1
+    assert tables_1 == tables_2
+    client.delete_flow(flow1.id(), saved_objects_to_delete=tables, force=True)
 
-        tables = client.flow(flow_2_id).list_saved_objects()
-        tables_2 = set([item.object_name for item in tables[data_integration]])
-        assert table_name in tables_2
+    # Check flow indeed deleted and that the table no longer exists.
+    check_flow_doesnt_exist(client, flow1.id())
+    check_table_doesnt_exist(integration, table_name)
 
-        assert tables_1 == tables_2
+    # Try to delete table deleted by other flow.
+    with pytest.raises(Exception) as e_info:
+        client.delete_flow(flow2.id(), saved_objects_to_delete=tables, force=True)
+    assert str(e_info.value).startswith("Failed to delete")
 
-        client.delete_flow(flow_1_id, saved_objects_to_delete=tables, force=True)
-
-        # Check flow indeed deleted
-        check_flow_doesnt_exist(client, flow_1_id)
-        flow_ids_to_delete.remove(flow_1_id)
-
-        # Check table no longer exists
-        check_table_doesnt_exist(integration, table_name)
-
-        # Try to delete table deleted by other flow.
-        with pytest.raises(Exception) as e_info:
-            client.delete_flow(flow_2_id, saved_objects_to_delete=tables, force=True)
-        assert str(e_info.value).startswith("Failed to delete")
-
-        # Failed to delete tables, but flow should be removed.
-        check_flow_doesnt_exist(client, flow_2_id)
-        flow_ids_to_delete.remove(flow_2_id)
-
-    finally:
-        for flow_id in flow_ids_to_delete:
-            delete_flow(client, flow_id)
+    # Failed to delete tables, but flow should be removed.
+    check_flow_doesnt_exist(client, flow2.id())

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -89,9 +89,10 @@ def test_complex_flow(client, flow_name, data_integration, engine):
 
     # Test that metrics and checks can be implicitly included, and that a non-error check
     # failing does not fail the flow.
+    name = flow_name()
     flow = publish_flow_test(
         client,
-        flow_name(),
+        name,
         output_artifact,
         engine=engine,
     )
@@ -104,11 +105,11 @@ def test_complex_flow(client, flow_name, data_integration, engine):
 
     flow = publish_flow_test(
         client,
-        None,  # `flow` supplied instead.
+        name,
         output_artifact,
         engine=engine,
         checks=[success_check],  # failing_check will no longer be included.
-        flow=flow,
+        existing_flow=flow,
     )
 
     # Only the explicitly defined metrics and checks should have been included in this second run.

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -37,8 +37,8 @@ def test_basic_flow(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
         output_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -54,8 +54,8 @@ def test_sentiment_flow(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
         output_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -89,11 +89,10 @@ def test_complex_flow(client, flow_name, data_integration, engine):
 
     # Test that metrics and checks can be implicitly included, and that a non-error check
     # failing does not fail the flow.
-    name = flow_name()
     flow = publish_flow_test(
         client,
-        name,
         output_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -105,11 +104,10 @@ def test_complex_flow(client, flow_name, data_integration, engine):
 
     flow = publish_flow_test(
         client,
-        name,
         output_artifact,
+        existing_flow=flow,
         engine=engine,
         checks=[success_check],  # failing_check will no longer be included.
-        existing_flow=flow,
     )
 
     # Only the explicitly defined metrics and checks should have been included in this second run.
@@ -135,7 +133,7 @@ def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=[fn_artifact1, fn_artifact2],
         engine=engine,
     )
@@ -155,7 +153,7 @@ def test_publish_with_schedule(client, flow_name, data_integration, engine):
     execute_at = datetime.now() + timedelta(minutes=1)
     publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=[output_artifact],
         engine=engine,
         schedule=aqueduct.hourly(minute=aqueduct.Minute(execute_at.minute)),
@@ -188,8 +186,8 @@ def test_publish_flow_with_same_name(client, flow_name, data_integration, engine
     name = flow_name()
     flow = publish_flow_test(
         client,
-        name,
-        output_artifact,
+        name=name,
+        artifacts=output_artifact,
         engine=engine,
         schedule=aqueduct.daily(),
     )
@@ -199,8 +197,8 @@ def test_publish_flow_with_same_name(client, flow_name, data_integration, engine
 
     publish_flow_test(
         client,
-        name,
         metric,
+        name=name,
         engine=engine,
         schedule=aqueduct.daily(),
         existing_flow=flow,
@@ -217,8 +215,8 @@ def test_refresh_flow(client, flow_name, data_integration, engine):
 
     flow = publish_flow_test(
         client,
-        flow_name(),
         output_artifact,
+        name=flow_name(),
         engine=engine,
         schedule=aqueduct.hourly(),
     )
@@ -240,8 +238,8 @@ def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
 
     flow = publish_flow_test(
         client,
-        flow_name(),
         output_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -259,8 +257,8 @@ def test_get_artifact_reuse_for_computation(client, flow_name, data_integration,
     )
     flow = publish_flow_test(
         client,
-        flow_name(),
         output_artifact,
+        name=flow_name(),
         engine=engine,
     )
 
@@ -277,8 +275,8 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
 
     flow_1 = publish_flow_test(
         client,
-        flow_name(),
         output_artifact,
+        name=flow_name(),
         engine=engine,
         schedule="* * * * *",
         should_block=False,
@@ -286,8 +284,8 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
 
     flow_2 = publish_flow_test(
         client,
-        flow_name(),
         output_artifact_2,
+        name=flow_name(),
         engine=engine,
         schedule="* * * * *",
         should_block=False,
@@ -315,13 +313,12 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
     def generate_initial_table():
         return initial_table
 
-    setup_flow_name = flow_name()
     table = generate_initial_table()
     table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
 
     setup_flow = publish_flow_test(
         client,
-        setup_flow_name,
+        name=flow_name(),
         artifacts=table,
         engine=engine,
     )
@@ -336,7 +333,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
 
     flow = publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=output,
         engine=engine,
     )
@@ -350,10 +347,9 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
     table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
     publish_flow_test(
         client,
-        setup_flow_name,
         artifacts=table,
-        engine=engine,
         existing_flow=setup_flow,
+        engine=engine,
     )
 
     # Fetching the historical flow and materializing the data will not use the new data

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -159,7 +159,7 @@ def test_publish_with_schedule(client, flow_name, data_integration, engine):
         schedule=aqueduct.hourly(minute=aqueduct.Minute(execute_at.minute)),
 
         # Wait for two runs because registering a workflow always triggers an immediate run first.
-        expected_status=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
+        expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
     )
 
 

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -20,7 +20,7 @@ from utils import (
     generate_new_flow_name,
     generate_table_name,
     run_flow_test,
-    wait_for_flow_runs, publish_flow_test,
+    wait_for_flow_runs, publish_flow_test, trigger_flow_test,
 )
 
 import aqueduct
@@ -119,7 +119,7 @@ def test_complex_flow(client, flow_name, data_integration, engine):
     assert flow_run.artifact("failing_check artifact") is None
 
 
-def test_multiple_output_artifacts(client, data_integration, engine):
+def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact1 = db.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
     sql_artifact2 = db.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
@@ -133,14 +133,15 @@ def test_multiple_output_artifacts(client, data_integration, engine):
         config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
     )
 
-    run_flow_test(
+    publish_flow_test(
         client,
+        flow_name(),
         artifacts=[fn_artifact1, fn_artifact2],
         engine=engine,
     )
 
 
-def test_publish_with_schedule(client, data_integration, engine):
+def test_publish_with_schedule(client, flow_name, data_integration, engine):
     db = client.integration(
         data_integration,
     )
@@ -152,227 +153,213 @@ def test_publish_with_schedule(client, data_integration, engine):
 
     # Execute the flow 1 minute from now.
     execute_at = datetime.now() + timedelta(minutes=1)
-    run_flow_test(
+    publish_flow_test(
         client,
+        flow_name(),
         artifacts=[output_artifact],
         engine=engine,
         schedule=aqueduct.hourly(minute=aqueduct.Minute(execute_at.minute)),
-        num_runs=2,  # Wait for two runs because registering a workflow always triggers an immediate run first.
+
+        # Wait for two runs because registering a workflow always triggers an immediate run first.
+        expected_status=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
     )
 
 
 def test_invalid_flow(client):
     with pytest.raises(InvalidUserArgumentException):
-        client.publish_flow_test(
+        client.publish_flow(
             name=generate_new_flow_name(),
             artifacts=[],
         )
 
     with pytest.raises(Exception):
-        client.publish_flow_test(
+        client.publish_flow(
             name=generate_new_flow_name(),
             artifacts=["123"],
         )
 
 
-def test_publish_flow_with_same_name(client, data_integration, engine):
+def test_publish_flow_with_same_name(client, flow_name, data_integration, engine):
     """Tests flow editing behavior."""
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
 
-    # Remember to cleanup any created test data.
-    flow_ids_to_delete = set()
-    try:
-        flow_name = generate_new_flow_name()
-        flow = run_flow_test(
-            client,
-            artifacts=[output_artifact],
-            name=flow_name,
-            engine=engine,
-            schedule=aqueduct.daily(),
-            delete_flow_after=False,
-        )
-        flow_ids_to_delete.add(flow.id())
+    name = flow_name()
+    flow = publish_flow_test(
+        client,
+        name,
+        output_artifact,
+        engine=engine,
+        schedule=aqueduct.daily(),
+    )
 
-        # Add a metric to the flow and re-publish under the same name.
-        metric = constant_metric(output_artifact)
-        flow = run_flow_test(
-            client,
-            artifacts=[metric],
-            name=flow_name,
-            engine=engine,
-            schedule=aqueduct.daily(),
-            num_runs=2,
-            delete_flow_after=False,
-        )
-        flow_ids_to_delete.add(flow.id())
-    finally:
-        for flow_id in flow_ids_to_delete:
-            delete_flow(client, flow_id)
+    # Add a metric to the flow and re-publish under the same name.
+    metric = constant_metric(output_artifact)
+
+    publish_flow_test(
+        client,
+        name,
+        metric,
+        engine=engine,
+        schedule=aqueduct.daily(),
+        existing_flow=flow,
+    )
 
 
-def test_refresh_flow(client, data_integration, engine):
+def test_refresh_flow(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
     output_artifact.save(
         config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
     )
-    flow = client.publish_flow_test(
-        name=generate_new_flow_name(),
-        artifacts=output_artifact,
+
+    flow = publish_flow_test(
+        client,
+        flow_name(),
+        output_artifact,
         engine=engine,
         schedule=aqueduct.hourly(),
     )
 
-    # Wait for the first run, then refresh the workflow and verify that it runs at least
-    # one more time.
-    try:
-        wait_for_flow_runs(client, flow.id(), expected_statuses=[ExecutionStatus.SUCCEEDED])
-        client.trigger(flow.id())
-        wait_for_flow_runs(
-            client,
-            flow.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
-        )
-    finally:
-        client.delete_flow(flow.id())
+    # Trigger the workflow again verify that it runs one more time.
+    trigger_flow_test(
+        client,
+        flow,
+    )
 
 
-def test_get_artifact_from_flow(client, data_integration, engine):
+def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
     output_artifact.save(
         config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
     )
-    flow = client.publish_flow_test(
-        name=generate_new_flow_name(),
-        artifacts=output_artifact,
+
+    flow = publish_flow_test(
+        client,
+        flow_name(),
+        output_artifact,
         engine=engine,
     )
-    try:
-        wait_for_flow_runs(client, flow.id(), expected_statuses=[ExecutionStatus.SUCCEEDED])
-        artifact_return = flow.latest().artifact(output_artifact.name())
-        assert artifact_return.name() == output_artifact.name()
-        assert artifact_return.get().equals(output_artifact.get())
-    finally:
-        client.delete_flow(flow.id())
+
+    artifact_return = flow.latest().artifact(output_artifact.name())
+    assert artifact_return.name() == output_artifact.name()
+    assert artifact_return.get().equals(output_artifact.get())
 
 
-def test_get_artifact_reuse_for_computation(client, data_integration, engine):
+def test_get_artifact_reuse_for_computation(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
     output_artifact.save(
         config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
     )
-    flow = client.publish_flow_test(
-        name=generate_new_flow_name(),
-        artifacts=output_artifact,
+    flow = publish_flow_test(
+        client,
+        flow_name(),
+        output_artifact,
         engine=engine,
     )
-    try:
-        wait_for_flow_runs(client, flow.id(), expected_statuses=[ExecutionStatus.SUCCEEDED])
-        artifact_return = flow.latest().artifact(output_artifact.name())
-        with pytest.raises(Exception):
-            output_artifact = dummy_sentiment_model(artifact_return)
-    finally:
-        client.delete_flow(flow.id())
+
+    artifact_return = flow.latest().artifact(output_artifact.name())
+    with pytest.raises(Exception):
+        output_artifact = dummy_sentiment_model(artifact_return)
 
 
-def test_multiple_flows_with_same_schedule(client, data_integration, engine):
-    try:
-        db = client.integration(data_integration)
-        sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
-        output_artifact = dummy_sentiment_model(sql_artifact)
-        output_artifact_2 = dummy_model(sql_artifact)
+def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, engine):
+    db = client.integration(data_integration)
+    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    output_artifact = dummy_sentiment_model(sql_artifact)
+    output_artifact_2 = dummy_model(sql_artifact)
 
-        flow_1 = client.publish_flow_test(
-            name=generate_new_flow_name(),
-            artifacts=output_artifact,
-            engine=engine,
-            schedule="* * * * *",
-        )
+    flow_1 = publish_flow_test(
+        client,
+        flow_name(),
+        output_artifact,
+        engine=engine,
+        schedule="* * * * *",
+        should_block=False,
+    )
 
-        flow_2 = client.publish_flow_test(
-            name=generate_new_flow_name(),
-            artifacts=output_artifact_2,
-            engine=engine,
-            schedule="* * * * *",
-        )
+    flow_2 = publish_flow_test(
+        client,
+        flow_name(),
+        output_artifact_2,
+        engine=engine,
+        schedule="* * * * *",
+        should_block=False,
+    )
 
-        wait_for_flow_runs(
-            client,
-            flow_1.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
-        )
-        wait_for_flow_runs(
-            client,
-            flow_2.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
-        )
-    finally:
-        delete_flow(client, flow_1.id())
-        delete_flow(client, flow_2.id())
+    wait_for_flow_runs(
+        client,
+        flow_1.id(),
+        expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
+    )
+    wait_for_flow_runs(
+        client,
+        flow_2.id(),
+        expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
+    )
 
 
-def test_fetching_historical_flows_uses_old_data(client, data_integration, engine):
+def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
 
     # Write a new table into the demo db.
-    flows_to_delete = []
-    try:
-        initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
+    initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
 
-        @op
-        def generate_initial_table():
-            return initial_table
+    @op
+    def generate_initial_table():
+        return initial_table
 
-        setup_flow_name = generate_new_flow_name()
-        table = generate_initial_table()
-        table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
-        setup_flow = run_flow_test(
-            client, name=setup_flow_name, artifacts=[table], engine=engine, delete_flow_after=False
-        )
-        flows_to_delete.append(setup_flow.id())
+    setup_flow_name = flow_name()
+    table = generate_initial_table()
+    table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
 
-        @op
-        def noop(df):
-            return df
+    setup_flow = publish_flow_test(
+        client,
+        setup_flow_name,
+        artifacts=table,
+        engine=engine,
+    )
 
-        # Create a new flow that extracts this data.
-        output = db.sql("Select * from test_table", name="Test Table Query")
-        assert output.get().equals(initial_table)
+    @op
+    def noop(df):
+        return df
 
-        flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
-        flows_to_delete.append(flow.id())
+    # Create a new flow that extracts this data.
+    output = db.sql("Select * from test_table", name="Test Table Query")
+    assert output.get().equals(initial_table)
 
-        # Now, change the data that the new flow relies on, by populating data the same way as the setup flow.
-        @op
-        def generate_new_table():
-            return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
+    flow = publish_flow_test(
+        client,
+        flow_name(),
+        artifacts=output,
+        engine=engine,
+    )
 
-        table = generate_new_table()
-        table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
-        run_flow_test(
-            client,
-            name=setup_flow_name,
-            artifacts=[table],
-            engine=engine,
-            num_runs=2,
-            delete_flow_after=False,
-        )
+    # Now, change the data that the new flow relies on, by populating data the same way as the setup flow.
+    @op
+    def generate_new_table():
+        return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
-        # Fetching the historical flow and materializing the data will not use the new data
-        # that was just written. It will use a snapshot of the old data instead.
-        artifact = flow.latest().artifact(name="Test Table Query artifact")
-        assert artifact.get().equals(initial_table)
+    table = generate_new_table()
+    table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
+    publish_flow_test(
+        client,
+        setup_flow_name,
+        artifacts=table,
+        engine=engine,
+        existing_flow=setup_flow,
+    )
 
-    finally:
-        for flow_id in flows_to_delete:
-            delete_flow(client, flow_id)
+    # Fetching the historical flow and materializing the data will not use the new data
+    # that was just written. It will use a snapshot of the old data instead.
+    artifact = flow.latest().artifact(name="Test Table Query artifact")
+    assert artifact.get().equals(initial_table)
 
 
 def test_flow_with_args(client):
@@ -419,7 +406,7 @@ def test_publish_with_redundant_config_fields(client):
         validated=True,
     )
     with pytest.raises(InvalidUserArgumentException):
-        client.publish_flow_test(
+        client.publish_flow(
             generate_new_flow_name(),
             artifacts=[output],
             engine="something",
@@ -428,7 +415,7 @@ def test_publish_with_redundant_config_fields(client):
 
     # Test redundant `k_latest_runs` field.
     with pytest.raises(InvalidUserArgumentException):
-        client.publish_flow_test(
+        client.publish_flow(
             generate_new_flow_name(),
             artifacts=[output],
             k_latest_runs=10,

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -16,11 +16,11 @@ from test_functions.simple.model import (
 )
 from test_metrics.constant.model import constant_metric
 from utils import (
-    delete_flow,
     generate_new_flow_name,
     generate_table_name,
-    run_flow_test,
-    wait_for_flow_runs, publish_flow_test, trigger_flow_test,
+    publish_flow_test,
+    trigger_flow_test,
+    wait_for_flow_runs,
 )
 
 import aqueduct
@@ -157,7 +157,6 @@ def test_publish_with_schedule(client, flow_name, data_integration, engine):
         artifacts=[output_artifact],
         engine=engine,
         schedule=aqueduct.hourly(minute=aqueduct.Minute(execute_at.minute)),
-
         # Wait for two runs because registering a workflow always triggers an immediate run first.
         expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
     )

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -1,5 +1,5 @@
 from constants import SHORT_SENTIMENT_SQL_QUERY
-from utils import delete_flow, generate_new_flow_name, run_flow_test, publish_flow_test
+from utils import delete_flow, generate_new_flow_name, publish_flow_test
 
 from aqueduct import LoadUpdateMode, op
 
@@ -96,8 +96,7 @@ def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_in
     integration_name = list(data.keys())[0]
     assert len(data[integration_name]) == 2
     assert (
-        set([(item.object_name, item.update_mode) for item in data[integration_name]])
-        == data_set
+        set([(item.object_name, item.update_mode) for item in data[integration_name]]) == data_set
     )
 
 

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -1,81 +1,80 @@
 from constants import SHORT_SENTIMENT_SQL_QUERY
-from utils import delete_flow, generate_new_flow_name, run_flow_test
+from utils import delete_flow, generate_new_flow_name, run_flow_test, publish_flow_test
 
 from aqueduct import LoadUpdateMode, op
 
 
-def test_list_saved_objects(client, data_integration, engine):
+def test_list_saved_objects(client, flow_name, data_integration, engine):
     integration = client.integration(name=data_integration)
-    name = generate_new_flow_name()
-    flow_ids_to_delete = set()
 
-    try:
-        table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-        table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.REPLACE))
+    table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.REPLACE))
 
-        # This will create the table.
-        flow_ids_to_delete.add(
-            run_flow_test(
-                client, [table], name=name, engine=engine, num_runs=1, delete_flow_after=False
-            ).id()
-        )
+    # This will create the table.
+    name = flow_name()
+    flow = publish_flow_test(
+        client,
+        name,
+        table,
+        engine=engine,
+    )
 
-        # Change to append mode.
-        table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
-        flow_ids_to_delete.add(
-            run_flow_test(
-                client, [table], name=name, engine=engine, num_runs=2, delete_flow_after=False
-            ).id()
-        )
+    # Change to append mode.
+    table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
+    publish_flow_test(
+        client,
+        name,
+        table,
+        engine=engine,
+        existing_flow=flow,
+    )
 
-        # Redundant append mode change.
-        table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
-        flow_ids_to_delete.add(
-            run_flow_test(
-                client, [table], name=name, engine=engine, num_runs=3, delete_flow_after=False
-            ).id()
-        )
+    # Redundant append mode change.
+    table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
+    publish_flow_test(
+        client,
+        name,
+        table,
+        engine=engine,
+        existing_flow=flow,
+    )
 
-        # Create a different table from the same artifact.
-        table.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
-        flow_ids_to_delete.add(
-            run_flow_test(
-                client, [table], name=name, engine=engine, num_runs=4, delete_flow_after=False
-            ).id()
-        )
+    # Create a different table from the same artifact.
+    table.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
+    publish_flow_test(
+        client,
+        name,
+        table,
+        engine=engine,
+        existing_flow=flow,
+    )
 
-        ###
-        assert len(flow_ids_to_delete) == 1
-        data = client.flow(list(flow_ids_to_delete)[0]).list_saved_objects()
+    data = client.flow(flow.id()).list_saved_objects()
 
-        # Check all in same integration
-        assert len(data.keys()) == 1
+    # Check all in same integration
+    assert len(data.keys()) == 1
 
-        # table_name, update_mode in order of latest created
-        data_set = [
-            ("table_2", LoadUpdateMode.REPLACE),
-            ("table_1", LoadUpdateMode.APPEND),
-            ("table_1", LoadUpdateMode.REPLACE),
-        ]
-        integration_name = list(data.keys())[0]
-        assert len(data[integration_name]) == 3
-        for i in range(3):
-            item = data[integration_name][i]
-            assert (item.object_name, item.update_mode) == data_set[i]
+    # table_name, update_mode in order of latest created
+    data_set = [
+        ("table_2", LoadUpdateMode.REPLACE),
+        ("table_1", LoadUpdateMode.APPEND),
+        ("table_1", LoadUpdateMode.REPLACE),
+    ]
+    integration_name = list(data.keys())[0]
+    assert len(data[integration_name]) == 3
+    for i in range(3):
+        item = data[integration_name][i]
+        assert (item.object_name, item.update_mode) == data_set[i]
 
-        # Check mapping can be accessed correctly
-        # Can be accessed by string of integration name
-        assert len(data[data_integration]) == 3
+    # Check mapping can be accessed correctly
+    # Can be accessed by string of integration name
+    assert len(data[data_integration]) == 3
 
-        # Can be accessed by Integration object with integration name
-        assert len(data[integration]) == 3
-
-    finally:
-        for flow_id in flow_ids_to_delete:
-            delete_flow(client, flow_id)
+    # Can be accessed by Integration object with integration name
+    assert len(data[integration]) == 3
 
 
-def test_multiple_artifacts_saved_to_same_integration(client, data_integration, engine):
+def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_integration, engine):
     integration = client.integration(name=data_integration)
 
     table_1 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
@@ -83,30 +82,30 @@ def test_multiple_artifacts_saved_to_same_integration(client, data_integration, 
     table_2 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
     table_2.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
 
-    flow = run_flow_test(
-        client, artifacts=[table_1, table_2], engine=engine, delete_flow_after=False
+    flow = publish_flow_test(
+        client,
+        flow_name(),
+        artifacts=[table_1, table_2],
+        engine=engine,
     )
-    try:
-        data = client.flow(flow.id()).list_saved_objects()
 
-        assert len(data.keys()) == 1
-        data_set = {
-            ("table_1", LoadUpdateMode.REPLACE),
-            ("table_2", LoadUpdateMode.REPLACE),
-        }
+    data = client.flow(flow.id()).list_saved_objects()
 
-        integration_name = list(data.keys())[0]
-        assert len(data[integration_name]) == 2
-        assert (
-            set([(item.object_name, item.update_mode) for item in data[integration_name]])
-            == data_set
-        )
+    assert len(data.keys()) == 1
+    data_set = {
+        ("table_1", LoadUpdateMode.REPLACE),
+        ("table_2", LoadUpdateMode.REPLACE),
+    }
 
-    finally:
-        delete_flow(client, flow.id())
+    integration_name = list(data.keys())[0]
+    assert len(data[integration_name]) == 2
+    assert (
+        set([(item.object_name, item.update_mode) for item in data[integration_name]])
+        == data_set
+    )
 
 
-def test_lazy_artifact_with_save(client, data_integration, engine):
+def test_lazy_artifact_with_save(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     reviews = db.sql(SHORT_SENTIMENT_SQL_QUERY)
 
@@ -120,4 +119,9 @@ def test_lazy_artifact_with_save(client, data_integration, engine):
         config=db.config(table="test_timestamp_succeeded", update_mode=LoadUpdateMode.REPLACE)
     )
 
-    run_flow_test(client, artifacts=[review_copied], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        review_copied,
+        engine=engine,
+    )

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -11,11 +11,10 @@ def test_list_saved_objects(client, flow_name, data_integration, engine):
     table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.REPLACE))
 
     # This will create the table.
-    name = flow_name()
     flow = publish_flow_test(
         client,
-        name,
-        table,
+        name=flow_name(),
+        artifacts=table,
         engine=engine,
     )
 
@@ -23,30 +22,27 @@ def test_list_saved_objects(client, flow_name, data_integration, engine):
     table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
     publish_flow_test(
         client,
-        name,
-        table,
-        engine=engine,
         existing_flow=flow,
+        artifacts=table,
+        engine=engine,
     )
 
     # Redundant append mode change.
     table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
     publish_flow_test(
         client,
-        name,
-        table,
-        engine=engine,
         existing_flow=flow,
+        artifacts=table,
+        engine=engine,
     )
 
     # Create a different table from the same artifact.
     table.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
     publish_flow_test(
         client,
-        name,
-        table,
-        engine=engine,
         existing_flow=flow,
+        artifacts=table,
+        engine=engine,
     )
 
     data = client.flow(flow.id()).list_saved_objects()
@@ -84,7 +80,7 @@ def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_in
 
     flow = publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=[table_1, table_2],
         engine=engine,
     )
@@ -121,7 +117,7 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
         review_copied,
+        name=flow_name(),
         engine=engine,
     )

--- a/integration_tests/sdk/metrics_test.py
+++ b/integration_tests/sdk/metrics_test.py
@@ -3,7 +3,7 @@ import pytest
 from aqueduct.error import AqueductError
 from constants import SENTIMENT_SQL_QUERY
 from test_metrics.constant.model import constant_metric
-from utils import run_flow_test
+from utils import publish_flow_test
 
 from aqueduct import metric
 
@@ -40,11 +40,16 @@ def test_metric_bound(client, data_integration):
     assert not check_artifact.get()
 
 
-def test_register_metric(client, data_integration, engine):
+def test_register_metric(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     metric_artifact = constant_metric(sql_artifact)
-    run_flow_test(client, artifacts=[sql_artifact, metric_artifact], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        artifacts=[sql_artifact, metric_artifact],
+        engine=engine,
+    )
 
 
 @metric()
@@ -59,7 +64,7 @@ def metric_with_multiple_inputs(df1, m, df2):
     return m + 10
 
 
-def test_metric_mixed_inputs(client, data_integration, engine):
+def test_metric_mixed_inputs(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql1 = db.sql(query=SENTIMENT_SQL_QUERY)
     sql2 = db.sql(query=SENTIMENT_SQL_QUERY)
@@ -68,4 +73,9 @@ def test_metric_mixed_inputs(client, data_integration, engine):
     metric_output = metric_with_multiple_inputs(sql1, metric_input, sql2)
     assert metric_output.get() == 27.5
 
-    run_flow_test(client, artifacts=[metric_output], engine=engine)
+    publish_flow_test(
+        client,
+        flow_name(),
+        metric_output,
+        engine=engine,
+    )

--- a/integration_tests/sdk/metrics_test.py
+++ b/integration_tests/sdk/metrics_test.py
@@ -46,7 +46,7 @@ def test_register_metric(client, flow_name, data_integration, engine):
     metric_artifact = constant_metric(sql_artifact)
     publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=[sql_artifact, metric_artifact],
         engine=engine,
     )
@@ -75,7 +75,7 @@ def test_metric_mixed_inputs(client, flow_name, data_integration, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
         metric_output,
+        name=flow_name(),
         engine=engine,
     )

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -1,6 +1,6 @@
 import pytest
 from aqueduct.error import AqueductError
-from utils import run_flow_test, publish_flow_test
+from utils import publish_flow_test
 
 from aqueduct import op
 
@@ -29,7 +29,7 @@ def test_multiple_outputs(client, flow_name, engine):
 
     publish_flow_test(
         client,
-        flow_name(),
+        name=flow_name(),
         artifacts=[str_output, int_output],
         engine=engine,
     )

--- a/integration_tests/sdk/multiple_output_test.py
+++ b/integration_tests/sdk/multiple_output_test.py
@@ -1,11 +1,11 @@
 import pytest
 from aqueduct.error import AqueductError
-from utils import run_flow_test
+from utils import run_flow_test, publish_flow_test
 
 from aqueduct import op
 
 
-def test_multiple_outputs(client, engine):
+def test_multiple_outputs(client, flow_name, engine):
     @op(num_outputs=2)
     def generate_two_outputs():
         return "hello", 1234
@@ -27,8 +27,11 @@ def test_multiple_outputs(client, engine):
     assert str_output.get() == "hello world."
     assert int_output.get() == 2468
 
-    run_flow_test(
-        client, artifacts=[str_output, int_output], engine=engine, delete_flow_after=False
+    publish_flow_test(
+        client,
+        flow_name(),
+        artifacts=[str_output, int_output],
+        engine=engine,
     )
 
 

--- a/integration_tests/sdk/no_return_test.py
+++ b/integration_tests/sdk/no_return_test.py
@@ -1,4 +1,4 @@
-from utils import run_flow_test
+from utils import publish_flow_test
 
 from aqueduct import op
 
@@ -8,12 +8,15 @@ def no_return() -> None:
     return None
 
 
-def test_operator_with_no_return(client, engine):
+def test_operator_with_no_return(client, flow_name, engine):
     result = no_return()
     assert result.get() is None
-    try:
-        flow = run_flow_test(client, artifacts=[result], engine=engine, delete_flow_after=False)
-        artifact_return = flow.latest().artifact("no_return artifact")
-        assert artifact_return.get() is None
-    finally:
-        client.delete_flow(flow.id())
+
+    flow = publish_flow_test(
+        client,
+        result,
+        name=flow_name(),
+        engine=engine,
+    )
+    artifact_return = flow.latest().artifact("no_return artifact")
+    assert artifact_return.get() is None

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -203,7 +203,7 @@ def test_trigger_flow_with_different_param(client, data_integration, engine):
         wait_for_flow_runs(
             client,
             flow.id(),
-            expect_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
+            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
         )
 
         # Verify the parameters were configured as expected.
@@ -249,7 +249,7 @@ def test_trigger_flow_with_different_sql_param(client, data_integration, engine)
         wait_for_flow_runs(
             client,
             flow.id(),
-            expect_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
+            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
         )
 
         # Verify the parameters were configured as expected.
@@ -409,7 +409,7 @@ def test_parameter_type_changes(client, engine):
         wait_for_flow_runs(
             client,
             flow_id,
-            expect_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
+            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
         )
     finally:
         delete_flow(client, flow_id)

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -12,7 +12,7 @@ from aqueduct.error import (
 )
 from constants import SENTIMENT_SQL_QUERY
 from pandas._testing import assert_frame_equal
-from utils import delete_flow, generate_new_flow_name, run_flow_test, wait_for_flow_runs
+from utils import publish_flow_test, trigger_flow_test
 
 from aqueduct import metric, op
 
@@ -122,56 +122,46 @@ def test_parameter_in_basic_flow(client, data_integration):
     assert output_df.equals(input_df)
 
 
-def test_edit_param_for_flow(client, data_integration, engine):
+def test_edit_param_for_flow(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     row_to_add = ["new hotel", "09-28-1996", "US", "It was new."]
     new_row_param = client.create_param(name="new row", default=row_to_add)
     output = append_row_to_df(sql_artifact, new_row_param)
 
-    flow_name = generate_new_flow_name()
+    flow = publish_flow_test(
+        client,
+        output,
+        name=flow_name(),
+        engine=engine,
+    )
 
-    flow_id = None
-    try:
-        flow = run_flow_test(
-            client, artifacts=[output], name=flow_name, engine=engine, delete_flow_after=False
-        )
-        flow_id = flow.id()
+    # Edit the flow with a different row to append and re-publish
+    new_row_to_add = ["another new hotel", "10-10-1000", "ID", "It was really really new."]
+    new_row_param = client.create_param(name="new row", default=new_row_to_add)
+    output = append_row_to_df(sql_artifact, new_row_param)
 
-        # Edit the flow with a different row to append and re-publish
-        new_row_to_add = ["another new hotel", "10-10-1000", "ID", "It was really really new."]
-        new_row_param = client.create_param(name="new row", default=new_row_to_add)
-        output = append_row_to_df(sql_artifact, new_row_param)
+    flow = publish_flow_test(
+        client,
+        output,
+        existing_flow=flow,
+        engine=engine,
+    )
 
-        # Wait for the first run, then refresh the workflow and verify that it runs at least
-        # one more time (two runs total, since the original was manually triggered).
-        flow = run_flow_test(
-            client,
-            artifacts=[output],
-            name=flow_name,
-            engine=engine,
-            num_runs=2,
-            delete_flow_after=False,
-        )
+    # Verify that the parameters were edited as expected.
+    flow_runs = flow.list_runs()
+    assert len(flow_runs) == 2
 
-        # Verify that the parameters were edited as expected.
-        flow_runs = flow.list_runs()
-        assert len(flow_runs) == 2
+    historical_run = flow.fetch(flow_runs[1]["run_id"])
+    param_artifact = historical_run.artifact(name="new row")
+    assert isinstance(param_artifact, GenericArtifact)
+    assert param_artifact.get() == row_to_add
 
-        historical_run = flow.fetch(flow_runs[1]["run_id"])
-        param_artifact = historical_run.artifact(name="new row")
-        assert isinstance(param_artifact, GenericArtifact)
-        assert param_artifact.get() == row_to_add
+    latest_run = flow.latest()
+    param_artifact = latest_run.artifact(name="new row")
+    assert isinstance(param_artifact, GenericArtifact)
+    assert param_artifact.get() == new_row_to_add
 
-        latest_run = flow.latest()
-        param_artifact = latest_run.artifact(name="new row")
-        assert isinstance(param_artifact, GenericArtifact)
-        assert param_artifact.get() == new_row_to_add
-
-    finally:
-        client.delete_flow(flow_id)
-
-    assert flow_id == flow.id()
 
 
 @metric
@@ -181,7 +171,7 @@ def add_numbers(sql, num1, num2):
     return num1 + num2
 
 
-def test_trigger_flow_with_different_param(client, data_integration, engine):
+def test_trigger_flow_with_different_param(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
 
@@ -189,132 +179,114 @@ def test_trigger_flow_with_different_param(client, data_integration, engine):
     num2 = client.create_param(name="num2", default=5)
     output = add_numbers(sql_artifact, num1, num2)
 
-    flow_name = generate_new_flow_name()
-    flow = run_flow_test(
-        client, artifacts=[output], engine=engine, name=flow_name, delete_flow_after=False
+
+    flow = publish_flow_test(
+        client,
+        output,
+        name=flow_name(),
+        engine=engine,
     )
 
     # First, check that triggering the flow with a non-existant parameter will error.
     with pytest.raises(InvalidUserArgumentException):
         client.trigger(flow.id(), parameters={"non-existant": 10})
 
-    try:
-        client.trigger(flow.id(), parameters={"num1": 10})
-        wait_for_flow_runs(
-            client,
-            flow.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
-        )
+    trigger_flow_test(client, flow, parameters={"num1": 10})
 
-        # Verify the parameters were configured as expected.
-        flow_runs = flow.list_runs()
-        assert len(flow_runs) == 2
+    # Verify the parameters were configured as expected.
+    flow_runs = flow.list_runs()
+    assert len(flow_runs) == 2
 
-        historical_run = flow.fetch(flow_runs[1]["run_id"])
-        num1_artifact = historical_run.artifact(name="num1")
-        num2_artifact = historical_run.artifact(name="num2")
-        assert isinstance(num1_artifact, NumericArtifact)
-        assert isinstance(num2_artifact, NumericArtifact)
-        assert num1_artifact.get() == 5
-        assert num2_artifact.get() == 5
+    historical_run = flow.fetch(flow_runs[1]["run_id"])
+    num1_artifact = historical_run.artifact(name="num1")
+    num2_artifact = historical_run.artifact(name="num2")
+    assert isinstance(num1_artifact, NumericArtifact)
+    assert isinstance(num2_artifact, NumericArtifact)
+    assert num1_artifact.get() == 5
+    assert num2_artifact.get() == 5
 
-        latest_run = flow.latest()
-        num1_artifact = latest_run.artifact(name="num1")
-        num2_artifact = latest_run.artifact(name="num2")
-        assert isinstance(num1_artifact, NumericArtifact)
-        assert isinstance(num2_artifact, NumericArtifact)
-        assert num1_artifact.get() == 10
-        assert num2_artifact.get() == 5
-
-    finally:
-        client.delete_flow(flow.id())
+    latest_run = flow.latest()
+    num1_artifact = latest_run.artifact(name="num1")
+    num2_artifact = latest_run.artifact(name="num2")
+    assert isinstance(num1_artifact, NumericArtifact)
+    assert isinstance(num2_artifact, NumericArtifact)
+    assert num1_artifact.get() == 10
+    assert num2_artifact.get() == 5
 
 
-def test_trigger_flow_with_different_sql_param(client, data_integration, engine):
+def test_trigger_flow_with_different_sql_param(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
 
     _ = client.create_param("table_name", default="hotel_reviews")
     sql_artifact = db.sql(query="select * from {{ table_name}}")
 
-    flow_name = generate_new_flow_name()
+    flow = publish_flow_test(
+        client,
+        sql_artifact,
+        name=flow_name(),
+        engine=engine,
+    )
 
-    flow_id = None
-    try:
-        flow = run_flow_test(
-            client, artifacts=[sql_artifact], name=flow_name, engine=engine, delete_flow_after=False
-        )
-        flow_id = flow.id()
+    trigger_flow_test(client, flow, parameters={"table_name": "customer_activity"})
 
-        client.trigger(flow.id(), parameters={"table_name": "customer_activity"})
-        wait_for_flow_runs(
-            client,
-            flow.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
-        )
+    # Verify the parameters were configured as expected.
+    flow_runs = flow.list_runs()
+    assert len(flow_runs) == 2
 
-        # Verify the parameters were configured as expected.
-        flow_runs = flow.list_runs()
-        assert len(flow_runs) == 2
+    historical_run = flow.fetch(flow_runs[1]["run_id"])
+    param_artifact = historical_run.artifact(name="table_name")
+    assert isinstance(param_artifact, GenericArtifact)
+    assert param_artifact.get() == "hotel_reviews"
 
-        historical_run = flow.fetch(flow_runs[1]["run_id"])
-        param_artifact = historical_run.artifact(name="table_name")
-        assert isinstance(param_artifact, GenericArtifact)
-        assert param_artifact.get() == "hotel_reviews"
-
-        latest_run = flow.latest()
-        param_artifact = latest_run.artifact(name="table_name")
-        assert param_artifact.get() == "customer_activity"
-        assert isinstance(param_artifact, GenericArtifact)
-    finally:
-        client.delete_flow(flow_id)
+    latest_run = flow.latest()
+    param_artifact = latest_run.artifact(name="table_name")
+    assert param_artifact.get() == "customer_activity"
+    assert isinstance(param_artifact, GenericArtifact)
 
 
-def test_parameterizing_published_artifact(client, engine):
+def test_parameterizing_published_artifact(client, flow_name, engine):
     @op
     def generate_num():
         return 1234
 
     output = generate_num()
 
-    flow_id = None
-    try:
-        flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
-        flow_id = flow.id()
+    flow = publish_flow_test(
+        client,
+        artifacts=[output],
+        name=flow_name(),
+        engine=engine,
+    )
 
-        artifact = flow.latest().artifact(name="generate_num artifact")
+    artifact = flow.latest().artifact(name="generate_num artifact")
 
-        assert artifact.get() == 1234
-        assert isinstance(artifact, NumericArtifact)
-        with pytest.raises(NotImplementedError):
-            artifact.get(parameters={"name": "val"})
-
-    finally:
-        client.delete_flow(flow_id)
+    assert artifact.get() == 1234
+    assert isinstance(artifact, NumericArtifact)
+    with pytest.raises(NotImplementedError):
+        artifact.get(parameters={"name": "val"})
 
 
-def test_materializing_failed_artifact(client, engine):
+def test_materializing_failed_artifact(client, flow_name, engine):
     @op
     def fail_fn():
         5 / 0
 
     output = fail_fn.lazy()
-    flow_id = None
-    try:
-        flow = run_flow_test(
-            client, artifacts=[output], engine=engine, expect_success=False, delete_flow_after=False
-        )
-        flow_id = flow.id()
 
-        artifact = flow.latest().artifact(name="fail_fn artifact")
-        assert isinstance(artifact, GenericArtifact)
-        with pytest.raises(ArtifactNeverComputedException):
-            artifact.get()
-
-    finally:
-        client.delete_flow(flow_id)
+    flow = publish_flow_test(
+        client,
+        output,
+        name=flow_name(),
+        engine=engine,
+        expected_status=ExecutionStatus.FAILED,
+    )
+    artifact = flow.latest().artifact(name="fail_fn artifact")
+    assert isinstance(artifact, GenericArtifact)
+    with pytest.raises(ArtifactNeverComputedException):
+        artifact.get()
 
 
-def test_all_param_types(client, engine):
+def test_all_param_types(client, flow_name, engine):
     class EmptyClass:
         """
         For some reason, this class must be nested inside this test,
@@ -380,14 +352,15 @@ def test_all_param_types(client, engine):
     assert isinstance(list_output, GenericArtifact)
     assert list_output.get() == [4, 5, 6]
 
-    run_flow_test(
+    publish_flow_test(
         client,
+        name=flow_name(),
         artifacts=[pickle_output, bytes_output, string_output, tuple_output, list_output],
         engine=engine,
     )
 
 
-def test_parameter_type_changes(client, engine):
+def test_parameter_type_changes(client, flow_name, engine):
     @op
     def noop(input):
         return input
@@ -399,17 +372,12 @@ def test_parameter_type_changes(client, engine):
     with pytest.raises(Exception):
         output.get(parameters={"number": "This is a string."})
 
-    flow_id = None
-    try:
-        flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
-        flow_id = flow.id()
+    flow = publish_flow_test(
+        client,
+        output,
+        name=flow_name(),
+        engine=engine,
+    )
 
-        # TODO(ENG-1684): we should not allow the user to trigger successfully with the wrong type.
-        client.trigger(flow_id, parameters={"number": "This is a string"})
-        wait_for_flow_runs(
-            client,
-            flow_id,
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
-        )
-    finally:
-        delete_flow(client, flow_id)
+    # TODO(ENG-1684): we should not allow the user to trigger successfully with the wrong type.
+    trigger_flow_test(client, flow, expected_status=ExecutionStatus.FAILED, parameters={"number": "This is a string"})

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -163,7 +163,6 @@ def test_edit_param_for_flow(client, flow_name, data_integration, engine):
     assert param_artifact.get() == new_row_to_add
 
 
-
 @metric
 def add_numbers(sql, num1, num2):
     if not isinstance(num1, int) or not isinstance(num2, int):
@@ -178,7 +177,6 @@ def test_trigger_flow_with_different_param(client, flow_name, data_integration, 
     num1 = client.create_param(name="num1", default=5)
     num2 = client.create_param(name="num2", default=5)
     output = add_numbers(sql_artifact, num1, num2)
-
 
     flow = publish_flow_test(
         client,
@@ -380,4 +378,9 @@ def test_parameter_type_changes(client, flow_name, engine):
     )
 
     # TODO(ENG-1684): we should not allow the user to trigger successfully with the wrong type.
-    trigger_flow_test(client, flow, expected_status=ExecutionStatus.FAILED, parameters={"number": "This is a string"})
+    trigger_flow_test(
+        client,
+        flow,
+        expected_status=ExecutionStatus.FAILED,
+        parameters={"number": "This is a string"},
+    )

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -278,7 +278,7 @@ def test_materializing_failed_artifact(client, flow_name, engine):
         output,
         name=flow_name(),
         engine=engine,
-        expected_status=ExecutionStatus.FAILED,
+        expected_statuses=ExecutionStatus.FAILED,
     )
     artifact = flow.latest().artifact(name="fail_fn artifact")
     assert isinstance(artifact, GenericArtifact)

--- a/integration_tests/sdk/resources_test.py
+++ b/integration_tests/sdk/resources_test.py
@@ -1,10 +1,11 @@
 from os import cpu_count
 
 import pytest
-from aqueduct.enums import ServiceType, ExecutionStatus
+from aqueduct.enums import ExecutionStatus, ServiceType
 from aqueduct.error import AqueductError, InvalidUserArgumentException
-from aqueduct import global_config, op
 from utils import publish_flow_test
+
+from aqueduct import global_config, op
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
@@ -61,12 +62,9 @@ def test_custom_num_cpus(client, flow_name, engine):
         delete_flow_after=False,
     )
 
+    assert default_cpus_flow.latest().artifact("count_default_available_cpus artifact").get() == 2
     assert (
-        default_cpus_flow.latest().artifact("count_default_available_cpus artifact").get() == 2
-    )
-    assert (
-        custom_cpus_flow.latest().artifact("count_with_custom_available_cpus artifact").get()
-        == 6
+        custom_cpus_flow.latest().artifact("count_with_custom_available_cpus artifact").get() == 6
     )
 
 
@@ -83,7 +81,9 @@ def test_too_many_cpus_requested(client, flow_name, engine):
         too_many_cpus()
     output = too_many_cpus.lazy()
 
-    publish_flow_test(client, output, name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED)
+    publish_flow_test(
+        client, output, name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED
+    )
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
@@ -140,7 +140,9 @@ def test_too_much_memory_requested_K8s(client, flow_name, engine):
         _ = too_much_memory()
     output = too_much_memory.lazy()
 
-    publish_flow_test(client, [output], name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED)
+    publish_flow_test(
+        client, [output], name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED
+    )
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.LAMBDA)

--- a/integration_tests/sdk/resources_test.py
+++ b/integration_tests/sdk/resources_test.py
@@ -1,15 +1,14 @@
 from os import cpu_count
 
 import pytest
-from aqueduct.enums import ServiceType
+from aqueduct.enums import ServiceType, ExecutionStatus
 from aqueduct.error import AqueductError, InvalidUserArgumentException
-from utils import generate_new_flow_name, run_flow_test
-
 from aqueduct import global_config, op
+from utils import publish_flow_test
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_custom_num_cpus(client, engine):
+def test_custom_num_cpus(client, flow_name, engine):
     """Assumption: nodes in the K8s cluster have more than 4 CPUs.
 
     We run a special operator that checks the number of CPUs that are available.
@@ -46,41 +45,33 @@ def test_custom_num_cpus(client, engine):
     num_count_available_cpus = count_with_custom_available_cpus()
     assert num_count_available_cpus.get() == 4
 
-    flows = []
-    try:
-        default_cpus_flow = run_flow_test(
-            client,
-            name=generate_new_flow_name(),
-            artifacts=num_default_available_cpus,
-            engine=engine,
-            delete_flow_after=False,
-        )
-        flows.append(default_cpus_flow)
+    default_cpus_flow = publish_flow_test(
+        client,
+        name=flow_name(),
+        artifacts=num_default_available_cpus,
+        engine=engine,
+        delete_flow_after=False,
+    )
 
-        custom_cpus_flow = run_flow_test(
-            client,
-            name=generate_new_flow_name(),
-            artifacts=num_count_available_cpus,
-            engine=engine,
-            delete_flow_after=False,
-        )
-        flows.append(custom_cpus_flow)
+    custom_cpus_flow = publish_flow_test(
+        client,
+        name=flow_name(),
+        artifacts=num_count_available_cpus,
+        engine=engine,
+        delete_flow_after=False,
+    )
 
-        assert (
-            default_cpus_flow.latest().artifact("count_default_available_cpus artifact").get() == 2
-        )
-        assert (
-            custom_cpus_flow.latest().artifact("count_with_custom_available_cpus artifact").get()
-            == 6
-        )
-
-    finally:
-        for flow in flows:
-            client.delete_flow(flow.id())
+    assert (
+        default_cpus_flow.latest().artifact("count_default_available_cpus artifact").get() == 2
+    )
+    assert (
+        custom_cpus_flow.latest().artifact("count_with_custom_available_cpus artifact").get()
+        == 6
+    )
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_too_many_cpus_requested(client, engine):
+def test_too_many_cpus_requested(client, flow_name, engine):
     """Assumption: nodes in the k8s cluster have less then 20 CPUs."""
     global_config({"engine": engine})
 
@@ -92,11 +83,11 @@ def test_too_many_cpus_requested(client, engine):
         too_many_cpus()
     output = too_many_cpus.lazy()
 
-    run_flow_test(client, [output], engine=engine, expect_success=False)
+    publish_flow_test(client, output, name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED)
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
-def test_custom_memory(client, engine):
+def test_custom_memory(client, flow_name, engine):
     """Assumption: nodes in the K8s cluster have more than 200MB of capacity.
 
     Customize our memory to be 200MB. We will run two different methods, one that allocates less than
@@ -120,24 +111,24 @@ def test_custom_memory(client, engine):
         fn_expect_failure()
     failure_output = fn_expect_failure.lazy()
 
-    run_flow_test(
+    publish_flow_test(
         client,
-        name=generate_new_flow_name(),
+        name=flow_name(),
         artifacts=success_output,
         engine=engine,
     )
 
-    run_flow_test(
+    publish_flow_test(
         client,
-        name=generate_new_flow_name(),
+        name=flow_name,
         artifacts=failure_output,
         engine=engine,
-        expect_success=False,
+        expected_statuses=ExecutionStatus.FAILED,
     )
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_too_much_memory_requested_K8s(client, engine):
+def test_too_much_memory_requested_K8s(client, flow_name, engine):
     """Assumption: nodes in the k8s cluster have less then 100GB of memory."""
     global_config({"engine": engine})
 
@@ -149,11 +140,11 @@ def test_too_much_memory_requested_K8s(client, engine):
         _ = too_much_memory()
     output = too_much_memory.lazy()
 
-    run_flow_test(client, [output], engine=engine, expect_success=False)
+    publish_flow_test(client, [output], name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED)
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.LAMBDA)
-def test_too_much_memory_requested_lambda(client, engine):
+def test_too_much_memory_requested_lambda(client, flow_name, engine):
     """Lambda does not allow you to allocate more than 10,240MB of memory."""
     global_config({"engine": engine})
 
@@ -167,11 +158,11 @@ def test_too_much_memory_requested_lambda(client, engine):
     output = too_much_memory.lazy()
 
     with pytest.raises(InvalidUserArgumentException):
-        run_flow_test(client, [output], engine=engine)
+        publish_flow_test(client, name=flow_name(), artifacts=[output], engine=engine)
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_custom_gpus(client, engine):
+def test_custom_gpus(client, flow_name, engine):
     """Assumption: there is a GPU node in the K8s cluster. Also assumes the
     machine executing the test has pytorch installed.
 
@@ -195,29 +186,19 @@ def test_custom_gpus(client, engine):
 
     gpu_available = gpu_is_available()
 
-    flows = []
-    try:
-        no_gpu_flow = run_flow_test(
-            client,
-            name=generate_new_flow_name(),
-            artifacts=gpu_not_available,
-            engine=engine,
-            delete_flow_after=False,
-        )
-        flows.append(no_gpu_flow)
+    no_gpu_flow = publish_flow_test(
+        client,
+        name=flow_name(),
+        artifacts=gpu_not_available,
+        engine=engine,
+    )
 
-        gpu_flow = run_flow_test(
-            client,
-            name=generate_new_flow_name(),
-            artifacts=gpu_available,
-            engine=engine,
-            delete_flow_after=False,
-        )
-        flows.append(gpu_flow)
+    gpu_flow = publish_flow_test(
+        client,
+        name=flow_name(),
+        artifacts=gpu_available,
+        engine=engine,
+    )
 
-        assert not no_gpu_flow.latest().artifact("gpu_is_not_available artifact").get()
-        assert gpu_flow.latest().artifact("gpu_is_available artifact").get()
-
-    finally:
-        for flow in flows:
-            client.delete_flow(flow.id())
+    assert not no_gpu_flow.latest().artifact("gpu_is_not_available artifact").get()
+    assert gpu_flow.latest().artifact("gpu_is_available artifact").get()

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -2,7 +2,7 @@ import pytest
 from aqueduct.error import InvalidIntegrationException, InvalidUserArgumentException
 from constants import SENTIMENT_SQL_QUERY
 from test_functions.simple.model import dummy_sentiment_model
-from utils import generate_table_name, run_flow_test
+from utils import generate_table_name, publish_flow_test
 
 from aqueduct import LoadUpdateMode, metric
 
@@ -75,7 +75,7 @@ def test_sql_query_with_parameter(client, data_integration):
         _ = sql_artifact.get(parameters={"non-existant parameter": "blah"})
 
 
-def test_sql_query_with_multiple_parameters(client, data_integration, engine):
+def test_sql_query_with_multiple_parameters(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
 
     _ = client.create_param("table_name", default="hotel_reviews")
@@ -105,7 +105,7 @@ def test_sql_query_with_multiple_parameters(client, data_integration, engine):
     assert result.get() == len(nationality.get())
     assert result.get(parameters={"reviewer-nationality": "Australia"}) == len("Australia")
 
-    run_flow_test(client, artifacts=[result], engine=engine)
+    publish_flow_test(client, name=flow_name(), artifacts=[result], engine=engine)
 
 
 def test_sql_query_user_vs_builtin_precedence(client, data_integration):

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -26,7 +26,7 @@ def test_flow_fails_on_unexpected_type_output(client, engine):
         wait_for_flow_runs(
             client,
             flow.id(),
-            expect_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
+            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
         )
     finally:
         client.delete_flow(flow.id())
@@ -46,7 +46,7 @@ def test_flow_fails_on_unexpected_type_output_for_lazy(client, engine):
         wait_for_flow_runs(
             client,
             flow.id(),
-            expect_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
+            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
         )
     finally:
         client.delete_flow(flow.id())

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -3,7 +3,7 @@ from typing import Union
 import pytest
 from aqueduct.enums import ExecutionStatus
 from aqueduct.error import AqueductError
-from utils import run_flow_test, wait_for_flow_runs
+from utils import publish_flow_test, trigger_flow_test
 
 from aqueduct import op
 
@@ -15,41 +15,24 @@ def output_different_types(should_return_num: bool) -> Union[str, int]:
     return "not a number"
 
 
-def test_flow_fails_on_unexpected_type_output(client, engine):
+def test_flow_fails_on_unexpected_type_output(client, flow_name, engine):
     type_toggle = client.create_param("output_type_toggle", True)
     output = output_different_types(type_toggle)
 
-    flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
-
-    try:
-        client.trigger(flow.id(), parameters={"output_type_toggle": False})
-        wait_for_flow_runs(
-            client,
-            flow.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
-        )
-    finally:
-        client.delete_flow(flow.id())
+    flow = publish_flow_test(client, name=flow_name(), artifacts=output, engine=engine)
+    trigger_flow_test(client, flow, parameters={"output_type_toggle": False}, expected_status=ExecutionStatus.FAILED)
 
 
-def test_flow_fails_on_unexpected_type_output_for_lazy(client, engine):
+def test_flow_fails_on_unexpected_type_output_for_lazy(client, flow_name, engine):
     type_toggle = client.create_param("output_type_toggle", True)
     output = output_different_types.lazy(type_toggle)
 
     # The flow will first be lazily executed, and the new type information
     # will be persisted to the database.
-    flow = run_flow_test(client, artifacts=[output], engine=engine, delete_flow_after=False)
+    flow = publish_flow_test(client, name=flow_name(), artifacts=[output], engine=engine)
 
-    try:
-        # Because we are violating our inferred types, this will fail!
-        client.trigger(flow.id(), parameters={"output_type_toggle": False})
-        wait_for_flow_runs(
-            client,
-            flow.id(),
-            expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.FAILED],
-        )
-    finally:
-        client.delete_flow(flow.id())
+    # Because we are violating our inferred types, this will fail!
+    trigger_flow_test(client, flow, parameters={"output_type_toggle": False}, expected_status=ExecutionStatus.FAILED)
 
 
 def test_preview_artifact_backfilled_with_wrong_type(client):

--- a/integration_tests/sdk/type_enforcement_test.py
+++ b/integration_tests/sdk/type_enforcement_test.py
@@ -20,7 +20,12 @@ def test_flow_fails_on_unexpected_type_output(client, flow_name, engine):
     output = output_different_types(type_toggle)
 
     flow = publish_flow_test(client, name=flow_name(), artifacts=output, engine=engine)
-    trigger_flow_test(client, flow, parameters={"output_type_toggle": False}, expected_status=ExecutionStatus.FAILED)
+    trigger_flow_test(
+        client,
+        flow,
+        parameters={"output_type_toggle": False},
+        expected_status=ExecutionStatus.FAILED,
+    )
 
 
 def test_flow_fails_on_unexpected_type_output_for_lazy(client, flow_name, engine):
@@ -32,7 +37,12 @@ def test_flow_fails_on_unexpected_type_output_for_lazy(client, flow_name, engine
     flow = publish_flow_test(client, name=flow_name(), artifacts=[output], engine=engine)
 
     # Because we are violating our inferred types, this will fail!
-    trigger_flow_test(client, flow, parameters={"output_type_toggle": False}, expected_status=ExecutionStatus.FAILED)
+    trigger_flow_test(
+        client,
+        flow,
+        parameters={"output_type_toggle": False},
+        expected_status=ExecutionStatus.FAILED,
+    )
 
 
 def test_preview_artifact_backfilled_with_wrong_type(client):

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -167,7 +167,7 @@ def wait_for_flow_runs(
 
         expect_status_strs = [status.value for status in expected_statuses]
         assert statuses == expect_status_strs, (
-            "Unexpected workflow run status(es). In reverse chronological order, expected %s, got %s. "
+            "Unexpected workflow run status(es). In ascending chronological order (latest last), expected %s, got %s. "
             % (expect_status_strs, statuses)
         )
 

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -17,6 +17,18 @@ def generate_table_name() -> str:
     return "test_table_" + uuid.uuid4().hex[:24]
 
 
+def publish_flow(
+    client: aqueduct.Client,
+    artifacts: List[BaseArtifact],
+    metrics: Optional[List[BaseArtifact]] = None,
+    checks: Optional[List[BaseArtifact]] = None,
+    schedule: str = "",
+):
+
+    # TODO: register with context that will best-effort delete afterwards.
+    pass
+
+
 def run_flow_test(
     client: aqueduct.Client,
     artifacts: List[BaseArtifact],

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -24,14 +24,14 @@ def generate_table_name() -> str:
 
 def publish_flow_test(
     client: aqueduct.Client,
-    name: str,
     artifacts: Union[BaseArtifact, List[BaseArtifact]],
     engine: str,
     expected_status: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
+    name: Optional[str] = None,
+    existing_flow: Optional[Flow] = None,
     metrics: Optional[List[BaseArtifact]] = None,
     checks: Optional[List[BaseArtifact]] = None,
     schedule: str = "",
-    existing_flow: Optional[Flow] = None,
     should_block: bool = True
 ) -> Flow:
     """
@@ -40,7 +40,11 @@ def publish_flow_test(
     flow runs we want to wait for.
     What is flow for?
     """
-    assert isinstance(name, str)
+    assert name or existing_flow and not (name and existing_flow), "Either `name` or `existing_flow` can be set, but not both."
+
+    if existing_flow is not None:
+        name = existing_flow.name()
+    assert isinstance(name, str), "Flow name must be string, not %s type." % type(name)
 
     num_prev_runs = len(existing_flow.list_runs()) if existing_flow is not None else 0
     flow = client.publish_flow(
@@ -71,7 +75,7 @@ def trigger_flow_test(
     flow: Flow,
     expected_status: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
     parameters: Optional[Dict[str, Any]] = None,
-):
+) -> None:
     num_prev_runs = len(flow.list_runs())
     client.trigger(flow.id(), parameters=parameters)
 
@@ -83,6 +87,7 @@ def trigger_flow_test(
     )
 
 
+# TODO: remove
 def run_flow_test(
     client: aqueduct.Client,
     artifacts: List[BaseArtifact],

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -26,7 +26,7 @@ def publish_flow_test(
     client: aqueduct.Client,
     artifacts: Union[BaseArtifact, List[BaseArtifact]],
     engine: str,
-    expected_status: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
+    expected_statuses: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
     name: Optional[str] = None,
     existing_flow: Optional[Flow] = None,
     metrics: Optional[List[BaseArtifact]] = None,
@@ -65,7 +65,7 @@ def publish_flow_test(
             client,
             flow.id(),
             num_prev_runs=num_prev_runs,
-            expected_statuses=[expected_status] if isinstance(expected_status, ExecutionStatus) else expected_status,
+            expected_statuses=[expected_statuses] if isinstance(expected_statuses, ExecutionStatus) else expected_statuses,
         )
     return flow
 

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -32,6 +32,7 @@ def publish_flow_test(
     checks: Optional[List[BaseArtifact]] = None,
     schedule: str = "",
     existing_flow: Optional[Flow] = None,
+    should_block: bool = True
 ) -> Flow:
     """
     TODO:
@@ -39,6 +40,8 @@ def publish_flow_test(
     flow runs we want to wait for.
     What is flow for?
     """
+    assert isinstance(name, str)
+
     num_prev_runs = len(existing_flow.list_runs()) if existing_flow is not None else 0
     flow = client.publish_flow(
         name=name,
@@ -53,12 +56,13 @@ def publish_flow_test(
     # Necessary so that the flow is cleaned up at the end of the test.
     flow_name_to_id[name] = flow.id()
 
-    wait_for_flow_runs(
-        client,
-        flow.id(),
-        num_prev_runs=num_prev_runs,
-        expected_statuses=[expected_status] if isinstance(expected_status, ExecutionStatus) else expected_status,
-    )
+    if should_block:
+        wait_for_flow_runs(
+            client,
+            flow.id(),
+            num_prev_runs=num_prev_runs,
+            expected_statuses=[expected_status] if isinstance(expected_status, ExecutionStatus) else expected_status,
+        )
     return flow
 
 
@@ -121,7 +125,7 @@ def run_flow_test(
     return flow
 
 
-# TODO: make this private.
+# TODO: make this private. Or put a warning about using this.
 def wait_for_flow_runs(
     client: aqueduct.Client,
     flow_id: uuid.UUID,

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -24,14 +24,14 @@ def generate_table_name() -> str:
 
 def publish_flow_test(
     client: aqueduct.Client,
-    name: Optional[str],
+    name: str,
     artifacts: Union[BaseArtifact, List[BaseArtifact]],
     engine: str,
     expected_status: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
     metrics: Optional[List[BaseArtifact]] = None,
     checks: Optional[List[BaseArtifact]] = None,
     schedule: str = "",
-    flow: Optional[Flow] = None,
+    existing_flow: Optional[Flow] = None,
 ) -> Flow:
     """
     TODO:
@@ -39,9 +39,7 @@ def publish_flow_test(
     flow runs we want to wait for.
     What is flow for?
     """
-    assert (name or flow) and not (name and flow), "Either a new flow name or a previous flow must be supplied, but not both!"
-
-    num_prev_runs = len(flow.list_runs()) if flow is not None else 0
+    num_prev_runs = len(existing_flow.list_runs()) if existing_flow is not None else 0
     flow = client.publish_flow(
         name=name,
         artifacts=artifacts,

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -379,6 +379,9 @@ class Client:
         Returns:
             A flow object handle to be used to fetch information about this productionized flow.
         """
+        if not isinstance(name, str) or name == "":
+            raise InvalidUserArgumentException("A non-empty string must be supplied for the flow's name.")
+
         if config is not None:
             logger().warning(
                 "`config` is deprecated, please use the `engine` or `k_latest_runs` fields directly."

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -380,7 +380,9 @@ class Client:
             A flow object handle to be used to fetch information about this productionized flow.
         """
         if not isinstance(name, str) or name == "":
-            raise InvalidUserArgumentException("A non-empty string must be supplied for the flow's name.")
+            raise InvalidUserArgumentException(
+                "A non-empty string must be supplied for the flow's name."
+            )
 
         if config is not None:
             logger().warning(

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -327,7 +327,7 @@ class Client:
 
         The default execution engine of the flow is Aqueduct. In order to specify which
         execution engine the flow will be running on, use "config" parameter. Eg:
-        >>> flow = client.publish_flow(
+        >>> flow = client.publish_flow_test(
         >>>     name="k8s_example",
         >>>     artifacts=[output],
         >>>     engine="k8s_integration",

--- a/sdk/aqueduct/aqueduct_client.py
+++ b/sdk/aqueduct/aqueduct_client.py
@@ -327,7 +327,7 @@ class Client:
 
         The default execution engine of the flow is Aqueduct. In order to specify which
         execution engine the flow will be running on, use "config" parameter. Eg:
-        >>> flow = client.publish_flow_test(
+        >>> flow = client.publish_flow(
         >>>     name="k8s_example",
         >>>     artifacts=[output],
         >>>     engine="k8s_integration",

--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -13,7 +13,12 @@ from .enums import ArtifactType, OperatorType
 from .flow_run import FlowRun
 from .logger import logger
 from .operators import OperatorSpec, ParamSpec
-from .responses import SavedObjectUpdate, WorkflowDagResponse, WorkflowDagResultResponse, GetWorkflowResponse
+from .responses import (
+    GetWorkflowResponse,
+    SavedObjectUpdate,
+    WorkflowDagResponse,
+    WorkflowDagResultResponse,
+)
 from .utils import format_header_for_print, generate_ui_url, parse_user_supplied_id
 
 
@@ -47,6 +52,7 @@ class Flow:
         resp = self._get_workflow_resp()
         latest_result = resp.workflow_dag_results[-1]
         latest_workflow_dag = resp.workflow_dags[latest_result.workflow_dag_id]
+        assert latest_workflow_dag.metadata.name is not None
         return latest_workflow_dag.metadata.name
 
     def list_runs(self, limit: int = 10) -> List[Dict[str, str]]:

--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -13,7 +13,7 @@ from .enums import ArtifactType, OperatorType
 from .flow_run import FlowRun
 from .logger import logger
 from .operators import OperatorSpec, ParamSpec
-from .responses import SavedObjectUpdate, WorkflowDagResponse, WorkflowDagResultResponse
+from .responses import SavedObjectUpdate, WorkflowDagResponse, WorkflowDagResultResponse, GetWorkflowResponse
 from .utils import format_header_for_print, generate_ui_url, parse_user_supplied_id
 
 
@@ -35,6 +35,19 @@ class Flow:
     def id(self) -> uuid.UUID:
         """Returns the id of the flow."""
         return uuid.UUID(self._id)
+
+    def _get_workflow_resp(self) -> GetWorkflowResponse:
+        resp = globals.__GLOBAL_API_CLIENT__.get_workflow(self._id)
+        if len(resp.workflow_dag_results) == 0:
+            raise InvalidUserActionException("This flow has not been run yet.")
+        return resp
+
+    def name(self) -> str:
+        """Returns the latest name of the flow."""
+        resp = self._get_workflow_resp()
+        latest_result = resp.workflow_dag_results[-1]
+        latest_workflow_dag = resp.workflow_dags[latest_result.workflow_dag_id]
+        return latest_workflow_dag.metadata.name
 
     def list_runs(self, limit: int = 10) -> List[Dict[str, str]]:
         """Lists the historical runs associated with this flow, sorted chronologically from most to least recent.
@@ -78,10 +91,7 @@ class Flow:
         )
 
     def latest(self) -> FlowRun:
-        resp = globals.__GLOBAL_API_CLIENT__.get_workflow(self._id)
-        if len(resp.workflow_dag_results) == 0:
-            raise InvalidUserActionException("This flow has not been run yet.")
-
+        resp = self._get_workflow_resp()
         latest_result = resp.workflow_dag_results[-1]
         latest_workflow_dag = resp.workflow_dags[latest_result.workflow_dag_id]
         return self._construct_flow_run(latest_result, latest_workflow_dag)
@@ -89,10 +99,7 @@ class Flow:
     def fetch(self, run_id: Union[str, uuid.UUID]) -> FlowRun:
         run_id = parse_user_supplied_id(run_id)
 
-        resp = globals.__GLOBAL_API_CLIENT__.get_workflow(self._id)
-        assert (
-            len(resp.workflow_dag_results) > 0
-        ), "Every flow must have at least one run attached to it."
+        resp = self._get_workflow_resp()
 
         result = None
         for candidate_result in resp.workflow_dag_results:
@@ -122,7 +129,7 @@ class Flow:
 
     def describe(self) -> None:
         """Prints out a human-readable description of the flow."""
-        resp = globals.__GLOBAL_API_CLIENT__.get_workflow(self._id)
+        resp = self._get_workflow_resp()
         latest_result = resp.workflow_dag_results[-1]
         latest_workflow_dag = resp.workflow_dags[latest_result.workflow_dag_id]
 

--- a/src/golang/lib/engine/authenticate.go
+++ b/src/golang/lib/engine/authenticate.go
@@ -9,10 +9,6 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-const (
-	TestFilePath = "src/"
-)
-
 // Authenticates kubernetes configuration by trying to connect a client.
 func AuthenticateK8sConfig(ctx context.Context, authConf auth.Config) error {
 	conf, err := ParseK8sConfig(authConf)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
1) Introduces a `flow_name` fixture that allows the test suite to handle all the cleanup. The developer doesn't have to do any delete_flow() manipulation anymore. This fixture must be used as a function.
2) Replaces `run_flow_test()` with a better, updated version of the helper, `publish_flow_test()`. Also introduces a trigger counterpart `trigger_flow_test()`.
3) Adds the `name()` method to the Flow object.
4) Adds a `--keep-flows` flag to the command line, which will NOT delete flows that were created during the test. This helps preserve state when you're debugging an individual test, for example.
5) Adds an empty requirements file to `integration_tests/sdk`. This might help a little bit with perf on GH actions, but it should definitely help a lot when running against a backing engine like Kubernetes, for example. This requirements file is deleted in the periodic tests github action, to make sure that we're still covering inference.

## Related issue number (if any)
Not supposed to be addressed by this PR, but was: ENG-2031

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


