### PR TITLE
Bugfixes: Workflows Page and Data Page

### DIFF
--- a/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
@@ -89,6 +89,9 @@ export const CheckItem: React.FC<CheckItemProps> = ({ checks }) => {
         }
         case ExecutionStatus.Failed: {
           statusIcon = errorIcon;
+          if (checks[i].level === CheckLevel.Warning) {
+            statusIcon = warningIcon;
+          }
           break;
         }
         case ExecutionStatus.Succeeded: {

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -73,28 +73,34 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     const engineIconUrl =
       ServiceLogos[value.engine[0].toUpperCase() + value.engine.substring(1)];
 
-    const metrics = value.metrics.map((metric) => {
-      return {
-        metricId: metric.id,
-        name: metric.name,
-        value: metric.result?.content_serialized ?? '',
-        status: metric.result?.exec_state?.status ?? ExecutionStatus.Unknown,
-      };
-    });
+    let metrics = [];
+    if (value?.metrics) {
+      metrics = value.metrics.map((metric) => {
+        return {
+          metricId: metric.id,
+          name: metric.name,
+          value: metric.result?.content_serialized ?? '',
+          status: metric.result?.exec_state?.status ?? ExecutionStatus.Unknown,
+        };
+      });
+    }
 
-    const checks = value.checks.map((check) => {
-      const value =
-        check.result?.exec_state.status === 'succeeded' ? 'True' : 'False';
+    let checks = [];
+    if (value.checks) {
+      checks = value.checks.map((check) => {
+        const value =
+          check.result?.exec_state.status === 'succeeded' ? 'True' : 'False';
 
-      return {
-        checkId: check.id,
-        name: check.name,
-        level: check.spec?.check?.level ?? CheckLevel.Warning,
-        timestamp: check.result?.exec_state?.timestamps?.finished_at ?? '',
-        value,
-        status: check.result?.exec_state?.status ?? ExecutionStatus.Unknown,
-      };
-    });
+        return {
+          checkId: check.id,
+          name: check.name,
+          level: check.spec?.check?.level ?? CheckLevel.Warning,
+          timestamp: check.result?.exec_state?.timestamps?.finished_at ?? '',
+          value,
+          status: check.result?.exec_state?.status ?? ExecutionStatus.Unknown,
+        };
+      });
+    }
 
     const workflowTableRow: PaginatedSearchTableRow = {
       name: {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes two bugs with new workflows page:

1. Fix crash when no workflows are present. 
3. Fixes issue where warning checks aren't rendered as warning icons in workflows and data tables.

## Related issue number (if any)

## Loom demo (if any)
https://www.loom.com/share/aee6e427ff304f81b397c1040ea1cdcd

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


