### PR TITLE
[ENG-2015] Fixes bug where logs weren't displayed on operator details

### DIFF
--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -55,7 +55,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
           <Box
             sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
           >
-            <pre style={{ margin: '0px' }}>logs.stdout</pre>
+            <pre style={{ margin: '0px' }}>{logs.stdout}</pre>
           </Box>
         ) : (
           emptyElement
@@ -67,7 +67,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
           <Box
             sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
           >
-            <pre style={{ margin: '0px' }}>logs.stderr</pre>
+            <pre style={{ margin: '0px' }}>{logs.stderr}</pre>
           </Box>
         ) : (
           emptyElement


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There was a tiny bug in the log viewer where objects weren't actually rendered because we weren't treating them as objects.

## Related issue number (if any)
ENG-2015

## Loom demo (if any)
Logs are actually displayed now: 
<img width="2160" alt="image" src="https://user-images.githubusercontent.com/867892/205181286-b9159bc1-416a-4f10-87e4-c157833c7ce2.png">

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


