### PR TITLE
Fix a number of bugs in the conda integration

### DIFF
--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/down_postgres.go
@@ -1,5 +1,11 @@
 package _000021_add_gc_column_to_env_table
 
 const downPostgresScript = `
-ALTER TABLE execution_environment DROP COLUMN IF EXISTS garbage_collected;
+DROP TABLE IF EXISTS execution_environment;
+
+CREATE TABLE IF NOT EXISTS execution_environment (
+    id BLOB NOT NULL PRIMARY KEY,
+    spec BLOB NOT NULL,
+    hash BLOB NOT NULL UNIQUE
+);
 `

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_postgres.go
@@ -1,5 +1,12 @@
 package _000021_add_gc_column_to_env_table
 
 const upPostgresScript = `
-ALTER TABLE execution_environment ADD COLUMN garbage_collected BOOL DEFAULT FALSE NOT NULL;
+DROP TABLE IF EXISTS execution_environment;
+
+CREATE TABLE IF NOT EXISTS execution_environment (
+    id BLOB NOT NULL PRIMARY KEY,
+    spec BLOB NOT NULL,
+    hash BLOB NOT NULL,
+	garbage_collected BOOL DEFAULT FALSE NOT NULL
+);
 `

--- a/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000021_add_gc_column_to_env_table/up_sqlite.go
@@ -1,5 +1,12 @@
 package _000021_add_gc_column_to_env_table
 
 const upSqliteScript = `
-ALTER TABLE execution_environment ADD COLUMN garbage_collected BOOL DEFAULT FALSE NOT NULL;
+DROP TABLE IF EXISTS execution_environment;
+
+CREATE TABLE IF NOT EXISTS execution_environment (
+    id BLOB NOT NULL PRIMARY KEY,
+    spec BLOB NOT NULL,
+    hash BLOB NOT NULL,
+	garbage_collected BOOL DEFAULT FALSE NOT NULL
+);
 `

--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -93,6 +93,7 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 		args.integrationId,
 		h.OperatorReader,
 		h.CustomReader,
+		h.IntegrationReader,
 		h.Database,
 	)
 	if err != nil {
@@ -142,12 +143,14 @@ func validateNoActiveWorkflowOnIntegration(
 	id uuid.UUID,
 	operatorReader operator.Reader,
 	customReader queries.Reader,
+	integrationReader integration.Reader,
 	db database.Database,
 ) (int, error) {
 	interfaceResp, code, err := (&ListOperatorsForIntegrationHandler{
-		CustomReader:   customReader,
-		OperatorReader: operatorReader,
-		Database:       db,
+		CustomReader:      customReader,
+		OperatorReader:    operatorReader,
+		IntegrationReader: integrationReader,
+		Database:          db,
 	}).Perform(ctx, id)
 	if err != nil {
 		return code, errors.Wrap(err, "Error getting operators on this integration.")

--- a/src/golang/lib/collections/execution_environment/execution_environment.go
+++ b/src/golang/lib/collections/execution_environment/execution_environment.go
@@ -17,8 +17,8 @@ type DBExecutionEnvironment struct {
 type Reader interface {
 	GetExecutionEnvironment(ctx context.Context, id uuid.UUID, db database.Database) (*DBExecutionEnvironment, error)
 	GetExecutionEnvironments(ctx context.Context, ids []uuid.UUID, db database.Database) ([]DBExecutionEnvironment, error)
-	GetExecutionEnvironmentByHash(ctx context.Context, hash uuid.UUID, db database.Database) (*DBExecutionEnvironment, error)
-	GetExecutionEnvironmentsMapByOperatorID(
+	GetActiveExecutionEnvironmentByHash(ctx context.Context, hash uuid.UUID, db database.Database) (*DBExecutionEnvironment, error)
+	GetActiveExecutionEnvironmentsByOperatorID(
 		ctx context.Context,
 		opIDs []uuid.UUID,
 		db database.Database,

--- a/src/golang/lib/collections/execution_environment/noop.go
+++ b/src/golang/lib/collections/execution_environment/noop.go
@@ -49,7 +49,7 @@ func (r *noopReaderImpl) GetExecutionEnvironments(
 	return nil, utils.NoopInterfaceErrorHandling(r.throwError)
 }
 
-func (r *noopReaderImpl) GetExecutionEnvironmentByHash(
+func (r *noopReaderImpl) GetActiveExecutionEnvironmentByHash(
 	ctx context.Context,
 	hash uuid.UUID,
 	db database.Database,
@@ -57,7 +57,7 @@ func (r *noopReaderImpl) GetExecutionEnvironmentByHash(
 	return nil, utils.NoopInterfaceErrorHandling(r.throwError)
 }
 
-func (r *noopReaderImpl) GetExecutionEnvironmentsMapByOperatorID(
+func (r *noopReaderImpl) GetActiveExecutionEnvironmentsByOperatorID(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	db database.Database,

--- a/src/golang/lib/collections/execution_environment/standard.go
+++ b/src/golang/lib/collections/execution_environment/standard.go
@@ -71,13 +71,13 @@ func (r *standardReaderImpl) GetExecutionEnvironments(
 	return results, err
 }
 
-func (r *standardReaderImpl) GetExecutionEnvironmentByHash(
+func (r *standardReaderImpl) GetActiveExecutionEnvironmentByHash(
 	ctx context.Context,
 	hash uuid.UUID,
 	db database.Database,
 ) (*DBExecutionEnvironment, error) {
 	query := fmt.Sprintf(
-		"SELECT %s FROM execution_environment WHERE hash = $1;",
+		"SELECT %s FROM execution_environment WHERE hash = $1 AND garbage_collected = FALSE;",
 		allColumns(),
 	)
 	var result DBExecutionEnvironment
@@ -86,23 +86,25 @@ func (r *standardReaderImpl) GetExecutionEnvironmentByHash(
 	return &result, err
 }
 
-func (r *standardReaderImpl) GetExecutionEnvironmentsMapByOperatorID(
+func (r *standardReaderImpl) GetActiveExecutionEnvironmentsByOperatorID(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	db database.Database,
 ) (map[uuid.UUID]DBExecutionEnvironment, error) {
 	type resultRow struct {
-		Id         uuid.UUID `db:"id"`
-		OperatorId uuid.UUID `db:"operator_id"`
-		Hash       uuid.UUID `db:"hash"`
-		Spec       Spec      `db:"spec"`
+		Id               uuid.UUID `db:"id"`
+		OperatorId       uuid.UUID `db:"operator_id"`
+		Hash             uuid.UUID `db:"hash"`
+		Spec             Spec      `db:"spec"`
+		GarbageCollected bool      `db:"garbage_collected"`
 	}
 
 	query := fmt.Sprintf(`
 		SELECT operator.id AS operator_id, %s
 		FROM execution_environment, operator
 		WHERE operator.execution_environment_id = execution_environment.id
-		AND operator.id IN (%s);`,
+		AND operator.id IN (%s)
+		AND execution_environment.garbage_collected = FALSE;`,
 		allColumnsWithPrefix(),
 		stmt_preparers.GenerateArgsList(len(opIDs), 1),
 	)

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -279,7 +279,7 @@ func (eng *aqEngine) ExecuteWorkflow(
 		opIds = append(opIds, op.Id)
 	}
 
-	execEnvsByOpId, err := exec_env.GetExecutionEnvironmentsMapByOperatorIDs(
+	execEnvsByOpId, err := exec_env.GetActiveExecutionEnvironmentsByOperatorIDs(
 		ctx,
 		opIds,
 		eng.ExecutionEnvironmentReader,

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -162,7 +162,7 @@ func GetExecEnvFromDB(
 	execEnvReader db_exec_env.Reader,
 	db database.Database,
 ) (*ExecutionEnvironment, error) {
-	dbExecEnv, err := execEnvReader.GetExecutionEnvironmentByHash(ctx, hash, db)
+	dbExecEnv, err := execEnvReader.GetActiveExecutionEnvironmentByHash(ctx, hash, db)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +238,13 @@ func newFromDBExecutionEnvironment(
 	}
 }
 
-func GetExecutionEnvironmentsMapByOperatorIDs(
+func GetActiveExecutionEnvironmentsByOperatorIDs(
 	ctx context.Context,
 	opIDs []uuid.UUID,
 	envReader db_exec_env.Reader,
 	db database.Database,
 ) (map[uuid.UUID]ExecutionEnvironment, error) {
-	dbEnvMap, err := envReader.GetExecutionEnvironmentsMapByOperatorID(
+	dbEnvMap, err := envReader.GetActiveExecutionEnvironmentsByOperatorID(
 		ctx, opIDs, db,
 	)
 	if err != nil {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The main one is that previously, our execution_environment table's hash column is marked as "unique", but this doesn't work well with the added gc column, because once an env is gced, a new env should be allowed to be created with the same hash. So we modify the table to drop the "unique" constraint. Since the previous release doesn't expose conda to the user, we can safely delete the entire table and recreate a new one without this constraint.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


