### PR TITLE
Garbage collect unused exec envs after workflow registration

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -624,6 +624,13 @@ func ValidatePrerequisites(
 			)
 		}
 
+		if err = exec_env.ValidateCondaDevelop(); err != nil {
+			return http.StatusBadRequest, errors.Wrap(
+				err,
+				"You don't seem to have `conda develop` available. We use this to help set up conda environments. Please install the dependency before connecting Aqueduct to Conda. Typically, this can be done by running `conda install conda-build`.",
+			)
+		}
+
 		return http.StatusOK, nil
 	}
 

--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
+	db_exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	exec_env "github.com/aqueducthq/aqueduct/lib/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
@@ -34,11 +36,13 @@ type deleteIntegrationResponse struct{}
 type DeleteIntegrationHandler struct {
 	PostHandler
 
-	Database          database.Database
-	Vault             vault.Vault
-	OperatorReader    operator.Reader
-	IntegrationReader integration.Reader
-	IntegrationWriter integration.Writer
+	Database                   database.Database
+	Vault                      vault.Vault
+	OperatorReader             operator.Reader
+	IntegrationReader          integration.Reader
+	IntegrationWriter          integration.Writer
+	ExecutionEnvironmentReader db_exec_env.Reader
+	ExecutionEnvironmentWriter db_exec_env.Writer
 }
 
 func (*DeleteIntegrationHandler) Name() string {
@@ -89,8 +93,12 @@ func (h *DeleteIntegrationHandler) Prepare(r *http.Request) (interface{}, int, e
 
 func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
 	args := interfaceArgs.(*deleteIntegrationArgs)
-
 	emptyResp := deleteIntegrationResponse{}
+
+	integrationObject, err := h.IntegrationReader.GetIntegration(ctx, args.integrationId, h.Database)
+	if err != nil {
+		return emptyResp, http.StatusBadRequest, errors.Wrap(err, "failed to retrieve the given integration.")
+	}
 
 	txn, err := h.Database.BeginTx(ctx)
 	if err != nil {
@@ -103,7 +111,14 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred while deleting integration.")
 	}
 
-	if err := h.Vault.Delete(ctx, args.integrationId.String()); err != nil {
+	if err := cleanUpIntegration(
+		ctx,
+		integrationObject,
+		h.ExecutionEnvironmentReader,
+		h.ExecutionEnvironmentWriter,
+		h.Vault,
+		h.Database,
+	); err != nil {
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Failed to delete integration.")
 	}
 
@@ -112,4 +127,31 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 	}
 
 	return emptyResp, http.StatusOK, nil
+}
+
+// cleanUpIntegration deletes any side effects of an integration
+// in Aqueduct system, other than DB records.
+// For example, credentials stored in vault or base conda environments
+// created.
+func cleanUpIntegration(
+	ctx context.Context,
+	integrationObject *integration.Integration,
+	execEnvReader db_exec_env.Reader,
+	execEnvWriter db_exec_env.Writer,
+	vaultObject vault.Vault,
+	db database.Database,
+) error {
+	if integrationObject.Service == integration.Conda {
+		// Best effort to clean up
+		err := exec_env.CleanupUnusedEnvironments(
+			ctx, execEnvReader, execEnvWriter, db,
+		)
+		if err != nil {
+			return err
+		}
+
+		return exec_env.DeleteBaseEnvs()
+	}
+
+	return vaultObject.Delete(ctx, integrationObject.Id.String())
 }

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -17,6 +17,7 @@ import (
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/engine"
+	exec_env "github.com/aqueducthq/aqueduct/lib/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	shared_utils "github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/aqueducthq/aqueduct/lib/vault"
@@ -26,6 +27,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 )
 
 // Route: /workflow/register
@@ -278,6 +280,24 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to add user who created the workflow to watch.")
 		}
 	}
+
+	// Check unused Conda environments and garbage collect them.
+	go func() {
+		db, err := database.NewDatabase(h.Database.Config())
+		if err != nil {
+			log.Errorf("Error creating DB in go routine: %v", err)
+			return
+		}
+
+		err = exec_env.CleanupUnusedEnvironments(
+			context.Background(),
+			h.ExecutionEnvironmentReader,
+			db,
+		)
+		if err != nil {
+			log.Errorf("Error garbage collecting unused Conda environment: %v", err)
+		}
+	}()
 
 	return registerWorkflowResponse{Id: workflowId}, http.StatusOK, nil
 }

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -289,12 +289,15 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 			return
 		}
 
-		exec_env.CleanupUnusedEnvironments(
+		err = exec_env.CleanupUnusedEnvironments(
 			context.Background(),
 			h.ExecutionEnvironmentReader,
 			h.ExecutionEnvironmentWriter,
 			db,
 		)
+		if err != nil {
+			log.Errorf("%v", err)
+		}
 	}()
 
 	return registerWorkflowResponse{Id: workflowId}, http.StatusOK, nil

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -289,14 +289,12 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 			return
 		}
 
-		err = exec_env.CleanupUnusedEnvironments(
+		exec_env.CleanupUnusedEnvironments(
 			context.Background(),
 			h.ExecutionEnvironmentReader,
+			h.ExecutionEnvironmentWriter,
 			db,
 		)
-		if err != nil {
-			log.Errorf("Error garbage collecting unused Conda environment: %v", err)
-		}
 	}()
 
 	return registerWorkflowResponse{Id: workflowId}, http.StatusOK, nil

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -29,11 +29,13 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			RestartServer: s.Restart,
 		},
 		routes.DeleteIntegrationRoute: &handler.DeleteIntegrationHandler{
-			Database:          s.Database,
-			Vault:             s.Vault,
-			OperatorReader:    s.OperatorReader,
-			IntegrationReader: s.IntegrationReader,
-			IntegrationWriter: s.IntegrationWriter,
+			Database:                   s.Database,
+			Vault:                      s.Vault,
+			OperatorReader:             s.OperatorReader,
+			IntegrationReader:          s.IntegrationReader,
+			IntegrationWriter:          s.IntegrationWriter,
+			ExecutionEnvironmentReader: s.ExecutionEnvironmentReader,
+			ExecutionEnvironmentWriter: s.ExecutionEnvironmentWriter,
 		},
 		routes.DeleteWorkflowRoute: &handler.DeleteWorkflowHandler{
 			Database:   s.Database,

--- a/src/golang/lib/collections/execution_environment/execution_environment.go
+++ b/src/golang/lib/collections/execution_environment/execution_environment.go
@@ -22,6 +22,10 @@ type Reader interface {
 		opIDs []uuid.UUID,
 		db database.Database,
 	) (map[uuid.UUID]DBExecutionEnvironment, error)
+	GetUnusedExecutionEnvironments(
+		ctx context.Context,
+		db database.Database,
+	) ([]DBExecutionEnvironment, error)
 }
 
 type Writer interface {

--- a/src/golang/lib/collections/execution_environment/noop.go
+++ b/src/golang/lib/collections/execution_environment/noop.go
@@ -89,3 +89,10 @@ func (w *noopWriterImpl) DeleteExecutionEnvironments(
 ) error {
 	return utils.NoopInterfaceErrorHandling(w.throwError)
 }
+
+func (r *noopReaderImpl) GetUnusedExecutionEnvironments(
+	ctx context.Context,
+	db database.Database,
+) ([]DBExecutionEnvironment, error) {
+	return nil, utils.NoopInterfaceErrorHandling(r.throwError)
+}

--- a/src/golang/lib/collections/execution_environment/standard.go
+++ b/src/golang/lib/collections/execution_environment/standard.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow_dag_edge"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
 	"github.com/dropbox/godropbox/errors"
@@ -160,4 +161,56 @@ func (w *standardWriterImpl) DeleteExecutionEnvironments(
 
 	args := stmt_preparers.CastIdsListToInterfaceList(ids)
 	return db.Execute(ctx, deleteStmt, args...)
+}
+
+func (r *standardReaderImpl) GetUnusedExecutionEnvironments(
+	ctx context.Context,
+	db database.Database,
+) ([]DBExecutionEnvironment, error) {
+	// Note that we use `OperatorToArtifactType` as the filtering condition because an operator
+	// is guaranteed to generate at least one artifact, so this filter is guaranteed to capture
+	// all operators involved in a workflow DAG.
+	query := fmt.Sprintf(`
+	WITH latest_workflow_dag AS
+	(
+		SELECT 
+			workflow_dag.id 
+		FROM
+			workflow_dag 
+		WHERE 
+			created_at IN (
+				SELECT 
+					MAX(workflow_dag.created_at) 
+				FROM 
+					workflow, workflow_dag 
+				WHERE 
+					workflow.id = workflow_dag.workflow_id 
+				GROUP BY 
+					workflow.id
+			);
+	),
+	active_execution_environment AS
+	(
+		SELECT DISTINCT
+			operator.execution_environment_id AS id
+		FROM 
+			latest_workflow_dag, workflow_dag_edge, operator
+		WHERE
+			latest_workflow_dag.id = workflow_dag_edge.workflow_dag_id 
+			AND 
+			workflow_dag_edge.type = '%s' 
+			AND 
+			workflow_dag_edge.from_id = operator.id
+	)
+	SELECT 
+		%s
+	FROM 
+		execution_environment LEFT JOIN active_execution_environment 
+		ON execution_environment.id = active_execution_environment.id
+	WHERE 
+		active_execution_environment.id IS NULL;`, workflow_dag_edge.OperatorToArtifactType, allColumnsWithPrefix())
+	var results []DBExecutionEnvironment
+
+	err := db.Query(ctx, &results, query)
+	return results, err
 }

--- a/src/golang/lib/collections/execution_environment/standard.go
+++ b/src/golang/lib/collections/execution_environment/standard.go
@@ -187,7 +187,7 @@ func (r *standardReaderImpl) GetUnusedExecutionEnvironments(
 					workflow.id = workflow_dag.workflow_id 
 				GROUP BY 
 					workflow.id
-			);
+			)
 	),
 	active_execution_environment AS
 	(

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -279,7 +279,7 @@ func (eng *aqEngine) ExecuteWorkflow(
 		opIds = append(opIds, op.Id)
 	}
 
-	execEnvsByOpId, err := exec_env.GetExecutionEnvironmentsMapByOperatorIds(
+	execEnvsByOpId, err := exec_env.GetExecutionEnvironmentsMapByOperatorIDs(
 		ctx,
 		opIds,
 		eng.ExecutionEnvironmentReader,

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -303,7 +303,7 @@ func GetUnusedExecutionEnvironmentIDs(
 }
 
 // CleanupUnusedEnvironments is executed in a best-effort fashion, and we log all the errors within
-// the function and return an error object signaling whether there is at least one error occured.
+// the function and return an error object signaling whether there is at least one error occurred.
 func CleanupUnusedEnvironments(
 	ctx context.Context,
 	envReader db_exec_env.Reader,
@@ -344,7 +344,7 @@ func CleanupUnusedEnvironments(
 	}
 
 	if hasError {
-		return errors.New("An internal error occured within the cleanup function. Please see the server log for more information.")
+		return errors.New("An internal error occurred within the cleanup function. Please see the server log for more information.")
 	}
 
 	return nil

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -293,7 +293,7 @@ func GetUnusedExecutionEnvironmentIDs(
 		return nil, err
 	}
 
-	results := make([]uuid.UUID, len(dbEnvs))
+	results := make([]uuid.UUID, 0, len(dbEnvs))
 	for _, dbEnv := range dbEnvs {
 		results = append(results, dbEnv.Id)
 	}

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -315,7 +315,6 @@ func CleanupUnusedEnvironments(
 		return
 	}
 
-	var errIDs []uuid.UUID
 	var deletedIDs []uuid.UUID
 
 	for _, envID := range envIDs {
@@ -329,7 +328,7 @@ func CleanupUnusedEnvironments(
 
 		_, _, err := lib_utils.RunCmd(CondaCmdPrefix, deleteArgs...)
 		if err != nil {
-			errIDs = append(errIDs, envID)
+			log.Errorf("Error garbage collecting Conda environment %s: %v", envID, err)
 		} else {
 			deletedIDs = append(deletedIDs, envID)
 		}
@@ -338,9 +337,5 @@ func CleanupUnusedEnvironments(
 	err = envWriter.DeleteExecutionEnvironments(ctx, deletedIDs, db)
 	if err != nil {
 		log.Errorf("Error deleting database records of unused Conda environments: %v", err)
-	}
-
-	if len(errIDs) != 0 {
-		log.Errorf("Error garbage collecting Conda environments: %v", errIDs)
 	}
 }

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -189,7 +189,7 @@ func newFromDBExecutionEnvironment(
 	}
 }
 
-func GetExecutionEnvironmentsMapByOperatorIds(
+func GetExecutionEnvironmentsMapByOperatorIDs(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	envReader db_exec_env.Reader,
@@ -279,4 +279,52 @@ func CreateMissingAndSyncExistingEnvs(
 	}
 
 	return results, nil
+}
+
+func GetUnusedExecutionEnvironmentIDs(
+	ctx context.Context,
+	envReader db_exec_env.Reader,
+	db database.Database,
+) ([]uuid.UUID, error) {
+	dbEnvs, err := envReader.GetUnusedExecutionEnvironments(
+		ctx, db,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]uuid.UUID, len(dbEnvs))
+	for _, dbEnv := range dbEnvs {
+		results = append(results, dbEnv.Id)
+	}
+
+	return results, nil
+}
+
+func CleanupUnusedEnvironments(
+	ctx context.Context,
+	envReader db_exec_env.Reader,
+	db database.Database,
+) error {
+	envIDs, err := GetUnusedExecutionEnvironmentIDs(ctx, envReader, db)
+	if err != nil {
+		return err
+	}
+
+	for _, envID := range envIDs {
+		envName := fmt.Sprintf("%s_%s", "aqueduct", envID.String())
+		deleteArgs := []string{
+			"env",
+			"remove",
+			"-n",
+			envName,
+		}
+
+		_, _, err := lib_utils.RunCmd(CondaCmdPrefix, deleteArgs...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/src/ui/common/src/components/integrations/cards/condaCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/condaCard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { CondaConfig, Integration } from '../../../utils/integrations';
 import { ExecState, ExecutionStatus } from '../../../utils/shared';
-import ExecutionChip from '../../execution/chip';
+import CondaConnectionStatus from '../conda/condaConnectionStatus';
 
 type Props = {
   integration: Integration;
@@ -17,7 +17,7 @@ export const CondaCard: React.FC<Props> = ({ integration }) => {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-      <ExecutionChip status={execState.status} />
+      <CondaConnectionStatus state={execState} />
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/cards/detailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/detailCard.tsx
@@ -73,7 +73,7 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
   ) {
     createdOnText = (
       <Typography variant="body2">
-        <strong>Created On: </strong>
+        <strong>Connected On: </strong>
         {new Date(integration.createdAt * 1000).toLocaleString()}
       </Typography>
     );
@@ -92,14 +92,12 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
           src={SupportedIntegrations[integration.service].logo}
         />
         <Box sx={{ ml: 3 }}>
-          <Box display="flex" flexDirection="row">
+          <Box display="flex" flexDirection="row" marginBottom={1}>
             <Typography sx={{ fontFamily: 'Monospace' }} variant="h4">
               {integration.name}
             </Typography>
           </Box>
-
-          {createdOnText}
-
+          <Box marginBottom={1}>{createdOnText}</Box>
           {serviceCard}
         </Box>
       </Box>

--- a/src/ui/common/src/components/integrations/conda/condaConnectionStatus.tsx
+++ b/src/ui/common/src/components/integrations/conda/condaConnectionStatus.tsx
@@ -1,0 +1,43 @@
+import Alert from '@mui/material/Alert';
+import Box from '@mui/material/Typography';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { ExecState, ExecutionStatus } from '../../../utils/shared';
+import ExecutionChip from '../../execution/chip';
+
+type Props = {
+  state: ExecState;
+};
+
+const CondaConnectionStatus: React.FC<Props> = ({ state }) => {
+  const chip = <ExecutionChip status={state.status} />;
+  if (state.status === ExecutionStatus.Succeeded) {
+    return <Box width="fit-content">{chip}</Box>;
+  }
+
+  if (state.status === ExecutionStatus.Failed) {
+    return (
+      <Box display="flex" flexDirection="column">
+        <Box marginBottom={1}>{chip}</Box>
+        <Alert severity="error">
+          Failed to set up conda environments:{' '}
+          <code>{state.error.context}</code>. Once you resolved the error, you
+          can delete this integration and retry connection.
+        </Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <Box display="flex" flexDirection="row" alignItems="center">
+      <Box marginRight={1}>{chip}</Box>
+      <Typography variant="body2">
+        We are still setting up conda environments for you. It usually takes a
+        few minutes to complete.
+      </Typography>
+    </Box>
+  );
+};
+
+export default CondaConnectionStatus;

--- a/src/ui/common/src/components/integrations/dialogs/condaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/condaDialog.tsx
@@ -11,10 +11,17 @@ export const CondaDialog: React.FC = ({}) => {
           target="_blank"
           href="https://conda.io/projects/conda/en/latest/user-guide/install/index.html"
         >
-          conda installed
-        </Link>
-        . Once connected, aqueduct server will use conda environment to run your
-        future workflows.
+          conda
+        </Link>{' '}
+        and{' '}
+        <Link
+          target="_blank"
+          href="https://conda.io/projects/conda-build/en/latest/install-conda-build.html"
+        >
+          conda build
+        </Link>{' '}
+        installed. Once connected, Aqueduct will use conda environments to
+        run new workflows.
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## Describe your changes and why you are making these changes
At the end of workflow registration, we compute unused exec env IDs and garbage collect them. We also delete db records of successfully GCed Conda environments.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


