### PR TITLE
Fix SDK imports for CheckSeverity and LoadUpdateMode

### DIFF
--- a/integration_tests/sdk/package_test.py
+++ b/integration_tests/sdk/package_test.py
@@ -1,5 +1,6 @@
 import aqueduct
 
+
 # runs a test to ensure all APIs are accessible from `aqueduct` package.
 def test_package_methods():
     # schedule related

--- a/integration_tests/sdk/package_test.py
+++ b/integration_tests/sdk/package_test.py
@@ -1,0 +1,28 @@
+import aqueduct
+
+# runs a test to ensure all APIs are accessible from `aqueduct` package.
+def test_package_methods():
+    # schedule related
+    aqueduct.DayOfMonth
+    aqueduct.DayOfWeek
+    aqueduct.Hour
+    aqueduct.Minute
+    aqueduct.hourly
+    aqueduct.daily
+    aqueduct.monthly
+    aqueduct.weekly
+
+    # decorators
+    aqueduct.op
+    aqueduct.check
+    aqueduct.metric
+
+    # decorators related
+    aqueduct.CheckSeverity
+    aqueduct.LoadUpdateMode
+
+    # notebook related
+    aqueduct.get_apikey
+    aqueduct.infer_requirements
+    aqueduct.global_config
+    aqueduct.to_operator

--- a/sdk/aqueduct/__init__.py
+++ b/sdk/aqueduct/__init__.py
@@ -2,6 +2,7 @@ from typing import Any, List
 
 from aqueduct.client import Client, get_apikey, global_config, infer_requirements
 from aqueduct.constants import exports
+from aqueduct.constants.enums import CheckSeverity, LoadUpdateMode
 from aqueduct.decorator import check, metric, op, to_operator
 from aqueduct.flow import Flow
 from aqueduct.schedule import DayOfMonth, DayOfWeek, Hour, Minute, daily, hourly, monthly, weekly


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the issue that we could import `CheckSeverity` and `LoadUpdateMode` directly from `aqueduct` package. We also added an integration test to ensure all APIs linked to `aqueduct` is accessible.

## Related issue number (if any)
ENG-2097

## Test
The added test failed before fix, passed after fix.

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


