### PR TITLE
Backfill python type of previously created artifact results

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -26,7 +26,7 @@ server_directory = join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = join(os.environ["HOME"], ".aqueduct", "ui")
 
 # Make sure to update this if there is any schema change we want to include in the upgrade.
-SCHEMA_VERSION = "21"
+SCHEMA_VERSION = "22"
 
 
 def execute_command(args, cwd=None):

--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -24,6 +24,7 @@ import (
 	_000019 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000019_add_serialization_type_value_to_param_op"
 	_000020 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000020_add_execution_environment_table"
 	_000021 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000021_add_gc_column_to_env_table"
+	_000022 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000022_backfill_python_type"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -156,5 +157,11 @@ func init() {
 		upPostgres: _000021.UpPostgres, upSqlite: _000021.UpSqlite,
 		downPostgres: _000021.DownPostgres,
 		name:         "add gc column to the execution environment table",
+	}
+
+	registeredMigrations[22] = &migration{
+		upPostgres: _000022.Up, upSqlite: _000022.Up,
+		downPostgres: _000022.Down,
+		name:         "backfill python type to the artifact result table",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000022_backfill_python_type/main.go
+++ b/src/golang/cmd/migrator/versions/000022_backfill_python_type/main.go
@@ -1,0 +1,48 @@
+package _000022_backfill_python_type
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/aqueducthq/aqueduct/config"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	log "github.com/sirupsen/logrus"
+)
+
+var confPath = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "config", "config.yml")
+
+func Up(ctx context.Context, db database.Database) error {
+	artifactResults, err := getAllArtifactResults(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	if err := config.Init(confPath); err != nil {
+		return err
+	}
+
+	sConfig := config.Storage()
+	storageConfig := &sConfig
+
+	for _, artifactResult := range artifactResults {
+		if !artifactResult.Metadata.IsNull {
+			err = backfillPythonType(
+				ctx,
+				artifactResult.Metadata.SerializationType,
+				artifactResult.ContentPath,
+				storageConfig,
+				db,
+			)
+			if err != nil {
+				log.Errorf("Error backfilling Python type for artifact result %s: %v", artifactResult.Id, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func Down(ctx context.Context, db database.Database) error {
+	return nil
+}

--- a/src/golang/cmd/migrator/versions/000022_backfill_python_type/main.go
+++ b/src/golang/cmd/migrator/versions/000022_backfill_python_type/main.go
@@ -29,7 +29,8 @@ func Up(ctx context.Context, db database.Database) error {
 		if !artifactResult.Metadata.IsNull {
 			err = backfillPythonType(
 				ctx,
-				artifactResult.Metadata.SerializationType,
+				artifactResult.Id,
+				&(artifactResult.Metadata.Metadata),
 				artifactResult.ContentPath,
 				storageConfig,
 				db,
@@ -44,5 +45,6 @@ func Up(ctx context.Context, db database.Database) error {
 }
 
 func Down(ctx context.Context, db database.Database) error {
+	// We do not support down migration for our OSS version, so this implementation is left empty.
 	return nil
 }

--- a/src/golang/cmd/migrator/versions/000022_backfill_python_type/utils.go
+++ b/src/golang/cmd/migrator/versions/000022_backfill_python_type/utils.go
@@ -1,0 +1,156 @@
+package _000022_backfill_python_type
+
+import (
+	"bytes"
+	"context"
+	"database/sql/driver"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/gofrs/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	pythonExecutorPackage = "aqueduct_executor"
+	migrationPythonPath   = "migrators.backfill_python_type_000022.main"
+)
+
+type SerializationType string
+
+type ArtifactType string
+
+type Metadata struct {
+	Schema []map[string]string // Table Schema from Pandas
+	// Metrics from the system regarding the op used to create the artifact result.
+	// A key/value pair of [metricname]metricvalue e.g. SystemMetric["runtime"] -> "3.65"
+	SystemMetrics     map[string]string `json:"system_metadata,omitempty"`
+	SerializationType SerializationType `json:"serialization_type,omitempty"`
+	ArtifactType      ArtifactType      `json:"artifact_type,omitempty"`
+	PythonType        string            `json:"python_type,omitempty"`
+}
+
+type NullMetadata struct {
+	Metadata
+	IsNull bool
+}
+
+func (m *Metadata) Value() (driver.Value, error) {
+	return utils.ValueJsonB(*m)
+}
+
+func (m *Metadata) Scan(value interface{}) error {
+	return utils.ScanJsonB(value, m)
+}
+
+func (n *NullMetadata) Value() (driver.Value, error) {
+	if n.IsNull {
+		return nil, nil
+	}
+
+	return (&n.Metadata).Value()
+}
+
+func (n *NullMetadata) Scan(value interface{}) error {
+	if value == nil {
+		n.IsNull = true
+		return nil
+	}
+
+	metadata := &Metadata{}
+	if err := metadata.Scan(value); err != nil {
+		return err
+	}
+
+	n.Metadata, n.IsNull = *metadata, false
+	return nil
+}
+
+type ArtifactResult struct {
+	Id          uuid.UUID    `db:"id" json:"id"`
+	ContentPath string       `db:"content_path" json:"content_path"`
+	Metadata    NullMetadata `db:"metadata" json:"metadata"`
+}
+
+type MigrationSpec struct {
+	SerializationType SerializationType    `json:"serialization_type"`
+	StorageConfig     shared.StorageConfig `json:"storage_config"`
+	ContentPath       string               `json:"content_path"`
+}
+
+func getAllArtifactResults(
+	ctx context.Context,
+	db database.Database,
+) ([]ArtifactResult, error) {
+	query := "SELECT id, content_path, metadata FROM artifact_result;"
+
+	var response []ArtifactResult
+	err := db.Query(ctx, &response, query)
+	return response, err
+}
+
+func backfillPythonType(
+	ctx context.Context,
+	serializationType SerializationType,
+	contentPath string,
+	storageConfig *shared.StorageConfig,
+	db database.Database,
+) error {
+	migrationSpec := MigrationSpec{
+		SerializationType: serializationType,
+		StorageConfig:     *storageConfig,
+		ContentPath:       contentPath,
+	}
+
+	_, err := json.Marshal(migrationSpec)
+	if err != nil {
+		return err
+	}
+
+	// Launch the Python job to infer the type of the parameter value
+	cmd := exec.Command(
+		"python3",
+		"-m",
+		fmt.Sprintf("%s.%s", pythonExecutorPackage, migrationPythonPath),
+		"--spec",
+		base64.StdEncoding.EncodeToString(specData),
+	)
+	cmd.Env = os.Environ()
+
+	var outb, errb bytes.Buffer
+	cmd.Stdout = &outb
+	cmd.Stderr = &errb
+
+	err = cmd.Run()
+	if err != nil {
+		log.Errorf("Error running Python migration job. Stdout: %s, Stderr: %s.", outb.String(), errb.String())
+		return err
+	}
+
+	outputs := strings.Split(outb.String(), "\n")
+	param_type := outputs[0]
+	param_val = outputs[1]
+	operator.OpSpec.Param[serialization_type_key] = param_type
+
+	// We also change the param value to be a base64 encoding
+	operator.OpSpec.Param[value_key] = param_val
+
+	newParamSpec := &Spec{
+		Type:  operator.OpSpec.Type,
+		Param: operator.OpSpec.Param,
+	}
+
+	changes := map[string]interface{}{
+		spec_field: newParamSpec,
+	}
+
+	return utils.UpdateRecord(ctx, changes, "operator", "id", operator.Id, db)
+	return nil
+}

--- a/src/golang/lib/models/schema.go
+++ b/src/golang/lib/models/schema.go
@@ -4,4 +4,4 @@ package models
 // This is the source of truth for the required schema version
 // for both the server and executor. This value MUST be updated
 // when a new schema change is added.
-const SchemaVersion = 21
+const SchemaVersion = 22

--- a/src/python/aqueduct_executor/migrators/backfill_python_type_000022/execute.py
+++ b/src/python/aqueduct_executor/migrators/backfill_python_type_000022/execute.py
@@ -1,0 +1,16 @@
+import base64
+import json
+
+from aqueduct_executor.migrators.backfill_python_type_000022 import serialize
+from aqueduct_executor.migrators.backfill_python_type_000022.spec import MigrationSpec
+from aqueduct_executor.operators.utils.storage.parse import parse_storage
+
+
+def run(spec: MigrationSpec) -> None:
+    storage = parse_storage(spec.storage_config)
+    content = storage.get(spec.content_path)
+
+    deserialized_content = serialize.deserialization_function_mapping[spec.serialization_type](
+        content
+    )
+    print(type(deserialized_content).__name__)

--- a/src/python/aqueduct_executor/migrators/backfill_python_type_000022/main.py
+++ b/src/python/aqueduct_executor/migrators/backfill_python_type_000022/main.py
@@ -1,0 +1,15 @@
+import argparse
+import base64
+
+from aqueduct_executor.migrators.backfill_python_type_000022 import execute
+from aqueduct_executor.migrators.backfill_python_type_000022.spec import parse_spec
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--spec", required=True)
+    args = parser.parse_args()
+
+    spec_json = base64.b64decode(args.spec)
+    spec = parse_spec(spec_json)
+
+    execute.run(spec)

--- a/src/python/aqueduct_executor/migrators/backfill_python_type_000022/serialize.py
+++ b/src/python/aqueduct_executor/migrators/backfill_python_type_000022/serialize.py
@@ -1,0 +1,64 @@
+import base64
+import io
+import json
+from typing import Any, Callable, Dict, cast
+
+import cloudpickle as pickle
+import pandas as pd
+from aqueduct_executor.operators.utils.enums import ArtifactType, SerializationType
+from PIL import Image
+
+_DEFAULT_ENCODING = "utf8"
+
+
+def _read_table_content(content: bytes) -> pd.DataFrame:
+    return pd.read_json(io.BytesIO(content), orient="table")
+
+
+def _read_json_content(content: bytes) -> Any:
+    return json.loads(content.decode(_DEFAULT_ENCODING))
+
+
+def _read_pickle_content(content: bytes) -> Any:
+    return pickle.loads(content)
+
+
+def _read_image_content(content: bytes) -> Image.Image:
+    return Image.open(io.BytesIO(content))
+
+
+def _read_string_content(content: bytes) -> str:
+    return content.decode(_DEFAULT_ENCODING)
+
+
+def _read_bytes_content(content: bytes) -> bytes:
+    return content
+
+
+# Returns a tf.keras.Model type. We don't assume that every user has it installed,
+# so we return "Any" type.
+def _read_tf_keras_model(content: bytes) -> Any:
+    temp_model_dir = None
+    try:
+        temp_model_dir = make_temp_dir()
+        model_file_path = os.path.join(temp_model_dir, _TEMP_KERAS_MODEL_NAME)
+        with open(model_file_path, "wb") as f:
+            f.write(content)
+
+        from tensorflow import keras
+
+        return keras.load_model(model_file_path)
+    finally:
+        if temp_model_dir is not None and os.path.exists(temp_model_dir):
+            shutil.rmtree(temp_model_dir)
+
+
+deserialization_function_mapping: Dict[str, Callable[[bytes], Any]] = {
+    SerializationType.TABLE: _read_table_content,
+    SerializationType.JSON: _read_json_content,
+    SerializationType.PICKLE: _read_pickle_content,
+    SerializationType.IMAGE: _read_image_content,
+    SerializationType.STRING: _read_string_content,
+    SerializationType.BYTES: _read_bytes_content,
+    SerializationType.TF_KERAS: _read_tf_keras_model,
+}

--- a/src/python/aqueduct_executor/migrators/backfill_python_type_000022/serialize.py
+++ b/src/python/aqueduct_executor/migrators/backfill_python_type_000022/serialize.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import uuid
+from pathlib import Path
 from typing import Any, Callable, Dict, cast
 
 import cloudpickle as pickle

--- a/src/python/aqueduct_executor/migrators/backfill_python_type_000022/spec.py
+++ b/src/python/aqueduct_executor/migrators/backfill_python_type_000022/spec.py
@@ -1,0 +1,18 @@
+import json
+
+from aqueduct_executor.operators.utils.storage import config
+from pydantic import BaseModel, parse_obj_as
+
+
+class MigrationSpec(BaseModel):
+    serialization_type: str
+    storage_config: config.StorageConfig
+    content_path: str
+
+
+def parse_spec(spec_json: bytes) -> MigrationSpec:
+    """
+    Parses a JSON string into a FunctionSpec.
+    """
+    data = json.loads(spec_json)
+    return parse_obj_as(MigrationSpec, data)

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -20,7 +20,7 @@ import yaml
 from packaging.version import parse as parse_version
 from tqdm import tqdm
 
-SCHEMA_VERSION = "21"
+SCHEMA_VERSION = "22"
 CHUNK_SIZE = 4096
 
 base_directory = os.path.join(os.environ["HOME"], ".aqueduct")


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR performs a data migration that backfills the python type of previously created artifact results. I manually ran a regression test and verified that the python types were successfully backfilled.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


