### PR TITLE
Eng 2016 Return an error if user doesnt have conda-build installed

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -624,6 +624,13 @@ func ValidatePrerequisites(
 			)
 		}
 
+		if err = exec_env.ValidateCondaDevelop(); err != nil {
+			return http.StatusBadRequest, errors.Wrap(
+				err,
+				"You don't seem to have `conda develop` available. We use this to help setting up conda environments. Please install the dependency before connecting Aqueduct to Conda. Typically, this can be done by running `conda install conda-build`.",
+			)
+		}
+
 		return http.StatusOK, nil
 	}
 

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -627,7 +627,7 @@ func ValidatePrerequisites(
 		if err = exec_env.ValidateCondaDevelop(); err != nil {
 			return http.StatusBadRequest, errors.Wrap(
 				err,
-				"You don't seem to have `conda develop` available. We use this to help setting up conda environments. Please install the dependency before connecting Aqueduct to Conda. Typically, this can be done by running `conda install conda-build`.",
+				"You don't seem to have `conda develop` available. We use this to help set up conda environments. Please install the dependency before connecting Aqueduct to Conda. Typically, this can be done by running `conda install conda-build`.",
 			)
 		}
 

--- a/src/golang/lib/execution_environment/integration.go
+++ b/src/golang/lib/execution_environment/integration.go
@@ -107,6 +107,16 @@ func updateFailure(
 	}
 }
 
+func ValidateCondaDevelop() error {
+	// This is to ensure we can use `conda develop` to update the python path later on.
+	args := []string{
+		"develop",
+		"--help",
+	}
+	_, _, err := lib_utils.RunCmd(CondaCmdPrefix, args...)
+	return err
+}
+
 func InitializeConda(
 	ctx context.Context,
 	integrationID uuid.UUID,
@@ -149,28 +159,6 @@ func InitializeConda(
 	log.Infof("Conda base path is %s", condaPath)
 
 	err = createBaseEnvs(condaPath)
-	if err != nil {
-		updateFailure(
-			ctx,
-			out,
-			err.Error(),
-			condaPath,
-			&now,
-			integrationID,
-			integrationWriter,
-			db,
-		)
-
-		return
-	}
-
-	// This is to ensure we can use `conda develop` to update the python path later on.
-	args := []string{
-		"install",
-		"conda-build",
-		"-y",
-	}
-	_, _, err = lib_utils.RunCmd(CondaCmdPrefix, args...)
 	if err != nil {
 		updateFailure(
 			ctx,

--- a/src/ui/common/src/components/integrations/dialogs/condaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/condaDialog.tsx
@@ -11,10 +11,17 @@ export const CondaDialog: React.FC = ({}) => {
           target="_blank"
           href="https://conda.io/projects/conda/en/latest/user-guide/install/index.html"
         >
-          conda installed
-        </Link>
-        . Once connected, aqueduct server will use conda environment to run your
-        future workflows.
+          conda
+        </Link>{' '}
+        and{' '}
+        <Link
+          target="_blank"
+          href="https://conda.io/projects/conda-build/en/latest/install-conda-build.html"
+        >
+          conda build
+        </Link>{' '}
+        installed. Once connected, aqueduct server will use conda environment to
+        run your future workflows.
       </Typography>
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/condaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/condaDialog.tsx
@@ -20,8 +20,8 @@ export const CondaDialog: React.FC = ({}) => {
         >
           conda build
         </Link>{' '}
-        installed. Once connected, aqueduct server will use conda environment to
-        run your future workflows.
+        installed. Once connected, Aqueduct will use conda environments to
+        run new workflows.
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR modifies the behavior that we silently install `conda build` on user's behalf. Instead, we return an error on connection time informing the user that the required dependency is missing.

## Related issue number (if any)
ENG-2016

## Loom demo (if any)
When the user doesn't have `conda-build` installed:
<img width="1212" alt="Screen Shot 2022-12-01 at 3 55 28 PM" src="https://user-images.githubusercontent.com/10411887/205185514-ecc52840-a1b9-4c90-965f-296f7a875621.png">


Verified connection is successful if conda build is already installed.

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


