### PR TITLE
[SDK] Update our Save API to be integration.save()

### DIFF
--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -4,24 +4,10 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 from aqueduct.dag import DAG
-from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType, OperatorType
-from aqueduct.error import (
-    InvalidIntegrationException,
-    InvalidUserActionException,
-    InvalidUserArgumentException,
-)
-from aqueduct.operators import (
-    LoadSpec,
-    Operator,
-    OperatorSpec,
-    S3LoadParams,
-    SaveConfig,
-    get_operator_type,
-)
-from aqueduct.utils import generate_uuid
-
-from aqueduct import globals
+from aqueduct.integrations.save import save_artifact
+from aqueduct.logger import logger
+from aqueduct.operators import SaveConfig
 
 
 class BaseArtifact(ABC):
@@ -42,7 +28,7 @@ class BaseArtifact(ABC):
         """Fetch the name of this artifact."""
         return self._dag.must_get_artifact(artifact_id=self._artifact_id).name
 
-    def _get_type(self) -> ArtifactType:
+    def type(self) -> ArtifactType:
         return self._dag.must_get_artifact(artifact_id=self._artifact_id).type
 
     def _get_content(self) -> Any:
@@ -71,7 +57,7 @@ class BaseArtifact(ABC):
         pass
 
     def save(self, config: SaveConfig) -> None:
-        """Configure this artifact to be written to a specific integration after it's computed in a published flow.
+        """TODO: Configure this artifact to be written to a specific integration after it's computed in a published flow.
 
         Args:
             config:
@@ -86,75 +72,10 @@ class BaseArtifact(ABC):
             InvalidUserArgumentException:
                 An error occurred because some necessary fields are missing in the SaveConfig.
         """
-        integration_info = config.integration_info
-        integration_load_params = config.parameters
-        integrations_map = globals.__GLOBAL_API_CLIENT__.list_integrations()
-
-        if integration_info.name not in integrations_map:
-            raise InvalidIntegrationException("Not connected to db %s!" % integration_info.name)
-
-        # Non-tabular data cannot be saved into relational data stores.
-        if (
-            self._get_type() not in [ArtifactType.UNTYPED, ArtifactType.TABLE]
-            and integration_info.is_relational()
-        ):
-            raise InvalidUserActionException(
-                "Unable to load non-relational data into relational data store `%s`."
-                % integration_info.name
-            )
-
-        # Tabular data written into S3 must include a S3FileFormat hint.
-        if self._get_type() == ArtifactType.TABLE and isinstance(config.parameters, S3LoadParams):
-            if config.parameters.format is None:
-                raise InvalidUserArgumentException(
-                    "You must supply a file format when saving tabular data into S3 integration `%s`."
-                    % integration_info.name
-                )
-
-        # We currently do not allow multiple load operators on the same artifact to the same integration.
-        # We do allow multiple artifacts to write to the same integration, as well as a single artifact
-        # to write to multiple integrations.
-        # Multiple load operations to the same integration, of different artifacts, are guaranteed to
-        # have unique names.
-        load_op_name = None
-
-        # Replace any existing save operator on this artifact that goes to the same integration.
-        existing_load_ops = self._dag.list_operators(
-            filter_to=[OperatorType.LOAD],
-            on_artifact_id=self._artifact_id,
+        logger().warning(
+            "`artifact.save()` is deprecated. Please use `integration.save()` instead!"
         )
-        for op in existing_load_ops:
-            assert op.spec.load is not None
-            if op.spec.load.integration_id == integration_info.id:
-                load_op_name = op.name
 
-        # If the name is not set yet, we know we have to make a new load operator, so bump the
-        # suffix until a unique name is found.
-        if load_op_name is None:
-            load_op_name = self._dag.get_unclaimed_op_name(
-                prefix="save to %s" % integration_info.name
-            )
-
-        # Add the load operator as a terminal node.
-        assert load_op_name is not None
-        apply_deltas_to_dag(
-            self._dag,
-            deltas=[
-                AddOrReplaceOperatorDelta(
-                    op=Operator(
-                        id=generate_uuid(),
-                        name=load_op_name,
-                        description="",
-                        spec=OperatorSpec(
-                            load=LoadSpec(
-                                service=integration_info.service,
-                                integration_id=integration_info.id,
-                                parameters=integration_load_params,
-                            )
-                        ),
-                        inputs=[self._artifact_id],
-                    ),
-                    output_artifacts=[],
-                ),
-            ],
+        save_artifact(
+            self._artifact_id, self.type(), self._dag, config.integration_info, config.parameters
         )

--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -57,7 +57,9 @@ class BaseArtifact(ABC):
         pass
 
     def save(self, config: SaveConfig) -> None:
-        """TODO: Configure this artifact to be written to a specific integration after it's computed in a published flow.
+        """DEPRECATED: use integration.save() directly instead!
+        Configure this artifact to be written to a specific integration after it's computed in a published flow.
+
 
         Args:
             config:

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -88,5 +88,5 @@ class GenericArtifact(BaseArtifact):
         readable_dict["Inputs"] = [
             self._dag.must_get_artifact(artf).name for artf in input_operator.inputs
         ]
-        print(format_header_for_print(f"'{input_operator.name}' {self._get_type()} Artifact"))
+        print(format_header_for_print(f"'{input_operator.name}' {self.type()} Artifact"))
         print(json.dumps(readable_dict, sort_keys=False, indent=4))

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -67,7 +67,7 @@ class TableArtifact(BaseArtifact):
 
         >>> df = output_artifact.get()
         >>> print(df.head())
-        >>> output_artifact.save(warehouse.config(table_name="output_table"))
+        >>> warehouse.save(output_artifact, table_name="output_table", update_mode="replace")
     """
 
     def __init__(

--- a/sdk/aqueduct/integrations/google_sheets_integration.py
+++ b/sdk/aqueduct/integrations/google_sheets_integration.py
@@ -1,11 +1,14 @@
 from typing import Optional
 
+from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.artifacts.table_artifact import TableArtifact
 from aqueduct.dag import DAG
 from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType, GoogleSheetsSaveMode
 from aqueduct.integrations.integration import Integration, IntegrationInfo
+from aqueduct.integrations.save import save_artifact
+from aqueduct.logger import logger
 from aqueduct.operators import (
     ExtractSpec,
     GoogleSheetsExtractParams,
@@ -109,9 +112,26 @@ class GoogleSheetsIntegration(Integration):
         Returns:
             SaveConfig object to use in TableArtifact.save()
         """
+        logger().warning(
+            "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
+        )
         return SaveConfig(
             integration_info=self._metadata,
             parameters=GoogleSheetsLoadParams(filepath=filepath, save_mode=save_mode),
+        )
+
+    def save(
+        self,
+        artifact: BaseArtifact,
+        filepath: str,
+        save_mode: GoogleSheetsSaveMode = GoogleSheetsSaveMode.OVERWRITE,
+    ) -> None:
+        save_artifact(
+            artifact.id(),
+            artifact.type(),
+            self._dag,
+            self._metadata,
+            save_params=GoogleSheetsLoadParams(filepath=filepath, save_mode=save_mode),
         )
 
     def describe(self) -> None:

--- a/sdk/aqueduct/integrations/google_sheets_integration.py
+++ b/sdk/aqueduct/integrations/google_sheets_integration.py
@@ -93,7 +93,7 @@ class GoogleSheetsIntegration(Integration):
         filepath: str,
         save_mode: GoogleSheetsSaveMode = GoogleSheetsSaveMode.OVERWRITE,
     ) -> SaveConfig:
-        """
+        """TODO(ENG-2035): Deprecated and will be removed.
         Configuration for saving to Google Sheets Integration.
 
         Arguments:
@@ -126,6 +126,21 @@ class GoogleSheetsIntegration(Integration):
         filepath: str,
         save_mode: GoogleSheetsSaveMode = GoogleSheetsSaveMode.OVERWRITE,
     ) -> None:
+        """Registers a save operator of the given artifact, to be executed when it's computed in a published flow.
+
+        Args:
+            artifact:
+                The artifact to save into Google Sheets.
+            filepath:
+                The absolute file path to the Google Sheet to save to.
+            save_mode:
+                Defines the semantics of the save. Options are
+                - "overwrite"
+                - "create": Creates a new spreadsheet.
+                            If the spreadsheet doesn't exist, has `overwrite` behavior.
+                - "newsheet": Creates a new sheet in an existing spreadsheet.
+                              If the spreadsheet doesn't exist, has `create` behavior.
+        """
         save_artifact(
             artifact.id(),
             artifact.type(),

--- a/sdk/aqueduct/integrations/mongodb_integration.py
+++ b/sdk/aqueduct/integrations/mongodb_integration.py
@@ -131,6 +131,7 @@ class MongoDBCollectionIntegration(Integration):
             return TableArtifact(self._dag, output_artf_id)
 
     def config(self, update_mode: LoadUpdateMode) -> SaveConfig:
+        """TODO(ENG-2035): Deprecated and will be removed."""
         logger().warning(
             "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
         )
@@ -140,6 +141,15 @@ class MongoDBCollectionIntegration(Integration):
         )
 
     def save(self, artifact: BaseArtifact, update_mode: LoadUpdateMode) -> None:
+        """Registers a save operator of the given artifact, to be executed when it's computed in a published flow.
+
+        Args:
+            artifact:
+                The artifact to save into this collection.
+            update_mode:
+                Defines the semantics of the save if a table already exists.
+                Options are "replace", "append" (row-wise), or "fail" (if table already exists).
+        """
         save_artifact(
             artifact.id(),
             artifact.type(),
@@ -179,6 +189,7 @@ class MongoDBIntegration(Integration):
         self._metadata.describe()
 
     def config(self, collection: str, update_mode: LoadUpdateMode) -> SaveConfig:
+        """TODO(ENG-2035): Deprecated and will be removed."""
         logger().warning(
             "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
         )
@@ -188,7 +199,17 @@ class MongoDBIntegration(Integration):
         )
 
     def save(self, artifact: BaseArtifact, collection: str, update_mode: LoadUpdateMode) -> None:
-        """TODO"""
+        """Registers a save operator of the given artifact, to be executed when it's computed in a published flow.
+
+        Args:
+            artifact:
+                The artifact to save into the given collection.
+            collection:
+                The name of the collection to save to.
+            update_mode:
+                Defines the semantics of the save if a collection already exists.
+                Options are "replace", "append" (row-wise), or "fail" (if table already exists).
+        """
         save_artifact(
             artifact.id(),
             artifact.type(),

--- a/sdk/aqueduct/integrations/mongodb_integration.py
+++ b/sdk/aqueduct/integrations/mongodb_integration.py
@@ -10,7 +10,9 @@ from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType, ExecutionMode, LoadUpdateMode
 from aqueduct.error import InvalidUserArgumentException
 from aqueduct.integrations.integration import Integration, IntegrationInfo
+from aqueduct.integrations.save import save_artifact
 from aqueduct.integrations.sql_integration import find_parameter_artifacts, find_parameter_names
+from aqueduct.logger import logger
 from aqueduct.operators import (
     ExtractSpec,
     MongoExtractParams,
@@ -129,9 +131,23 @@ class MongoDBCollectionIntegration(Integration):
             return TableArtifact(self._dag, output_artf_id)
 
     def config(self, update_mode: LoadUpdateMode) -> SaveConfig:
+        logger().warning(
+            "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
+        )
         return SaveConfig(
             integration_info=self._metadata,
             parameters=RelationalDBLoadParams(table=self._collection_name, update_mode=update_mode),
+        )
+
+    def save(self, artifact: BaseArtifact, update_mode: LoadUpdateMode) -> None:
+        save_artifact(
+            artifact.id(),
+            artifact.type(),
+            self._dag,
+            self._metadata,
+            save_params=RelationalDBLoadParams(
+                table=self._collection_name, update_mode=update_mode
+            ),
         )
 
 
@@ -163,7 +179,20 @@ class MongoDBIntegration(Integration):
         self._metadata.describe()
 
     def config(self, collection: str, update_mode: LoadUpdateMode) -> SaveConfig:
+        logger().warning(
+            "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
+        )
         return SaveConfig(
             integration_info=self._metadata,
             parameters=RelationalDBLoadParams(table=collection, update_mode=update_mode),
+        )
+
+    def save(self, artifact: BaseArtifact, collection: str, update_mode: LoadUpdateMode) -> None:
+        """TODO"""
+        save_artifact(
+            artifact.id(),
+            artifact.type(),
+            self._dag,
+            self._metadata,
+            save_params=RelationalDBLoadParams(table=collection, update_mode=update_mode),
         )

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -9,6 +9,8 @@ from aqueduct.dag import DAG
 from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType, ExecutionMode, S3TableFormat
 from aqueduct.integrations.integration import Integration, IntegrationInfo
+from aqueduct.integrations.save import save_artifact
+from aqueduct.logger import logger
 from aqueduct.operators import (
     ExtractSpec,
     Operator,
@@ -153,9 +155,24 @@ class S3Integration(Integration):
         Returns:
             SaveConfig object to use in Artifact.save()
         """
+        logger().warning(
+            "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
+        )
         return SaveConfig(
             integration_info=self._metadata,
             parameters=S3LoadParams(filepath=filepath, format=format),
+        )
+
+    def save(
+        self, artifact: BaseArtifact, filepath: str, format: Optional[S3TableFormat] = None
+    ) -> None:
+        """TODO"""
+        save_artifact(
+            artifact.id(),
+            artifact.type(),
+            self._dag,
+            self._metadata,
+            save_params=S3LoadParams(filepath=filepath, format=format),
         )
 
     def describe(self) -> None:

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -144,7 +144,7 @@ class S3Integration(Integration):
             return to_artifact_class(self._dag, output_artifact_id, artifact_type)
 
     def config(self, filepath: str, format: Optional[S3TableFormat] = None) -> SaveConfig:
-        """
+        """TODO(ENG-2035): Deprecated and will be removed.
         Configuration for saving to S3 Integration.
 
         Arguments:
@@ -166,7 +166,17 @@ class S3Integration(Integration):
     def save(
         self, artifact: BaseArtifact, filepath: str, format: Optional[S3TableFormat] = None
     ) -> None:
-        """TODO"""
+        """Registers a save operator of the given artifact, to be executed when it's computed in a published flow.
+
+        Args:
+            artifact:
+                The artifact to save into S3.
+            filepath:
+                The S3 path to save to. Will overwrite any existing object at that path.
+            format:
+                Defines the format that the artifact will be saved as.
+                Options are "CSV", "JSON", "Parquet".
+        """
         save_artifact(
             artifact.id(),
             artifact.type(),

--- a/sdk/aqueduct/integrations/salesforce_integration.py
+++ b/sdk/aqueduct/integrations/salesforce_integration.py
@@ -81,7 +81,7 @@ class SalesforceIntegration(Integration):
         )
 
     def config(self, object: str) -> SaveConfig:
-        """
+        """TODO(ENG-2035): Deprecated and will be removed.
         Configuration for saving to Salesforce Integration.
 
         Arguments:
@@ -99,7 +99,14 @@ class SalesforceIntegration(Integration):
         )
 
     def save(self, artifact: BaseArtifact, object: str) -> None:
-        """TODO"""
+        """Registers a save operator of the given artifact, to be executed when it's computed in a published flow.
+
+        Args:
+            artifact:
+                The artifact to save into Salesforce.
+            object:
+                The name of the Salesforce object to save to.
+        """
         save_artifact(
             artifact.id(),
             artifact.type(),

--- a/sdk/aqueduct/integrations/salesforce_integration.py
+++ b/sdk/aqueduct/integrations/salesforce_integration.py
@@ -1,12 +1,15 @@
 import uuid
 from typing import Optional
 
+from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.metadata import ArtifactMetadata
 from aqueduct.artifacts.table_artifact import TableArtifact
 from aqueduct.dag import DAG
 from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
-from aqueduct.enums import ArtifactType, SalesforceExtractType
+from aqueduct.enums import ArtifactType, LoadUpdateMode, SalesforceExtractType
 from aqueduct.integrations.integration import Integration, IntegrationInfo
+from aqueduct.integrations.save import save_artifact
+from aqueduct.logger import logger
 from aqueduct.operators import (
     ExtractSpec,
     Operator,
@@ -87,9 +90,22 @@ class SalesforceIntegration(Integration):
         Returns:
             SaveConfig object to use in TableArtifact.save()
         """
+        logger().warning(
+            "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
+        )
         return SaveConfig(
             integration_info=self._metadata,
             parameters=SalesforceLoadParams(object=object),
+        )
+
+    def save(self, artifact: BaseArtifact, object: str) -> None:
+        """TODO"""
+        save_artifact(
+            artifact.id(),
+            artifact.type(),
+            self._dag,
+            self._metadata,
+            save_params=SalesforceLoadParams(object=object),
         )
 
     def _add_extract_operation(

--- a/sdk/aqueduct/integrations/save.py
+++ b/sdk/aqueduct/integrations/save.py
@@ -16,7 +16,6 @@ from aqueduct.operators import (
     OperatorSpec,
     S3LoadParams,
     UnionLoadParams,
-    get_operator_type,
 )
 from aqueduct.utils import generate_uuid
 

--- a/sdk/aqueduct/integrations/save.py
+++ b/sdk/aqueduct/integrations/save.py
@@ -1,10 +1,7 @@
 import uuid
 
 from aqueduct.dag import DAG
-from aqueduct.dag_deltas import (
-    AddOrReplaceOperatorDelta,
-    apply_deltas_to_dag,
-)
+from aqueduct.dag_deltas import AddOrReplaceOperatorDelta, apply_deltas_to_dag
 from aqueduct.enums import ArtifactType, OperatorType
 from aqueduct.error import (
     InvalidIntegrationException,
@@ -13,7 +10,14 @@ from aqueduct.error import (
 )
 from aqueduct.globals import __GLOBAL_API_CLIENT__ as global_api_client
 from aqueduct.integrations.integration import IntegrationInfo
-from aqueduct.operators import LoadSpec, Operator, OperatorSpec, S3LoadParams, UnionLoadParams, get_operator_type
+from aqueduct.operators import (
+    LoadSpec,
+    Operator,
+    OperatorSpec,
+    S3LoadParams,
+    UnionLoadParams,
+    get_operator_type,
+)
 from aqueduct.utils import generate_uuid
 
 
@@ -92,9 +96,7 @@ def save_artifact(
     # If the name is not set yet, we know we have to make a new load operator, so bump the
     # suffix until a unique name is found.
     if load_op_name is None:
-        load_op_name = dag.get_unclaimed_op_name(
-            prefix="save to %s" % integration_info.name
-        )
+        load_op_name = dag.get_unclaimed_op_name(prefix="save to %s" % integration_info.name)
 
     apply_deltas_to_dag(
         dag,

--- a/sdk/aqueduct/integrations/save.py
+++ b/sdk/aqueduct/integrations/save.py
@@ -1,0 +1,111 @@
+import uuid
+
+from aqueduct.dag import DAG
+from aqueduct.dag_deltas import (
+    AddOrReplaceOperatorDelta,
+    apply_deltas_to_dag,
+)
+from aqueduct.enums import ArtifactType, OperatorType
+from aqueduct.error import (
+    InvalidIntegrationException,
+    InvalidUserActionException,
+    InvalidUserArgumentException,
+)
+from aqueduct.globals import __GLOBAL_API_CLIENT__ as global_api_client
+from aqueduct.integrations.integration import IntegrationInfo
+from aqueduct.operators import LoadSpec, Operator, OperatorSpec, S3LoadParams, UnionLoadParams, get_operator_type
+from aqueduct.utils import generate_uuid
+
+
+def save_artifact(
+    artifact_id: uuid.UUID,
+    artifact_type: ArtifactType,
+    dag: DAG,
+    integration_info: IntegrationInfo,
+    save_params: UnionLoadParams,
+) -> None:
+    """TODO: Configure this artifact to be written to a specific integration after it's computed in a published flow.
+
+    TODO(ENG-2035): Move this method into the base integration object.
+
+    Args:
+        config:
+            SaveConfig object generated from integration using
+            the <integration>.config(...) method.
+    Raises:
+        InvalidIntegrationException:
+            An error occurred because the requested integration could not be
+            found.
+        InvalidUserActionException:
+            An error occurred because you are trying to load non-relational data into a relational integration.
+        InvalidUserArgumentException:
+            An error occurred because some necessary fields are missing in the SaveConfig.
+    """
+    integrations_map = global_api_client.list_integrations()
+
+    if integration_info.name not in integrations_map:
+        raise InvalidIntegrationException("Not connected to db %s!" % integration_info.name)
+
+    # Non-tabular data cannot be saved into relational data stores.
+    if (
+        artifact_type not in [ArtifactType.UNTYPED, ArtifactType.TABLE]
+        and integration_info.is_relational()
+    ):
+        raise InvalidUserActionException(
+            "Unable to load non-relational data into relational data store `%s`."
+            % integration_info.name
+        )
+
+    # Tabular data written into S3 must include a S3FileFormat hint.
+    if artifact_type == ArtifactType.TABLE and isinstance(save_params, S3LoadParams):
+        if save_params.format is None:
+            raise InvalidUserArgumentException(
+                "You must supply a file format when saving tabular data into S3 integration `%s`."
+                % integration_info.name
+            )
+
+    # We currently do not allow multiple load operators on the same artifact to the same integration.
+    # We do allow multiple artifacts to write to the same integration, as well as a single artifact
+    # to write to multiple integrations.
+    # Multiple load operations to the same integration, of different artifacts, are guaranteed to
+    # have unique names.
+    load_op_name = None
+
+    # Replace any existing save operator on this artifact that goes to the same integration.
+    existing_load_ops = dag.list_operators(
+        filter_to=[OperatorType.LOAD],
+        on_artifact_id=artifact_id,
+    )
+    for op in existing_load_ops:
+        assert op.spec.load is not None
+        if op.spec.load.integration_id == integration_info.id:
+            load_op_name = op.name
+
+    # If the name is not set yet, we know we have to make a new load operator, so bump the
+    # suffix until a unique name is found.
+    if load_op_name is None:
+        load_op_name = dag.get_unclaimed_op_name(
+            prefix="save to %s" % integration_info.name
+        )
+
+    apply_deltas_to_dag(
+        dag,
+        deltas=[
+            AddOrReplaceOperatorDelta(
+                op=Operator(
+                    id=generate_uuid(),
+                    name=load_op_name,
+                    description="",
+                    spec=OperatorSpec(
+                        load=LoadSpec(
+                            service=integration_info.service,
+                            integration_id=integration_info.id,
+                            parameters=save_params,
+                        )
+                    ),
+                    inputs=[artifact_id],
+                ),
+                output_artifacts=[],
+            ),
+        ],
+    )

--- a/sdk/aqueduct/integrations/save.py
+++ b/sdk/aqueduct/integrations/save.py
@@ -24,14 +24,22 @@ def save_artifact(
     integration_info: IntegrationInfo,
     save_params: UnionLoadParams,
 ) -> None:
-    """TODO: Configure this artifact to be written to a specific integration after it's computed in a published flow.
+    """Configures the given artifact to be written to a specific integration after it's computed in a published flow.
 
     TODO(ENG-2035): Move this method into the base integration object.
 
     Args:
-        config:
-            SaveConfig object generated from integration using
-            the <integration>.config(...) method.
+        artifact_id:
+            The artifact who's contents will be saved.
+        artifact_type:
+            The type of the given artifact.
+        dag:
+            The dag object that we will attach the load operator to.
+        integration_info:
+            Config info for the destination integration.
+        save_params:
+            Save configuration info (eg. table name, update mode).
+
     Raises:
         InvalidIntegrationException:
             An error occurred because the requested integration could not be
@@ -39,7 +47,7 @@ def save_artifact(
         InvalidUserActionException:
             An error occurred because you are trying to load non-relational data into a relational integration.
         InvalidUserArgumentException:
-            An error occurred because some necessary fields are missing in the SaveConfig.
+            An error occurred because some necessary fields are missing in the SaveParams.
     """
     integrations_map = global_api_client.list_integrations()
 

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -268,7 +268,8 @@ class RelationalDBIntegration(Integration):
             return TableArtifact(self._dag, sql_output_artifact_id)
 
     def config(self, table: str, update_mode: LoadUpdateMode) -> SaveConfig:
-        """Configuration for saving to RelationalDB Integration.
+        """TODO(ENG-2035): Deprecated and will be removed.
+        Configuration for saving to RelationalDB Integration.
 
         Arguments:
             table:
@@ -295,7 +296,17 @@ class RelationalDBIntegration(Integration):
         )
 
     def save(self, artifact: BaseArtifact, table_name: str, update_mode: LoadUpdateMode) -> None:
-        """TODO"""
+        """Registers a save operator of the given artifact, to be executed when it's computed in a published flow.
+
+        Args:
+            artifact:
+                The artifact to save into this sql integration.
+            table_name:
+                The table to save the artifact to.
+            update_mode:
+                Defines the semantics of the save if a table already exists.
+                Options are "replace", "append" (row-wise), or "fail" (if table already exists).
+        """
         save_artifact(
             artifact.id(),
             artifact.type(),

--- a/sdk/aqueduct/operators.py
+++ b/sdk/aqueduct/operators.py
@@ -121,6 +121,7 @@ UnionLoadParams = Union[
 ]
 
 
+# TODO(ENG-2035) This deprecated and will be removed.
 # Internal class used by SDK to represent the config for loading to an integration.
 class SaveConfig(BaseModel):
     integration_info: IntegrationInfo

--- a/sdk/aqueduct/operators.py
+++ b/sdk/aqueduct/operators.py
@@ -122,7 +122,7 @@ UnionLoadParams = Union[
 
 
 # TODO(ENG-2035) This deprecated and will be removed.
-# Internal class used by SDK to represent the config for loading to an integration.
+# A user-facing class used by SDK to represent the config for loading to an integration.
 class SaveConfig(BaseModel):
     integration_info: IntegrationInfo
     parameters: UnionLoadParams

--- a/sdk/aqueduct/utils.py
+++ b/sdk/aqueduct/utils.py
@@ -15,20 +15,11 @@ import multipart
 import numpy as np
 import pkg_resources
 import requests
-from aqueduct.config import (
-    AirflowEngineConfig,
-    EngineConfig,
-    FlowConfig,
-    K8sEngineConfig,
-    LambdaEngineConfig,
-)
+from aqueduct.config import AirflowEngineConfig, EngineConfig, K8sEngineConfig, LambdaEngineConfig
 from aqueduct.dag import DAG, RetentionPolicy, Schedule
 from aqueduct.enums import ArtifactType, OperatorType, RuntimeType, ServiceType, TriggerType
 from aqueduct.error import *
-from aqueduct.integrations.airflow_integration import AirflowIntegration
 from aqueduct.integrations.integration import IntegrationInfo
-from aqueduct.integrations.k8s_integration import K8sIntegration
-from aqueduct.integrations.lambda_integration import LambdaIntegration
 from aqueduct.logger import logger
 from aqueduct.operators import Operator, ParamSpec
 from aqueduct.serialization import (


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Instead of the hard-to-read `output_artifact.save()`, we should use `integration.save(output_artifact, ..)` instead.

This PR also does the following:
- Deprecates the old path by logging a warning each time. but does not eliminate the path. All the places we should remove are tagged with TODO(ENG-2035).
- Updates a lot of the docstrings to give the user context for what their saves mean.

The testing portion is large and is in a follow-up PR.

cc: @vsreekanti since this is a user-facing.

## Related issue number (if any)
ENG-1947

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


