### PR TITLE
Fix error message when check or metric is called with no inputs

### DIFF
--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -571,7 +571,7 @@ def metric(
             assert isinstance(description, str)
 
             if len(input_artifacts) == 0:
-                raise InvalidUserArgumentException("The metric has no input.")
+                raise InvalidUserArgumentException("Metrics must have an input. Did you forget to call this metric on an artifact?")
 
             artifacts = _convert_input_arguments_to_parameters(
                 *input_artifacts,

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -571,7 +571,9 @@ def metric(
             assert isinstance(description, str)
 
             if len(input_artifacts) == 0:
-                raise InvalidUserArgumentException("Metrics must have an input. Did you forget to call this metric on an artifact?")
+                raise InvalidUserArgumentException(
+                    "Metrics must have an input. Did you forget to call this metric on an artifact?"
+                )
 
             artifacts = _convert_input_arguments_to_parameters(
                 *input_artifacts,

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -570,6 +570,9 @@ def metric(
             assert isinstance(name, str)
             assert isinstance(description, str)
 
+            if len(input_artifacts) == 0:
+                raise InvalidUserArgumentException("The metric has no input.")
+
             artifacts = _convert_input_arguments_to_parameters(
                 *input_artifacts,
                 func_params=inspect.signature(func).parameters,
@@ -712,6 +715,9 @@ def check(
             """
             assert isinstance(name, str)
             assert isinstance(description, str)
+
+            if len(input_artifacts) == 0:
+                raise InvalidUserArgumentException("The check has no input.")
 
             artifacts = _convert_input_arguments_to_parameters(
                 *input_artifacts,

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -719,7 +719,9 @@ def check(
             assert isinstance(description, str)
 
             if len(input_artifacts) == 0:
-                raise InvalidUserArgumentException("The check has no input.")
+                raise InvalidUserArgumentException(
+                    "Check must have an input. Did you forget to call this check on an artifact?"
+                )
 
             artifacts = _convert_input_arguments_to_parameters(
                 *input_artifacts,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR Fix error message when @check or @metric is called with no inputs. When the metric and function is called with no input, the SDK side will error out.
<img width="1062" alt="Screen Shot 2022-12-06 at 10 03 33 AM" src="https://user-images.githubusercontent.com/78303449/205987786-afe6fd91-3aa0-4549-a8f9-88cff6ee64ef.png">

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1767/fix-error-message-when-check-or-metric-is-called-with-no-inputs
## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


