### PR TITLE
Fix aqueduct bin script to only run conda update if the user has conda installed

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -46,6 +46,8 @@ The Web UI and the backend server (v%s) are accessible at: http://%s:%d/login?ap
 ***************************************************
 """
 
+conda_cmd_prefix = "conda"
+
 
 def update_config_yaml(file):
     s = string.ascii_uppercase + string.digits
@@ -101,13 +103,21 @@ def update_executable_permissions():
     os.chmod(os.path.join(server_directory, "bin", "executor"), 0o755)
     os.chmod(os.path.join(server_directory, "bin", "migrator"), 0o755)
 
+
+def is_tool(name):
+    """Check whether `name` is on PATH and marked as executable."""
+    # from whichcraft import which
+    from shutil import which
+    return which(name) is not None
+
+
 # Retrive all conda environments. This does not need to be 100% accurate
 # as we only care about aqueduct-internal ones.
 #
 # It runs `conda env list` under the hood, and we ignore any error
 # when running the command.
 def get_conda_environments():
-    cmd_result = subprocess.run(['conda', 'env', 'list'], stdout=subprocess.PIPE)
+    cmd_result = subprocess.run([conda_cmd_prefix, 'env', 'list'], stdout=subprocess.PIPE)
     if cmd_result.returncode == 0:
         results = set()
         for line in cmd_result.stdout.decode().split("\n"):
@@ -126,7 +136,7 @@ def update_base_conda_environments():
         if env_name in conda_envs:
             print(f"Updating conda environment {env_name}")
             execute_command([
-                "conda",
+                conda_cmd_prefix,
                 "run",
                 "-n",
                 env_name,
@@ -317,7 +327,8 @@ def update():
     if require_update(server_version_file):
         try:
             update_server_version()
-            update_base_conda_environments()
+            if is_tool(conda_cmd_prefix):
+                update_base_conda_environments()
         except Exception as e:
             print(e)
             if os.path.isfile(server_version_file):


### PR DESCRIPTION
## Describe your changes and why you are making these changes

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


