### PR TITLE
WIP: Adds some initial docstrings to ui/common.

### DIFF
--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -45,6 +45,7 @@
         "rollup-plugin-postcss": "^4.0.2",
         "size-limit": "^7.0.8",
         "tslib": "^2.4.0",
+        "typedoc": "^0.23.23",
         "typescript": "^3.9.10",
         "vite": "^3.1.0",
         "vite-plugin-externalize-deps": "^0.4.0",
@@ -22254,6 +22255,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -22848,6 +22855,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/luxon": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
@@ -23027,6 +23040,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/math-log2": {
@@ -29622,6 +29647,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -31476,6 +31512,48 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
@@ -32730,6 +32808,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "node_modules/vt-pbf": {
@@ -50488,6 +50578,12 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -50868,6 +50964,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "luxon": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
@@ -51014,6 +51116,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
       "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
+      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
       "dev": true
     },
     "math-log2": {
@@ -55978,6 +56086,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.11.1.tgz",
+      "integrity": "sha512-EugY9VASFuDqOexOgXR18ZV+TbFrQHeCpEYaXamO+SZlsnT/2LxuLBX25GGtIrwaEVFXUAbUQ601SWE2rMwWHA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "^6.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -57488,6 +57607,38 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.23",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.23.tgz",
+      "integrity": "sha512-cg1YQWj+/BU6wq74iott513U16fbrPCbyYs04PHZgvoKJIc6EY4xNobyDZh4KMfRGW8Yjv6wwIzQyoqopKOUGw==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.4",
+        "minimatch": "^5.1.1",
+        "shiki": "^0.11.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "3.9.10",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
@@ -58339,6 +58490,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-6.0.0.tgz",
+      "integrity": "sha512-gu73tuZfJgu+mvCSy4UZwd2JXykjK9zAZsfmDeut5dx/1a7FeTk0XwJsSuqQn+cuMCGVbIBfl+s53X4T19DnzQ==",
       "dev": true
     },
     "vt-pbf": {

--- a/src/ui/common/package.json
+++ b/src/ui/common/package.json
@@ -15,6 +15,7 @@
     "node": ">=10"
   },
   "scripts": {
+    "docs": "typedoc",
     "preinstall": "npx force-resolutions",
     "start": "vite",
     "build": "vite build",
@@ -123,6 +124,7 @@
     "size-limit": "^7.0.8",
     "tslib": "^2.4.0",
     "typescript": "^3.9.10",
+    "typedoc": "^0.23.23",
     "vite": "^3.1.0",
     "vite-plugin-externalize-deps": "^0.4.0",
     "webpack": "^5.74.0"

--- a/src/ui/common/src/components/CodeBlock/index.tsx
+++ b/src/ui/common/src/components/CodeBlock/index.tsx
@@ -3,10 +3,19 @@ import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
 
 type Props = {
+  /**
+   * Programming language to be syntax highlighted in the code block.
+   */
   language: string;
+  /**
+   * Code string to be rendered in the code block.
+   */
   children: string;
 };
 
+/**
+ * Component used to show syntax highlighted code on the UI.
+ */
 export const CodeBlock: React.FC<Props> = ({ language, children }) => {
   return (
     <SyntaxHighlighter

--- a/src/ui/common/src/components/DataPreviewer/index.tsx
+++ b/src/ui/common/src/components/DataPreviewer/index.tsx
@@ -20,6 +20,9 @@ type Props = {
   dataTableHeight?: string;
 };
 
+/**
+ * Shows a preview for an artifact depending on it's serialization type.
+ */
 export const DataPreviewer: React.FC<Props> = ({
   previewData,
   error,

--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -33,9 +33,15 @@ const InfoCard = styled(Box)({
 });
 
 type GettingStartedTutorialProps = {
+  /**
+   * User to be rendered in greeting message on Getting Started tutorial card.
+   */
   user: UserProfile;
 };
 
+/**
+ * Card to be shown on the home page when the user first enters the web application.
+ */
 const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
   user,
 }) => {
@@ -44,6 +50,9 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
     greeting = 'Welcome to Aqueduct!';
   }
 
+  /**
+   * Animation effect to make hand emoji wave when user first loads the page.
+   */
   const waveEmoji = () => {
     const emojiElement = document.getElementById('greet-emoji');
     emojiElement.style.transitionDuration = '.4s';
@@ -82,6 +91,7 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
         flexDirection: 'column',
       }}
     >
+      {/* TODO: Move this image to a constant somewhere. Might be a good idea to put all logos together  */}
       <img
         src="https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct-logo-two-tone/1x/aqueduct-logo-two-tone-1x.png"
         width="300px"

--- a/src/ui/common/src/utils/reactflow.ts
+++ b/src/ui/common/src/utils/reactflow.ts
@@ -11,36 +11,84 @@ import {
 import { Artifact } from './artifacts';
 import { Operator } from './operators';
 
+/**
+ * Type representing the various lines used to connect DAG nodes to one another on the DAG view.
+ */
 export const EdgeTypes = {
   quadratic: AqueductQuadratic,
   straight: AqueductStraight,
   curved: AqueductBezier,
 };
 
+/**
+ * Type representing the various nodes shown on the DAG view.
+ */
 export enum ReactflowNodeType {
   Operator = 'operator',
   Artifact = 'artifact',
 }
 
+/**
+ * Type representing the data contained in each DAG node on the DAG view.
+ */
 export type ReactFlowNodeData = {
+  /**
+   * Callback function to call when the node changes.
+   * @returns void
+   */
   onChange: () => void;
+  /**
+   * Callback function to be called when the user drags a line from one node's handle to another.
+   * NOTE: Currently we do not support editing the DAG, so this function is not used.
+   * @param any input parameters needed (if any) to be called when two DAG nodes are connected to one another
+   * @returns void.
+   */
   onConnect: (any) => void;
+  /**
+   * Where to place the handles used to position connecting edge lines.
+   * Handles are also used to allow users to drag and drop a line connecting two nodes.
+   * This functionality is currently unsupported in Aqueduct.
+   */
   targetHandlePosition?: Position;
+  /**
+   * The type of the node to be rendered on the DAG.
+   */
   nodeType: ReactflowNodeType;
+  /**
+   * Unique identifier of the node.
+   */
   nodeId: string;
+  /**
+   * Label text to show on the node.
+   */
   label?: string;
-  // Used to present metric or check results inside the node
+  /**
+   * Used to present metric or check results inside the node.
+   */
   result?: string;
 };
 
+/**
+ * Response type used to store operator and artifact x and y positions on the DAG viewer.
+ */
 export type GetPositionResponse = {
   operator_positions: { [opId: string]: NodePos };
   artifact_positions: { [artfId: string]: NodePos };
 };
 
-// These are generic dag supports
+/**
+ * x and y position for a node on the DAG viewer.
+ */
 type NodePos = { x: number; y: number };
 
+/**
+ * Converts an Aqueduct operator node into a react-flow node.
+ * @param op The operator to be rendered.
+ * @param pos x and y position of the operator.
+ * @param onChange Callback function to be called when the operator node changes.
+ * @param onConnect Callback function to be called when user drags and drops one node's handle to another. This functionality is currently not used.
+ * @returns A react flow node representing an Aqueduct Operator to be rendered in the DAG view.
+ */
 export function getOperatorNode(
   op: Operator,
   pos: NodePos,
@@ -62,6 +110,14 @@ export function getOperatorNode(
   };
 }
 
+/**
+ * Converts an Aqueduct artifact node into a react-flow node.
+ * @param artf The artifact to be rendered.
+ * @param pos x and y position of the artifact.
+ * @param onChange Callback function to be called when the artifact node changes.
+ * @param onConnect Callback function to be called when user drags and drops one node's handle to another. This functionality is currently not used.
+ * @returns A react-flow ndoe representing an Aqueduct Artifact to be rendered in the DAG view.
+ */
 export function getArtifactNode(
   artf: Artifact,
   pos: NodePos,
@@ -83,6 +139,11 @@ export function getArtifactNode(
   };
 }
 
+/**
+ * Retrieves a list of edges for a given set of operators.
+ * @param operators Map of operators to retrieve DAG edges for,
+ * @returns An array of input and output edges for each operator of the operators map.
+ */
 export function getEdges(operators: { [id: string]: Operator }): Edge[] {
   const results = [];
   Object.values(operators).forEach((op) => {

--- a/src/ui/common/src/utils/shared.ts
+++ b/src/ui/common/src/utils/shared.ts
@@ -1,3 +1,6 @@
+/**
+ * Enum representing the various loading statuses that occur when making a call to the REST API.
+ */
 export enum LoadingStatusEnum {
   Initial = 'initial',
   Loading = 'loading',
@@ -5,27 +8,53 @@ export enum LoadingStatusEnum {
   Succeeded = 'succeeded',
 }
 
+/**
+ * Type representing a request's loading status and an error string.
+ */
 export type LoadingStatus = {
   loading: LoadingStatusEnum;
   err: string;
 };
 
+/**
+ * Convenience function used to determine if a request is in the initial loading state.
+ * @param status The loading status of the request.
+ * @returns true if the request is in the initial loading state, false otherwise.
+ */
 export function isInitial(status: LoadingStatus): boolean {
   return status.loading === LoadingStatusEnum.Initial;
 }
 
+/**
+ * Convenience function used to determine if a request is in the loading state.
+ * @param status The loading status of the request.
+ * @returns true if request is in the loading state, false otherwise.
+ */
 export function isLoading(status: LoadingStatus): boolean {
   return status.loading === LoadingStatusEnum.Loading;
 }
 
+/**
+ * Convenience function used to determine if a request has successfully loaded.
+ * @param status The loading status of the request.
+ * @returns true if the request has successfully loaded, false otherwise.
+ */
 export function isSucceeded(status: LoadingStatus): boolean {
   return status.loading === LoadingStatusEnum.Succeeded;
 }
 
+/**
+ * Convenience function used to determine if a request has failed to load.
+ * @param status The loading status of the request.
+ * @returns true if the request has failed to load, false otherwise.
+ */
 export function isFailed(status: LoadingStatus): boolean {
   return status.loading === LoadingStatusEnum.Failed;
 }
 
+/**
+ * Enum representing the different statuses that an Operator can have while being executed.
+ */
 export enum ExecutionStatus {
   Unknown = 'unknown',
   Succeeded = 'succeeded',
@@ -36,6 +65,9 @@ export enum ExecutionStatus {
   Running = 'running',
 }
 
+/**
+ * Type representing when each state transition occurs for a given operator.
+ */
 export type ExecutionTimestamps = {
   registered_at?: string;
   pending_at?: string;
@@ -43,14 +75,35 @@ export type ExecutionTimestamps = {
   finished_at?: string;
 };
 
+/**
+ * Type representing a given operator's lifecyle during execution.
+ */
 export type ExecState = {
+  /**
+   * Current execution status of the operator.
+   */
   status: ExecutionStatus;
+  /**
+   * Whether or not the operator has failed to execute.
+   */
   failure_type?: FailureType;
+  /**
+   * Stack trace for execution error and useful tip for user to fix the execution error.
+   */
   error?: Error;
+  /**
+   * Logs that may appear in stdin or stdout
+   */
   user_logs?: Logs;
+  /**
+   * Times when each state transition occured for the operator.
+   */
   timestamps?: ExecutionTimestamps;
 };
 
+/**
+ * Enum representing the different levels of error severity that an operator can have while executing.
+ */
 export enum FailureType {
   Succeess = 0,
   System = 1,
@@ -58,6 +111,9 @@ export enum FailureType {
   UserNonFatal = 3,
 }
 
+/**
+ * Enum represnting whether or not a Check operator has passed.
+ */
 export enum CheckStatus {
   Succeeded = 'True',
   Failed = 'False',
@@ -68,14 +124,23 @@ export const TransitionLengthInMs = 200;
 
 export const WidthTransition = `width ${TransitionLengthInMs}ms ease-in-out`;
 
+/**
+ * User generated logs to show for a given operator.
+ */
 export type Logs = {
   stdout?: string;
   stderr?: string;
 };
 
+/**
+ * Type representing an operator execution error. Contains a stack trace as well as a useful tip to show the user to resolve their error.
+ */
 export type Error = {
   context?: string;
   tip?: string;
 };
 
+/**
+ * Link used to file an issue against the Aqueduct open source repo.
+ */
 export const GithubIssueLink = `https://github.com/aqueducthq/aqueduct/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D`;

--- a/src/ui/common/typedoc.json
+++ b/src/ui/common/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.tsx"],
+  "out": "doc",
+  "externalPattern": "**/node_modules/**",
+  "exclude": "**/node_modules/**"
+}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds some docstrics in tsdoc format to ui/common. 

TSDoc is a standard for documenting typescript code. We can use this in conjunction with a tool like TypeDoc to generate documentation for our frontend codebases.

Here's a nice blog post which details the process of documenting some code and generating the documentation website using TypeDoc: https://coryrylan.com/blog/intro-to-typescript-documentation-with-tsdoc

TODO: set up TypeDoc for use with our repo:
https://typedoc.org/guides/installation/

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


