### PR TITLE
Fix bug where delete confirmation dialog is massive

### DIFF
--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -662,7 +662,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     <Dialog
       open={showSavedObjectDeletionResultsDialog}
       onClose={() => navigate('/workflows')}
-      maxWidth={false}
+      maxWidth="sm"
       fullWidth
     >
       <DialogTitle>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
As title.
Before:
<img width="663" alt="Screen Shot 2022-12-13 at 12 18 43 PM" src="https://user-images.githubusercontent.com/78303449/207435314-1f22ccc6-4fd9-46ac-b32f-b15f99322e6c.png">

After:
<img width="990" alt="Screen Shot 2022-12-12 at 12 49 50 PM" src="https://user-images.githubusercontent.com/78303449/207435072-ff051b7e-edb9-43aa-b9d8-d056a38953c2.png">

## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-1927/fix-bug-where-delete-confirmation-dialog-is-massive
## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


