### PR TITLE
[UI] Add engine_config field to operator spec

### DIFF
--- a/src/ui/common/src/utils/engine.ts
+++ b/src/ui/common/src/utils/engine.ts
@@ -7,9 +7,23 @@ export enum EngineType {
 
 export type EngineConfig = {
   type: EngineType;
+  aqueduct_config?: AqueductConfig;
   airflow_config?: AirflowConfig;
+  k8s_config?: K8sConfig;
+  lambda_config?: LambdaConfig;
 };
 
+export type AqueductConfig = {};
+
 export type AirflowConfig = {
+  integration_id: string;
   matches_airflow: boolean;
+};
+
+export type K8sConfig = {
+  integration_id: string;
+};
+
+export type LambdaConfig = {
+  integration_id: string;
 };

--- a/src/ui/common/src/utils/engine.ts
+++ b/src/ui/common/src/utils/engine.ts
@@ -13,7 +13,7 @@ export type EngineConfig = {
   lambda_config?: LambdaConfig;
 };
 
-export type AqueductConfig = {};
+export type AqueductConfig = Record<string, never>;
 
 export type AirflowConfig = {
   integration_id: string;

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -1,6 +1,7 @@
 import { apiAddress } from '../components/hooks/useAqueductConsts';
 import UserProfile from './auth';
 import { ExecState, ExecutionStatus } from './shared';
+import {EngineConfig} from "./engine";
 
 export const PREV_TABLE_TAG = '$';
 export const LEFT_PARAMS_TAG = '{{';
@@ -138,6 +139,9 @@ export type OperatorSpec = {
   load?: Load;
   check?: Check;
   param?: Param;
+
+  // If set, the operator definitely executed on this engine.
+  engine_config?: EngineConfig;
 };
 
 export type Operator = {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -1,7 +1,7 @@
 import { apiAddress } from '../components/hooks/useAqueductConsts';
 import UserProfile from './auth';
+import { EngineConfig } from './engine';
 import { ExecState, ExecutionStatus } from './shared';
-import {EngineConfig} from "./engine";
 
 export const PREV_TABLE_TAG = '$';
 export const LEFT_PARAMS_TAG = '{{';
@@ -142,7 +142,6 @@ export type OperatorSpec = {
 
   // If set, the operator definitely executed on this engine.
   engine_config?: EngineConfig;
-
 };
 
 export type Operator = {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -142,6 +142,7 @@ export type OperatorSpec = {
 
   // If set, the operator definitely executed on this engine.
   engine_config?: EngineConfig;
+
 };
 
 export type Operator = {

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -103,7 +103,7 @@ export type WorkflowDag = {
   created_at: number;
   s3_config: S3Config;
 
-  // The default engine that this workflow was run with. Can we overriden by individual operator specs.
+  // The default engine that this workflow was run with. Can be overriden by individual operator specs.
   engine_config: EngineConfig;
   storage_config: StorageConfig;
 

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -102,6 +102,8 @@ export type WorkflowDag = {
   workflow_id: string;
   created_at: number;
   s3_config: S3Config;
+
+  // The default engine that this workflow was run with. Can we overriden by individual operator specs.
   engine_config: EngineConfig;
   storage_config: StorageConfig;
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This isn't used anywhere in the UI, but just adding it as important context once we start showing the engine type on the UI :) These fields are populated correctly once this PR merges.

## Related issue number (if any)
ENG-2039

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


