### PR TITLE
Refactor job manager interface to always return a JobError

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -38,8 +38,6 @@ const (
 	pollAuthenticateTimeout  = 2 * time.Minute
 )
 
-var ErrNoIntegrationName = errors.New("Integration name is not provided")
-
 // Route: /integration/connect
 // Method: POST
 // Request:
@@ -108,7 +106,7 @@ func (h *ConnectIntegrationHandler) Prepare(r *http.Request) (interface{}, int, 
 	}
 
 	if name == "" {
-		return nil, http.StatusBadRequest, ErrNoIntegrationName
+		return nil, http.StatusBadRequest, errors.New("Integration name is not provided")
 	}
 
 	if service == integration.Github || service == integration.GoogleSheets {

--- a/src/golang/cmd/server/handler/handler.go
+++ b/src/golang/cmd/server/handler/handler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/aqueducthq/aqueduct/cmd/server/response"
-	"github.com/dropbox/godropbox/errors"
 )
 
 type RequestMethod string
@@ -20,8 +19,6 @@ type AuthMethod string
 const (
 	ApiKeyAuthMethod AuthMethod = "ApiKey"
 )
-
-var ErrUnsupportedAuthMethod = errors.New("Auth method is not supported.")
 
 type Handler interface {
 	Name() string

--- a/src/golang/cmd/server/handler/test_integration.go
+++ b/src/golang/cmd/server/handler/test_integration.go
@@ -16,8 +16,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrNoAccessPermission = errors.New("You don't have permission to access this integration.")
-
 // Route: /integration/{integrationId}/test
 // Method: POST
 // Params: integrationId
@@ -75,7 +73,7 @@ func (h *TestIntegrationHandler) Prepare(r *http.Request) (interface{}, int, err
 	}
 
 	if !hasPermission {
-		return nil, http.StatusForbidden, ErrNoAccessPermission
+		return nil, http.StatusForbidden, errors.New("You don't have permission to access this integration.")
 	}
 
 	return &TestIntegrationArgs{AqContext: aqContext, IntegrationId: integrationID}, http.StatusOK, nil

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -262,7 +262,7 @@ func (s *AqServer) AddHandler(route string, handlerObj handler.Handler) {
 			authentication.RequireApiKey(s.UserRepo, s.Database),
 		)
 	} else {
-		panic(handler.ErrUnsupportedAuthMethod)
+		panic(errors.New("Auth method is not supported."))
 	}
 
 	s.Router.Method(

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -16,8 +16,6 @@ const (
 	TipUnknownInternalError = "Sorry, we've run into an unexpected error! " + TipCreateBugReport
 )
 
-var ErrInvalidStorageConfig = errors.New("Invalid Storage Config")
-
 type ExecutionStatus string
 
 const (

--- a/src/golang/lib/collections/utils/utils.go
+++ b/src/golang/lib/collections/utils/utils.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrNoopDbInterface = errors.New("The no-op database interface is being used, which should not happen.")
-
 // CountResult is useful when querying for `COUNT(*)`
 type CountResult struct {
 	Count int `db:"count"`
@@ -71,14 +69,10 @@ func UpdateRecord(
 }
 
 func NoopInterfaceErrorHandling(throwError bool) error {
-	var err errors.DropboxError
 	if throwError {
-		err = ErrNoopDbInterface
-	} else {
-		err = nil
+		return errors.New("The noop database interface is being used, which should not happen.")
 	}
-
-	return err
+	return nil
 }
 
 // Checks if the given UUID exists in the given table

--- a/src/golang/lib/cronjob/cronjob.go
+++ b/src/golang/lib/cronjob/cronjob.go
@@ -2,15 +2,6 @@ package cronjob
 
 import (
 	"context"
-
-	"github.com/dropbox/godropbox/errors"
-)
-
-var (
-	ErrInvalidJobManagerConfig = errors.New("Job manager config is not valid.")
-	ErrJobNotExist             = errors.New("Job does not exist.")
-	ErrJobAlreadyExists        = errors.New("Job already exists.")
-	ErrPollJobTimeout          = errors.New("Reached timeout waiting for the job to finish.")
 )
 
 type CronjobManager interface {

--- a/src/golang/lib/database/database.go
+++ b/src/golang/lib/database/database.go
@@ -14,7 +14,6 @@ const (
 
 var (
 	ErrNoRows            = errors.New("Query returned no rows.")
-	ErrInvalidConfig     = errors.New("Invalid database ")
 	ErrUnsupportedDbType = errors.New("DB Type is not supported")
 )
 
@@ -69,7 +68,7 @@ func TxnRollbackIgnoreErr(ctx context.Context, txn Transaction) {
 func NewDatabase(conf *DatabaseConfig) (Database, error) {
 	if conf.Type == PostgresType {
 		if conf.Postgres == nil {
-			return nil, ErrInvalidConfig
+			return nil, errors.New("Invalid database config, expected `Postgres` field to be set.")
 		}
 
 		return NewPostgresDatabase(conf.Postgres)

--- a/src/golang/lib/execution_environment/dependency.go
+++ b/src/golang/lib/execution_environment/dependency.go
@@ -15,11 +15,6 @@ const (
 	PythonVersionFileName = "python_version"
 )
 
-var (
-	ErrPythonVersionMissing    = errors.New("Python version file is missing.")
-	ErrRequirementsFileMissing = errors.New("Requirement file is missing.")
-)
-
 func ExtractDependenciesFromZipFile(zipball []byte) (*ExecutionEnvironment, error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(zipball), int64(len(zipball)))
 	if err != nil {
@@ -70,11 +65,11 @@ func ExtractDependenciesFromZipFile(zipball []byte) (*ExecutionEnvironment, erro
 	}
 
 	if !hasReqFile {
-		return nil, ErrRequirementsFileMissing
+		return nil, errors.New("Requirements file is missing.")
 	}
 
 	if !hasVersionFile {
-		return nil, ErrPythonVersionMissing
+		return nil, errors.New("Python version file is missing.")
 	}
 
 	return env, nil

--- a/src/golang/lib/job/errors.go
+++ b/src/golang/lib/job/errors.go
@@ -1,0 +1,75 @@
+package job
+
+import "github.com/dropbox/godropbox/errors"
+
+// JobErrorCode come from our JobManagers when they fail to properly guide
+// their a job through its proper lifecycle. Errors surfaced this way are propagated
+// outside of the python executor context. Their meaning is consistent across all
+// types of JobManagers.
+type JobErrorCode int
+
+const (
+	// System indicates an unexpected system issue that we cannot recover from.
+	System JobErrorCode = 0
+
+	// User error code indicates that the issue was the user's fault, and to surface that message
+	// to the user.
+	User = 1
+
+	// JobMissing indicates that the job manager could not find the specified job.
+	JobMissing = 2
+
+	// Noop indicates that the job manager does not have the context to make a definitive claim
+	// as to whether the job has succeeded or not. In such cases, the caller is expected
+	// to make a decision using other factors. This is equivalent to saying "Do not ask me, I don't know.".
+	//
+	// For example, polling a Lambda JobManager will return this error because there is no concept of
+	// fetching job information from a Lambda service. The caller will have to figure out the status
+	// of the job by other means.
+	Noop = 2
+)
+
+type JobError interface {
+	errors.DropboxError
+
+	Code() JobErrorCode
+}
+
+type jobError struct {
+	errors.DropboxError
+	code JobErrorCode
+}
+
+func (je *jobError) Code() JobErrorCode {
+	return je.code
+}
+
+func wrapInJobError(code JobErrorCode, err error) JobError {
+	if dropboxErr, ok := err.(errors.DropboxError); ok {
+		return &jobError{
+			DropboxError: dropboxErr,
+			code:         code,
+		}
+	}
+
+	return &jobError{
+		DropboxError: errors.New(err.Error()),
+		code:         code,
+	}
+}
+
+func systemError(err error) JobError {
+	return wrapInJobError(System, err)
+}
+
+func userError(err error) JobError {
+	return wrapInJobError(User, err)
+}
+
+func jobMissingError(err error) JobError {
+	return wrapInJobError(JobMissing, err)
+}
+
+func noopError(err error) JobError {
+	return wrapInJobError(Noop, err)
+}

--- a/src/golang/lib/job/errors.go
+++ b/src/golang/lib/job/errors.go
@@ -20,12 +20,11 @@ const (
 	JobMissing = 2
 
 	// Noop indicates that the job manager does not have the context to make a definitive claim
-	// as to whether the job has succeeded or not. In such cases, the caller is expected
-	// to make a decision using other factors. This is equivalent to saying "Do not ask me, I don't know.".
+	// as to whether the job has succeeded or not. This is equivalent to saying "Do not ask me, I don't know.".
 	//
 	// For example, polling a Lambda JobManager will return this error because there is no concept of
-	// fetching job information from a Lambda service. The caller will have to figure out the status
-	// of the job by other means.
+	// fetching a specific job's information from Lambda. The caller must figure out the job status
+	// through other means.
 	Noop = 2
 )
 
@@ -35,24 +34,24 @@ type JobError interface {
 	Code() JobErrorCode
 }
 
-type jobError struct {
+type jobErrorImpl struct {
 	errors.DropboxError
 	code JobErrorCode
 }
 
-func (je *jobError) Code() JobErrorCode {
+func (je *jobErrorImpl) Code() JobErrorCode {
 	return je.code
 }
 
 func wrapInJobError(code JobErrorCode, err error) JobError {
 	if dropboxErr, ok := err.(errors.DropboxError); ok {
-		return &jobError{
+		return &jobErrorImpl{
 			DropboxError: dropboxErr,
 			code:         code,
 		}
 	}
 
-	return &jobError{
+	return &jobErrorImpl{
 		DropboxError: errors.New(err.Error()),
 		code:         code,
 	}

--- a/src/golang/lib/job/job.go
+++ b/src/golang/lib/job/job.go
@@ -7,80 +7,40 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-var (
-	ErrInvalidJobManagerConfig = errors.New("Job manager config is not valid.")
-	ErrJobNotExist             = errors.New("Job does not exist.")
-	ErrJobAlreadyExists        = errors.New("Job already exists.")
-	ErrAsyncExecution          = errors.New("Unknown job status due to asynchronous execution.")
-	ErrPollJobTimeout          = errors.New("Reached timeout waiting for the job to finish.")
-)
-
-// These error codes come from our JobManagers when they fail to properly guide
-// their a job through its proper lifecycle. Errors surfaced this way are propagated
-// outside the python executor context. Their meaning is consistent across all
-// types of JobManagers.
-type JobErrorCode int
-
-const (
-	// Indicates an unknown system issue that we cannot recover from.
-	System JobErrorCode = 0
-
-	// Indicates that the issue was the user's fault, and to surface the error message
-	// to the user.
-	User = 1
-)
-
-type JobError struct {
-	errors.DropboxError
-	Code JobErrorCode
-}
-
-func wrapInJobError(code JobErrorCode, err error) error {
-	if dropboxErr, ok := err.(errors.DropboxError); ok {
-		return &JobError{
-			DropboxError: dropboxErr,
-			Code:         code,
-		}
-	}
-
-	return &JobError{
-		DropboxError: errors.New(err.Error()),
-		Code:         code,
-	}
-}
+var ErrAsyncExecution = errors.New("Unknown job status due to asynchronous execution.")
 
 type JobManager interface {
 	Config() Config
-	Launch(ctx context.Context, name string, spec Spec) error
-	Poll(ctx context.Context, name string) (shared.ExecutionStatus, error)
-	DeployCronJob(ctx context.Context, name string, period string, spec Spec) error
+	Launch(ctx context.Context, name string, spec Spec) JobError
+	Poll(ctx context.Context, name string) (shared.ExecutionStatus, JobError)
+	DeployCronJob(ctx context.Context, name string, period string, spec Spec) JobError
 	CronJobExists(ctx context.Context, name string) bool
-	EditCronJob(ctx context.Context, name string, cronString string) error
-	DeleteCronJob(ctx context.Context, name string) error
+	EditCronJob(ctx context.Context, name string, cronString string) JobError
+	DeleteCronJob(ctx context.Context, name string) JobError
 }
 
 func NewJobManager(conf Config) (JobManager, error) {
 	if conf.Type() == ProcessType {
 		processConfig, ok := conf.(*ProcessConfig)
 		if !ok {
-			return nil, ErrInvalidJobManagerConfig
+			return nil, errors.New("JobManager config is not of type Process.")
 		}
 		return NewProcessJobManager(processConfig)
 	}
 	if conf.Type() == K8sType {
 		k8sConfig, ok := conf.(*K8sJobManagerConfig)
 		if !ok {
-			return nil, ErrInvalidJobManagerConfig
+			return nil, errors.New("JobManager config is not of type K8s.")
 		}
 		return NewK8sJobManager(k8sConfig)
 	}
 	if conf.Type() == LambdaType {
 		lambdaConfig, ok := conf.(*LambdaJobManagerConfig)
 		if !ok {
-			return nil, ErrInvalidJobManagerConfig
+			return nil, errors.New("JobManager config is not of type Lambda.")
 		}
 		return NewLambdaJobManager(lambdaConfig)
 	}
 
-	return nil, ErrInvalidJobManagerConfig
+	return nil, errors.Newf("JobManager config is of unsupported type %s", conf.Type())
 }

--- a/src/golang/lib/job/job.go
+++ b/src/golang/lib/job/job.go
@@ -7,8 +7,6 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-var ErrAsyncExecution = errors.New("Unknown job status due to asynchronous execution.")
-
 type JobManager interface {
 	Config() Config
 	Launch(ctx context.Context, name string, spec Spec) JobError

--- a/src/golang/lib/job/poll.go
+++ b/src/golang/lib/job/poll.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"time"
 
+
+	"github.com/dropbox/godropbox/errors"
+
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 )
 
@@ -32,7 +35,7 @@ func PollJob(
 				return status, nil
 			}
 		case <-timeout.C:
-			return shared.UnknownExecutionStatus, ErrPollJobTimeout
+			return shared.UnknownExecutionStatus, errors.Newf("Reached timeout waiting for the job %s to finish.", name)
 		}
 	}
 }

--- a/src/golang/lib/job/poll.go
+++ b/src/golang/lib/job/poll.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"time"
 
-
-	"github.com/dropbox/godropbox/errors"
-
 	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/dropbox/godropbox/errors"
 )
 
 // PollJob waits for the specified job to finish and returns its status.

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -106,7 +106,7 @@ func (j *ProcessJobManager) deleteCronMap(key string) {
 	j.cronMutex.Unlock()
 }
 
-func NewProcessJobManager(conf *ProcessConfig) (*ProcessJobManager, error) {
+func NewProcessJobManager(conf *ProcessConfig) (*ProcessJobManager, JobError) {
 	if conf.PythonExecutorPackage == "" {
 		conf.PythonExecutorPackage = defaultPythonExecutorPackage
 	}
@@ -291,18 +291,18 @@ func (j *ProcessJobManager) Config() Config {
 }
 
 func (j *ProcessJobManager) Launch(
-	ctx context.Context,
+	_ context.Context,
 	name string,
 	spec Spec,
-) error {
+) JobError {
 	log.Infof("Running %s job %s.", spec.Type(), name)
 	if _, ok := j.getCmd(name); ok {
-		return ErrJobAlreadyExists
+		return systemError(errors.Newf("Reached timeout waiting for the job %s to finish.", name))
 	}
 
 	cmd, err := j.mapJobTypeToCmd(name, spec)
 	if err != nil {
-		return err
+		return systemError(err)
 	}
 	cmd.Env = os.Environ()
 
@@ -316,23 +316,27 @@ func (j *ProcessJobManager) Launch(
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	return cmd.Start()
+	err = cmd.Start()
+	if err != nil {
+		return systemError(err)
+	}
+	return nil
 }
 
-func (j *ProcessJobManager) Poll(ctx context.Context, name string) (shared.ExecutionStatus, error) {
+func (j *ProcessJobManager) Poll(ctx context.Context, name string) (shared.ExecutionStatus, JobError) {
 	command, ok := j.getCmd(name)
 	if !ok {
-		return shared.UnknownExecutionStatus, ErrJobNotExist
+		return shared.UnknownExecutionStatus, jobMissingError(errors.Newf("Job %s does not exist.", name))
 	}
 
 	proc, err := process.NewProcess(int32(command.cmd.Process.Pid))
 	if err != nil {
-		return shared.UnknownExecutionStatus, err
+		return shared.UnknownExecutionStatus, systemError(err)
 	}
 
 	status, err := proc.Status()
 	if err != nil {
-		return shared.UnknownExecutionStatus, err
+		return shared.UnknownExecutionStatus, systemError(err)
 	}
 
 	if status == processRunningStatus {
@@ -366,9 +370,9 @@ func (j *ProcessJobManager) DeployCronJob(
 	name string,
 	period string,
 	spec Spec,
-) error {
+) JobError {
 	if _, ok := j.getCronMap(name); ok {
-		return errors.Newf("Cron job with name %s already exists", name)
+		return systemError(errors.Newf("Cron job with name %s already exists", name))
 	}
 
 	cron := &cronMetadata{
@@ -381,7 +385,7 @@ func (j *ProcessJobManager) DeployCronJob(
 	if period != "" {
 		cronJob, err := j.cronScheduler.Cron(period).Do(j.generateCronFunction(name, spec))
 		if err != nil {
-			return err
+			return systemError(err)
 		}
 
 		cron.cronJob = cronJob
@@ -395,20 +399,20 @@ func (j *ProcessJobManager) CronJobExists(ctx context.Context, name string) bool
 	return ok
 }
 
-func (j *ProcessJobManager) EditCronJob(ctx context.Context, name string, cronString string) error {
+func (j *ProcessJobManager) EditCronJob(ctx context.Context, name string, cronString string) JobError {
 	cronMetadata, ok := j.getCronMap(name)
 	if !ok {
-		return errors.New("Cron job not found")
+		return systemError(errors.New("Cron job not found"))
 	} else {
 		if cronMetadata.cronJob == nil {
 			// This means the current cron job is paused.
 			if cronString == "" {
-				return errors.Newf("Attempting to pause an already paused cron job %s", name)
+				return systemError(errors.Newf("Attempting to pause an already paused cron job %s", name))
 			}
 
 			cronJob, err := j.cronScheduler.Cron(cronString).Do(j.generateCronFunction(name, cronMetadata.jobSpec))
 			if err != nil {
-				return err
+				return systemError(err)
 			}
 
 			cronMetadata.cronJob = cronJob
@@ -420,7 +424,7 @@ func (j *ProcessJobManager) EditCronJob(ctx context.Context, name string, cronSt
 			} else {
 				_, err := j.cronScheduler.Job(cronMetadata.cronJob).Cron(cronString).Update()
 				if err != nil {
-					return err
+					return systemError(err)
 				}
 			}
 		}
@@ -428,7 +432,7 @@ func (j *ProcessJobManager) EditCronJob(ctx context.Context, name string, cronSt
 	}
 }
 
-func (j *ProcessJobManager) DeleteCronJob(ctx context.Context, name string) error {
+func (j *ProcessJobManager) DeleteCronJob(ctx context.Context, name string) JobError {
 	cronMetadata, ok := j.getCronMap(name)
 	if ok {
 		j.cronScheduler.RemoveByReference(cronMetadata.cronJob)

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -106,7 +106,7 @@ func (j *ProcessJobManager) deleteCronMap(key string) {
 	j.cronMutex.Unlock()
 }
 
-func NewProcessJobManager(conf *ProcessConfig) (*ProcessJobManager, JobError) {
+func NewProcessJobManager(conf *ProcessConfig) (*ProcessJobManager, error) {
 	if conf.PythonExecutorPackage == "" {
 		conf.PythonExecutorPackage = defaultPythonExecutorPackage
 	}

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -21,10 +21,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var (
-	ErrInvalidJobSpec           = errors.New("Invalid job spec.")
-	ErrInvalidSerializationType = errors.New("Invalid serialization type.")
-)
+var ErrInvalidJobSpec = errors.New("Invalid job spec.")
 
 type JobType string
 
@@ -547,7 +544,7 @@ func EncodeSpec(spec Spec, serializationType SerializationType) (string, error) 
 		return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 	}
 
-	return "", ErrInvalidSerializationType
+	return "", errors.Newf("Unsupported serialization type %s.", serializationType)
 }
 
 func DecodeSpec(specData string, serializationType SerializationType) (Spec, error) {
@@ -599,5 +596,5 @@ func DecodeSpec(specData string, serializationType SerializationType) (Spec, err
 		return spec, nil
 	}
 
-	return nil, ErrInvalidSerializationType
+	return nil, errors.Newf("Unsupported serialization type %s.", serializationType)
 }

--- a/src/golang/lib/vault/vault.go
+++ b/src/golang/lib/vault/vault.go
@@ -8,8 +8,6 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-var ErrInvalidVaultConfig = errors.New("Vault config is invalid.")
-
 type Vault interface {
 	Put(ctx context.Context, name string, secrets map[string]string) error
 	Get(ctx context.Context, name string) (map[string]string, error)

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -266,7 +266,7 @@ func (bo *baseOperator) Poll(ctx context.Context) (*shared.ExecutionState, error
 			)
 			return bo.ExecState(), nil
 		} else {
-			return nil, errors.Newf("Unsupposed Job Error code %v", err.Code())
+			return nil, errors.Newf("Unexpected JobErrorCode: %v", err.Code())
 		}
 	} else {
 		// The job just completed, so we know we can fetch the results (succeeded/failed).

--- a/src/golang/lib/workflow/operator/connector/github/manager.go
+++ b/src/golang/lib/workflow/operator/connector/github/manager.go
@@ -7,8 +7,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrInvalidManagerConfig = errors.New("Invalid github manager config.")
-
 type Manager interface {
 	Config() ManagerConfig
 	GetClient(ctx context.Context, userId uuid.UUID) (Client, error)
@@ -19,5 +17,5 @@ func NewManager(config ManagerConfig) (Manager, error) {
 		return NewUnimplementedManager(), nil
 	}
 
-	return nil, ErrInvalidManagerConfig
+	return nil, errors.New("Invalid github manager config.")
 }

--- a/src/golang/lib/workflow/operator/connector/github/unimplemented.go
+++ b/src/golang/lib/workflow/operator/connector/github/unimplemented.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrGithubNotImplemented = errors.New("Github features are not implemented yet.")
-
 type UnimplementedManager struct{}
 
 func NewUnimplementedManager() *UnimplementedManager {
@@ -28,9 +26,9 @@ func (*UnimplementedManager) GetClient(ctx context.Context, userId uuid.UUID) (C
 type UnimplementedClient struct{}
 
 func (*UnimplementedClient) PullAndUpdateFunction(ctx context.Context, spec *function.Function, alwaysExtract bool) (bool, []byte, error) {
-	return false, nil, ErrGithubNotImplemented
+	return false, nil, errors.New("Github features are not implemented yet.")
 }
 
 func (*UnimplementedClient) PullExtract(ctx context.Context, spec *connector.Extract) (bool, error) {
-	return false, ErrGithubNotImplemented
+	return false, errors.New("Github features are not implemented yet.")
 }

--- a/src/golang/lib/workflow/operator/connector/github/utils.go
+++ b/src/golang/lib/workflow/operator/connector/github/utils.go
@@ -78,7 +78,7 @@ func PullOperator(
 	}
 
 	if storageConfig == nil {
-		return true, shared.ErrInvalidStorageConfig
+		return true, errors.New("Invalid Storage Config")
 	}
 
 	storagePath := uuid.New().String()

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -19,8 +19,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrInvalidStatusToLaunch = errors.New("Cannot launch operator. The operator is in an invalid status.")
-
 // Operator is an interface for managing and inspecting the lifecycle of an operator
 // used by a workflow run.
 type Operator interface {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Finishes what I started a few weeks ago when dealing with job manager errors coming from K8s and Lambda that were user-facing.

Additionally, we want to move away from the 
```
ErrPollJobTimeout = errors.New("Reached timeout waiting for the job to finish.")
```
pattern, since the stack trace that error captures is completely useless for our debugging (since stack trace capture happens at error creation time). By wrapping these errors on the fly in a JobError, we make it possible to both 1) record useful stack trace information when returning errors from the job manager and 2) perform any conditional checks on the specific type of error with `JobError.Code()`.

## Related issue number (if any)
ENG-2009

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


