### PR TITLE
Fix bug where metrics graph and history is not sorted by time

### DIFF
--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -64,13 +64,15 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
     ),
   };
 
+  const dataSortedByLatest = historicalData.data.sort((x,y) => ((Date.parse(y["timestamp"] as string)) - Date.parse(x["timestamp"] as string)));
+
   return (
     <Box mt="32px">
       <Typography variant="h6" fontWeight="normal">
         History
       </Typography>
 
-      {historicalData.data.map((entry, index) => {
+      {dataSortedByLatest.map((entry, index) => {
         let backgroundColor, hoverColor, icon;
         if (entry.status === ExecutionStatus.Succeeded) {
           backgroundColor = theme.palette.green[100];

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -64,7 +64,11 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
     ),
   };
 
-  const dataSortedByLatest = historicalData.data.sort((x,y) => ((Date.parse(y["timestamp"] as string)) - Date.parse(x["timestamp"] as string)));
+  const dataSortedByLatest = historicalData.data.sort(
+    (x, y) =>
+      Date.parse(y['timestamp'] as string) -
+      Date.parse(x['timestamp'] as string)
+  );
 
   return (
     <Box mt="32px">

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -12,7 +12,7 @@ import Plot from 'react-plotly.js';
 
 import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
 import { theme } from '../../../../styles/theme/theme';
-import { Data, DataSchema } from '../../../../utils/data';
+import { Data, DataSchema, TableRow } from '../../../../utils/data';
 import ExecutionStatus, {
   isFailed,
   isInitial,
@@ -62,10 +62,10 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
       }
     ),
   };
-
+  const dataSortedByLatest = historicalData.data.sort((x,y) => ((Date.parse(y["timestamp"] as string)) - Date.parse(x["timestamp"] as string)));
   const dataToPlot = historicalData.data.filter(
     (x) => !!x['timestamp'] && !!x['value']
-  );
+  ).sort((x,y) => (Date.parse(x["timestamp"] as string)) - (Date.parse(y["timestamp"] as string)));
   const timestamps = dataToPlot.map((x) => x['timestamp']);
   const values = dataToPlot.map((x) => x['value']);
 
@@ -106,7 +106,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
         <Typography variant="h6" fontWeight="normal">
           History
         </Typography>
-        {historicalData.data.map((entry, index) => {
+        {dataSortedByLatest.map((entry, index) => {
           let backgroundColor, hoverColor, icon;
           if (entry.status === ExecutionStatus.Succeeded) {
             backgroundColor = theme.palette.green[100];

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -12,7 +12,7 @@ import Plot from 'react-plotly.js';
 
 import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
 import { theme } from '../../../../styles/theme/theme';
-import { Data, DataSchema, TableRow } from '../../../../utils/data';
+import { Data, DataSchema } from '../../../../utils/data';
 import ExecutionStatus, {
   isFailed,
   isInitial,
@@ -62,10 +62,18 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
       }
     ),
   };
-  const dataSortedByLatest = historicalData.data.sort((x,y) => ((Date.parse(y["timestamp"] as string)) - Date.parse(x["timestamp"] as string)));
-  const dataToPlot = historicalData.data.filter(
-    (x) => !!x['timestamp'] && !!x['value']
-  ).sort((x,y) => (Date.parse(x["timestamp"] as string)) - (Date.parse(y["timestamp"] as string)));
+  const dataSortedByLatest = historicalData.data.sort(
+    (x, y) =>
+      Date.parse(y['timestamp'] as string) -
+      Date.parse(x['timestamp'] as string)
+  );
+  const dataToPlot = historicalData.data
+    .filter((x) => !!x['timestamp'] && !!x['value'])
+    .sort(
+      (x, y) =>
+        Date.parse(x['timestamp'] as string) -
+        Date.parse(y['timestamp'] as string)
+    );
   const timestamps = dataToPlot.map((x) => x['timestamp']);
   const values = dataToPlot.map((x) => x['value']);
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR makes the metrics and check history sorted by time of creation on UI side. The graph displays metric left to right from oldest to newest. The history displays metric top to buttom from newest to oldest. 
Metric:
<img width="602" alt="Screen Shot 2022-12-01 at 8 27 49 PM" src="https://user-images.githubusercontent.com/78303449/205215704-18b26d05-4fe0-48c7-a553-4512406f9cfa.png">
Check:
<img width="604" alt="Screen Shot 2022-12-01 at 8 27 55 PM" src="https://user-images.githubusercontent.com/78303449/205215718-4d0ca2cb-2bef-4bd3-9722-f1d88d9c7e0e.png">



## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1933/fix-bug-where-metrics-graph-and-history-is-not-sorted-by-time
## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


