### PR TITLE
Parallelize CreateLambdaFunction() via ErrGroup 

### DIFF
--- a/src/golang/go.mod
+++ b/src/golang/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2
-	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	google.golang.org/api v0.88.0
 	google.golang.org/grpc v1.48.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/src/golang/go.mod
+++ b/src/golang/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	google.golang.org/api v0.88.0
 	google.golang.org/grpc v1.48.0
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/src/golang/lib/engine/authenticate.go
+++ b/src/golang/lib/engine/authenticate.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -54,6 +55,7 @@ func AuthenticateLambdaConfig(ctx context.Context, authConf auth.Config) error {
 		errGroup.Go(func() error {
 			return lambda_utils.CreateLambdaFunction(lambdaFunctionType, lambdaConf.RoleArn)
 		})
+		time.Sleep(3 * time.Second)
 	}
 
 	if err := errGroup.Wait(); err != nil {


### PR DESCRIPTION
## Describe your changes and why you are making these changes

- In this PR, I parallelize `CreateLambdaFunction()` using ErrGroup package, which creates a new go-routine for each  `CreateLambdaFunction()` using `sync.Waitgroup`.
- One thing worth noticing is that if running without `time.Sleep(x second)` ,connecting lambda through EC2 is fine but connecting lambda through Mac kept failing randomly at different spot. It seems like a concurrency issue and after I add the `time.Sleep`, it works fine. Might want to get more input on that.

## Performance Benchmark

- EC2: ~12min ->>> 3min 10 sec
- Mac: ~20min ->>> ~12min(11m47s, 13m26s,12m36s)

## Testing
I did multiple run on connecting to lambda through Mac and Ec2 and publish workflow for the lambda function.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


