### PR TITLE
Adds GC column to the env table

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -26,7 +26,7 @@ server_directory = join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = join(os.environ["HOME"], ".aqueduct", "ui")
 
 # Make sure to update this if there is any schema change we want to include in the upgrade.
-SCHEMA_VERSION = "20"
+SCHEMA_VERSION = "21"
 
 
 def execute_command(args, cwd=None):

--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -23,6 +23,7 @@ import (
 	_000018 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000018_add_dag_result_exec_state_column"
 	_000019 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000019_add_serialization_type_value_to_param_op"
 	_000020 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000020_add_execution_environment_table"
+	_000021 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000021_add_gc_column_to_env_table"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -149,5 +150,11 @@ func init() {
 		upPostgres: _000020.UpPostgres, upSqlite: _000020.UpSqlite,
 		downPostgres: _000020.DownPostgres,
 		name:         "add execution environment table",
+	}
+
+	registeredMigrations[21] = &migration{
+		upPostgres: _000021.UpPostgres, upSqlite: _000021.UpSqlite,
+		downPostgres: _000021.DownPostgres,
+		name:         "add gc column to the execution environment table",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/down_postgres.go
@@ -1,0 +1,5 @@
+package _000021_add_gc_column_to_env_table
+
+const downPostgresScript = `
+ALTER TABLE execution_environment DROP COLUMN IF EXISTS garbage_collected;
+`

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/down_postgres.go
@@ -1,5 +1,11 @@
 package _000021_add_gc_column_to_env_table
 
 const downPostgresScript = `
-ALTER TABLE execution_environment DROP COLUMN IF EXISTS garbage_collected;
+DROP TABLE IF EXISTS execution_environment;
+
+CREATE TABLE IF NOT EXISTS execution_environment (
+    id BLOB NOT NULL PRIMARY KEY,
+    spec BLOB NOT NULL,
+    hash BLOB NOT NULL UNIQUE
+);
 `

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/main.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/main.go
@@ -1,0 +1,19 @@
+package _000021_add_gc_column_to_env_table
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func UpPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upPostgresScript)
+}
+
+func UpSqlite(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upSqliteScript)
+}
+
+func DownPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, downPostgresScript)
+}

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_postgres.go
@@ -1,5 +1,12 @@
 package _000021_add_gc_column_to_env_table
 
 const upPostgresScript = `
-ALTER TABLE execution_environment ADD COLUMN garbage_collected BOOL DEFAULT FALSE NOT NULL;
+DROP TABLE IF EXISTS execution_environment;
+
+CREATE TABLE IF NOT EXISTS execution_environment (
+    id BLOB NOT NULL PRIMARY KEY,
+    spec BLOB NOT NULL,
+    hash BLOB NOT NULL,
+	garbage_collected BOOL DEFAULT FALSE NOT NULL
+);
 `

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_postgres.go
@@ -1,0 +1,5 @@
+package _000021_add_gc_column_to_env_table
+
+const upPostgresScript = `
+ALTER TABLE execution_environment ADD COLUMN garbage_collected BOOL DEFAULT FALSE NOT NULL;
+`

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_sqlite.go
@@ -1,5 +1,12 @@
 package _000021_add_gc_column_to_env_table
 
 const upSqliteScript = `
-ALTER TABLE execution_environment ADD COLUMN garbage_collected BOOL DEFAULT FALSE NOT NULL;
+DROP TABLE IF EXISTS execution_environment;
+
+CREATE TABLE IF NOT EXISTS execution_environment (
+    id BLOB NOT NULL PRIMARY KEY,
+    spec BLOB NOT NULL,
+    hash BLOB NOT NULL,
+	garbage_collected BOOL DEFAULT FALSE NOT NULL
+);
 `

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_sqlite.go
@@ -1,0 +1,5 @@
+package _000021_add_gc_column_to_env_table
+
+const upSqliteScript = `
+ALTER TABLE execution_environment ADD COLUMN garbage_collected BOOL DEFAULT FALSE NOT NULL;
+`

--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -93,6 +93,7 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 		args.integrationId,
 		h.OperatorReader,
 		h.CustomReader,
+		h.IntegrationReader,
 		h.Database,
 	)
 	if err != nil {
@@ -142,12 +143,14 @@ func validateNoActiveWorkflowOnIntegration(
 	id uuid.UUID,
 	operatorReader operator.Reader,
 	customReader queries.Reader,
+	integrationReader integration.Reader,
 	db database.Database,
 ) (int, error) {
 	interfaceResp, code, err := (&ListOperatorsForIntegrationHandler{
-		CustomReader:   customReader,
-		OperatorReader: operatorReader,
-		Database:       db,
+		CustomReader:      customReader,
+		OperatorReader:    operatorReader,
+		IntegrationReader: integrationReader,
+		Database:          db,
 	}).Perform(ctx, id)
 	if err != nil {
 		return code, errors.Wrap(err, "Error getting operators on this integration.")

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -281,7 +281,7 @@ func (h *RegisterWorkflowHandler) Perform(ctx context.Context, interfaceArgs int
 		}
 	}
 
-	// Check unused Conda environments and garbage collect them.
+	// Check unused conda environments and garbage collect them.
 	go func() {
 		db, err := database.NewDatabase(h.Database.Config())
 		if err != nil {

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -43,9 +43,11 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			JobManager: s.JobManager,
 			Vault:      s.Vault,
 
-			OperatorReader:    s.OperatorReader,
-			IntegrationReader: s.IntegrationReader,
-			WorkflowReader:    s.WorkflowReader,
+			OperatorReader:             s.OperatorReader,
+			IntegrationReader:          s.IntegrationReader,
+			WorkflowReader:             s.WorkflowReader,
+			ExecutionEnvironmentReader: s.ExecutionEnvironmentReader,
+			ExecutionEnvironmentWriter: s.ExecutionEnvironmentWriter,
 		},
 		routes.EditIntegrationRoute: &handler.EditIntegrationHandler{
 			Database:          s.Database,

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -136,9 +136,10 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			WorkflowReader:     s.WorkflowReader,
 		},
 		routes.ListOperatorsForIntegrationRoute: &handler.ListOperatorsForIntegrationHandler{
-			Database:       s.Database,
-			OperatorReader: s.OperatorReader,
-			CustomReader:   s.CustomReader,
+			Database:          s.Database,
+			OperatorReader:    s.OperatorReader,
+			CustomReader:      s.CustomReader,
+			IntegrationReader: s.IntegrationReader,
 		},
 		routes.ListWorkflowsRoute: &handler.ListWorkflowsHandler{
 			Database:                s.Database,

--- a/src/golang/lib/collections/execution_environment/constants.go
+++ b/src/golang/lib/collections/execution_environment/constants.go
@@ -9,9 +9,10 @@ const (
 	tableName = "execution_environment"
 
 	// ExecutionEnvironment table column names
-	IdColumn   = "id"
-	SpecColumn = "spec"
-	HashColumn = "hash"
+	IdColumn               = "id"
+	SpecColumn             = "spec"
+	HashColumn             = "hash"
+	GarbageCollectedColumn = "garbage_collected"
 )
 
 // Returns a joined string of all ExecutionEnvironment columns.
@@ -21,6 +22,7 @@ func allColumns() string {
 			IdColumn,
 			SpecColumn,
 			HashColumn,
+			GarbageCollectedColumn,
 		},
 		",",
 	)
@@ -34,6 +36,7 @@ func allColumnsWithPrefix() string {
 			fmt.Sprintf("%s.%s", tableName, IdColumn),
 			fmt.Sprintf("%s.%s", tableName, SpecColumn),
 			fmt.Sprintf("%s.%s", tableName, HashColumn),
+			fmt.Sprintf("%s.%s", tableName, GarbageCollectedColumn),
 		},
 		",",
 	)

--- a/src/golang/lib/collections/execution_environment/execution_environment.go
+++ b/src/golang/lib/collections/execution_environment/execution_environment.go
@@ -17,8 +17,8 @@ type DBExecutionEnvironment struct {
 type Reader interface {
 	GetExecutionEnvironment(ctx context.Context, id uuid.UUID, db database.Database) (*DBExecutionEnvironment, error)
 	GetExecutionEnvironments(ctx context.Context, ids []uuid.UUID, db database.Database) ([]DBExecutionEnvironment, error)
-	GetExecutionEnvironmentByHash(ctx context.Context, hash uuid.UUID, db database.Database) (*DBExecutionEnvironment, error)
-	GetExecutionEnvironmentsMapByOperatorID(
+	GetActiveExecutionEnvironmentByHash(ctx context.Context, hash uuid.UUID, db database.Database) (*DBExecutionEnvironment, error)
+	GetActiveExecutionEnvironmentsByOperatorID(
 		ctx context.Context,
 		opIDs []uuid.UUID,
 		db database.Database,

--- a/src/golang/lib/collections/execution_environment/execution_environment.go
+++ b/src/golang/lib/collections/execution_environment/execution_environment.go
@@ -8,9 +8,10 @@ import (
 )
 
 type DBExecutionEnvironment struct {
-	Id   uuid.UUID `db:"id"`
-	Spec Spec      `db:"spec"`
-	Hash uuid.UUID `db:"hash"`
+	Id               uuid.UUID `db:"id"`
+	Spec             Spec      `db:"spec"`
+	Hash             uuid.UUID `db:"hash"`
+	GarbageCollected bool      `db:"garbage_collected"`
 }
 
 type Reader interface {

--- a/src/golang/lib/collections/execution_environment/noop.go
+++ b/src/golang/lib/collections/execution_environment/noop.go
@@ -49,7 +49,7 @@ func (r *noopReaderImpl) GetExecutionEnvironments(
 	return nil, utils.NoopInterfaceErrorHandling(r.throwError)
 }
 
-func (r *noopReaderImpl) GetExecutionEnvironmentByHash(
+func (r *noopReaderImpl) GetActiveExecutionEnvironmentByHash(
 	ctx context.Context,
 	hash uuid.UUID,
 	db database.Database,
@@ -57,7 +57,7 @@ func (r *noopReaderImpl) GetExecutionEnvironmentByHash(
 	return nil, utils.NoopInterfaceErrorHandling(r.throwError)
 }
 
-func (r *noopReaderImpl) GetExecutionEnvironmentsMapByOperatorID(
+func (r *noopReaderImpl) GetActiveExecutionEnvironmentsByOperatorID(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	db database.Database,

--- a/src/golang/lib/collections/execution_environment/standard.go
+++ b/src/golang/lib/collections/execution_environment/standard.go
@@ -71,13 +71,13 @@ func (r *standardReaderImpl) GetExecutionEnvironments(
 	return results, err
 }
 
-func (r *standardReaderImpl) GetExecutionEnvironmentByHash(
+func (r *standardReaderImpl) GetActiveExecutionEnvironmentByHash(
 	ctx context.Context,
 	hash uuid.UUID,
 	db database.Database,
 ) (*DBExecutionEnvironment, error) {
 	query := fmt.Sprintf(
-		"SELECT %s FROM execution_environment WHERE hash = $1;",
+		"SELECT %s FROM execution_environment WHERE hash = $1 AND garbage_collected = FALSE;",
 		allColumns(),
 	)
 	var result DBExecutionEnvironment
@@ -86,23 +86,25 @@ func (r *standardReaderImpl) GetExecutionEnvironmentByHash(
 	return &result, err
 }
 
-func (r *standardReaderImpl) GetExecutionEnvironmentsMapByOperatorID(
+func (r *standardReaderImpl) GetActiveExecutionEnvironmentsByOperatorID(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	db database.Database,
 ) (map[uuid.UUID]DBExecutionEnvironment, error) {
 	type resultRow struct {
-		Id         uuid.UUID `db:"id"`
-		OperatorId uuid.UUID `db:"operator_id"`
-		Hash       uuid.UUID `db:"hash"`
-		Spec       Spec      `db:"spec"`
+		Id               uuid.UUID `db:"id"`
+		OperatorId       uuid.UUID `db:"operator_id"`
+		Hash             uuid.UUID `db:"hash"`
+		Spec             Spec      `db:"spec"`
+		GarbageCollected bool      `db:"garbage_collected"`
 	}
 
 	query := fmt.Sprintf(`
 		SELECT operator.id AS operator_id, %s
 		FROM execution_environment, operator
 		WHERE operator.execution_environment_id = execution_environment.id
-		AND operator.id IN (%s);`,
+		AND operator.id IN (%s)
+		AND execution_environment.garbage_collected = FALSE;`,
 		allColumnsWithPrefix(),
 		stmt_preparers.GenerateArgsList(len(opIDs), 1),
 	)

--- a/src/golang/lib/collections/execution_environment/standard.go
+++ b/src/golang/lib/collections/execution_environment/standard.go
@@ -208,6 +208,8 @@ func (r *standardReaderImpl) GetUnusedExecutionEnvironments(
 		execution_environment LEFT JOIN active_execution_environment 
 		ON execution_environment.id = active_execution_environment.id
 	WHERE 
+		execution_environment.garbage_collected = FALSE 
+		AND 
 		active_execution_environment.id IS NULL;`, workflow_dag_edge.OperatorToArtifactType, allColumnsWithPrefix())
 	var results []DBExecutionEnvironment
 

--- a/src/golang/lib/collections/operator/operator.go
+++ b/src/golang/lib/collections/operator/operator.go
@@ -47,9 +47,13 @@ type Reader interface {
 		operatorId uuid.UUID,
 		db database.Database,
 	) (bool, error)
-	GetOperatorsByIntegrationId(
+	GetOperatorsByDataIntegrationId(
 		ctx context.Context,
 		integrationId uuid.UUID,
+		db database.Database,
+	) ([]DBOperator, error)
+	GetOperatorsWithCondaEnv(
+		ctx context.Context,
 		db database.Database,
 	) ([]DBOperator, error)
 }

--- a/src/golang/lib/collections/operator/postgres.go
+++ b/src/golang/lib/collections/operator/postgres.go
@@ -60,7 +60,7 @@ func (r *postgresReaderImpl) GetLoadOperatorsForWorkflowAndIntegration(
 	return operators, err
 }
 
-func (r *postgresReaderImpl) GetOperatorsByIntegrationId(
+func (r *postgresReaderImpl) GetOperatorsByDataIntegrationId(
 	ctx context.Context,
 	integrationId uuid.UUID,
 	db database.Database,

--- a/src/golang/lib/collections/operator/sqlite.go
+++ b/src/golang/lib/collections/operator/sqlite.go
@@ -25,7 +25,7 @@ func newSqliteWriter() Writer {
 	return &sqliteWriterImpl{standardWriterImpl{}}
 }
 
-func (r *sqliteReaderImpl) GetOperatorsByIntegrationId(
+func (r *sqliteReaderImpl) GetOperatorsByDataIntegrationId(
 	ctx context.Context,
 	integrationId uuid.UUID,
 	db database.Database,

--- a/src/golang/lib/collections/operator/standard.go
+++ b/src/golang/lib/collections/operator/standard.go
@@ -160,3 +160,16 @@ func (r *standardReaderImpl) ValidateOperatorOwnership(
 ) (bool, error) {
 	return utils.ValidateNodeOwnership(ctx, organizationId, operatorId, db)
 }
+
+func (r *standardReaderImpl) GetOperatorsWithCondaEnv(
+	ctx context.Context,
+	db database.Database,
+) ([]DBOperator, error) {
+	query := fmt.Sprintf(
+		"SELECT %s FROM operator WHERE execution_environment_id IS NOT NULL;", allColumns(),
+	)
+
+	var operators []DBOperator
+	err := db.Query(ctx, &operators, query)
+	return operators, err
+}

--- a/src/golang/lib/collections/tests/operator_test.go
+++ b/src/golang/lib/collections/tests/operator_test.go
@@ -91,7 +91,7 @@ func TestCreateOperator(t *testing.T) {
 	requireDeepEqual(t, expectedOperator, actualOperator)
 }
 
-func TestGetOperatorsByIntegrationId(t *testing.T) {
+func TestGetOperatorsByDataIntegrationId(t *testing.T) {
 	defer resetDatabase(t)
 
 	integrations := seedIntegration(t, 1)
@@ -120,7 +120,7 @@ func TestGetOperatorsByIntegrationId(t *testing.T) {
 	)
 	require.Nil(t, err)
 
-	actualOperators, err := readers.operatorReader.GetOperatorsByIntegrationId(
+	actualOperators, err := readers.operatorReader.GetOperatorsByDataIntegrationId(
 		context.Background(),
 		integrations[0].Id,
 		db,

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -279,7 +279,7 @@ func (eng *aqEngine) ExecuteWorkflow(
 		opIds = append(opIds, op.Id)
 	}
 
-	execEnvsByOpId, err := exec_env.GetExecutionEnvironmentsMapByOperatorIDs(
+	execEnvsByOpId, err := exec_env.GetActiveExecutionEnvironmentsByOperatorIDs(
 		ctx,
 		opIds,
 		eng.ExecutionEnvironmentReader,

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -162,7 +162,7 @@ func GetExecEnvFromDB(
 	execEnvReader db_exec_env.Reader,
 	db database.Database,
 ) (*ExecutionEnvironment, error) {
-	dbExecEnv, err := execEnvReader.GetExecutionEnvironmentByHash(ctx, hash, db)
+	dbExecEnv, err := execEnvReader.GetActiveExecutionEnvironmentByHash(ctx, hash, db)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +238,13 @@ func newFromDBExecutionEnvironment(
 	}
 }
 
-func GetExecutionEnvironmentsMapByOperatorIDs(
+func GetActiveExecutionEnvironmentsByOperatorIDs(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	envReader db_exec_env.Reader,
 	db database.Database,
 ) (map[uuid.UUID]ExecutionEnvironment, error) {
-	dbEnvMap, err := envReader.GetExecutionEnvironmentsMapByOperatorID(
+	dbEnvMap, err := envReader.GetActiveExecutionEnvironmentsByOperatorID(
 		ctx, opIDs, db,
 	)
 	if err != nil {

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -396,7 +396,7 @@ func CleanupUnusedEnvironments(
 			hasError = true
 			log.Errorf("Error garbage collecting conda environment %s: %v", envID, err)
 		} else {
-			envWriter.UpdateExecutionEnvironment(
+			_, err = envWriter.UpdateExecutionEnvironment(
 				ctx,
 				envID,
 				map[string]interface{}{
@@ -404,6 +404,7 @@ func CleanupUnusedEnvironments(
 				},
 				db,
 			)
+			log.Errorf("Error updating the garbage collection column of conda environment %s: %v", envID, err)
 		}
 	}
 

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -380,7 +380,6 @@ func CleanupUnusedEnvironments(
 		return err
 	}
 
-	var deletedIDs []uuid.UUID
 	hasError := false
 
 	for _, envID := range envIDs {
@@ -397,14 +396,15 @@ func CleanupUnusedEnvironments(
 			hasError = true
 			log.Errorf("Error garbage collecting conda environment %s: %v", envID, err)
 		} else {
-			deletedIDs = append(deletedIDs, envID)
+			envWriter.UpdateExecutionEnvironment(
+				ctx,
+				envID,
+				map[string]interface{}{
+					"garbage_collected": true,
+				},
+				db,
+			)
 		}
-	}
-
-	err = envWriter.DeleteExecutionEnvironments(ctx, deletedIDs, db)
-	if err != nil {
-		hasError = true
-		log.Errorf("Error deleting database records of unused conda environments: %v", err)
 	}
 
 	if hasError {

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -20,7 +20,7 @@ import yaml
 from packaging.version import parse as parse_version
 from tqdm import tqdm
 
-SCHEMA_VERSION = "20"
+SCHEMA_VERSION = "21"
 CHUNK_SIZE = 4096
 
 base_directory = os.path.join(os.environ["HOME"], ".aqueduct")

--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -55,7 +55,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
           <Box
             sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
           >
-            <pre style={{ margin: '0px' }}>logs.stdout</pre>
+            <pre style={{ margin: '0px' }}>{logs.stdout}</pre>
           </Box>
         ) : (
           emptyElement
@@ -67,7 +67,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
           <Box
             sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
           >
-            <pre style={{ margin: '0px' }}>logs.stderr</pre>
+            <pre style={{ margin: '0px' }}>{logs.stderr}</pre>
           </Box>
         ) : (
           emptyElement


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a GC column to the execution environment table, and modifies existing logic to update this column correctly.
The PR also adds an async GC routine after the user deletes an workflow, as after that there could be exec envs that are no longer used.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


