### PR TITLE
Fixes bug where canvas position is reset after clicking into a node.

### DIFF
--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -28,22 +28,11 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     (state: RootState) => state.workflowReducer.selectedDagPosition
   );
 
-  const currentNode = useSelector(
-    (state: RootState) => state.nodeSelectionReducer.selected
-  );
-
   const { fitView } = useReactFlow();
-  useEffect(() => {
-    setTimeout(fitView, 1000);
-  }, [dagPositionState, fitView]);
 
   useEffect(() => {
-    // NOTE(vikram): There's a timeout here because there seems to be a
-    // race condition between calling `fitView` and the viewport
-    // updating. This might be because of the width transition we use, but
-    // we're not 100% sure.
-    setTimeout(fitView, 100);
-  }, [currentNode, fitView]);
+    fitView();
+  }, [dagPositionState, fitView]);
 
   const { edges, nodes } = dagPositionState.result ?? { edges: [], nodes: [] };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR updates the logic behind when fitView() is called on the workflow details page and makes it so that the DAG view no longer jumps around when users select a node to view.

## Related issue number (if any)
ENG-1878

## Loom demo (if any)
https://www.loom.com/share/bd357e19051e477e9720233eba2a8428

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


