### PR TITLE
Eng 2067 Update conda base environments when updating aqueduct

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -101,6 +101,41 @@ def update_executable_permissions():
     os.chmod(os.path.join(server_directory, "bin", "executor"), 0o755)
     os.chmod(os.path.join(server_directory, "bin", "migrator"), 0o755)
 
+# Retrive all conda environments. This does not need to be 100% accurate
+# as we only care about aqueduct-internal ones.
+#
+# It runs `conda env list` under the hood, and we ignore any error
+# when running the command.
+def get_conda_environments():
+    cmd_result = subprocess.run(['conda', 'env', 'list'], stdout=subprocess.PIPE)
+    if cmd_result.returncode == 0:
+        results = set()
+        for line in cmd_result.stdout.decode().split("\n"):
+            # skip helper message lines like `# conda environments:`
+            if not line.startswith('#'):
+                results.add(line.split(' ')[0])
+        return results
+    # we ignore none-zero exit code and assuming it's due to the command not available.
+    return set()
+
+
+def update_base_conda_environments():
+    conda_envs = get_conda_environments()
+    for py_version in ["3.7", "3.8", "3.9", "3.10"]:
+        env_name = f"aqueduct_python{py_version}"
+        if env_name in conda_envs:
+            print(f"Updating conda environment {env_name}")
+            execute_command([
+                "conda",
+                "run",
+                "-n",
+                env_name,
+                "pip3",
+                "install",
+                "-q", # hide most pip outputs, which is noisy
+                f"aqueduct-ml=={package_version}",
+            ])
+
 
 def _download_file(s3_url, f, prefix=None):
     response = requests.get(s3_url, stream=True)
@@ -282,6 +317,7 @@ def update():
     if require_update(server_version_file):
         try:
             update_server_version()
+            update_base_conda_environments()
         except Exception as e:
             print(e)
             if os.path.isfile(server_version_file):


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR updates the main python script to update base conda environments when updaating aqueduct versions.

## Related issue number (if any)
ENG-2067

## Tests
Run local install and manually downgrade `version` file. Validated that we are attempting to install.
Also validated we are not attempting to install if there's no version mismatch.

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


