### PR TITLE
[1/2] Make `data_integration` terminology consistent in the SDK integration tests

### DIFF
--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -35,8 +35,7 @@ def success_on_multiple_mixed_inputs(metric, df):
 
 def test_check_on_table(client, flow_name, data_integration, engine):
     """Test check on a function operator."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     check_artifact = success_on_single_table_input(sql_artifact)
     assert check_artifact.get()
 
@@ -50,8 +49,7 @@ def test_check_on_table(client, flow_name, data_integration, engine):
 
 def test_check_on_metric(client, flow_name, data_integration, engine):
     """Test check on a metric operator."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     metric = constant_metric(sql_artifact)
 
     check_artifact = success_on_single_metric_input(metric)
@@ -67,11 +65,10 @@ def test_check_on_metric(client, flow_name, data_integration, engine):
 
 def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, engine):
     """Test check on multiple tables and metrics."""
-    db = client.integration(data_integration)
-    sql_artifact1 = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     metric = constant_metric(sql_artifact1)
 
-    sql_artifact2 = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     table = dummy_sentiment_model(sql_artifact2)
 
     check_artifact = success_on_multiple_mixed_inputs(metric, table)
@@ -87,8 +84,7 @@ def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, eng
 
 def test_edit_check(client, data_integration):
     """Test that checks can be edited by replacing with the same name."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     @check()
     def check_op(df):
@@ -111,8 +107,7 @@ def test_edit_check(client, data_integration):
 
 def test_delete_check(client, data_integration):
     """Test that checks can be deleted by name."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     with pytest.raises(InvalidUserActionException):
         sql_artifact.remove_check(name="nonexistant_check")
@@ -130,8 +125,7 @@ def test_delete_check(client, data_integration):
 
 
 def test_check_wrong_input_type(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     # User function receives a dataframe when it's expecting a metric.
     with pytest.raises(AqueductError):
@@ -146,9 +140,8 @@ def test_check_wrong_input_type(client, data_integration):
 
 
 def test_check_wrong_number_of_inputs(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact1 = db.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     # TODO(ENG-863): Do we want a more specific error here?
     with pytest.raises(AqueductError):
@@ -156,8 +149,7 @@ def test_check_wrong_number_of_inputs(client, data_integration):
 
 
 def test_check_with_numpy_bool_output(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=CHURN_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=CHURN_SQL_QUERY)
 
     @check()
     def success_check_return_numpy_bool(df):
@@ -168,8 +160,7 @@ def test_check_with_numpy_bool_output(client, data_integration):
 
 
 def test_check_with_series_output(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     @check()
     def success_check_return_series_of_booleans(df):
@@ -194,8 +185,7 @@ def test_check_with_series_output(client, flow_name, data_integration, engine):
 
 
 def test_check_failure_with_varying_severity(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     # An error check will fail the workflow, but a warning check will not.
     @check(severity=CheckSeverity.WARNING)

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -31,21 +31,6 @@ API_KEY_ENV_NAME = "API_KEY"
 SERVER_ADDR_ENV_NAME = "SERVER_ADDRESS"
 
 
-@pytest.fixture(scope="session")
-def data_integration(pytestconfig):
-    return pytestconfig.getoption("data")
-
-
-@pytest.fixture(scope="session")
-def engine(pytestconfig):
-    return pytestconfig.getoption("engine")
-
-
-@pytest.fixture(autouse=True, scope="session")
-def use_deprecated(pytestconfig):
-    utils.use_deprecated_code_paths = pytestconfig.getoption("deprecated")
-
-
 @pytest.fixture(scope="function")
 def client(pytestconfig):
     # Reset the global dag variable, in case it was dirtied by a previous test,
@@ -60,6 +45,21 @@ def client(pytestconfig):
         )
 
     return aqueduct.Client(api_key, server_address)
+
+
+@pytest.fixture(scope="function")
+def data_integration(pytestconfig, client):
+    return client.integration(pytestconfig.getoption("data"))
+
+
+@pytest.fixture(scope="session")
+def engine(pytestconfig):
+    return pytestconfig.getoption("engine")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def use_deprecated(pytestconfig):
+    utils.use_deprecated_code_paths = pytestconfig.getoption("deprecated")
 
 
 # Pulled from: https://stackoverflow.com/questions/28179026/how-to-skip-a-pytest-using-an-external-fixture

--- a/integration_tests/sdk/error_handling_test.py
+++ b/integration_tests/sdk/error_handling_test.py
@@ -20,17 +20,14 @@ TIP_OP_EXECUTION = "Error executing operator. Please refer to the stack trace fo
 
 
 def test_handle_relational_query_error(client, data_integration):
-    db = client.integration(data_integration)
-
     try:
-        sql_artifact = db.sql(query=BAD_QUERY)
+        sql_artifact = data_integration.sql(query=BAD_QUERY)
     except AqueductError as e:
         assert TIP_EXTRACT in e.message
 
 
 def test_handle_bad_op_error(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=GOOD_QUERY)
+    sql_artifact = data_integration.sql(query=GOOD_QUERY)
 
     try:
         bad_op(sql_artifact)

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -30,10 +30,9 @@ from aqueduct import check, metric, op
 
 
 def test_basic_flow(client, flow_name, data_integration, engine, validator):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -46,10 +45,9 @@ def test_basic_flow(client, flow_name, data_integration, engine, validator):
 
 def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
     """Actually run the full sentiment model (with nltk dependency)."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = sentiment_model(sql_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -61,13 +59,12 @@ def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
 
 
 def test_complex_flow(client, flow_name, data_integration, engine, validator):
-    db = client.integration(data_integration)
-    sql_artifact1 = db.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = db.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
+    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
 
     fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact1, sql_artifact2)
     output_artifact = dummy_model(fn_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     @check()
     def successful_check(df):
@@ -118,14 +115,13 @@ def test_complex_flow(client, flow_name, data_integration, engine, validator):
 
 
 def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact1 = db.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = db.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
+    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
 
     fn_artifact1 = dummy_sentiment_model(sql_artifact1)
     fn_artifact2 = dummy_model(sql_artifact2)
-    save(db, fn_artifact1)
-    save(db, fn_artifact2)
+    save(data_integration, fn_artifact1)
+    save(data_integration, fn_artifact2)
 
     publish_flow_test(
         client,
@@ -136,12 +132,9 @@ def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
 
 
 def test_publish_with_schedule(client, flow_name, data_integration, engine):
-    db = client.integration(
-        data_integration,
-    )
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     # Execute the flow 1 minute from now.
     execute_at = datetime.now() + timedelta(minutes=1)
@@ -172,8 +165,7 @@ def test_invalid_flow(client):
 
 def test_publish_flow_with_same_name(client, flow_name, data_integration, engine):
     """Tests flow editing behavior."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
 
     name = flow_name()
@@ -199,10 +191,9 @@ def test_publish_flow_with_same_name(client, flow_name, data_integration, engine
 
 
 def test_refresh_flow(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -220,10 +211,9 @@ def test_refresh_flow(client, flow_name, data_integration, engine):
 
 
 def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -238,10 +228,9 @@ def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
 
 
 def test_get_artifact_reuse_for_computation(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
-    save(db, output_artifact)
+    save(data_integration, output_artifact)
 
     flow = publish_flow_test(
         client,
@@ -256,8 +245,7 @@ def test_get_artifact_reuse_for_computation(client, flow_name, data_integration,
 
 
 def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
     output_artifact_2 = dummy_model(sql_artifact)
 
@@ -292,8 +280,6 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
 
 
 def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-
     # Write a new table into the demo db.
     initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
 
@@ -303,7 +289,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
 
     table = generate_initial_table()
     table_name = generate_table_name()
-    save(db, table, name=table_name)
+    save(data_integration, table, name=table_name)
 
     setup_flow = publish_flow_test(
         client,
@@ -317,7 +303,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return df
 
     # Create a new flow that extracts this data.
-    output = db.sql("SELECT * FROM %s" % table_name, name="Test Table Query")
+    output = data_integration.sql("SELECT * FROM %s" % table_name, name="Test Table Query")
     assert output.get().equals(initial_table)
 
     flow = publish_flow_test(
@@ -333,7 +319,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
     table = generate_new_table()
-    save(db, table, name=table_name)
+    save(data_integration, table, name=table_name)
     publish_flow_test(
         client,
         artifacts=table,

--- a/integration_tests/sdk/lazy_execution_test.py
+++ b/integration_tests/sdk/lazy_execution_test.py
@@ -12,8 +12,7 @@ from aqueduct import check, global_config, metric, op
 
 
 def test_lazy_sql_extractor(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY, lazy=True)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, lazy=True)
     assert sql_artifact._get_content() is None
     assert isinstance(sql_artifact.get(), pd.DataFrame)
     # After calling get(), artifact's content should be materialized.
@@ -72,8 +71,7 @@ def test_eager_operator_after_lazy(client):
 
 
 def test_table_artifact_lazy_syntax_sugar(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY, lazy=True)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, lazy=True)
     num_rows_artifact = sql_artifact.number_of_rows(lazy=True)
     assert num_rows_artifact._get_content() is None
     assert isinstance(num_rows_artifact.get(), float)
@@ -117,15 +115,14 @@ def test_lazy_global_config(client, data_integration):
         global_config({"lazy": True})
 
         # Basic SQL artifact that was lazily computed.
-        db = client.integration(data_integration)
-        sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+        sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
         assert sql_artifact._get_content() is None
         assert isinstance(sql_artifact.get(), pd.DataFrame)
         # After calling get(), artifact's content should be materialized.
         assert sql_artifact._get_content() is not None
 
         # For a lazily-created metric used pre-defined functions.
-        sql_artifact = db.sql(query=WINE_SQL_QUERY)
+        sql_artifact = data_integration.sql(query=WINE_SQL_QUERY)
         max_metric = sql_artifact.max(column_id="fixed_acidity")
         assert max_metric._get_content() is None
         assert math.isclose(max_metric.get(), 15.899, rel_tol=1e-3)

--- a/integration_tests/sdk/load_test.py
+++ b/integration_tests/sdk/load_test.py
@@ -7,14 +7,12 @@ from aqueduct import op
 
 
 def test_list_saved_objects(client, flow_name, data_integration, engine, validator):
-    integration = client.integration(name=data_integration)
-
     table_1_save_name = generate_table_name()
     table_2_save_name = generate_table_name()
 
-    table = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    table = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
     extracted_table_data = table.get()
-    save(integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.REPLACE)
+    save(data_integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.REPLACE)
 
     # This will create the table.
     flow = publish_flow_test(
@@ -26,7 +24,7 @@ def test_list_saved_objects(client, flow_name, data_integration, engine, validat
     validator.check_saved_artifact(flow, table.id(), expected_data=extracted_table_data)
 
     # Change to append mode.
-    save(integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.APPEND)
+    save(data_integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.APPEND)
     publish_flow_test(
         client,
         existing_flow=flow,
@@ -40,7 +38,7 @@ def test_list_saved_objects(client, flow_name, data_integration, engine, validat
     )
 
     # Redundant append mode change
-    save(integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.APPEND)
+    save(data_integration, table, name=table_1_save_name, update_mode=LoadUpdateMode.APPEND)
     publish_flow_test(
         client,
         existing_flow=flow,
@@ -56,7 +54,7 @@ def test_list_saved_objects(client, flow_name, data_integration, engine, validat
     )
 
     # Create a different table from the same artifact.
-    save(integration, table, name=table_2_save_name, update_mode=LoadUpdateMode.REPLACE)
+    save(data_integration, table, name=table_2_save_name, update_mode=LoadUpdateMode.REPLACE)
     publish_flow_test(
         client,
         existing_flow=flow,
@@ -82,14 +80,13 @@ def test_list_saved_objects(client, flow_name, data_integration, engine, validat
 def test_multiple_artifacts_saved_to_same_integration(
     client, flow_name, data_integration, engine, validator
 ):
-    integration = client.integration(name=data_integration)
     table_1_save_name = generate_table_name()
     table_2_save_name = generate_table_name()
 
-    table_1 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    save(integration, table_1, name=table_1_save_name, update_mode=LoadUpdateMode.REPLACE)
-    table_2 = integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
-    save(integration, table_2, name=table_2_save_name, update_mode=LoadUpdateMode.REPLACE)
+    table_1 = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    save(data_integration, table_1, name=table_1_save_name, update_mode=LoadUpdateMode.REPLACE)
+    table_2 = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    save(data_integration, table_2, name=table_2_save_name, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
         client,
@@ -111,8 +108,7 @@ def test_multiple_artifacts_saved_to_same_integration(
 
 
 def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, validator):
-    db = client.integration(data_integration)
-    reviews = db.sql(SHORT_SENTIMENT_SQL_QUERY)
+    reviews = data_integration.sql(SHORT_SENTIMENT_SQL_QUERY)
 
     @op()
     def copy_field(df):
@@ -120,7 +116,7 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, va
         return df
 
     review_copied = copy_field.lazy(reviews)
-    save(db, review_copied, update_mode=LoadUpdateMode.REPLACE)
+    save(data_integration, review_copied, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
         client,

--- a/integration_tests/sdk/local_test.py
+++ b/integration_tests/sdk/local_test.py
@@ -7,8 +7,7 @@ from test_metrics.constant.model import constant_metric
 
 
 def test_local_operator(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
     output_cloud = output_artifact.get()
 
@@ -18,8 +17,7 @@ def test_local_operator(client, data_integration):
 
 
 def test_local_metric(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     metric = constant_metric(sql_artifact)
     assert metric.get() == 17.5
@@ -27,16 +25,14 @@ def test_local_metric(client, data_integration):
 
 
 def test_local_check(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     check = success_on_single_table_input
     assert check(sql_artifact)
     assert check.local(sql_artifact)
 
 
 def test_local_dataframe_input(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_cloud = dummy_sentiment_model(sql_artifact).get()
     output_local = dummy_sentiment_model.local(sql_artifact.get())
     assert type(output_local) is DataFrame
@@ -44,9 +40,8 @@ def test_local_dataframe_input(client, data_integration):
 
 
 def test_local_on_multiple_inputs(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_cloud = dummy_sentiment_model_multiple_input(sql_artifact, sql_artifact2).get()
 
     output_local = dummy_sentiment_model_multiple_input.local(sql_artifact, sql_artifact2)

--- a/integration_tests/sdk/metrics_test.py
+++ b/integration_tests/sdk/metrics_test.py
@@ -9,16 +9,14 @@ from aqueduct import metric
 
 
 def test_basic_metric(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     metric = constant_metric(sql_artifact)
     assert metric.get() == 17.5
 
 
 def test_metric_bound(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     metric = constant_metric(sql_artifact)
     check_artifact = metric.bound(upper=100)
@@ -41,8 +39,7 @@ def test_metric_bound(client, data_integration):
 
 
 def test_register_metric(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     metric_artifact = constant_metric(sql_artifact)
     publish_flow_test(
         client,
@@ -65,9 +62,8 @@ def metric_with_multiple_inputs(df1, m, df2):
 
 
 def test_metric_mixed_inputs(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql1 = db.sql(query=SENTIMENT_SQL_QUERY)
-    sql2 = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     metric_input = constant_metric(sql1)
 
     metric_output = metric_with_multiple_inputs(sql1, metric_input, sql2)

--- a/integration_tests/sdk/mixed_compute_test.py
+++ b/integration_tests/sdk/mixed_compute_test.py
@@ -8,9 +8,7 @@ from aqueduct import op
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
 def test_flow_with_multiple_compute_using_op_spec(client, flow_name, data_integration, engine):
-    integration = client.integration(data_integration)
-
-    sql_artifact = integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     @op
     def noop(input):

--- a/integration_tests/sdk/naming_test.py
+++ b/integration_tests/sdk/naming_test.py
@@ -15,8 +15,8 @@ def test_extract_with_default_name_collision(client, data_integration):
     sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
-    assert sql_artifact_1.name() == "%s query 1 artifact" % data_integration
-    assert sql_artifact_2.name() == "%s query 2 artifact" % data_integration
+    assert sql_artifact_1.name() == "%s query 1 artifact" % data_integration._metadata.name
+    assert sql_artifact_2.name() == "%s query 2 artifact" % data_integration._metadata.name
 
     fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact_1, sql_artifact_2)
     fn_df = fn_artifact.get()

--- a/integration_tests/sdk/naming_test.py
+++ b/integration_tests/sdk/naming_test.py
@@ -12,9 +12,8 @@ from test_functions.simple.model import (
 def test_extract_with_default_name_collision(client, data_integration):
     # In the case where no explicit name is supplied, we expect new extract
     # operators to always be created.
-    db = client.integration(data_integration)
-    sql_artifact_1 = db.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact_2 = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     assert sql_artifact_1.name() == "%s query 1 artifact" % data_integration
     assert sql_artifact_2.name() == "%s query 2 artifact" % data_integration
@@ -34,12 +33,11 @@ def test_extract_with_default_name_collision(client, data_integration):
 
 def test_extract_with_explicit_name_collision(client, data_integration):
     # In the case where an explicit name is supplied, we will overwrite any colliding ops.
-    db = client.integration(data_integration)
-    sql_artifact_1 = db.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
 
     fn_artifact = dummy_sentiment_model(sql_artifact_1)
 
-    sql_artifact_2 = db.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
     assert sql_artifact_2.name() == "sql query artifact"
 
     # Cannot preview an artifact with a dependency that has been deleted,
@@ -65,9 +63,7 @@ def test_extract_with_explicit_name_collision(client, data_integration):
 
 def test_function_with_name_collision(client, data_integration):
     """Colliding functions are always overwritten."""
-
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
 
     # There's not an easy way to programmatically change the function, so lets
     # just run the same function twice and check that the latest one wins.
@@ -90,24 +86,22 @@ def test_function_with_name_collision(client, data_integration):
 
 def test_naming_collision_with_different_types(client, data_integration):
     # An overwrite is invalid because the operators are of different types.
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
 
     # Function collides with existing sql artifact
-    _ = db.sql(query=SENTIMENT_SQL_QUERY, name="dummy_model")
+    _ = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="dummy_model")
     with pytest.raises(InvalidUserActionException):
         dummy_model(sql_artifact)
 
     # SQL collides with existing function
     _ = dummy_sentiment_model(sql_artifact)
     with pytest.raises(InvalidUserActionException):
-        _ = db.sql(query=SENTIMENT_SQL_QUERY, name="dummy_sentiment_model")
+        _ = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="dummy_sentiment_model")
 
 
 def test_naming_collision_with_dependency(client, data_integration):
     # Overwrite is invalid when the operator being replaced is an upstream dependency.
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY, name="sentiment_model")
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sentiment_model")
     dummy_model_output = dummy_model(sql_artifact)
     dummy_model_2_output = dummy_model_2(dummy_model_output)
 

--- a/integration_tests/sdk/no_input_test.py
+++ b/integration_tests/sdk/no_input_test.py
@@ -20,9 +20,8 @@ def test_basic_no_input_function(client):
     assert result.equals(expected)
 
 
-def test_flow_with_no_input_function(client):
-    warehouse = client.integration(name="aqueduct_demo")
-    customers_table = warehouse.sql(query="SELECT * FROM customers;")
+def test_flow_with_no_input_function(client, data_integration):
+    customers_table = data_integration.sql(query="SELECT * FROM customers;")
 
     result = join(no_input(), customers_table)
     expected = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})

--- a/integration_tests/sdk/operator_hierarchy_test.py
+++ b/integration_tests/sdk/operator_hierarchy_test.py
@@ -32,8 +32,7 @@ def regular_function(args):
 
 def test_check_artifact_restriction(client, data_integration):
     """Test that an artifact produced by a check operator cannot be used as an argument to any operator types."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     check_artifact = produce_check_artifact(sql_artifact)
     with pytest.raises(InvalidUserActionException):
@@ -46,8 +45,7 @@ def test_check_artifact_restriction(client, data_integration):
 
 def test_metric_artifact_restriction(client, data_integration):
     """Test that an artifact produced by a metric operator cannot be used as an argument to function operator."""
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     metric_artifact = produce_metric_artifact(sql_artifact)
     with pytest.raises(InvalidUserActionException):

--- a/integration_tests/sdk/operator_test.py
+++ b/integration_tests/sdk/operator_test.py
@@ -6,8 +6,7 @@ from aqueduct import op
 
 
 def test_to_operator_local_function(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     @op
     def dummy_sentiment_model(df):
@@ -27,8 +26,7 @@ def test_to_operator_local_function(client, data_integration):
 
 
 def test_to_operator_imported_function(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     @op(file_dependencies=["test_function.py"])
     def decorated_func(df):

--- a/integration_tests/sdk/param_test.py
+++ b/integration_tests/sdk/param_test.py
@@ -109,8 +109,7 @@ def append_row_to_df(df, row):
 
 
 def test_parameter_in_basic_flow(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     row_to_add = ["new hotel", "09-28-1996", "US", "It was new."]
     new_row_param = client.create_param(name="new row", default=row_to_add)
     output = append_row_to_df(sql_artifact, new_row_param)
@@ -123,8 +122,7 @@ def test_parameter_in_basic_flow(client, data_integration):
 
 
 def test_edit_param_for_flow(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     row_to_add = ["new hotel", "09-28-1996", "US", "It was new."]
     new_row_param = client.create_param(name="new row", default=row_to_add)
     output = append_row_to_df(sql_artifact, new_row_param)
@@ -171,8 +169,7 @@ def add_numbers(sql, num1, num2):
 
 
 def test_trigger_flow_with_different_param(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     num1 = client.create_param(name="num1", default=5)
     num2 = client.create_param(name="num2", default=5)
@@ -213,10 +210,8 @@ def test_trigger_flow_with_different_param(client, flow_name, data_integration, 
 
 
 def test_trigger_flow_with_different_sql_param(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-
     _ = client.create_param("table_name", default="hotel_reviews")
-    sql_artifact = db.sql(query="select * from {{ table_name}}")
+    sql_artifact = data_integration.sql(query="select * from {{ table_name}}")
 
     flow = publish_flow_test(
         client,

--- a/integration_tests/sdk/preview_test.py
+++ b/integration_tests/sdk/preview_test.py
@@ -20,8 +20,7 @@ from aqueduct import global_config, op
 
 
 def test_basic_get(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     sql_df = sql_artifact.get()
     assert list(sql_df) == ["hotel_name", "review_date", "reviewer_nationality", "review"]
     assert sql_df.shape[0] == 100
@@ -39,9 +38,8 @@ def test_basic_get(client, data_integration):
 
 
 def test_multiple_input_get(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact1 = db.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = db.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
+    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
 
     fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact1, sql_artifact2)
     fn_df = fn_artifact.get()
@@ -71,8 +69,7 @@ def test_multiple_input_get(client, data_integration):
 
 
 def test_basic_file_dependencies(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     output_artifact = model_with_file_dependency(sql_artifact)
     output_df = output_artifact.get()
@@ -87,8 +84,7 @@ def test_basic_file_dependencies(client, data_integration):
 
 
 def test_invalid_file_dependencies(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
 
     with pytest.raises(AqueductError):
         model_with_invalid_dependencies(sql_artifact)
@@ -115,8 +111,7 @@ def test_table_with_non_string_column_name(client):
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
 def test_basic_get_by_engine(client, data_integration, engine):
     global_config({"engine": engine})
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     sql_df = sql_artifact.get()
     assert list(sql_df) == ["hotel_name", "review_date", "reviewer_nationality", "review"]
     assert sql_df.shape[0] == 100

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -33,7 +33,9 @@ def test_invalid_destination_integration(client, data_integration):
 
 
 def test_sql_today_tag(client, data_integration):
-    sql_artifact_today = data_integration.sql(query="select * from hotel_reviews where review_date = {{today}}")
+    sql_artifact_today = data_integration.sql(
+        query="select * from hotel_reviews where review_date = {{today}}"
+    )
     assert sql_artifact_today.get().empty
     sql_artifact_not_today = data_integration.sql(
         query="select * from hotel_reviews where review_date < {{today}}"
@@ -101,12 +103,16 @@ def test_sql_query_with_multiple_parameters(client, flow_name, data_integration,
 
 def test_sql_query_user_vs_builtin_precedence(client, data_integration):
     """If a user defines an expansion that collides with a built-in one, the user-defined one should take precedence."""
-    sql_artifact = data_integration.sql(query="select * from hotel_reviews where review_date > {{today}}")
+    sql_artifact = data_integration.sql(
+        query="select * from hotel_reviews where review_date > {{today}}"
+    )
     builtin_result = sql_artifact.get()
 
     datestring = "'2016-01-01'"
     _ = client.create_param("today", datestring)
-    sql_artifact = data_integration.sql(query="select * from hotel_reviews where review_date > {{today}}")
+    sql_artifact = data_integration.sql(
+        query="select * from hotel_reviews where review_date > {{today}}"
+    )
     user_param_result = sql_artifact.get()
     assert not builtin_result.equals(user_param_result)
 

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -8,8 +8,7 @@ from aqueduct import metric
 
 
 def test_sql_integration_load_table(client, data_integration):
-    db = client.integration(data_integration)
-    df = db.table(name="hotel_reviews")
+    df = data_integration.table(name="hotel_reviews")
     assert len(df) == 100
     assert list(df) == [
         "hotel_name",
@@ -25,43 +24,39 @@ def test_invalid_source_integration(client):
 
 
 def test_invalid_destination_integration(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact = db.sql(query=SENTIMENT_SQL_QUERY)
+    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     output_artifact = dummy_sentiment_model(sql_artifact)
 
     with pytest.raises(InvalidIntegrationException):
-        db._metadata.name = "bad name"
-        save(db, output_artifact)
+        data_integration._metadata.name = "bad name"
+        save(data_integration, output_artifact)
 
 
 def test_sql_today_tag(client, data_integration):
-    db = client.integration(data_integration)
-    sql_artifact_today = db.sql(query="select * from hotel_reviews where review_date = {{today}}")
+    sql_artifact_today = data_integration.sql(query="select * from hotel_reviews where review_date = {{today}}")
     assert sql_artifact_today.get().empty
-    sql_artifact_not_today = db.sql(
+    sql_artifact_not_today = data_integration.sql(
         query="select * from hotel_reviews where review_date < {{today}}"
     )
     assert len(sql_artifact_not_today.get()) == 100
 
 
 def test_sql_query_with_parameter(client, data_integration):
-    db = client.integration(data_integration)
-
     # Missing parameters.
     with pytest.raises(InvalidUserArgumentException):
-        _ = db.sql(query="select * from {{missing_parameter}}")
+        _ = data_integration.sql(query="select * from {{missing_parameter}}")
 
     # The parameter is not a string type.
     _ = client.create_param("table_name", default=1234)
     with pytest.raises(InvalidUserArgumentException):
-        _ = db.sql(query="select * from {{ table_name }}")
+        _ = data_integration.sql(query="select * from {{ table_name }}")
 
     client.create_param("table_name", default="hotel_reviews")
-    sql_artifact = db.sql(query="select * from {{ table_name }}")
+    sql_artifact = data_integration.sql(query="select * from {{ table_name }}")
 
-    expected_sql_artifact = db.sql(query="select * from hotel_reviews")
+    expected_sql_artifact = data_integration.sql(query="select * from hotel_reviews")
     assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = db.sql(query="select * from customer_activity")
+    expected_sql_artifact = data_integration.sql(query="select * from customer_activity")
     assert sql_artifact.get(parameters={"table_name": "customer_activity"}).equals(
         expected_sql_artifact.get()
     )
@@ -74,20 +69,18 @@ def test_sql_query_with_parameter(client, data_integration):
 
 
 def test_sql_query_with_multiple_parameters(client, flow_name, data_integration, engine):
-    db = client.integration(data_integration)
-
     _ = client.create_param("table_name", default="hotel_reviews")
     nationality = client.create_param(
         "reviewer-nationality", default="United Kingdom"
     )  # check that dashes work.
-    sql_artifact = db.sql(
+    sql_artifact = data_integration.sql(
         query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer-nationality }}' and review_date < {{ today}}"
     )
-    expected_sql_artifact = db.sql(
+    expected_sql_artifact = data_integration.sql(
         "select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}"
     )
     assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = db.sql(
+    expected_sql_artifact = data_integration.sql(
         "select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}"
     )
     assert sql_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
@@ -108,18 +101,16 @@ def test_sql_query_with_multiple_parameters(client, flow_name, data_integration,
 
 def test_sql_query_user_vs_builtin_precedence(client, data_integration):
     """If a user defines an expansion that collides with a built-in one, the user-defined one should take precedence."""
-    db = client.integration(data_integration)
-
-    sql_artifact = db.sql(query="select * from hotel_reviews where review_date > {{today}}")
+    sql_artifact = data_integration.sql(query="select * from hotel_reviews where review_date > {{today}}")
     builtin_result = sql_artifact.get()
 
     datestring = "'2016-01-01'"
     _ = client.create_param("today", datestring)
-    sql_artifact = db.sql(query="select * from hotel_reviews where review_date > {{today}}")
+    sql_artifact = data_integration.sql(query="select * from hotel_reviews where review_date > {{today}}")
     user_param_result = sql_artifact.get()
     assert not builtin_result.equals(user_param_result)
 
-    expected_sql_artifact = db.sql(
+    expected_sql_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > %s" % datestring
     )
     assert user_param_result.equals(expected_sql_artifact.get())

--- a/integration_tests/sdk/table_artifact_test.py
+++ b/integration_tests/sdk/table_artifact_test.py
@@ -8,8 +8,7 @@ from aqueduct import op
 
 
 def test_great_expectations_check(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=WINE_SQL_QUERY)
+    table = data_integration.sql(query=WINE_SQL_QUERY)
     ge_check = table.validate_with_expectation(
         "expect_column_values_to_be_unique", {"column": "fixed_acidity"}
     )
@@ -48,8 +47,7 @@ def mem_intensive_function(table: pd.DataFrame) -> pd.DataFrame:
 
 
 def test_system_runtime_metric(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=SENTIMENT_SQL_QUERY)
+    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     timed_table = timed_function(table)
 
     runtime_metric = timed_table.system_metric("runtime")
@@ -58,8 +56,7 @@ def test_system_runtime_metric(client, data_integration):
 
 
 def test_system_max_memory_metric(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=SENTIMENT_SQL_QUERY)
+    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     timed_table = mem_intensive_function(table)
 
     max_mem_metric = timed_table.system_metric("max_memory")
@@ -68,8 +65,7 @@ def test_system_max_memory_metric(client, data_integration):
 
 
 def test_number_of_missing_values(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=SENTIMENT_SQL_QUERY)
+    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     missing_metric = table.number_of_missing_values(column_id="hotel_name")
     assert missing_metric.get() == 0
 
@@ -82,8 +78,7 @@ def test_number_of_missing_values(client, data_integration):
 
 
 def test_number_of_rows(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=SENTIMENT_SQL_QUERY)
+    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     missing_metric = table.number_of_rows()
     assert missing_metric.get() == 100
 
@@ -93,8 +88,7 @@ def test_number_of_rows(client, data_integration):
 
 
 def test_max(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=WINE_SQL_QUERY)
+    table = data_integration.sql(query=WINE_SQL_QUERY)
     missing_metric = table.max(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 15.8999, rel_tol=1e-3)
 
@@ -103,8 +97,7 @@ def test_max(client, data_integration):
 
 
 def test_min(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=WINE_SQL_QUERY)
+    table = data_integration.sql(query=WINE_SQL_QUERY)
     missing_metric = table.min(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 3.7999, rel_tol=1e-3)
 
@@ -113,8 +106,7 @@ def test_min(client, data_integration):
 
 
 def test_mean(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=WINE_SQL_QUERY)
+    table = data_integration.sql(query=WINE_SQL_QUERY)
     missing_metric = table.mean(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 7.2153, rel_tol=1e-3)
 
@@ -123,8 +115,7 @@ def test_mean(client, data_integration):
 
 
 def test_std(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=WINE_SQL_QUERY)
+    table = data_integration.sql(query=WINE_SQL_QUERY)
     missing_metric = table.std(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 1.2964, rel_tol=1e-3)
 
@@ -133,8 +124,7 @@ def test_std(client, data_integration):
 
 
 def test_head_standard(client, data_integration):
-    db = client.integration(data_integration)
-    table = db.sql(query=SENTIMENT_SQL_QUERY)
+    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
     assert table.get().shape[0] == 100
 
     table_head = table.head()


### PR DESCRIPTION
## Describe your changes and why you are making these changes
First step in unlocking cross-data-integration tests is to get rid of the relational db assumptions that we've encoded in the naming of things, eg. calling everything `db`.

Additionally, I took this opportunity to convert the `data_integration` fixture into an actual integration object, instead of a string. This saves one line of `data_integration = client.integration(data_integration_name)` in each test case.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


