### PR TITLE
ENG-2047 Bugfix: User unable to switch workflows after hitting back button in browser

### DIFF
--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -30,7 +30,7 @@ const App = () => {
   const pathPrefix = getPathPrefix();
   let routesContent: React.ReactElement;
   routesContent = (
-    <Routes>      
+    <Routes>
       <Route path={`${pathPrefix ?? "/"}`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/data`} element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/integrations`} element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
@@ -42,7 +42,7 @@ const App = () => {
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/operator/:operatorId`} element={<RequireAuth user={user}><OperatorDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/artifact/:artifactId`} element={<RequireAuth user={user}><ArtifactDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/metric/:metricOperatorId`} element={<RequireAuth user={user}><MetricDetailsPage user={user} /> </RequireAuth>} />
-      <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/check/:checkOperatorId`} element={<RequireAuth user={user}><CheckDetailsPage user={user} /> </RequireAuth>} />      
+      <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/check/:checkOperatorId`} element={<RequireAuth user={user}><CheckDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/404`} element={user && user.apiKey ? <RequireAuth user={user}><ErrorPage user={user} /> </RequireAuth> : <ErrorPage />} />
       <Route path="*" element={<Navigate replace to={`/404`} />} />
     </Routes>

--- a/src/ui/app/index.tsx
+++ b/src/ui/app/index.tsx
@@ -30,7 +30,7 @@ const App = () => {
   const pathPrefix = getPathPrefix();
   let routesContent: React.ReactElement;
   routesContent = (
-    <Routes>
+    <Routes>      
       <Route path={`${pathPrefix ?? "/"}`} element={<RequireAuth user={user}><HomePage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/data`} element={<RequireAuth user={user}><DataPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/integrations`} element={<RequireAuth user={user}><IntegrationsPage user={user} /> </RequireAuth>} />
@@ -42,7 +42,7 @@ const App = () => {
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/operator/:operatorId`} element={<RequireAuth user={user}><OperatorDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/artifact/:artifactId`} element={<RequireAuth user={user}><ArtifactDetailsPage user={user} /> </RequireAuth>} />
       <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/metric/:metricOperatorId`} element={<RequireAuth user={user}><MetricDetailsPage user={user} /> </RequireAuth>} />
-      <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/check/:checkOperatorId`} element={<RequireAuth user={user}><CheckDetailsPage user={user} /> </RequireAuth>} />
+      <Route path={`/${pathPrefix}/workflow/:workflowId/result/:workflowDagResultId/check/:checkOperatorId`} element={<RequireAuth user={user}><CheckDetailsPage user={user} /> </RequireAuth>} />      
       <Route path={`/${pathPrefix}/404`} element={user && user.apiKey ? <RequireAuth user={user}><ErrorPage user={user} /> </RequireAuth> : <ErrorPage />} />
       <Route path="*" element={<Navigate replace to={`/404`} />} />
     </Routes>

--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aqueducthq/common",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aqueducthq/common",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "hasInstallScript": true,
       "devDependencies": {
         "@babel/core": "^7.19.3",

--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -67,7 +67,8 @@ export class BreadcrumbLink {
 const NavBar: React.FC<{
   user: UserProfile;
   breadcrumbs: BreadcrumbLink[];
-}> = ({ user, breadcrumbs }) => {
+  onBreadCrumbClicked?: (name: string) => void;
+}> = ({ user, breadcrumbs, onBreadCrumbClicked = null }) => {
   const [userPopoverAnchorEl, setUserPopoverAnchorEl] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
 
@@ -130,6 +131,11 @@ const NavBar: React.FC<{
                 color="inherit"
                 to={link.address}
                 component={RouterLink}
+                onClick={() => {
+                  if (onBreadCrumbClicked) {
+                    onBreadCrumbClicked(link.name);
+                  }
+                }}
               >
                 {link.name}
               </Link>

--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -16,12 +16,19 @@ type Props = {
   user: UserProfile;
   children: React.ReactElement | React.ReactElement[];
   breadcrumbs: BreadcrumbLink[];
+  /**
+   * Function to be called when breadcrumbs are clicked. Useful for doing cleanup on navigation.
+   */
+  onBreadCrumbClicked?: (name: string) => void;
+  onSidebarItemClicked?: (name: string) => void;
 };
 
 export const DefaultLayout: React.FC<Props> = ({
   user,
   children,
   breadcrumbs,
+  onBreadCrumbClicked = null,
+  onSidebarItemClicked = null,
 }) => {
   return (
     <Box
@@ -33,8 +40,12 @@ export const DefaultLayout: React.FC<Props> = ({
       }}
     >
       <Box sx={{ width: '100%', height: '100%', display: 'flex', flex: 1 }}>
-        <MenuSidebar user={user} />
-        <NavBar user={user} breadcrumbs={breadcrumbs} />
+        <MenuSidebar user={user} onSidebarItemClicked={onSidebarItemClicked} />
+        <NavBar
+          user={user}
+          breadcrumbs={breadcrumbs}
+          onBreadCrumbClicked={onBreadCrumbClicked}
+        />
         {/* Pad top for breadcrumbs (64px). */}
         {/* The margin here is fixed to be a constant (50px) more than the sidebar, which is a fixed width (200px). */}
         <Box

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -39,6 +39,7 @@ export type SidebarButtonProps = {
   text: string;
   selected?: boolean;
   numUpdates?: number;
+  onClick?: () => void;
 };
 
 const BUTTON_STYLE_OVERRIDE = {
@@ -57,9 +58,11 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
   text,
   numUpdates = 0,
   selected = false,
+  onClick,
 }) => {
   return (
     <Button
+      onClick={onClick}
       sx={{
         ...BUTTON_STYLE_OVERRIDE,
         bg: 'blue.800',
@@ -110,7 +113,10 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
  * is pinned on the left-hand side of every page in our UI, and it includes
  * quick links to core abstractions in our system (workflows, integrations, etc).
  */
-const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
+const MenuSidebar: React.FC<{
+  user: UserProfile;
+  onSidebarItemClicked?: (name: string) => void;
+}> = ({ user, onSidebarItemClicked }) => {
   const dispatch: AppDispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(undefined);
   const location = useLocation();
@@ -131,6 +137,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
         underline="none"
         style={menuSidebarLogoLink}
         component={RouterLink}
+        onClick={() => {
+          if (onSidebarItemClicked) {
+            onSidebarItemClicked('home');
+          }
+        }}
       >
         <img
           src={
@@ -150,6 +161,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
             component={RouterLink}
           >
             <SidebarButton
+              onClick={() => {
+                if (onSidebarItemClicked) {
+                  onSidebarItemClicked('workflows');
+                }
+              }}
               icon={
                 <FontAwesomeIcon style={menuSidebarIcon} icon={faShareNodes} />
               }
@@ -167,6 +183,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
             component={RouterLink}
           >
             <SidebarButton
+              onClick={() => {
+                if (onSidebarItemClicked) {
+                  onSidebarItemClicked('integrations');
+                }
+              }}
               icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faPlug} />}
               text=""
               selected={currentPage === '/integrations'}
@@ -182,6 +203,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
             component={RouterLink}
           >
             <SidebarButton
+              onClick={() => {
+                if (onSidebarItemClicked) {
+                  onSidebarItemClicked('data');
+                }
+              }}
               icon={
                 <FontAwesomeIcon style={menuSidebarIcon} icon={faDatabase} />
               }
@@ -198,6 +224,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           <Tooltip title="Documentation" placement="right" arrow>
             <Link href="https://docs.aqueducthq.com" underline="none">
               <SidebarButton
+                onClick={() => {
+                  if (onSidebarItemClicked) {
+                    onSidebarItemClicked('documentation');
+                  }
+                }}
                 icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faBook} />}
                 text=""
               />
@@ -209,6 +240,11 @@ const MenuSidebar: React.FC<{ user: UserProfile }> = ({ user }) => {
           <Tooltip title="Report Issue" placement="right" arrow>
             <Link href="mailto:support@aqueducthq.com" underline="none">
               <SidebarButton
+                onClick={() => {
+                  if (onSidebarItemClicked) {
+                    onSidebarItemClicked('report_issue');
+                  }
+                }}
                 icon={
                   <FontAwesomeIcon style={menuSidebarIcon} icon={faMessage} />
                 }

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -333,7 +333,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -380,7 +381,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -399,7 +401,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -418,7 +421,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -85,36 +85,28 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   const dagName = workflow.selectedDag?.metadata?.name;
 
   useEffect(() => {
-    console.log('location: ', location);
-  }, [location]);
-
-  useEffect(() => {
     if (workflow.selectedDag !== undefined) {
       document.title = `${dagName} | Aqueduct`;
     }
-  }, [workflow.selectedDag]);
+  }, [workflow.selectedDag, dagName]);
 
   const resetWorkflowState = () => {
-    console.log('resetWorkflowState()');
     dispatch(resetState());
   };
 
   useEffect(() => {
     window.onpopstate = () => {
-      console.log('inside onpopstate');
       resetWorkflowState();
     };
 
-    dispatch(resetState());
+    resetWorkflowState();
   }, []);
 
   useEffect(() => {
-    console.log('navigate value: ', navigate);
     if (
       workflow.selectedResult !== undefined &&
       !urlSearchParams.workflowDagResultId
     ) {
-      console.log('navigating with url params');
       navigate(
         `?workflowDagResultId=${encodeURI(workflow.selectedResult.id)}`,
         { replace: true }
@@ -341,8 +333,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -389,8 +380,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -409,8 +399,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -429,8 +418,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -456,12 +444,10 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
       ]}
       user={user}
       onBreadCrumbClicked={() => {
-        console.log('onBreadcrumbclicked');
-        dispatch(resetState());
+        resetWorkflowState();
       }}
       onSidebarItemClicked={() => {
-        console.log('onSidebarItemClicked');
-        dispatch(resetState());
+        resetWorkflowState();
       }}
     >
       <Box

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -22,7 +22,6 @@ type Props = {
 
 const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   const dispatch: AppDispatch = useDispatch();
-
   const [filterText, setFilterText] = useState<string>('');
 
   useEffect(() => {

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -94,6 +94,8 @@ const initialState: WorkflowState = {
   artifactResults: {},
   operatorResults: {},
   watcherAuthIds: [],
+  selectedDag: undefined,
+  selectedResult: undefined,
   selectedDagPosition: {
     loadingStatus: { loading: LoadingStatusEnum.Initial, err: '' },
     result: { nodes: [], edges: [] },
@@ -472,6 +474,7 @@ export const workflowSlice = createSlice({
   name: 'workflowReducer',
   initialState,
   reducers: {
+    resetState: () => initialState,
     selectResultIdx: (state, { payload }: PayloadAction<number>) => {
       state.artifactResults = {};
       state.operatorResults = {};
@@ -661,5 +664,5 @@ export const workflowSlice = createSlice({
   },
 });
 
-export const { selectResultIdx } = workflowSlice.actions;
+export const { resetState, selectResultIdx } = workflowSlice.actions;
 export default workflowSlice.reducer;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where user is unable to switch workflows after clicking back from workflow details page.

## Related issue number (if any)
ENG-2047

## Loom demo (if any)
https://www.loom.com/share/92f1f04d1e9b48fabfc435a86c5184ba

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


