### PR TITLE
[15/N] Replaces custom queries with repos

### DIFF
--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -97,6 +97,7 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 		ctx,
 		args.integrationID,
 		h.OperatorReader,
+		h.OperatorRepo,
 		h.DAGRepo,
 		h.IntegrationRepo,
 		h.Database,
@@ -147,6 +148,7 @@ func validateNoActiveWorkflowOnIntegration(
 	ctx context.Context,
 	id uuid.UUID,
 	operatorReader operator.Reader,
+	operatorRepo repos.Operator,
 	dagRepo repos.DAG,
 	integrationRepo repos.Integration,
 	DB database.Database,
@@ -154,9 +156,11 @@ func validateNoActiveWorkflowOnIntegration(
 	interfaceResp, code, err := (&ListOperatorsForIntegrationHandler{
 		Database: DB,
 
+		OperatorReader: operatorReader,
+
 		DAGRepo:         dagRepo,
 		IntegrationRepo: integrationRepo,
-		OperatorReader:  operatorReader,
+		OperatorRepo:    operatorRepo,
 	}).Perform(ctx, id)
 	if err != nil {
 		return code, errors.Wrap(err, "Error getting operators on this integration.")

--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/aqueducthq/aqueduct/cmd/server/queries"
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 	db_exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
@@ -42,13 +41,13 @@ type DeleteIntegrationHandler struct {
 	Database database.Database
 	Vault    vault.Vault
 
-	CustomReader queries.Reader
 	// TODO: Replace with repos.Operator once ExecEnv methods are added
 	OperatorReader operator.Reader
 
 	ExecutionEnvironmentReader db_exec_env.Reader
 	ExecutionEnvironmentWriter db_exec_env.Writer
 
+	DAGRepo         repos.DAG
 	IntegrationRepo repos.Integration
 	OperatorRepo    repos.Operator
 }
@@ -98,7 +97,7 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 		ctx,
 		args.integrationID,
 		h.OperatorReader,
-		h.CustomReader,
+		h.DAGRepo,
 		h.IntegrationRepo,
 		h.Database,
 	)
@@ -148,15 +147,16 @@ func validateNoActiveWorkflowOnIntegration(
 	ctx context.Context,
 	id uuid.UUID,
 	operatorReader operator.Reader,
-	customReader queries.Reader,
+	dagRepo repos.DAG,
 	integrationRepo repos.Integration,
 	DB database.Database,
 ) (int, error) {
 	interfaceResp, code, err := (&ListOperatorsForIntegrationHandler{
-		CustomReader:    customReader,
-		OperatorReader:  operatorReader,
+		Database: DB,
+
+		DAGRepo:         dagRepo,
 		IntegrationRepo: integrationRepo,
-		Database:        DB,
+		OperatorReader:  operatorReader,
 	}).Perform(ctx, id)
 	if err != nil {
 		return code, errors.Wrap(err, "Error getting operators on this integration.")

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -118,7 +118,7 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 // self-orchestrated engine for the user's organization.
 func syncSelfOrchestratedWorkflows(ctx context.Context, h *ListWorkflowsHandler, orgID string) error {
 	// Sync workflows running on self-orchestrated engines
-	airflowDagIDObjects, err := h.DAGRepo.GetLatestIDsByOrgAndEngine(
+	airflowDagIDs, err := h.DAGRepo.GetLatestIDsByOrgAndEngine(
 		ctx,
 		orgID,
 		shared.AirflowEngineType,
@@ -126,11 +126,6 @@ func syncSelfOrchestratedWorkflows(ctx context.Context, h *ListWorkflowsHandler,
 	)
 	if err != nil {
 		return err
-	}
-
-	airflowDagIDs := make([]uuid.UUID, 0, len(airflowDagIDObjects))
-	for _, dagID := range airflowDagIDObjects {
-		airflowDagIDs = append(airflowDagIDs, dagID.ID)
 	}
 
 	if err := airflow.SyncDAGs(

--- a/src/golang/cmd/server/server/cron.go
+++ b/src/golang/cmd/server/server/cron.go
@@ -55,7 +55,7 @@ func (s *AqServer) triggerMissedCronJobs(
 // triggers the workflow if the cron triggering did not happen.
 func (s *AqServer) RunMissedCronJobs() error {
 	ctx := context.Background()
-	workflowLastRunResponse, err := s.CustomReader.GetWorkflowLastRunByEngine(
+	wfLastRuns, err := s.WorkflowRepo.GetLastRunByEngine(
 		ctx,
 		shared.AqueductEngineType,
 		s.Database,
@@ -66,16 +66,16 @@ func (s *AqServer) RunMissedCronJobs() error {
 
 	workflowsRan := map[uuid.UUID]bool{}
 
-	for _, workflowLastRun := range workflowLastRunResponse {
-		if workflowLastRun.Schedule.CronSchedule != "" && !workflowLastRun.Schedule.Paused {
+	for _, wfLastRun := range wfLastRuns {
+		if wfLastRun.Schedule.CronSchedule != "" && !wfLastRun.Schedule.Paused {
 			s.triggerMissedCronJobs(
 				ctx,
-				workflowLastRun.WorkflowId,
-				string(workflowLastRun.Schedule.CronSchedule),
-				workflowLastRun.LastRunAt,
+				wfLastRun.ID,
+				string(wfLastRun.Schedule.CronSchedule),
+				wfLastRun.LastRunAt,
 			)
 		}
-		workflowsRan[workflowLastRun.WorkflowId] = true
+		workflowsRan[wfLastRun.ID] = true
 	}
 
 	allWorkflows, err := s.WorkflowReader.GetAllWorkflows(ctx, s.Database)

--- a/src/golang/cmd/server/server/database.go
+++ b/src/golang/cmd/server/server/database.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"github.com/aqueducthq/aqueduct/cmd/server/queries"
 	exec_env "github.com/aqueducthq/aqueduct/lib/collections/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/schema_version"
@@ -31,7 +30,6 @@ type Readers struct {
 	OperatorReader             operator.Reader
 	WorkflowReader             workflow.Reader
 	SchemaVersionReader        schema_version.Reader
-	CustomReader               queries.Reader
 	ExecutionEnvironmentReader exec_env.Reader
 }
 
@@ -72,11 +70,6 @@ func CreateReaders(dbConfig *database.DatabaseConfig) (*Readers, error) {
 		return nil, err
 	}
 
-	queriesReader, err := queries.NewReader(dbConfig)
-	if err != nil {
-		return nil, err
-	}
-
 	execEnvReader, err := exec_env.NewReader(dbConfig)
 	if err != nil {
 		return nil, err
@@ -86,7 +79,6 @@ func CreateReaders(dbConfig *database.DatabaseConfig) (*Readers, error) {
 		OperatorReader:             operatorReader,
 		WorkflowReader:             workflowReader,
 		SchemaVersionReader:        schemaVersionReader,
-		CustomReader:               queriesReader,
 		ExecutionEnvironmentReader: execEnvReader,
 	}, nil
 }

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -80,8 +80,13 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			DAGResultRepo:      s.DAGResultRepo,
 		},
 		routes.GetArtifactVersionsRoute: &handler.GetArtifactVersionsHandler{
-			Database:     s.Database,
-			CustomReader: s.CustomReader,
+			Database: s.Database,
+
+			ArtifactRepo:       s.ArtifactRepo,
+			ArtifactResultRepo: s.ArtifactResultRepo,
+			DAGRepo:            s.DAGRepo,
+			OperatorRepo:       s.OperatorRepo,
+			OperatorResultRepo: s.OperatorResultRepo,
 		},
 		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
 		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{
@@ -150,9 +155,8 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			OperatorRepo:    s.OperatorRepo,
 		},
 		routes.ListWorkflowsRoute: &handler.ListWorkflowsHandler{
-			Database:     s.Database,
-			Vault:        s.Vault,
-			CustomReader: s.CustomReader,
+			Database: s.Database,
+			Vault:    s.Vault,
 
 			ArtifactRepo:       s.ArtifactRepo,
 			ArtifactResultRepo: s.ArtifactResultRepo,
@@ -185,9 +189,8 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			JobManager: s.JobManager,
 			Vault:      s.Vault,
 
-			CustomReader: s.CustomReader,
-
 			IntegrationRepo: s.IntegrationRepo,
+			OperatorRepo:    s.OperatorRepo,
 		},
 		routes.ListIntegrationObjectsRoute: &handler.ListIntegrationObjectsHandler{
 			Database:   s.Database,

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -30,12 +30,12 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			Database: s.Database,
 			Vault:    s.Vault,
 
-			CustomReader:   s.CustomReader,
 			OperatorReader: s.OperatorReader,
 
 			ExecutionEnvironmentReader: s.ExecutionEnvironmentReader,
 			ExecutionEnvironmentWriter: s.ExecutionEnvironmentWriter,
 
+			DAGRepo:         s.DAGRepo,
 			IntegrationRepo: s.IntegrationRepo,
 			OperatorRepo:    s.OperatorRepo,
 		},
@@ -144,9 +144,10 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 		routes.ListOperatorsForIntegrationRoute: &handler.ListOperatorsForIntegrationHandler{
 			Database:       s.Database,
 			OperatorReader: s.OperatorReader,
-			CustomReader:   s.CustomReader,
 
+			DAGRepo:         s.DAGRepo,
 			IntegrationRepo: s.IntegrationRepo,
+			OperatorRepo:    s.OperatorRepo,
 		},
 		routes.ListWorkflowsRoute: &handler.ListWorkflowsHandler{
 			Database:     s.Database,

--- a/src/golang/lib/models/views/artifact_result.go
+++ b/src/golang/lib/models/views/artifact_result.go
@@ -1,0 +1,17 @@
+package views
+
+import (
+	"time"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/google/uuid"
+)
+
+// ArtifactResultStatus contains the status of an ArtifactResult as well
+// as additional metadata
+type ArtifactResultStatus struct {
+	ArtifactID  uuid.UUID              `db:"artifact_id" json:"artifact_id"`
+	DAGResultID uuid.UUID              `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
+	Status      shared.ExecutionStatus `db:"status" json:"status"`
+	Timestamp   time.Time              `db:"timestamp" json:"timestamp"`
+}

--- a/src/golang/lib/models/views/id.go
+++ b/src/golang/lib/models/views/id.go
@@ -1,0 +1,8 @@
+package views
+
+import "github.com/google/uuid"
+
+// ObjectID is a wrapper around any ID
+type ObjectID struct {
+	ID uuid.UUID `db:"id" json:"id"`
+}

--- a/src/golang/lib/models/views/operator.go
+++ b/src/golang/lib/models/views/operator.go
@@ -28,3 +28,11 @@ type LoadOperatorSpec struct {
 	WorkflowID   uuid.UUID     `db:"workflow_id" json:"workflow_id"`
 	Spec         operator.Spec `db:"spec" json:"spec"`
 }
+
+// OperatorRelation is a wrapper around an Operator's ID and the IDs of
+// the Workflow and DAG it is associated to.
+type OperatorRelation struct {
+	WorkflowID uuid.UUID `db:"workflow_id" json:"workflow_id"`
+	DagID      uuid.UUID `db:"workflow_dag_id" json:"workflow_dag_id"`
+	OperatorID uuid.UUID `db:"operator_id" json:"operator_id"`
+}

--- a/src/golang/lib/models/views/operator.go
+++ b/src/golang/lib/models/views/operator.go
@@ -3,11 +3,12 @@ package views
 import (
 	"time"
 
+	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/google/uuid"
 )
 
-// Specifically used by GetDistinctLoadOperatorsByWorkflow
+// LoadOperator contains metadata about a Load Operator
 type LoadOperator struct {
 	OperatorName    string         `db:"operator_name" json:"operator_name"`
 	ModifiedAt      time.Time      `db:"modified_at" json:"modified_at"`
@@ -16,4 +17,14 @@ type LoadOperator struct {
 	Service         shared.Service `db:"service" json:"service"`
 	TableName       string         `db:"table_name" json:"object_name"`
 	UpdateMode      string         `db:"update_mode" json:"update_mode"`
+}
+
+// LoadOperatorSpec is a wrapper around a Load Operator's spec and other metadata
+type LoadOperatorSpec struct {
+	ArtifactID   uuid.UUID     `db:"artifact_id" json:"artifact_id"`
+	ArtifactName string        `db:"artifact_name" json:"artifact_name"`
+	OperatorID   uuid.UUID     `db:"load_operator_id" json:"load_operator_id"`
+	WorkflowName string        `db:"workflow_name" json:"workflow_name"`
+	WorkflowID   uuid.UUID     `db:"workflow_id" json:"workflow_id"`
+	Spec         operator.Spec `db:"spec" json:"spec"`
 }

--- a/src/golang/lib/models/views/operator_result.go
+++ b/src/golang/lib/models/views/operator_result.go
@@ -2,13 +2,15 @@ package views
 
 import (
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/google/uuid"
 )
 
 // OperatorResultStatus is a wrapper around the ExecutionState of an
 // OperatorResult and additional metadata.
 type OperatorResultStatus struct {
-	ArtifactID  uuid.UUID              `db:"artifact_id" json:"artifact_id"`
-	Metadata    *shared.ExecutionState `db:"metadata" json:"metadata"`
-	DAGResultID uuid.UUID              `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
+	ArtifactID   uuid.UUID              `db:"artifact_id"`
+	Metadata     *shared.ExecutionState `db:"metadata"`
+	DAGResultID  uuid.UUID              `db:"workflow_dag_result_id"`
+	OperatorName utils.NullString       `db:"operator_name"`
 }

--- a/src/golang/lib/models/views/operator_result.go
+++ b/src/golang/lib/models/views/operator_result.go
@@ -1,0 +1,14 @@
+package views
+
+import (
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/google/uuid"
+)
+
+// OperatorResultStatus is a wrapper around the ExecutionState of an
+// OperatorResult and additional metadata.
+type OperatorResultStatus struct {
+	ArtifactID  uuid.UUID              `db:"artifact_id" json:"artifact_id"`
+	Metadata    *shared.ExecutionState `db:"metadata" json:"metadata"`
+	DAGResultID uuid.UUID              `db:"workflow_dag_result_id" json:"workflow_dag_result_id"`
+}

--- a/src/golang/lib/models/views/workflow.go
+++ b/src/golang/lib/models/views/workflow.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow"
 	"github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/google/uuid"
 )
@@ -18,4 +19,12 @@ type LatestWorkflowStatus struct {
 	LastRunAt   utils.NullTime             `db:"last_run_at" json:"last_run_at"`
 	Status      shared.NullExecutionStatus `db:"status" json:"status"`
 	Engine      string                     `db:"engine" json:"engine"`
+}
+
+// WorkflowLastRun is a wrapper around the last run at time for a Workflow
+// and additional metadata.
+type WorkflowLastRun struct {
+	ID        uuid.UUID         `db:"workflow_id" json:"workflow_id"`
+	Schedule  workflow.Schedule `db:"schedule" json:"schedule"`
+	LastRunAt time.Time         `db:"last_run_at" json:"last_run_at"`
 }

--- a/src/golang/lib/repos/artifact.go
+++ b/src/golang/lib/repos/artifact.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
-	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -29,14 +28,14 @@ type artifactReader interface {
 	// GetByDAG returns the Artifacts created by the workflow DAG with ID dagID.
 	GetByDAG(ctx context.Context, dagID uuid.UUID, DB database.Database) ([]models.Artifact, error)
 
-	// GetIDsByDAGAndDownstreamOPBatch returns the ID of all Artifacts belonging to a DAG
+	// GetIDsByDAGAndDownstreamOPBatch returns a list of Artifact IDs belonging to a DAG
 	// in dagIDs if it is connected via a DAGEdge to an operator in operatorIDs.
 	GetIDsByDAGAndDownstreamOPBatch(
 		ctx context.Context,
 		dagIDs []uuid.UUID,
 		operatorIDs []uuid.UUID,
 		DB database.Database,
-	) ([]views.ObjectID, error)
+	) ([]uuid.UUID, error)
 
 	// ValidateOrg returns whether the Artifact was created by a user in orgID.
 	ValidateOrg(ctx context.Context, ID uuid.UUID, orgID string, DB database.Database) (bool, error)

--- a/src/golang/lib/repos/artifact.go
+++ b/src/golang/lib/repos/artifact.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -27,6 +28,15 @@ type artifactReader interface {
 
 	// GetByDAG returns the Artifacts created by the workflow DAG with ID dagID.
 	GetByDAG(ctx context.Context, dagID uuid.UUID, DB database.Database) ([]models.Artifact, error)
+
+	// GetIDsByDAGAndDownstreamOPBatch returns the ID of all Artifacts belonging to a DAG
+	// in dagIDs if it is connected via a DAGEdge to an operator in operatorIDs.
+	GetIDsByDAGAndDownstreamOPBatch(
+		ctx context.Context,
+		dagIDs []uuid.UUID,
+		operatorIDs []uuid.UUID,
+		DB database.Database,
+	) ([]views.ObjectID, error)
 
 	// ValidateOrg returns whether the Artifact was created by a user in orgID.
 	ValidateOrg(ctx context.Context, ID uuid.UUID, orgID string, DB database.Database) (bool, error)

--- a/src/golang/lib/repos/artifact_result.go
+++ b/src/golang/lib/repos/artifact_result.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -35,6 +36,10 @@ type artifactResultReader interface {
 
 	// GetByDAGResults returns the ArtifactResult from a workflow DAG result with an ID in the dagResultIDs list.
 	GetByDAGResults(ctx context.Context, dagResultIDs []uuid.UUID, DB database.Database) ([]models.ArtifactResult, error)
+
+	// GetStatusByArtifactBatch returns an ArtifactResultStatus for each ArtifactResult associated
+	// with an Artifact in artifactIDs.
+	GetStatusByArtifactBatch(ctx context.Context, artifactIDs []uuid.UUID, DB database.Database) ([]views.ArtifactResultStatus, error)
 }
 
 type artifactResultWriter interface {

--- a/src/golang/lib/repos/dag.go
+++ b/src/golang/lib/repos/dag.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -40,6 +41,19 @@ type dagReader interface {
 	// GetLatestByWorkflow returns the latest DAG for the Workflow specified.
 	// It returns a database.ErrNoRows if no rows are found.
 	GetLatestByWorkflow(ctx context.Context, workflowID uuid.UUID, DB database.Database) (*models.DAG, error)
+
+	// GetLatestIDsByOrg returns the IDs of the latest DAG for all Workflows created by
+	// the organization specified.
+	GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.ObjectID, error)
+
+	// GetLatestIDsByOrg returns the IDs of the latest DAG for all Workflows created by
+	// the organization specified if the DAG is running on the given engine.
+	GetLatestIDsByOrgAndEngine(
+		ctx context.Context,
+		orgID string,
+		engine shared.EngineType,
+		DB database.Database,
+	) ([]views.ObjectID, error)
 
 	// List returns all DAGs.
 	List(ctx context.Context, DB database.Database) ([]models.DAG, error)

--- a/src/golang/lib/repos/dag.go
+++ b/src/golang/lib/repos/dag.go
@@ -6,7 +6,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
-	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -48,7 +47,7 @@ type dagReader interface {
 
 	// GetLatestIDsByOrg returns the IDs of the latest DAG for all Workflows created by
 	// the organization specified.
-	GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.ObjectID, error)
+	GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]uuid.UUID, error)
 
 	// GetLatestIDsByOrg returns the IDs of the latest DAG for all Workflows created by
 	// the organization specified if the DAG is running on the given engine.
@@ -57,7 +56,7 @@ type dagReader interface {
 		orgID string,
 		engine shared.EngineType,
 		DB database.Database,
-	) ([]views.ObjectID, error)
+	) ([]uuid.UUID, error)
 
 	// List returns all DAGs.
 	List(ctx context.Context, DB database.Database) ([]models.DAG, error)

--- a/src/golang/lib/repos/dag.go
+++ b/src/golang/lib/repos/dag.go
@@ -42,6 +42,10 @@ type dagReader interface {
 	// It returns a database.ErrNoRows if no rows are found.
 	GetLatestByWorkflow(ctx context.Context, workflowID uuid.UUID, DB database.Database) (*models.DAG, error)
 
+	// GetLatestIDByWorkflowBatch returns a map of each Workflow ID in workflowIDs
+	// to the ID of the latest DAG for that Workflow.
+	GetLatestIDByWorkflowBatch(ctx context.Context, workflowIDs []uuid.UUID, DB database.Database) (map[uuid.UUID]uuid.UUID, error)
+
 	// GetLatestIDsByOrg returns the IDs of the latest DAG for all Workflows created by
 	// the organization specified.
 	GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.ObjectID, error)

--- a/src/golang/lib/repos/operator.go
+++ b/src/golang/lib/repos/operator.go
@@ -56,8 +56,11 @@ type operatorReader interface {
 	// organization's Workflows.
 	GetLoadOPSpecsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.LoadOperatorSpec, error)
 
+	// GetRelationBatch returns an OperatorRelation for each Operator in IDs.
+	GetRelationBatch(ctx context.Context, IDs []uuid.UUID, DB database.Database) ([]views.OperatorRelation, error)
+
 	// ValidateOrg returns whether the Operator was created by the specified organization.
-	ValidateOrg(ctx context.Context, operatorId uuid.UUID, orgID string, DB database.Database) (bool, error)
+	ValidateOrg(ctx context.Context, ID uuid.UUID, orgID string, DB database.Database) (bool, error)
 }
 
 type operatorWriter interface {

--- a/src/golang/lib/repos/operator.go
+++ b/src/golang/lib/repos/operator.go
@@ -52,6 +52,10 @@ type operatorReader interface {
 		DB database.Database,
 	) ([]models.Operator, error)
 
+	// GetLoadOPSpecsByOrg returns a LoadOperatorSpec for each Load Operator in any of the specified
+	// organization's Workflows.
+	GetLoadOPSpecsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.LoadOperatorSpec, error)
+
 	// ValidateOrg returns whether the Operator was created by the specified organization.
 	ValidateOrg(ctx context.Context, operatorId uuid.UUID, orgID string, DB database.Database) (bool, error)
 }

--- a/src/golang/lib/repos/operator_result.go
+++ b/src/golang/lib/repos/operator_result.go
@@ -29,6 +29,15 @@ type operatorResultReader interface {
 	// GetByDAGResultBatch returns all OperatorResults for the DAGResults specified.
 	GetByDAGResultBatch(ctx context.Context, dagResultIDs []uuid.UUID, DB database.Database) ([]models.OperatorResult, error)
 
+	// GetCheckStatusByArtifactBatch returns an OperatorResultStatus for all OperatorResults
+	// associated with a Check Operator where the Operator has incoming DAGEdge
+	// from an Artifact in artifactIDs.
+	GetCheckStatusByArtifactBatch(
+		ctx context.Context,
+		artifactIDs []uuid.UUID,
+		DB database.Database,
+	) ([]views.OperatorResultStatus, error)
+
 	// GetStatusByDAGResultAndArtifactBatch returns an OperatorResultStatus for each
 	// OperatorResult belonging to a DAGResult in dagResultIDs where the OperatorResult
 	// corresponds to an Operator that has an outgoing DAGEdge to an Artifact in artifactIDs.

--- a/src/golang/lib/repos/operator_result.go
+++ b/src/golang/lib/repos/operator_result.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 )
 
@@ -27,6 +28,16 @@ type operatorResultReader interface {
 
 	// GetByDAGResultBatch returns all OperatorResults for the DAGResults specified.
 	GetByDAGResultBatch(ctx context.Context, dagResultIDs []uuid.UUID, DB database.Database) ([]models.OperatorResult, error)
+
+	// GetStatusByDAGResultAndArtifactBatch returns an OperatorResultStatus for each
+	// OperatorResult belonging to a DAGResult in dagResultIDs where the OperatorResult
+	// corresponds to an Operator that has an outgoing DAGEdge to an Artifact in artifactIDs.
+	GetStatusByDAGResultAndArtifactBatch(
+		ctx context.Context,
+		dagResultIDs []uuid.UUID,
+		artifactIDs []uuid.UUID,
+		DB database.Database,
+	) ([]views.OperatorResultStatus, error)
 }
 
 type operatorResultWriter interface {

--- a/src/golang/lib/repos/sqlite/artifact.go
+++ b/src/golang/lib/repos/sqlite/artifact.go
@@ -83,7 +83,7 @@ func (*artifactReader) GetIDsByDAGAndDownstreamOPBatch(
 	dagIDs []uuid.UUID,
 	operatorIDs []uuid.UUID,
 	DB database.Database,
-) ([]views.ObjectID, error) {
+) ([]uuid.UUID, error) {
 	// Get all the unique `artifact_id`s with an outgoing edge to an operator specified by `operatorIds`
 	// from workflow DAGs specified by `workflowDagIds`.
 	query := fmt.Sprintf(
@@ -101,7 +101,16 @@ func (*artifactReader) GetIDsByDAGAndDownstreamOPBatch(
 
 	var objectIDs []views.ObjectID
 	err := DB.Query(ctx, &objectIDs, query, args...)
-	return objectIDs, err
+	if err != nil {
+		return nil, err
+	}
+
+	IDs := make([]uuid.UUID, 0, len(objectIDs))
+	for _, objectID := range objectIDs {
+		IDs = append(IDs, objectID.ID)
+	}
+
+	return IDs, nil
 }
 
 func (*artifactReader) ValidateOrg(ctx context.Context, ID uuid.UUID, orgID string, DB database.Database) (bool, error) {

--- a/src/golang/lib/repos/sqlite/dag.go
+++ b/src/golang/lib/repos/sqlite/dag.go
@@ -207,7 +207,7 @@ func (*dagReader) GetLatestIDByWorkflowBatch(
 	return workflowToDAG, nil
 }
 
-func (*dagReader) GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.ObjectID, error) {
+func (*dagReader) GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]uuid.UUID, error) {
 	query := `
 		SELECT workflow_dag.id 
 		FROM workflow_dag 
@@ -225,7 +225,16 @@ func (*dagReader) GetLatestIDsByOrg(ctx context.Context, orgID string, DB databa
 
 	var objectIDs []views.ObjectID
 	err := DB.Query(ctx, &objectIDs, query, args...)
-	return objectIDs, err
+	if err != nil {
+		return nil, err
+	}
+
+	IDs := make([]uuid.UUID, 0, len(objectIDs))
+	for _, objectID := range objectIDs {
+		IDs = append(IDs, objectID.ID)
+	}
+
+	return IDs, nil
 }
 
 func (*dagReader) GetLatestIDsByOrgAndEngine(
@@ -233,7 +242,7 @@ func (*dagReader) GetLatestIDsByOrgAndEngine(
 	orgID string,
 	engine shared.EngineType,
 	DB database.Database,
-) ([]views.ObjectID, error) {
+) ([]uuid.UUID, error) {
 	query := `
 		SELECT workflow_dag.id 
 		FROM workflow_dag 
@@ -252,7 +261,16 @@ func (*dagReader) GetLatestIDsByOrgAndEngine(
 
 	var objectIDs []views.ObjectID
 	err := DB.Query(ctx, &objectIDs, query, args...)
-	return objectIDs, err
+	if err != nil {
+		return nil, err
+	}
+
+	IDs := make([]uuid.UUID, 0, len(objectIDs))
+	for _, objectID := range objectIDs {
+		IDs = append(IDs, objectID.ID)
+	}
+
+	return IDs, nil
 }
 
 func (*dagReader) List(ctx context.Context, DB database.Database) ([]models.DAG, error) {

--- a/src/golang/lib/repos/sqlite/dag.go
+++ b/src/golang/lib/repos/sqlite/dag.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
 	"github.com/aqueducthq/aqueduct/lib/models"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
@@ -164,6 +165,54 @@ func (*dagReader) GetLatestByWorkflow(ctx context.Context, workflowID uuid.UUID,
 	args := []interface{}{workflowID}
 
 	return getDAG(ctx, DB, query, args...)
+}
+
+func (*dagReader) GetLatestIDsByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.ObjectID, error) {
+	query := `
+		SELECT workflow_dag.id 
+		FROM workflow_dag 
+		WHERE created_at IN 
+		(
+			SELECT MAX(workflow_dag.created_at) 
+			FROM app_user, workflow, workflow_dag 
+			WHERE 
+				app_user.id = workflow.user_id 
+				AND workflow.id = workflow_dag.workflow_id 
+				AND app_user.organization_id = $1 
+			GROUP BY workflow.id
+		);`
+	args := []interface{}{orgID}
+
+	var objectIDs []views.ObjectID
+	err := DB.Query(ctx, &objectIDs, query, args...)
+	return objectIDs, err
+}
+
+func (*dagReader) GetLatestIDsByOrgAndEngine(
+	ctx context.Context,
+	orgID string,
+	engine shared.EngineType,
+	DB database.Database,
+) ([]views.ObjectID, error) {
+	query := `
+		SELECT workflow_dag.id 
+		FROM workflow_dag 
+		WHERE created_at IN 
+		(
+			SELECT MAX(workflow_dag.created_at) 
+			FROM app_user, workflow, workflow_dag 
+			WHERE 
+				app_user.id = workflow.user_id 
+				AND workflow.id = workflow_dag.workflow_id 
+				AND app_user.organization_id = $1 
+				AND json_extract(workflow_dag.engine_config, '$.type') = $2
+		 	GROUP BY workflow.id
+		);`
+	args := []interface{}{orgID, engine}
+
+	var objectIDs []views.ObjectID
+	err := DB.Query(ctx, &objectIDs, query, args...)
+	return objectIDs, err
 }
 
 func (*dagReader) List(ctx context.Context, DB database.Database) ([]models.DAG, error) {

--- a/src/golang/lib/repos/sqlite/operator.go
+++ b/src/golang/lib/repos/sqlite/operator.go
@@ -217,8 +217,57 @@ func (*operatorReader) GetLoadOPSpecsByOrg(ctx context.Context, orgID string, DB
 	return specs, err
 }
 
-func (*operatorReader) ValidateOrg(ctx context.Context, operatorId uuid.UUID, orgID string, DB database.Database) (bool, error) {
-	return utils.ValidateNodeOwnership(ctx, orgID, operatorId, DB)
+func (*operatorReader) GetRelationBatch(
+	ctx context.Context,
+	IDs []uuid.UUID,
+	DB database.Database,
+) ([]views.OperatorRelation, error) {
+	// Given a list of `operatorIds`, find all workflow DAGs that has the id in the
+	// `from_id` or `to_id` field.
+	query := fmt.Sprintf(
+		`
+		SELECT
+			workflow.id as workflow_id,
+			workflow_dag.id as workflow_dag_id,
+			workflow_dag_edge.from_id as operator_id
+		FROM
+			workflow,
+			workflow_dag,
+			workflow_dag_edge 
+		WHERE 
+			workflow_dag_edge.workflow_dag_id = workflow_dag.id
+			AND workflow.id = workflow_dag.workflow_id
+			AND workflow_dag_edge.type = '%s'
+			AND workflow_dag_edge.from_id IN (%s)
+		UNION
+		SELECT
+			workflow.id as workflow_id,
+			workflow_dag.id as workflow_dag_id,
+			workflow_dag_edge.to_id as operator_id
+		FROM
+			workflow,
+			workflow_dag,
+			workflow_dag_edge 
+		WHERE 
+			workflow_dag_edge.workflow_dag_id = workflow_dag.id
+			AND workflow.id = workflow_dag.workflow_id
+			AND workflow_dag_edge.type = '%s'
+			AND workflow_dag_edge.to_id IN (%s)
+		`,
+		shared.OperatorToArtifactDAGEdge,
+		stmt_preparers.GenerateArgsList(len(IDs), 1),
+		shared.ArtifactToOperatorDAGEdge,
+		stmt_preparers.GenerateArgsList(len(IDs), 1),
+	)
+	args := stmt_preparers.CastIdsListToInterfaceList(IDs)
+
+	var relations []views.OperatorRelation
+	err := DB.Query(ctx, &relations, query, args...)
+	return relations, err
+}
+
+func (*operatorReader) ValidateOrg(ctx context.Context, ID uuid.UUID, orgID string, DB database.Database) (bool, error) {
+	return utils.ValidateNodeOwnership(ctx, orgID, ID, DB)
 }
 
 func (*operatorWriter) Create(

--- a/src/golang/lib/repos/workflow.go
+++ b/src/golang/lib/repos/workflow.go
@@ -3,6 +3,7 @@ package repos
 import (
 	"context"
 
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	"github.com/aqueducthq/aqueduct/lib/collections/workflow"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/models"
@@ -31,6 +32,10 @@ type workflowReader interface {
 	// GetByOwnerAndName returns the workflow created by ownerID named name.
 	// It returns a database.ErrNoRows if no rows are found.
 	GetByOwnerAndName(ctx context.Context, ownerID uuid.UUID, name string, DB database.Database) (*models.Workflow, error)
+
+	// GetLastRunByEngine returns a WorkflowLastRun for each Workflow where the latest
+	// DAGResult created is associated with a DAG running on engine.
+	GetLastRunByEngine(ctx context.Context, engine shared.EngineType, DB database.Database) ([]views.WorkflowLastRun, error)
 
 	// GetLatestStatusesByOrg returns the LatestWorkflowStatus for each workflow owned by orgID.
 	GetLatestStatusesByOrg(ctx context.Context, orgID string, DB database.Database) ([]views.LatestWorkflowStatus, error)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR takes all of the adhoc "custom" queries and turns them into the relevant `Views` and `Repos`. The motivation was to make these queries as clean as possible in terms of fitting into a Repo that made logical sense, rather than having a collection of adhoc queries. 

TODO: Writing the database integration tests.

## Related issue number (if any)
ENG 1903

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


