### PR TITLE
ENG-2124: Reduce sigfigs on the metrics preview in data list page and workflows list page

### DIFF
--- a/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 
 import { theme } from '../../../../styles/theme/theme';
 import ExecutionStatus from '../../../../utils/shared';
+import { parseMetricResult } from '../../../workflows/nodes/MetricOperatorNode';
 
 interface ShowMoreProps {
   totalItems: number;
@@ -84,7 +85,7 @@ const MetricItem: React.FC<MetricItemProps> = ({ metrics }) => {
               </Box>
             </Tooltip>
           ) : (
-            <Typography variant="body1">{metrics[i].value}</Typography>
+            <Typography variant="body1">{parseMetricResult(metrics[i].value, 3)}</Typography>
           )}
         </Box>
       );

--- a/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
@@ -85,7 +85,9 @@ const MetricItem: React.FC<MetricItemProps> = ({ metrics }) => {
               </Box>
             </Tooltip>
           ) : (
-            <Typography variant="body1">{parseMetricResult(metrics[i].value, 3)}</Typography>
+            <Typography variant="body1">
+              {parseMetricResult(metrics[i].value, 3)}
+            </Typography>
           )}
         </Box>
       );

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -26,7 +26,13 @@ export const parseMetricResult = (
   metricValue: string,
   sigfigs: number
 ): string => {
-  return parseFloat(metricValue).toFixed(sigfigs);
+  // Check if the number passed in is a whole number, return that if so.
+  const parsedFloat = parseFloat(metricValue);
+  if (parsedFloat % 1 === 0) {
+    return metricValue;
+  }
+  // Only show three decimal points.
+  return parsedFloat.toFixed(sigfigs);
 };
 
 const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -22,6 +22,10 @@ type Props = {
 
 export const metricOperatorNodeIcon = faTemperatureHalf;
 
+export const parseMetricResult = (metricValue: string, sigfigs: number) => {
+  return parseFloat(metricValue).toFixed(sigfigs);
+};
+
 const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
   const defaultLabel = 'Metric';
   const label = data.label ? data.label : defaultLabel;
@@ -112,7 +116,7 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
       >
         {data.result && (
           <Typography variant="h5">
-            {parseFloat(data.result).toFixed(3)}
+            {parseMetricResult(data.result, 3)}
           </Typography>
         )}
       </Box>

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -22,7 +22,10 @@ type Props = {
 
 export const metricOperatorNodeIcon = faTemperatureHalf;
 
-export const parseMetricResult = (metricValue: string, sigfigs: number) => {
+export const parseMetricResult = (
+  metricValue: string,
+  sigfigs: number
+): string => {
   return parseFloat(metricValue).toFixed(sigfigs);
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR reduces the number of significant figures for metrics on data list page and workflows list page.

## Related issue number (if any)
ENG-2124

## Loom demo (if any)
Screenshot:
<img width="548" alt="image" src="https://user-images.githubusercontent.com/1031759/208550696-706e4c9f-74ca-4474-84f0-dc6edaf0d0f0.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


