### PR TITLE
Eng 2025 restrict delete integration to check for only active workflows

### DIFF
--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/aqueducthq/aqueduct/cmd/server/queries"
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 	db_exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
@@ -38,6 +39,7 @@ type DeleteIntegrationHandler struct {
 
 	Database                   database.Database
 	Vault                      vault.Vault
+	CustomReader               queries.Reader
 	OperatorReader             operator.Reader
 	IntegrationReader          integration.Reader
 	IntegrationWriter          integration.Writer
@@ -76,15 +78,6 @@ func (h *DeleteIntegrationHandler) Prepare(r *http.Request) (interface{}, int, e
 		return nil, http.StatusBadRequest, errors.Wrap(err, "The organization does not own this integration.")
 	}
 
-	// Fetch all operators on this integration.
-	operators, err := h.OperatorReader.GetOperatorsByIntegrationId(r.Context(), integrationId, h.Database)
-	if err != nil {
-		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to retrieve operators.")
-	}
-	if len(operators) > 0 {
-		return nil, http.StatusBadRequest, errors.New("Unable to delete because the integration is in use.")
-	}
-
 	return &deleteIntegrationArgs{
 		AqContext:     aqContext,
 		integrationId: integrationId,
@@ -94,6 +87,17 @@ func (h *DeleteIntegrationHandler) Prepare(r *http.Request) (interface{}, int, e
 func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
 	args := interfaceArgs.(*deleteIntegrationArgs)
 	emptyResp := deleteIntegrationResponse{}
+
+	code, err := validateNoActiveWorkflowOnIntegration(
+		ctx,
+		args.integrationId,
+		h.OperatorReader,
+		h.CustomReader,
+		h.Database,
+	)
+	if err != nil {
+		return emptyResp, code, err
+	}
 
 	integrationObject, err := h.IntegrationReader.GetIntegration(ctx, args.integrationId, h.Database)
 	if err != nil {
@@ -127,6 +131,41 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 	}
 
 	return emptyResp, http.StatusOK, nil
+}
+
+// validateNoActiveWorkflowOnIntegration
+// verifies there's no active workflow using the integration given the integration ID.
+// It errors if there's any error occurred and passes if there's indeed no active workflow
+// using that integration.
+func validateNoActiveWorkflowOnIntegration(
+	ctx context.Context,
+	id uuid.UUID,
+	operatorReader operator.Reader,
+	customReader queries.Reader,
+	db database.Database,
+) (int, error) {
+	interfaceResp, code, err := (&ListOperatorsForIntegrationHandler{
+		CustomReader:   customReader,
+		OperatorReader: operatorReader,
+		Database:       db,
+	}).Perform(ctx, id)
+	if err != nil {
+		return code, errors.Wrap(err, "Error getting operators on this integration.")
+	}
+
+	operatorsOnIntegrationResp, ok := interfaceResp.(listOperatorsForIntegrationResponse)
+	if !ok {
+		return http.StatusInternalServerError, errors.New("Error getting operators on this integration.")
+	}
+
+	operatorsOnIntegration := operatorsOnIntegrationResp.OperatorWithIds
+	for _, opState := range operatorsOnIntegration {
+		if opState.IsActive {
+			return http.StatusBadRequest, errors.New("We cannot delete this integration. There are still active workflows using it.")
+		}
+	}
+
+	return http.StatusOK, nil
 }
 
 // cleanUpIntegration deletes any side effects of an integration

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -31,6 +31,7 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 		routes.DeleteIntegrationRoute: &handler.DeleteIntegrationHandler{
 			Database:                   s.Database,
 			Vault:                      s.Vault,
+			CustomReader:               s.CustomReader,
 			OperatorReader:             s.OperatorReader,
 			IntegrationReader:          s.IntegrationReader,
 			IntegrationWriter:          s.IntegrationWriter,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR modifies the check in `delete integration` route against only active workflows. Previously, we block integration deletion even if there are historical runs on this integraiton.

## Related issue number (if any)
ENG-2025

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


