### PR TITLE
[7/N] Replaces notification DB reader/writer with repo

### DIFF
--- a/src/golang/cmd/executor/executor/database.go
+++ b/src/golang/cmd/executor/executor/database.go
@@ -5,7 +5,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
 	exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
-	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/workflow_watcher"
@@ -30,15 +29,15 @@ type Writers struct {
 	OperatorResultWriter  operator_result.Writer
 	ArtifactWriter        artifact.Writer
 	ArtifactResultWriter  artifact_result.Writer
-	NotificationWriter    notification.Writer
 }
 
 type Repos struct {
-	DAGRepo       repos.DAG
-	DAGEdgeRepo   repos.DAGEdge
-	DAGResultRepo repos.DAGResult
-	WatcherRepo   repos.Watcher
-	WorkflowRepo  repos.Workflow
+	DAGRepo          repos.DAG
+	DAGEdgeRepo      repos.DAGEdge
+	DAGResultRepo    repos.DAGResult
+	NotificationRepo repos.Notification
+	WatcherRepo      repos.Watcher
+	WorkflowRepo     repos.Workflow
 }
 
 func createReaders(dbConf *database.DatabaseConfig) (*Readers, error) {
@@ -108,28 +107,23 @@ func createWriters(dbConf *database.DatabaseConfig) (*Writers, error) {
 		return nil, err
 	}
 
-	notificationWriter, err := notification.NewWriter(dbConf)
-	if err != nil {
-		return nil, err
-	}
-
 	return &Writers{
 		WorkflowWatcherWriter: workflowWatcherWriter,
 		OperatorWriter:        operatorWriter,
 		OperatorResultWriter:  operatorResultWriter,
 		ArtifactWriter:        artifactWriter,
 		ArtifactResultWriter:  artifactResultWriter,
-		NotificationWriter:    notificationWriter,
 	}, nil
 }
 
 func createRepos() *Repos {
 	return &Repos{
-		DAGRepo:       sqlite.NewDAGRepo(),
-		DAGEdgeRepo:   sqlite.NewDAGEdgeRepo(),
-		DAGResultRepo: sqlite.NewDAGResultRepo(),
-		WatcherRepo:   sqlite.NewWatcherRepo(),
-		WorkflowRepo:  sqlite.NewWorklowRepo(),
+		DAGRepo:          sqlite.NewDAGRepo(),
+		DAGEdgeRepo:      sqlite.NewDAGEdgeRepo(),
+		DAGResultRepo:    sqlite.NewDAGResultRepo(),
+		NotificationRepo: sqlite.NewNotificationRepo(),
+		WatcherRepo:      sqlite.NewWatcherRepo(),
+		WorkflowRepo:     sqlite.NewWorklowRepo(),
 	}
 }
 
@@ -150,16 +144,16 @@ func getEngineWriters(writers *Writers) *engine.EngineWriters {
 		OperatorResultWriter: writers.OperatorResultWriter,
 		ArtifactWriter:       writers.ArtifactWriter,
 		ArtifactResultWriter: writers.ArtifactResultWriter,
-		NotificationWriter:   writers.NotificationWriter,
 	}
 }
 
 func getEngineRepos(repos *Repos) *engine.Repos {
 	return &engine.Repos{
-		DAGRepo:       repos.DAGRepo,
-		DAGEdgeRepo:   repos.DAGEdgeRepo,
-		DAGResultRepo: repos.DAGResultRepo,
-		WatcherRepo:   repos.WatcherRepo,
-		WorkflowRepo:  repos.WorkflowRepo,
+		DAGRepo:          repos.DAGRepo,
+		DAGEdgeRepo:      repos.DAGEdgeRepo,
+		DAGResultRepo:    repos.DAGResultRepo,
+		NotificationRepo: repos.NotificationRepo,
+		WatcherRepo:      repos.WatcherRepo,
+		WorkflowRepo:     repos.WorkflowRepo,
 	}
 }

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/airflow"
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact"
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
-	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
@@ -57,7 +56,6 @@ type ListWorkflowsHandler struct {
 	OperatorWriter       operator.Writer
 	OperatorResultWriter operator_result.Writer
 	ArtifactResultWriter artifact_result.Writer
-	NotificationWriter   notification.Writer
 
 	DAGRepo       repos.DAG
 	DAGEdgeRepo   repos.DAGEdge

--- a/src/golang/cmd/server/handler/register_airflow_workflow.go
+++ b/src/golang/cmd/server/handler/register_airflow_workflow.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aqueducthq/aqueduct/cmd/server/request"
 	"github.com/aqueducthq/aqueduct/lib/airflow"
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
-	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/workflow"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
@@ -38,7 +37,6 @@ type RegisterAirflowWorkflowHandler struct {
 
 	OperatorResultWriter operator_result.Writer
 	ArtifactResultWriter artifact_result.Writer
-	NotificationWriter   notification.Writer
 
 	DAGResultRepo repos.DAGResult
 }

--- a/src/golang/cmd/server/server/database.go
+++ b/src/golang/cmd/server/server/database.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
 	exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
-	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
 	"github.com/aqueducthq/aqueduct/lib/collections/schema_version"
@@ -18,17 +17,17 @@ import (
 )
 
 type Repos struct {
-	DAGRepo       repos.DAG
-	DAGEdgeRepo   repos.DAGEdge
-	DAGResultRepo repos.DAGResult
-	UserRepo      repos.User
-	WatcherRepo   repos.Watcher
-	WorkflowRepo  repos.Workflow
+	DAGRepo          repos.DAG
+	DAGEdgeRepo      repos.DAGEdge
+	DAGResultRepo    repos.DAGResult
+	NotificationRepo repos.Notification
+	UserRepo         repos.User
+	WatcherRepo      repos.Watcher
+	WorkflowRepo     repos.Workflow
 }
 
 type Readers struct {
 	IntegrationReader          integration.Reader
-	NotificationReader         notification.Reader
 	ArtifactReader             artifact.Reader
 	ArtifactResultReader       artifact_result.Reader
 	OperatorReader             operator.Reader
@@ -41,7 +40,6 @@ type Readers struct {
 
 type Writers struct {
 	IntegrationWriter          integration.Writer
-	NotificationWriter         notification.Writer
 	ArtifactWriter             artifact.Writer
 	ArtifactResultWriter       artifact_result.Writer
 	OperatorWriter             operator.Writer
@@ -51,22 +49,18 @@ type Writers struct {
 
 func CreateRepos() *Repos {
 	return &Repos{
-		DAGRepo:       sqlite.NewDAGRepo(),
-		DAGEdgeRepo:   sqlite.NewDAGEdgeRepo(),
-		DAGResultRepo: sqlite.NewDAGResultRepo(),
-		UserRepo:      sqlite.NewUserRepo(),
-		WatcherRepo:   sqlite.NewWatcherRepo(),
-		WorkflowRepo:  sqlite.NewWorklowRepo(),
+		DAGRepo:          sqlite.NewDAGRepo(),
+		DAGEdgeRepo:      sqlite.NewDAGEdgeRepo(),
+		DAGResultRepo:    sqlite.NewDAGResultRepo(),
+		NotificationRepo: sqlite.NewNotificationRepo(),
+		UserRepo:         sqlite.NewUserRepo(),
+		WatcherRepo:      sqlite.NewWatcherRepo(),
+		WorkflowRepo:     sqlite.NewWorklowRepo(),
 	}
 }
 
 func CreateReaders(dbConfig *database.DatabaseConfig) (*Readers, error) {
 	integrationReader, err := integration.NewReader(dbConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	notificationReader, err := notification.NewReader(dbConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +107,6 @@ func CreateReaders(dbConfig *database.DatabaseConfig) (*Readers, error) {
 
 	return &Readers{
 		IntegrationReader:          integrationReader,
-		NotificationReader:         notificationReader,
 		ArtifactReader:             artifactReader,
 		ArtifactResultReader:       artifactResultReader,
 		OperatorReader:             operatorReader,
@@ -127,11 +120,6 @@ func CreateReaders(dbConfig *database.DatabaseConfig) (*Readers, error) {
 
 func CreateWriters(dbConfig *database.DatabaseConfig) (*Writers, error) {
 	integrationWriter, err := integration.NewWriter(dbConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	notificationWriter, err := notification.NewWriter(dbConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +151,6 @@ func CreateWriters(dbConfig *database.DatabaseConfig) (*Writers, error) {
 
 	return &Writers{
 		IntegrationWriter:          integrationWriter,
-		NotificationWriter:         notificationWriter,
 		ArtifactWriter:             artifactWriter,
 		ArtifactResultWriter:       artifactResultWriter,
 		OperatorWriter:             operatorWriter,
@@ -189,16 +176,16 @@ func GetEngineWriters(writers *Writers) *engine.EngineWriters {
 		OperatorResultWriter: writers.OperatorResultWriter,
 		ArtifactWriter:       writers.ArtifactWriter,
 		ArtifactResultWriter: writers.ArtifactResultWriter,
-		NotificationWriter:   writers.NotificationWriter,
 	}
 }
 
 func GetEngineRepos(repos *Repos) *engine.Repos {
 	return &engine.Repos{
-		DAGRepo:       repos.DAGRepo,
-		DAGEdgeRepo:   repos.DAGEdgeRepo,
-		DAGResultRepo: repos.DAGResultRepo,
-		WatcherRepo:   repos.WatcherRepo,
-		WorkflowRepo:  repos.WorkflowRepo,
+		DAGRepo:          repos.DAGRepo,
+		DAGEdgeRepo:      repos.DAGEdgeRepo,
+		DAGResultRepo:    repos.DAGResultRepo,
+		NotificationRepo: repos.NotificationRepo,
+		WatcherRepo:      repos.WatcherRepo,
+		WorkflowRepo:     repos.WorkflowRepo,
 	}
 }

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -8,9 +8,9 @@ import (
 func (s *AqServer) Handlers() map[string]handler.Handler {
 	return map[string]handler.Handler{
 		routes.ArchiveNotificationRoute: &handler.ArchiveNotificationHandler{
-			NotificationReader: s.NotificationReader,
-			NotificationWriter: s.NotificationWriter,
-			Database:           s.Database,
+			Database: s.Database,
+
+			NotificationRepo: s.NotificationRepo,
 		},
 		routes.ConnectIntegrationRoute: &handler.ConnectIntegrationHandler{
 			Database:   s.Database,
@@ -136,9 +136,10 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			IntegrationReader: s.IntegrationReader,
 		},
 		routes.ListNotificationsRoute: &handler.ListNotificationsHandler{
-			Database:           s.Database,
-			NotificationReader: s.NotificationReader,
-			WorkflowReader:     s.WorkflowReader,
+			Database: s.Database,
+
+			DAGResultRepo:    s.DAGResultRepo,
+			NotificationRepo: s.NotificationRepo,
 		},
 		routes.ListOperatorsForIntegrationRoute: &handler.ListOperatorsForIntegrationHandler{
 			Database:          s.Database,
@@ -156,7 +157,6 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			OperatorWriter:       s.OperatorWriter,
 			OperatorResultWriter: s.OperatorResultWriter,
 			ArtifactResultWriter: s.ArtifactResultWriter,
-			NotificationWriter:   s.NotificationWriter,
 
 			DAGRepo:       s.DAGRepo,
 			DAGEdgeRepo:   s.DAGEdgeRepo,
@@ -250,7 +250,6 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			},
 			OperatorResultWriter: s.OperatorResultWriter,
 			ArtifactResultWriter: s.ArtifactResultWriter,
-			NotificationWriter:   s.NotificationWriter,
 
 			DAGResultRepo: s.DAGResultRepo,
 		},

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/artifact_result"
 	db_exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
-	"github.com/aqueducthq/aqueduct/lib/collections/notification"
 	operator_db "github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/param"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator_result"
@@ -62,16 +61,16 @@ type EngineWriters struct {
 	OperatorResultWriter operator_result.Writer
 	ArtifactWriter       artifact_db.Writer
 	ArtifactResultWriter artifact_result.Writer
-	NotificationWriter   notification.Writer
 }
 
 // Repos contains the repos needed by the Engine
 type Repos struct {
-	DAGRepo       repos.DAG
-	DAGEdgeRepo   repos.DAGEdge
-	DAGResultRepo repos.DAGResult
-	WatcherRepo   repos.Watcher
-	WorkflowRepo  repos.Workflow
+	DAGRepo          repos.DAG
+	DAGEdgeRepo      repos.DAGEdge
+	DAGResultRepo    repos.DAGResult
+	NotificationRepo repos.Notification
+	WatcherRepo      repos.Watcher
+	WorkflowRepo     repos.Workflow
 }
 
 type aqEngine struct {
@@ -221,7 +220,7 @@ func (eng *aqEngine) ExecuteWorkflow(
 			execState,
 			eng.DAGResultRepo,
 			eng.WorkflowRepo,
-			eng.NotificationWriter,
+			eng.NotificationRepo,
 			eng.Database,
 		); updateErr != nil {
 			log.Errorf("Unable to update DAGResult metadata for %v", dagResult.ID)

--- a/src/golang/lib/models/views/dag_result.go
+++ b/src/golang/lib/models/views/dag_result.go
@@ -1,0 +1,10 @@
+package views
+
+import "github.com/google/uuid"
+
+// DAGResultWorkflowMetadata contains Workflow metadata for a DAGResult.
+type DAGResultWorkflowMetadata struct {
+	WorkflowID  uuid.UUID `db:"id" json:"id"`
+	Name        string    `db:"name" json:"name"`
+	DAGResultID uuid.UUID `db:"dag_result_id" json:"dag_result_id"`
+}

--- a/src/golang/lib/repos/dag_result.go
+++ b/src/golang/lib/repos/dag_result.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -29,6 +30,9 @@ type dagResultReader interface {
 	// GetKOffsetByWorkflow returns the DAGResults of all DAGs associated with the Workflow with workflowID
 	// except for the last k DAGResults ordered by DAGResult.CreatedAt.
 	GetKOffsetByWorkflow(ctx context.Context, workflowID uuid.UUID, k int, DB database.Database) ([]models.DAGResult, error)
+
+	// GetWorkflowMetadataBatch returns a map of each DAGResult's ID in IDs to its DAGResultWorkflowMetadata.
+	GetWorkflowMetadataBatch(ctx context.Context, IDs []uuid.UUID, DB database.Database) (map[uuid.UUID]views.DAGResultWorkflowMetadata, error)
 }
 
 type dagResultWriter interface {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR replaces the notification DB readers and writer usage with the repo.

It also adds a new API to the DAGResultRepo for getting the workflow metadata associated with a DAGResult. This is necessary for the ListNotifications handler. There is a test case added for this new method. 

It also does a fix to a different test case.

## Related issue number (if any)
ENG 2053

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


