### PR TITLE
Eng 2104 [2/2][ui] Fix a bug where mongo collection preview crashes

### DIFF
--- a/src/ui/common/src/components/tables/PaginatedTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedTable.tsx
@@ -93,6 +93,9 @@ export const PaginatedTable: React.FC<PaginatedTableProps> = ({ data }) => {
                       const value = row[column.name];
                       let displayedValue = '';
                       if (!!value) {
+                        // when the column type is json or object,
+                        // the value parsed from backend API will be an arbitrary json object.
+                        // Here we need to serialize the object to render it properly.
                         if (
                           column.type === 'json' ||
                           column.type === 'object'

--- a/src/ui/common/src/components/tables/PaginatedTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedTable.tsx
@@ -91,12 +91,23 @@ export const PaginatedTable: React.FC<PaginatedTableProps> = ({ data }) => {
                   >
                     {columns.map((column, columnIndex) => {
                       const value = row[column.name];
+                      let displayedValue = '';
+                      if (!!value) {
+                        if (
+                          column.type === 'json' ||
+                          column.type === 'object'
+                        ) {
+                          displayedValue = JSON.stringify(value);
+                        } else {
+                          displayedValue = value.toString();
+                        }
+                      }
                       return (
                         <TableCell
                           key={`table-col-${columnIndex}`}
                           align={'left'}
                         >
-                          {value ? value.toString() : ''}
+                          {displayedValue}
                         </TableCell>
                       );
                     })}

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -65,6 +65,7 @@ const ArtifactContent: React.FC<Props> = ({
           artifact.result.serialization_type === SerializationType.BsonTable
         ) {
           const rows = rawData as TableRow[];
+          // bson table does not include schema when serialized.
           const schema = inferSchema(rows);
           return <PaginatedTable data={{ schema: schema, data: rows }} />;
         }

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { ArtifactResultResponse } from '../../../handlers/responses/artifact';
 import { ContentWithLoadingStatus } from '../../../reducers/artifactResultContents';
 import { SerializationType } from '../../../utils/artifacts';
+import { Data, inferSchema, TableRow } from '../../../utils/data';
 import { isFailed, isInitial, isLoading } from '../../../utils/shared';
 import PaginatedTable from '../../tables/PaginatedTable';
 
@@ -57,9 +58,18 @@ const ArtifactContent: React.FC<Props> = ({
 
   switch (artifact.result.serialization_type) {
     case SerializationType.Table:
+    case SerializationType.BsonTable:
       try {
-        const data = JSON.parse(contentWithLoadingStatus.data);
-        return <PaginatedTable data={data} />;
+        const rawData = JSON.parse(contentWithLoadingStatus.data);
+        if (
+          artifact.result.serialization_type === SerializationType.BsonTable
+        ) {
+          const rows = rawData as TableRow[];
+          const schema = inferSchema(rows);
+          return <PaginatedTable data={{ schema: schema, data: rows }} />;
+        }
+
+        return <PaginatedTable data={rawData as Data} />;
       } catch (err) {
         return (
           <Alert severity="error" title="Cannot parse table data.">

--- a/src/ui/common/src/handlers/getArtifactResultContent.ts
+++ b/src/ui/common/src/handlers/getArtifactResultContent.ts
@@ -51,6 +51,7 @@ export const handleGetArtifactResultContent = createAsyncThunk<
       if (
         artifactResult.serialization_type === SerializationType.String ||
         artifactResult.serialization_type === SerializationType.Table ||
+        artifactResult.serialization_type === SerializationType.BsonTable ||
         artifactResult.serialization_type === SerializationType.Json
       ) {
         artifactResult.data = await (formData.get('data') as File).text();

--- a/src/ui/common/src/reducers/integration.ts
+++ b/src/ui/common/src/reducers/integration.ts
@@ -155,11 +155,18 @@ export const handleLoadIntegrationObject = createAsyncThunk<
     } else {
       const serialized = (objectResponseBody as ObjectPreviewResponse).data;
       const rawData = JSON.parse(serialized);
+
+      // Distinguish between serialization types `table` vs `bson_table`,
+      // since this information is not returned by backend.
+      // TODO: We can remove this once the backend output format is more unified.
       if ('schema' in rawData) {
         return rawData as Data;
       }
 
-      // this is a bson_table
+      // This is a bson_table. We need to infer schema as the serialization
+      // does not include the schema.
+      // For now, `inferSchema` simply takes columns in first row and assume
+      // they are 'object' type.
       const rows = rawData as TableRow[];
       return {
         schema: inferSchema(rows),

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -167,6 +167,7 @@ export const handleGetArtifactResults = createAsyncThunk<
         if (
           artifactResult.serialization_type === SerializationType.String ||
           artifactResult.serialization_type === SerializationType.Table ||
+          artifactResult.serialization_type === SerializationType.BsonTable ||
           artifactResult.serialization_type === SerializationType.Json
         ) {
           artifactResult.data = await (formData.get('data') as File).text();

--- a/src/ui/common/src/utils/data.ts
+++ b/src/ui/common/src/utils/data.ts
@@ -71,16 +71,16 @@ export type DataPreview = {
 };
 
 export function inferSchema(rows: TableRow[]): DataSchema {
-  const columnNames = new Set<string>();
-  const columns: DataColumn[] = [];
-  rows.forEach((r) =>
-    Object.keys(r).forEach((col) => {
-      if (!(col in columnNames)) {
-        columns.push({ name: col, displayName: col, type: 'object' });
-        columnNames.add(col);
-      }
-    })
-  );
+  if (!rows) {
+    return { fields: [], pandas_version: '' };
+  }
 
-  return { fields: columns, pandas_version: '' };
+  return {
+    fields: Object.keys(rows[0]).map((col) => ({
+      name: col,
+      displayName: col,
+      type: 'object',
+    })),
+    pandas_version: '',
+  };
 }

--- a/src/ui/common/src/utils/data.ts
+++ b/src/ui/common/src/utils/data.ts
@@ -8,6 +8,7 @@ export const DataColumnTypeNames = [
   'boolean',
   'datetime',
   'json',
+  'object',
 ] as const;
 
 export type DataColumnType = typeof DataColumnTypeNames[number];
@@ -68,3 +69,18 @@ export type DataPreview = {
   historical_versions: Record<string, DataPreviewInfo>;
   latest_versions: Record<string, DataPreviewInfo>;
 };
+
+export function inferSchema(rows: TableRow[]): DataSchema {
+  const columnNames = new Set<string>();
+  const columns: DataColumn[] = [];
+  rows.forEach((r) =>
+    Object.keys(r).forEach((col) => {
+      if (!(col in columnNames)) {
+        columns.push({ name: col, displayName: col, type: 'object' });
+        columnNames.add(col);
+      }
+    })
+  );
+
+  return { fields: columns, pandas_version: '' };
+}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR introduce necessary UI change to render `bson_table` serialization type in UI, as introduced in #820 .

## Related issue number (if any)
ENG 2104

## Loom demo (if any)
Verified with a mongo workflow with extract, function, and load operator. We checked the table renders in following pages: table preview in integration page, artifact content preview, and artifact versions in data page.
table preview (does not reproduce original problem):
<img width="1054" alt="Screen Shot 2022-12-16 at 5 37 26 PM" src="https://user-images.githubusercontent.com/10411887/208217646-e1776abb-c973-456b-b4fb-70b4662d6c9d.png">

artifact preview:
<img width="800" alt="Screen Shot 2022-12-16 at 5 34 03 PM" src="https://user-images.githubusercontent.com/10411887/208217699-4479a8e1-869a-4a4d-b2a2-106b13196ae7.png">

data page (technically this is not affected by this change):
<img width="1150" alt="Screen Shot 2022-12-16 at 5 49 54 PM" src="https://user-images.githubusercontent.com/10411887/208217735-d3e67f55-2b4e-45c8-ba3e-9dcae84c462c.png">

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


