### PR TITLE
Update the integration tests to support the new Save API

### DIFF
--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 from aqueduct.dag import DAG, Metadata
+import utils
+from validator import Validator
 from utils import delete_flow, flow_name_to_id, generate_new_flow_name
 
 import aqueduct
@@ -12,6 +14,9 @@ def pytest_addoption(parser):
     parser.addoption(f"--data", action="store", default="aqueduct_demo")
     parser.addoption(f"--engine", action="store", default=None)
     parser.addoption(f"--keep-flows", action="store_true", default=False)
+
+    # Sets a global flag that can be toggled if we want to check that a deprecated code path still works.
+    parser.addoption(f"--deprecated", action="store_true", default=False)
 
 
 def pytest_configure(config):
@@ -33,6 +38,11 @@ def data_integration(pytestconfig):
 @pytest.fixture(scope="session")
 def engine(pytestconfig):
     return pytestconfig.getoption("engine")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def use_deprecated(pytestconfig):
+    utils.use_deprecated_code_paths = pytestconfig.getoption("deprecated")
 
 
 @pytest.fixture(scope="function")
@@ -106,3 +116,9 @@ def flow_name(client, request, pytestconfig):
 
     request.addfinalizer(cleanup_flows)
     return get_new_flow_name
+
+
+@pytest.fixture(scope="function")
+def validator(client, data_integration):
+    integration = client.integration(data_integration)
+    return Validator(client, integration)

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -1,10 +1,10 @@
 import os
 
 import pytest
-from aqueduct.dag import DAG, Metadata
 import utils
-from validator import Validator
+from aqueduct.dag import DAG, Metadata
 from utils import delete_flow, flow_name_to_id, generate_new_flow_name
+from validator import Validator
 
 import aqueduct
 

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -1,5 +1,5 @@
-import pytest
 import pandas as pd
+import pytest
 from aqueduct.error import InvalidRequestError
 from constants import SHORT_SENTIMENT_SQL_QUERY
 from utils import (
@@ -84,7 +84,9 @@ def test_delete_workflow_saved_objects(client, flow_name, data_integration, engi
     check_table_doesnt_exist(integration, table_name)
 
 
-def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration, engine, validator):
+def test_delete_workflow_saved_objects_twice(
+    client, flow_name, data_integration, engine, validator
+):
     """Checking the successful deletion case and unsuccessful deletion case works as expected.
     To test this, I have two workflows that write to the same table. When I delete the table in the first workflow,
     it is successful but when I delete it in the second workflow, it is unsuccessful because the table has already

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 from aqueduct.error import InvalidRequestError
 from constants import SHORT_SENTIMENT_SQL_QUERY
 from utils import (
@@ -7,6 +8,7 @@ from utils import (
     check_table_exists,
     generate_table_name,
     publish_flow_test,
+    save,
 )
 
 from aqueduct import LoadUpdateMode
@@ -15,10 +17,9 @@ from aqueduct import LoadUpdateMode
 def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integration, engine):
     """Check the flow cannot delete an object it had not saved."""
     integration = client.integration(data_integration)
-    table_name = generate_table_name()
 
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
+    save(integration, table)
 
     flow = publish_flow_test(
         client,
@@ -39,12 +40,12 @@ def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integrati
     client.flow(flow.id())
 
 
-def test_delete_workflow_saved_objects(client, flow_name, data_integration, engine):
+def test_delete_workflow_saved_objects(client, flow_name, data_integration, engine, validator):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     integration = client.integration(data_integration)
     table_name = generate_table_name()
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
+    save(integration, table, name=table_name, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
         client,
@@ -53,7 +54,7 @@ def test_delete_workflow_saved_objects(client, flow_name, data_integration, engi
         engine=engine,
     )
 
-    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
+    save(integration, table, name=table_name, update_mode=LoadUpdateMode.APPEND)
     flow = publish_flow_test(
         client,
         table,
@@ -61,19 +62,19 @@ def test_delete_workflow_saved_objects(client, flow_name, data_integration, engi
         existing_flow=flow,
     )
 
+    extracted_table_data = table.get()
+    validator.check_saved_artifact(
+        flow,
+        table.id(),
+        expected_data=pd.concat([extracted_table_data, extracted_table_data], ignore_index=True),
+    )
+
     tables = client.flow(flow.id()).list_saved_objects()
     assert table_name in [item.object_name for item in tables[data_integration]]
-
-    # Check table is properly created at the integration.
-    # Need to poll initially in case still writing table.
-    check_table_exists(integration, table_name)
 
     # Doesn't work if don't force because it is created in append mode.
     with pytest.raises(InvalidRequestError):
         client.delete_flow(flow.id(), saved_objects_to_delete=tables, force=False)
-
-    # Check table is properly created at the integration.
-    integration.sql(f"SELECT * FROM {table_name}").get()
 
     # Actually delete the flow.
     client.delete_flow(flow.id(), saved_objects_to_delete=tables, force=True)
@@ -83,7 +84,7 @@ def test_delete_workflow_saved_objects(client, flow_name, data_integration, engi
     check_table_doesnt_exist(integration, table_name)
 
 
-def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration, engine):
+def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration, engine, validator):
     """Checking the successful deletion case and unsuccessful deletion case works as expected.
     To test this, I have two workflows that write to the same table. When I delete the table in the first workflow,
     it is successful but when I delete it in the second workflow, it is unsuccessful because the table has already
@@ -93,7 +94,7 @@ def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration
     table_name = generate_table_name()
 
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.REPLACE))
+    save(integration, table, name=table_name, update_mode=LoadUpdateMode.REPLACE)
 
     # Workflow 1's name not specified, so given a random workflow name.
     flow1 = publish_flow_test(
@@ -104,12 +105,19 @@ def test_delete_workflow_saved_objects_twice(client, flow_name, data_integration
     )
 
     # Workflow 2's name not specified, so given a random workflow name.
-    table.save(integration.config(table=table_name, update_mode=LoadUpdateMode.APPEND))
+    save(integration, table, name=table_name, update_mode=LoadUpdateMode.APPEND)
     flow2 = publish_flow_test(
         client,
         table,
         name=flow_name(),
         engine=engine,
+    )
+
+    extracted_table_data = table.get()
+    validator.check_saved_artifact(
+        flow1,
+        table.id(),
+        expected_data=pd.concat([extracted_table_data, extracted_table_data], ignore_index=True),
     )
 
     # Check table is properly created at the integration.

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -17,6 +17,7 @@ from test_functions.simple.model import (
 from test_metrics.constant.model import constant_metric
 from utils import (
     generate_new_flow_name,
+    generate_table_name,
     publish_flow_test,
     save,
     trigger_flow_test,
@@ -300,7 +301,8 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return initial_table
 
     table = generate_initial_table()
-    save(db, table, name="test_table")
+    table_name = generate_table_name()
+    save(db, table, name=table_name)
 
     setup_flow = publish_flow_test(
         client,
@@ -314,7 +316,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return df
 
     # Create a new flow that extracts this data.
-    output = db.sql("Select * from test_table", name="Test Table Query")
+    output = db.sql("SELECT * FROM %s" % table_name, name="Test Table Query")
     assert output.get().equals(initial_table)
 
     flow = publish_flow_test(
@@ -330,7 +332,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
     table = generate_new_table()
-    save(db, table, name="test_table")
+    save(db, table, name=table_name)
     publish_flow_test(
         client,
         artifacts=table,

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -17,59 +17,55 @@ from test_functions.simple.model import (
 from test_metrics.constant.model import constant_metric
 from utils import (
     generate_new_flow_name,
-    generate_table_name,
     publish_flow_test,
+    save,
     trigger_flow_test,
     wait_for_flow_runs,
 )
 
 import aqueduct
-from aqueduct import FlowConfig, LoadUpdateMode, check, metric, op
+from aqueduct import FlowConfig, check, metric, op
 
 
-def test_basic_flow(client, flow_name, data_integration, engine):
+def test_basic_flow(client, flow_name, data_integration, engine, validator):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
 
-    publish_flow_test(
+    flow = publish_flow_test(
         client,
         output_artifact,
         name=flow_name(),
         engine=engine,
     )
+    validator.check_saved_artifact(flow, output_artifact.id(), expected_data=output_artifact.get())
 
 
-def test_sentiment_flow(client, flow_name, data_integration, engine):
+def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
     """Actually run the full sentiment model (with nltk dependency)."""
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = sentiment_model(sql_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
 
-    publish_flow_test(
+    flow = publish_flow_test(
         client,
         output_artifact,
         name=flow_name(),
         engine=engine,
     )
+    validator.check_saved_artifact(flow, output_artifact.id(), expected_data=output_artifact.get())
 
 
-def test_complex_flow(client, flow_name, data_integration, engine):
+def test_complex_flow(client, flow_name, data_integration, engine, validator):
     db = client.integration(data_integration)
     sql_artifact1 = db.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
     sql_artifact2 = db.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
 
     fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact1, sql_artifact2)
     output_artifact = dummy_model(fn_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
 
     @check()
     def successful_check(df):
@@ -95,6 +91,7 @@ def test_complex_flow(client, flow_name, data_integration, engine):
         name=flow_name(),
         engine=engine,
     )
+    validator.check_saved_artifact(flow, output_artifact.id(), expected_data=output_artifact.get())
 
     # Metrics and checks should have been computed.
     flow_run = flow.latest()
@@ -109,6 +106,7 @@ def test_complex_flow(client, flow_name, data_integration, engine):
         engine=engine,
         checks=[success_check],  # failing_check will no longer be included.
     )
+    validator.check_saved_artifact(flow, output_artifact.id(), expected_data=output_artifact.get())
 
     # Only the explicitly defined metrics and checks should have been included in this second run.
     flow_run = flow.latest()
@@ -124,12 +122,8 @@ def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
 
     fn_artifact1 = dummy_sentiment_model(sql_artifact1)
     fn_artifact2 = dummy_model(sql_artifact2)
-    fn_artifact1.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
-    fn_artifact2.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, fn_artifact1)
+    save(db, fn_artifact2)
 
     publish_flow_test(
         client,
@@ -145,9 +139,7 @@ def test_publish_with_schedule(client, flow_name, data_integration, engine):
     )
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
 
     # Execute the flow 1 minute from now.
     execute_at = datetime.now() + timedelta(minutes=1)
@@ -208,9 +200,7 @@ def test_refresh_flow(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -231,9 +221,7 @@ def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -251,9 +239,8 @@ def test_get_artifact_reuse_for_computation(client, flow_name, data_integration,
     db = client.integration(data_integration)
     sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact.save(
-        config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, output_artifact)
+
     flow = publish_flow_test(
         client,
         output_artifact,
@@ -313,7 +300,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return initial_table
 
     table = generate_initial_table()
-    table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
+    save(db, table, name="test_table")
 
     setup_flow = publish_flow_test(
         client,
@@ -343,7 +330,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
     table = generate_new_table()
-    table.save(db.config(table="test_table", update_mode=LoadUpdateMode.REPLACE))
+    save(db, table, name="test_table")
     publish_flow_test(
         client,
         artifacts=table,

--- a/integration_tests/sdk/lazy_execution_test.py
+++ b/integration_tests/sdk/lazy_execution_test.py
@@ -148,7 +148,7 @@ def test_lazy_global_config(client, data_integration):
         check_result = dummy_check(op_result)
 
         assert op_result._get_content() is None
-        assert op_result._get_type() == ArtifactType.UNTYPED
+        assert op_result.type() == ArtifactType.UNTYPED
         assert metric_result._get_content() is None
         assert check_result._get_content() is None
 
@@ -158,7 +158,7 @@ def test_lazy_global_config(client, data_integration):
 
         # After get(), everything should be materialized on the artifacts.
         assert op_result._get_content() is not None
-        assert op_result._get_type() == ArtifactType.STRING
+        assert op_result.type() == ArtifactType.STRING
         assert metric_result._get_content() is not None
         assert check_result._get_content() is not None
 
@@ -177,25 +177,25 @@ def test_lazy_artifacts_backfilled_by_downstream(client):
 
     # Eager execution will type the upstream operator, but will not backfill the contents!
     num = generate_number.lazy()
-    assert num._get_type() == ArtifactType.UNTYPED
+    assert num.type() == ArtifactType.UNTYPED
     assert num._get_content() is None
     output = double_number(num)
 
-    assert num._get_type() == ArtifactType.NUMERIC
+    assert num.type() == ArtifactType.NUMERIC
     assert num._get_content() is None
-    assert output._get_type() == ArtifactType.NUMERIC
+    assert output.type() == ArtifactType.NUMERIC
     assert output._get_content() == 4.0
 
     # .get() will also type the upstream operator, same as above.
     num = generate_number.lazy()
     output = double_number.lazy(num)
-    assert output._get_type() == ArtifactType.UNTYPED
+    assert output.type() == ArtifactType.UNTYPED
     assert output._get_content() is None
     assert output.get() == 4.0
 
-    assert num._get_type() == ArtifactType.NUMERIC
+    assert num.type() == ArtifactType.NUMERIC
     assert num._get_content() is None
-    assert output._get_type() == ArtifactType.NUMERIC
+    assert output.type() == ArtifactType.NUMERIC
     assert output._get_content() == 4.0
 
 
@@ -208,9 +208,9 @@ def test_lazy_artifacts_with_custom_parameters(client):
         return 2 * num
 
     doubled = double_number.lazy(num)
-    assert doubled._get_type() == ArtifactType.UNTYPED
+    assert doubled.type() == ArtifactType.UNTYPED
     assert doubled._get_content() is None
 
     assert doubled.get(parameters={"number": 20}) == 40
-    assert doubled._get_type() == ArtifactType.NUMERIC
+    assert doubled.type() == ArtifactType.NUMERIC
     assert doubled._get_content() is None  # do not manifest the contents!

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -1,14 +1,18 @@
 from constants import SHORT_SENTIMENT_SQL_QUERY
-from utils import delete_flow, generate_new_flow_name, publish_flow_test
-
+from utils import publish_flow_test, save, generate_table_name
+import pandas as pd
 from aqueduct import LoadUpdateMode, op
 
 
-def test_list_saved_objects(client, flow_name, data_integration, engine):
+def test_list_saved_objects(client, flow_name, data_integration, engine, validator):
     integration = client.integration(name=data_integration)
 
+    table_1_save_name = generate_table_name()
+    table_2_save_name = generate_table_name()
+
     table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.REPLACE))
+    extracted_table_data = table.get()
+    save(integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.REPLACE)
 
     # This will create the table.
     flow = publish_flow_test(
@@ -17,66 +21,66 @@ def test_list_saved_objects(client, flow_name, data_integration, engine):
         artifacts=table,
         engine=engine,
     )
+    validator.check_saved_artifact(flow, table.id(), expected_data=extracted_table_data)
 
     # Change to append mode.
-    table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
+    save(integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.APPEND)
     publish_flow_test(
         client,
         existing_flow=flow,
         artifacts=table,
         engine=engine,
     )
+    validator.check_saved_artifact(
+        flow,
+        table.id(),
+        expected_data=pd.concat([extracted_table_data, extracted_table_data], ignore_index=True),
+    )
 
-    # Redundant append mode change.
-    table.save(integration.config(table="table_1", update_mode=LoadUpdateMode.APPEND))
+    # Redundant append mode change
+    save(integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.APPEND)
     publish_flow_test(
         client,
         existing_flow=flow,
         artifacts=table,
         engine=engine,
+    )
+    validator.check_saved_artifact(
+        flow,
+        table.id(),
+        expected_data=pd.concat([extracted_table_data, extracted_table_data, extracted_table_data], ignore_index=True),
     )
 
     # Create a different table from the same artifact.
-    table.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
+    save(integration, table, name=table_2_save_name, update_mode=LoadUpdateMode.REPLACE)
     publish_flow_test(
         client,
         existing_flow=flow,
         artifacts=table,
         engine=engine,
     )
+    validator.check_saved_artifact(
+        flow,
+        table.id(),
+        expected_data=extracted_table_data,
+    )
 
-    data = client.flow(flow.id()).list_saved_objects()
-
-    # Check all in same integration
-    assert len(data.keys()) == 1
-
-    # table_name, update_mode in order of latest created
-    data_set = [
-        ("table_2", LoadUpdateMode.REPLACE),
-        ("table_1", LoadUpdateMode.APPEND),
-        ("table_1", LoadUpdateMode.REPLACE),
-    ]
-    integration_name = list(data.keys())[0]
-    assert len(data[integration_name]) == 3
-    for i in range(3):
-        item = data[integration_name][i]
-        assert (item.object_name, item.update_mode) == data_set[i]
-
-    # Check mapping can be accessed correctly
-    # Can be accessed by string of integration name
-    assert len(data[data_integration]) == 3
-
-    # Can be accessed by Integration object with integration name
-    assert len(data[integration]) == 3
+    validator.check_saved_update_mode_changes(flow, expected_updates=[
+        (table_2_save_name, LoadUpdateMode.REPLACE),
+        (table_1_save_name, LoadUpdateMode.APPEND),
+        (table_1_save_name, LoadUpdateMode.REPLACE),
+    ])
 
 
-def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_integration, engine):
+def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_integration, engine, validator):
     integration = client.integration(name=data_integration)
+    table_1_save_name = generate_table_name()
+    table_2_save_name = generate_table_name()
 
     table_1 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    table_1.save(integration.config(table="table_1", update_mode=LoadUpdateMode.REPLACE))
+    save(integration, table_1, name=table_1_save_name, update_mode=LoadUpdateMode.REPLACE)
     table_2 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    table_2.save(integration.config(table="table_2", update_mode=LoadUpdateMode.REPLACE))
+    save(integration, table_2, name=table_2_save_name, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
         client,
@@ -85,22 +89,15 @@ def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_in
         engine=engine,
     )
 
-    data = client.flow(flow.id()).list_saved_objects()
-
-    assert len(data.keys()) == 1
-    data_set = {
-        ("table_1", LoadUpdateMode.REPLACE),
-        ("table_2", LoadUpdateMode.REPLACE),
-    }
-
-    integration_name = list(data.keys())[0]
-    assert len(data[integration_name]) == 2
-    assert (
-        set([(item.object_name, item.update_mode) for item in data[integration_name]]) == data_set
-    )
+    validator.check_saved_artifact(flow, table_1.id(), expected_data=table_1.get())
+    validator.check_saved_artifact(flow, table_2.id(), expected_data=table_2.get())
+    validator.check_saved_update_mode_changes(flow, expected_updates=[
+        (table_2_save_name, LoadUpdateMode.REPLACE),
+        (table_1_save_name, LoadUpdateMode.REPLACE),
+    ], order_matters=False)
 
 
-def test_lazy_artifact_with_save(client, flow_name, data_integration, engine):
+def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, validator):
     db = client.integration(data_integration)
     reviews = db.sql(SHORT_SENTIMENT_SQL_QUERY)
 
@@ -110,13 +107,12 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine):
         return df
 
     review_copied = copy_field.lazy(reviews)
-    review_copied.save(
-        config=db.config(table="test_timestamp_succeeded", update_mode=LoadUpdateMode.REPLACE)
-    )
+    save(db, review_copied, name=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
 
-    publish_flow_test(
+    flow = publish_flow_test(
         client,
         review_copied,
         name=flow_name(),
         engine=engine,
     )
+    validator.check_saved_artifact(flow, review_copied.id(), expected_data=copy_field.local(reviews))

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -1,6 +1,7 @@
-from constants import SHORT_SENTIMENT_SQL_QUERY
-from utils import publish_flow_test, save, generate_table_name
 import pandas as pd
+from constants import SHORT_SENTIMENT_SQL_QUERY
+from utils import generate_table_name, publish_flow_test, save
+
 from aqueduct import LoadUpdateMode, op
 
 
@@ -48,7 +49,9 @@ def test_list_saved_objects(client, flow_name, data_integration, engine, validat
     validator.check_saved_artifact(
         flow,
         table.id(),
-        expected_data=pd.concat([extracted_table_data, extracted_table_data, extracted_table_data], ignore_index=True),
+        expected_data=pd.concat(
+            [extracted_table_data, extracted_table_data, extracted_table_data], ignore_index=True
+        ),
     )
 
     # Create a different table from the same artifact.
@@ -65,14 +68,19 @@ def test_list_saved_objects(client, flow_name, data_integration, engine, validat
         expected_data=extracted_table_data,
     )
 
-    validator.check_saved_update_mode_changes(flow, expected_updates=[
-        (table_2_save_name, LoadUpdateMode.REPLACE),
-        (table_1_save_name, LoadUpdateMode.APPEND),
-        (table_1_save_name, LoadUpdateMode.REPLACE),
-    ])
+    validator.check_saved_update_mode_changes(
+        flow,
+        expected_updates=[
+            (table_2_save_name, LoadUpdateMode.REPLACE),
+            (table_1_save_name, LoadUpdateMode.APPEND),
+            (table_1_save_name, LoadUpdateMode.REPLACE),
+        ],
+    )
 
 
-def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_integration, engine, validator):
+def test_multiple_artifacts_saved_to_same_integration(
+    client, flow_name, data_integration, engine, validator
+):
     integration = client.integration(name=data_integration)
     table_1_save_name = generate_table_name()
     table_2_save_name = generate_table_name()
@@ -91,10 +99,14 @@ def test_multiple_artifacts_saved_to_same_integration(client, flow_name, data_in
 
     validator.check_saved_artifact(flow, table_1.id(), expected_data=table_1.get())
     validator.check_saved_artifact(flow, table_2.id(), expected_data=table_2.get())
-    validator.check_saved_update_mode_changes(flow, expected_updates=[
-        (table_2_save_name, LoadUpdateMode.REPLACE),
-        (table_1_save_name, LoadUpdateMode.REPLACE),
-    ], order_matters=False)
+    validator.check_saved_update_mode_changes(
+        flow,
+        expected_updates=[
+            (table_2_save_name, LoadUpdateMode.REPLACE),
+            (table_1_save_name, LoadUpdateMode.REPLACE),
+        ],
+        order_matters=False,
+    )
 
 
 def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, validator):
@@ -107,7 +119,7 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, va
         return df
 
     review_copied = copy_field.lazy(reviews)
-    save(db, review_copied, name=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
+    save(db, review_copied, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
         client,
@@ -115,4 +127,6 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, va
         name=flow_name(),
         engine=engine,
     )
-    validator.check_saved_artifact(flow, review_copied.id(), expected_data=copy_field.local(reviews))
+    validator.check_saved_artifact(
+        flow, review_copied.id(), expected_data=copy_field.local(reviews)
+    )

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -2,7 +2,7 @@ import pytest
 from aqueduct.error import InvalidIntegrationException, InvalidUserArgumentException
 from constants import SENTIMENT_SQL_QUERY
 from test_functions.simple.model import dummy_sentiment_model
-from utils import generate_table_name, publish_flow_test
+from utils import generate_table_name, publish_flow_test, save
 
 from aqueduct import LoadUpdateMode, metric
 
@@ -31,9 +31,7 @@ def test_invalid_destination_integration(client, data_integration):
 
     with pytest.raises(InvalidIntegrationException):
         db._metadata.name = "bad name"
-        output_artifact.save(
-            config=db.config(table=generate_table_name(), update_mode=LoadUpdateMode.REPLACE)
-        )
+        save(db, output_artifact)
 
 
 def test_sql_today_tag(client, data_integration):

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Union
 
 from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.enums import ExecutionStatus
+from aqueduct.enums import ExecutionStatus, LoadUpdateMode, RelationalDBServices
 
 import aqueduct
 from aqueduct import Flow
@@ -13,6 +13,18 @@ from aqueduct import Flow
 #  since that is generated in the test by `publish_flow()`. Therefore, we must register every
 #  flow we publish in `publish_flow_test` in this dictionary.
 flow_name_to_id: Dict[str, uuid.UUID] = {}
+
+# Toggles whether we should test deprecated code paths. The is useful for ensuring both the new and
+# old code paths continue to work when the API changes, but we want to continue to ensure backwards
+# compatibility for a while.
+use_deprecated_code_paths = False
+
+# Global map tracking all the artifacts we've saved in the test suite and the path that they were saved to.
+artifact_id_to_saved_identifier: Dict[str, str] = {}
+
+
+def use_deprecated_code_path() -> bool:
+    return use_deprecated_code_paths
 
 
 def generate_new_flow_name() -> str:
@@ -185,6 +197,30 @@ def wait_for_flow_runs(
         poll_threshold=1,
         timeout_comment="Timed out waiting for workflow run to complete.",
     )
+
+
+def save(
+    integration,
+    artifact: BaseArtifact,
+    name: Optional[str] = None,
+    update_mode: Optional[LoadUpdateMode] = None,
+):
+    assert (
+        integration._metadata.service in RelationalDBServices
+    ), "Currently, only relational data integrations are supported."
+
+    if name is None:
+        name = generate_table_name()
+    if update_mode is None:
+        update_mode = LoadUpdateMode.REPLACE
+
+    if use_deprecated_code_path():
+        artifact.save(integration.config(name, update_mode))
+    else:
+        integration.save(artifact, name, update_mode)
+
+    # Record exactly where the artifact was saved, so we can validate the data later, after the flow is published.
+    artifact_id_to_saved_identifier[str(artifact.id())] = name
 
 
 def delete_flow(client: aqueduct.Client, workflow_id: uuid.UUID) -> None:

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -205,6 +205,7 @@ def save(
     name: Optional[str] = None,
     update_mode: Optional[LoadUpdateMode] = None,
 ):
+    """NOTE: if `name` is set, make sure that it is set to a globally unique value, since test cases can be run concurrently."""
     assert (
         integration._metadata.service in RelationalDBServices
     ), "Currently, only relational data integrations are supported."

--- a/integration_tests/sdk/validator.py
+++ b/integration_tests/sdk/validator.py
@@ -1,0 +1,59 @@
+import uuid
+from typing import Any, List, Tuple
+
+from aqueduct import Flow, LoadUpdateMode, Client
+from aqueduct.integrations.integration import Integration
+from aqueduct.integrations.sql_integration import RelationalDBIntegration
+from utils import artifact_id_to_saved_identifier
+
+
+class Validator():
+    """TODO: describe what these validators are trying to do."""
+    _client: Client
+    _integration: Integration
+
+    def __init__(self, client: Client, integration: Integration):
+        self._client = client
+        self._integration = integration
+
+    def check_saved_artifact(self, flow: Flow, artifact_id: uuid.UUID, expected_data: Any):
+        """TODO: talk about limitations across workflow runs.
+
+        # TODO: this only works with SQL-based integrations!
+        """
+        assert isinstance(self._integration, RelationalDBIntegration), "Currently, only relational data integrations are supported."
+
+        # Check that given saved artifacts were indeed saved based on the flow API.
+        all_saved_objects = flow.list_saved_objects()[self._integration._metadata.name]
+        all_saved_object_identifiers = [item.object_name for item in all_saved_objects]
+        saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
+        assert saved_object_identifier in all_saved_object_identifiers
+
+        # Verify that the actual data was saved.
+        saved_data = self._integration.sql(f"SELECT * FROM {saved_object_identifier}").get()
+        if not saved_data.equals(expected_data):
+            print("Expected data: ", expected_data)
+            print("Actual data: ", saved_data)
+            raise Exception("Mismatch between expected and actual saved data.")
+
+    def check_saved_update_mode_changes(self, flow: Flow, expected_updates: List[Tuple[str, LoadUpdateMode]], order_matters: bool = True):
+        # TODO: table_name, update_mode in order of latest created
+
+        data = self._client.flow(flow.id()).list_saved_objects()
+
+        # Check all objects were saved to the same integration.
+        assert len(data.keys()) == 1
+        integration_name = list(data.keys())[0]
+        assert integration_name == self._integration._metadata.name
+
+        assert len(data[integration_name]) == len(expected_updates)
+        saved_objects = data[integration_name]
+        actual_updates = [(saved_objects[i].object_name, saved_objects[i].update_mode) for i, (name, _) in enumerate(expected_updates)]
+
+        if order_matters:
+            assert expected_updates == actual_updates, "Expected %s, got %s." % (expected_updates, actual_updates)
+        else:
+            assert all(actual_update in expected_updates for actual_update in actual_updates)
+
+        # Check that mapping can be accessed by integration object too.
+        assert data[self._integration] == data[integration_name]

--- a/sdk/aqueduct/integrations/save.py
+++ b/sdk/aqueduct/integrations/save.py
@@ -10,13 +10,7 @@ from aqueduct.error import (
 )
 from aqueduct.globals import __GLOBAL_API_CLIENT__ as global_api_client
 from aqueduct.integrations.integration import IntegrationInfo
-from aqueduct.operators import (
-    LoadSpec,
-    Operator,
-    OperatorSpec,
-    S3LoadParams,
-    UnionLoadParams,
-)
+from aqueduct.operators import LoadSpec, Operator, OperatorSpec, S3LoadParams, UnionLoadParams
 from aqueduct.utils import generate_uuid
 
 

--- a/sdk/aqueduct/integrations/save.py
+++ b/sdk/aqueduct/integrations/save.py
@@ -10,7 +10,13 @@ from aqueduct.error import (
 )
 from aqueduct.globals import __GLOBAL_API_CLIENT__ as global_api_client
 from aqueduct.integrations.integration import IntegrationInfo
-from aqueduct.operators import LoadSpec, Operator, OperatorSpec, S3LoadParams, UnionLoadParams
+from aqueduct.operators import (
+    LoadSpec,
+    Operator,
+    OperatorSpec,
+    S3LoadParams,
+    UnionLoadParams,
+)
 from aqueduct.utils import generate_uuid
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This is the testing follow-up of: https://github.com/aqueducthq/aqueduct/pull/769

Because of the Save API change, we should now abstract away our `save()` helper. This PR does the following:
- Adds a `save()` helper that should be used by the test cases (instead of directly using the SDK's Save API).
- Add a flag `--deprecated`, which allows us to continue to provide coverage to code paths that are deprecated, but need to be temporary support. See `save()` for how this switch works.
- Adds a `Validator` class instance (see `validator.py`), which can be included in tests that need it. This Validator can be used to check certain things about the flow after `publish_flow_test()` is called. The reason I made this a class is 1) it's easier to include as a fixture and 2) its easier to organize all our validators and 3) in the future, we can improve performance by caching common data that multiple validations need to use.

## Related issue number (if any)
ENG-1947

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


