### PR TITLE
Fixes bug where multiple save operators to the same integration crashes the UI

### DIFF
--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -4,18 +4,21 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 from aqueduct.dag import DAG
-from aqueduct.dag_deltas import (
-    AddOrReplaceOperatorDelta,
-    apply_deltas_to_dag,
-    find_duplicate_load_operator,
-)
+from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType, OperatorType
 from aqueduct.error import (
     InvalidIntegrationException,
     InvalidUserActionException,
     InvalidUserArgumentException,
 )
-from aqueduct.operators import LoadSpec, Operator, OperatorSpec, S3LoadParams, SaveConfig
+from aqueduct.operators import (
+    LoadSpec,
+    Operator,
+    OperatorSpec,
+    S3LoadParams,
+    SaveConfig,
+    get_operator_type,
+)
 from aqueduct.utils import generate_uuid
 
 from aqueduct import globals
@@ -108,13 +111,31 @@ class BaseArtifact(ABC):
                     % integration_info.name
                 )
 
-        # We deduplicate load operators based on name (and therefore integration) AND
-        # the input artifact. This allows multiple artifacts to write to the same integration,
-        # as well as a single artifact to write to multiple integrations, all while keeping
-        # the name of the load operator readable.
-        load_op_name = "save to %s" % integration_info.name
+        # We currently do not allow multiple load operators on the same artifact to the same integration.
+        # We do allow multiple artifacts to write to the same integration, as well as a single artifact
+        # to write to multiple integrations.
+        # Multiple load operations to the same integration, of different artifacts, are deduplicated by name.
+        load_op_name = None
+
+        # Replace any existing save operator on this artifact that goes to the same integration.
+        existing_load_ops = self._dag.list_operators(
+            filter_to=[OperatorType.LOAD],
+            on_artifact_id=self._artifact_id,
+        )
+        for op in existing_load_ops:
+            assert op.spec.load is not None
+            if op.spec.load.integration_id == integration_info.id:
+                load_op_name = op.name
+
+        # If the name is not set yet, we know we have to make a new load operator, so deduplicate against
+        # all other loads in the dag.
+        if load_op_name is None:
+            load_op_name = self._dag.get_unclaimed_op_name(
+                prefix="save to %s" % integration_info.name
+            )
 
         # Add the load operator as a terminal node.
+        assert load_op_name is not None
         apply_deltas_to_dag(
             self._dag,
             deltas=[
@@ -133,7 +154,6 @@ class BaseArtifact(ABC):
                         inputs=[self._artifact_id],
                     ),
                     output_artifacts=[],
-                    find_duplicate_fn=find_duplicate_load_operator,
                 ),
             ],
         )

--- a/sdk/aqueduct/dag_deltas.py
+++ b/sdk/aqueduct/dag_deltas.py
@@ -32,21 +32,6 @@ def find_duplicate_operator_by_name(dag: DAG, op: Operator) -> Optional[Operator
     return dag.get_operator(with_name=op.name)
 
 
-def find_duplicate_load_operator(dag: DAG, op: Operator) -> Optional[Operator]:
-    """Load operators are only duplicates if they are loading the same artifact into the same integration."""
-    assert get_operator_type(op) == OperatorType.LOAD
-    assert len(op.inputs) == 1
-
-    artifact_to_load = dag.must_get_artifact(op.inputs[0])
-    existing_load_ops = dag.list_operators(
-        filter_to=[OperatorType.LOAD], on_artifact_id=artifact_to_load.id
-    )
-    for existing_load_op in existing_load_ops:
-        if existing_load_op.name == op.name:
-            return existing_load_op
-    return None
-
-
 class AddOrReplaceOperatorDelta(DAGDelta):
     """Adds an operator and its output artifacts to the DAG.
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This fails because of mismatches expectations between the SDK and backend. The SDK thinks that having multiple save operators with the same name is fine, as long as they are in different branches. However, this crashes when the UI attempts to display these kinds of DAGs.

The solution for now is to deduplicate save operators the same way we duplicate extract operators (with a suffix starting at "1" and gradually incrementing). However, save operators on the same artifact to the same integration are not duplicated. In those cases, we will simply overwrite the existing operator (this allows for updating of saves).

Of course, this means that you cannot currently save the same artifact to different places into the same integration.

Example workflow:
```
db = client.integration("aqueduct_demo")
output1 = db.sql("Select * from hotel_reviews;")
output2 = db.sql("Select * from hotel_reviews;")

output1.save(db.config("table_1", "replace"))
output2.save(db.config("table_2", "replace"))
```


## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


