### PR TITLE
Cleanup some low-hanging bad error patterns in the golang codebase

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -38,8 +38,6 @@ const (
 	pollAuthenticateTimeout  = 2 * time.Minute
 )
 
-var ErrNoIntegrationName = errors.New("Integration name is not provided")
-
 // Route: /integration/connect
 // Method: POST
 // Request:
@@ -108,7 +106,7 @@ func (h *ConnectIntegrationHandler) Prepare(r *http.Request) (interface{}, int, 
 	}
 
 	if name == "" {
-		return nil, http.StatusBadRequest, ErrNoIntegrationName
+		return nil, http.StatusBadRequest, errors.New("Integration name is not provided")
 	}
 
 	if service == integration.Github || service == integration.GoogleSheets {

--- a/src/golang/cmd/server/handler/handler.go
+++ b/src/golang/cmd/server/handler/handler.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/aqueducthq/aqueduct/cmd/server/response"
-	"github.com/dropbox/godropbox/errors"
 )
 
 type RequestMethod string
@@ -20,8 +19,6 @@ type AuthMethod string
 const (
 	ApiKeyAuthMethod AuthMethod = "ApiKey"
 )
-
-var ErrUnsupportedAuthMethod = errors.New("Auth method is not supported.")
 
 type Handler interface {
 	Name() string

--- a/src/golang/cmd/server/handler/test_integration.go
+++ b/src/golang/cmd/server/handler/test_integration.go
@@ -16,8 +16,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrNoAccessPermission = errors.New("You don't have permission to access this integration.")
-
 // Route: /integration/{integrationId}/test
 // Method: POST
 // Params: integrationId
@@ -75,7 +73,7 @@ func (h *TestIntegrationHandler) Prepare(r *http.Request) (interface{}, int, err
 	}
 
 	if !hasPermission {
-		return nil, http.StatusForbidden, ErrNoAccessPermission
+		return nil, http.StatusForbidden, errors.New("You don't have permission to access this integration.")
 	}
 
 	return &TestIntegrationArgs{AqContext: aqContext, IntegrationId: integrationID}, http.StatusOK, nil

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -262,7 +262,7 @@ func (s *AqServer) AddHandler(route string, handlerObj handler.Handler) {
 			authentication.RequireApiKey(s.UserRepo, s.Database),
 		)
 	} else {
-		panic(handler.ErrUnsupportedAuthMethod)
+		panic(errors.New("Auth method is not supported."))
 	}
 
 	s.Router.Method(

--- a/src/golang/lib/collections/shared/types.go
+++ b/src/golang/lib/collections/shared/types.go
@@ -16,8 +16,6 @@ const (
 	TipUnknownInternalError = "Sorry, we've run into an unexpected error! " + TipCreateBugReport
 )
 
-var ErrInvalidStorageConfig = errors.New("Invalid Storage Config")
-
 type ExecutionStatus string
 
 const (

--- a/src/golang/lib/collections/utils/utils.go
+++ b/src/golang/lib/collections/utils/utils.go
@@ -69,7 +69,6 @@ func UpdateRecord(
 }
 
 func NoopInterfaceErrorHandling(throwError bool) error {
-	var err errors.DropboxError
 	if throwError {
 		return errors.New("The noop database interface is being used, which should not happen.")
 	}

--- a/src/golang/lib/collections/utils/utils.go
+++ b/src/golang/lib/collections/utils/utils.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrNoopDbInterface = errors.New("The no-op database interface is being used, which should not happen.")
-
 // CountResult is useful when querying for `COUNT(*)`
 type CountResult struct {
 	Count int `db:"count"`
@@ -73,12 +71,9 @@ func UpdateRecord(
 func NoopInterfaceErrorHandling(throwError bool) error {
 	var err errors.DropboxError
 	if throwError {
-		err = ErrNoopDbInterface
-	} else {
-		err = nil
+		return errors.New("The noop database interface is being used, which should not happen.")
 	}
-
-	return err
+	return nil
 }
 
 // Checks if the given UUID exists in the given table

--- a/src/golang/lib/cronjob/cronjob.go
+++ b/src/golang/lib/cronjob/cronjob.go
@@ -2,15 +2,6 @@ package cronjob
 
 import (
 	"context"
-
-	"github.com/dropbox/godropbox/errors"
-)
-
-var (
-	ErrInvalidJobManagerConfig = errors.New("Job manager config is not valid.")
-	ErrJobNotExist             = errors.New("Job does not exist.")
-	ErrJobAlreadyExists        = errors.New("Job already exists.")
-	ErrPollJobTimeout          = errors.New("Reached timeout waiting for the job to finish.")
 )
 
 type CronjobManager interface {

--- a/src/golang/lib/database/database.go
+++ b/src/golang/lib/database/database.go
@@ -14,7 +14,6 @@ const (
 
 var (
 	ErrNoRows            = errors.New("Query returned no rows.")
-	ErrInvalidConfig     = errors.New("Invalid database ")
 	ErrUnsupportedDbType = errors.New("DB Type is not supported")
 )
 
@@ -69,7 +68,7 @@ func TxnRollbackIgnoreErr(ctx context.Context, txn Transaction) {
 func NewDatabase(conf *DatabaseConfig) (Database, error) {
 	if conf.Type == PostgresType {
 		if conf.Postgres == nil {
-			return nil, ErrInvalidConfig
+			return nil, errors.New("Invalid database config, expected `Postgres` field to be set.")
 		}
 
 		return NewPostgresDatabase(conf.Postgres)

--- a/src/golang/lib/execution_environment/dependency.go
+++ b/src/golang/lib/execution_environment/dependency.go
@@ -15,11 +15,6 @@ const (
 	PythonVersionFileName = "python_version"
 )
 
-var (
-	ErrPythonVersionMissing    = errors.New("Python version file is missing.")
-	ErrRequirementsFileMissing = errors.New("Requirement file is missing.")
-)
-
 func ExtractDependenciesFromZipFile(zipball []byte) (*ExecutionEnvironment, error) {
 	zipReader, err := zip.NewReader(bytes.NewReader(zipball), int64(len(zipball)))
 	if err != nil {
@@ -70,11 +65,11 @@ func ExtractDependenciesFromZipFile(zipball []byte) (*ExecutionEnvironment, erro
 	}
 
 	if !hasReqFile {
-		return nil, ErrRequirementsFileMissing
+		return nil, errors.New("Requirements file is missing.")
 	}
 
 	if !hasVersionFile {
-		return nil, ErrPythonVersionMissing
+		return nil, errors.New("Python version file is missing.")
 	}
 
 	return env, nil

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -22,8 +22,7 @@ import (
 )
 
 var (
-	ErrInvalidJobSpec           = errors.New("Invalid job spec.")
-	ErrInvalidSerializationType = errors.New("Invalid serialization type.")
+	ErrInvalidJobSpec = errors.New("Invalid job spec.")
 )
 
 type JobType string
@@ -547,7 +546,7 @@ func EncodeSpec(spec Spec, serializationType SerializationType) (string, error) 
 		return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 	}
 
-	return "", ErrInvalidSerializationType
+	return "", errors.Newf("Unsupported serialization type %s.", serializationType)
 }
 
 func DecodeSpec(specData string, serializationType SerializationType) (Spec, error) {
@@ -599,5 +598,5 @@ func DecodeSpec(specData string, serializationType SerializationType) (Spec, err
 		return spec, nil
 	}
 
-	return nil, ErrInvalidSerializationType
+	return nil, errors.Newf("Unsupported serialization type %s.", serializationType)
 }

--- a/src/golang/lib/job/spec.go
+++ b/src/golang/lib/job/spec.go
@@ -21,9 +21,7 @@ import (
 	"github.com/google/uuid"
 )
 
-var (
-	ErrInvalidJobSpec = errors.New("Invalid job spec.")
-)
+var ErrInvalidJobSpec = errors.New("Invalid job spec.")
 
 type JobType string
 

--- a/src/golang/lib/vault/vault.go
+++ b/src/golang/lib/vault/vault.go
@@ -8,8 +8,6 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-var ErrInvalidVaultConfig = errors.New("Vault config is invalid.")
-
 type Vault interface {
 	Put(ctx context.Context, name string, secrets map[string]string) error
 	Get(ctx context.Context, name string) (map[string]string, error)

--- a/src/golang/lib/workflow/operator/connector/github/manager.go
+++ b/src/golang/lib/workflow/operator/connector/github/manager.go
@@ -7,8 +7,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrInvalidManagerConfig = errors.New("Invalid github manager config.")
-
 type Manager interface {
 	Config() ManagerConfig
 	GetClient(ctx context.Context, userId uuid.UUID) (Client, error)
@@ -19,5 +17,5 @@ func NewManager(config ManagerConfig) (Manager, error) {
 		return NewUnimplementedManager(), nil
 	}
 
-	return nil, ErrInvalidManagerConfig
+	return nil, errors.New("Invalid github manager config.")
 }

--- a/src/golang/lib/workflow/operator/connector/github/unimplemented.go
+++ b/src/golang/lib/workflow/operator/connector/github/unimplemented.go
@@ -9,8 +9,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrGithubNotImplemented = errors.New("Github features are not implemented yet.")
-
 type UnimplementedManager struct{}
 
 func NewUnimplementedManager() *UnimplementedManager {
@@ -28,9 +26,9 @@ func (*UnimplementedManager) GetClient(ctx context.Context, userId uuid.UUID) (C
 type UnimplementedClient struct{}
 
 func (*UnimplementedClient) PullAndUpdateFunction(ctx context.Context, spec *function.Function, alwaysExtract bool) (bool, []byte, error) {
-	return false, nil, ErrGithubNotImplemented
+	return false, nil, errors.New("Github features are not implemented yet.")
 }
 
 func (*UnimplementedClient) PullExtract(ctx context.Context, spec *connector.Extract) (bool, error) {
-	return false, ErrGithubNotImplemented
+	return false, errors.New("Github features are not implemented yet.")
 }

--- a/src/golang/lib/workflow/operator/connector/github/utils.go
+++ b/src/golang/lib/workflow/operator/connector/github/utils.go
@@ -78,7 +78,7 @@ func PullOperator(
 	}
 
 	if storageConfig == nil {
-		return true, shared.ErrInvalidStorageConfig
+		return true, errors.New("Invalid Storage Config")
 	}
 
 	storagePath := uuid.New().String()

--- a/src/golang/lib/workflow/operator/operator.go
+++ b/src/golang/lib/workflow/operator/operator.go
@@ -19,8 +19,6 @@ import (
 	"github.com/google/uuid"
 )
 
-var ErrInvalidStatusToLaunch = errors.New("Cannot launch operator. The operator is in an invalid status.")
-
 // Operator is an interface for managing and inspecting the lifecycle of an operator
 // used by a workflow run.
 type Operator interface {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Did one simple pass over places that we define errors inline that can be very easily fixed. This does not cover all the places in which we do this - the remaining bad error patterns will require a bit more refactoring, potentially similar to how JobError does it now. This does cleanup the codebase a little bit though.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


