### PR TITLE
Removes auth0ID from ListWorkflow response

### DIFF
--- a/src/golang/cmd/server/handler/get_workflow.go
+++ b/src/golang/cmd/server/handler/get_workflow.go
@@ -47,8 +47,6 @@ type getWorkflowResponse struct {
 	WorkflowDags map[uuid.UUID]*workflow_dag.DBWorkflowDag `json:"workflow_dags"`
 	// a list of dag results. Each result's `workflow_dag_id` field correspond to the
 	WorkflowDagResults []workflowDagResult `json:"workflow_dag_results"`
-	// a list of auth0Ids associated with workflow watchers
-	WatcherAuthIds []string `json:"watcherAuthIds"`
 }
 
 type workflowDagResult struct {
@@ -208,19 +206,8 @@ func (h *GetWorkflowHandler) Perform(ctx context.Context, interfaceArgs interfac
 		})
 	}
 
-	workflowWatcherUsers, err := h.UserReader.GetWatchersByWorkflowId(ctx, args.workflowId, h.Database)
-	if err != nil {
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving users watching current workflow.")
-	}
-
-	WatcherAuthIds := []string{}
-	for _, user := range workflowWatcherUsers {
-		WatcherAuthIds = append(WatcherAuthIds, user.Auth0Id)
-	}
-
 	return getWorkflowResponse{
 		WorkflowDags:       workflowDags,
 		WorkflowDagResults: workflowDagResults,
-		WatcherAuthIds:     WatcherAuthIds,
 	}, http.StatusOK, nil
 }

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -36,14 +36,13 @@ import (
 //		serialized `listWorkflowsResponse`, a list of workflow information in the user's org
 
 type workflowResponse struct {
-	Id              uuid.UUID              `json:"id"`
-	Name            string                 `json:"name"`
-	Description     string                 `json:"description"`
-	CreatedAt       int64                  `json:"created_at"`
-	LastRunAt       int64                  `json:"last_run_at"`
-	Status          shared.ExecutionStatus `json:"status"`
-	Engine          string                 `json:"engine"`
-	WatcherAuth0Ids []string               `json:"watcher_auth0_id"`
+	Id          uuid.UUID              `json:"id"`
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	CreatedAt   int64                  `json:"created_at"`
+	LastRunAt   int64                  `json:"last_run_at"`
+	Status      shared.ExecutionStatus `json:"status"`
+	Engine      string                 `json:"engine"`
 }
 
 type ListWorkflowsHandler struct {
@@ -107,27 +106,13 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 
 	workflows := make([]workflowResponse, 0, len(dbWorkflows))
 	if len(workflowIds) > 0 {
-		watchersInfo, err := h.WorkflowReader.GetWatchersInBatch(ctx, workflowIds, h.Database)
-		if err != nil {
-			return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to Get Watchers in Batch.")
-		}
-
-		watchersMap := make(map[uuid.UUID][]string)
-		for _, row := range watchersInfo {
-			if _, ok := watchersMap[row.WorkflowId]; !ok {
-				watchersMap[row.WorkflowId] = make([]string, 0, len(watchersInfo))
-			}
-			watchersMap[row.WorkflowId] = append(watchersMap[row.WorkflowId], row.Auth0Id)
-		}
-
 		for _, dbWorkflow := range dbWorkflows {
 			response := workflowResponse{
-				Id:              dbWorkflow.Id,
-				Name:            dbWorkflow.Name,
-				Description:     dbWorkflow.Description,
-				CreatedAt:       dbWorkflow.CreatedAt.Unix(),
-				Engine:          dbWorkflow.Engine,
-				WatcherAuth0Ids: watchersMap[dbWorkflow.Id],
+				Id:          dbWorkflow.Id,
+				Name:        dbWorkflow.Name,
+				Description: dbWorkflow.Description,
+				CreatedAt:   dbWorkflow.CreatedAt.Unix(),
+				Engine:      dbWorkflow.Engine,
 			}
 
 			if !dbWorkflow.LastRunAt.IsNull {

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -70,7 +70,6 @@ export type WorkflowState = {
   savedObjectDeletion: SavedObjectDeletionResult;
   dags: { [id: string]: WorkflowDag };
   dagResults: WorkflowDagResultSummary[];
-  watcherAuthIds: string[];
 
   selectedResult?: WorkflowDagResultSummary;
   selectedDag?: WorkflowDag;
@@ -93,7 +92,6 @@ const initialState: WorkflowState = {
   dagResults: [],
   artifactResults: {},
   operatorResults: {},
-  watcherAuthIds: [],
   selectedDag: undefined,
   selectedResult: undefined,
   selectedDagPosition: {
@@ -619,7 +617,6 @@ export const workflowSlice = createSlice({
       (state, { payload }: PayloadAction<GetWorkflowResponse>) => {
         state.dags = payload.workflow_dags;
         state.dagResults = payload.workflow_dag_results;
-        state.watcherAuthIds = payload.watcherAuthIds;
 
         state.artifactResults = {};
         state.operatorResults = {};

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -34,7 +34,6 @@ export type ListWorkflowSummary = {
   last_run_at: number;
   status: ExecutionStatus;
   engine: string;
-  watcher_auth0_id: string[];
 };
 
 export type WorkflowDagResultSummary = {

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -87,7 +87,6 @@ export function normalizeWorkflowDag(dag: WorkflowDag): WorkflowDag {
 export type GetWorkflowResponse = {
   workflow_dags: { [id: string]: WorkflowDag };
   workflow_dag_results: WorkflowDagResultSummary[];
-  watcherAuthIds: string[];
 };
 
 export type SavedObject = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR removes the `auth0IDs` from the `ListWorkflow` route response. Since the auth0ID is no longer used by the frontend there is no need for us to return this. This also helps reduce the DB project refactor by 1 method 😎 

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


