### PR TITLE
ENG 2061 Remove data section for compute integrations

### DIFF
--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -6,7 +6,8 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
-
+import { SupportedIntegrations, IntegrationCategories } from '../../../../utils/integrations';
+ 
 import { DetailIntegrationCard } from '../../../../components/integrations/cards/detailCard';
 import AddTableDialog from '../../../../components/integrations/dialogs/addTableDialog';
 import DeleteIntegrationDialog from '../../../../components/integrations/dialogs/deleteIntegrationDialog';
@@ -179,8 +180,8 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             .
           </Typography>
         )}
-
-        <IntegrationObjectList user={user} integration={selectedIntegration} />
+        
+        {SupportedIntegrations[selectedIntegration.service].category !== IntegrationCategories.COMPUTE && <IntegrationObjectList user={user} integration={selectedIntegration} />}
 
         <Typography
           variant="h5"

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -6,8 +6,7 @@ import Typography from '@mui/material/Typography';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
-import { SupportedIntegrations, IntegrationCategories } from '../../../../utils/integrations';
- 
+
 import { DetailIntegrationCard } from '../../../../components/integrations/cards/detailCard';
 import AddTableDialog from '../../../../components/integrations/dialogs/addTableDialog';
 import DeleteIntegrationDialog from '../../../../components/integrations/dialogs/deleteIntegrationDialog';
@@ -27,6 +26,10 @@ import { handleLoadIntegrations } from '../../../../reducers/integrations';
 import { handleFetchAllWorkflowSummaries } from '../../../../reducers/listWorkflowSummaries';
 import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
+import {
+  IntegrationCategories,
+  SupportedIntegrations,
+} from '../../../../utils/integrations';
 import { isFailed, isLoading, isSucceeded } from '../../../../utils/shared';
 import IntegrationOptions from '../../../integrations/options';
 import { LayoutProps } from '../../types';
@@ -180,8 +183,14 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             .
           </Typography>
         )}
-        
-        {SupportedIntegrations[selectedIntegration.service].category !== IntegrationCategories.COMPUTE && <IntegrationObjectList user={user} integration={selectedIntegration} />}
+
+        {SupportedIntegrations[selectedIntegration.service].category !==
+          IntegrationCategories.COMPUTE && (
+          <IntegrationObjectList
+            user={user}
+            integration={selectedIntegration}
+          />
+        )}
 
         <Typography
           variant="h5"

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -6,7 +6,10 @@ import { useLocation } from 'react-router-dom';
 
 import { BreadcrumbLink } from '../../../components/layouts/NavBar';
 import UserProfile from '../../../utils/auth';
-import { SupportedIntegrations, IntegrationCategories } from '../../../utils/integrations';
+import {
+  IntegrationCategories,
+  SupportedIntegrations,
+} from '../../../utils/integrations';
 import { LoadingStatus, LoadingStatusEnum } from '../../../utils/shared';
 import AddIntegrations from '../../integrations/addIntegrations';
 import { ConnectedIntegrations } from '../../integrations/connectedIntegrations';

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -6,7 +6,7 @@ import { useLocation } from 'react-router-dom';
 
 import { BreadcrumbLink } from '../../../components/layouts/NavBar';
 import UserProfile from '../../../utils/auth';
-import { SupportedIntegrations } from '../../../utils/integrations';
+import { SupportedIntegrations, IntegrationCategories } from '../../../utils/integrations';
 import { LoadingStatus, LoadingStatusEnum } from '../../../utils/shared';
 import AddIntegrations from '../../integrations/addIntegrations';
 import { ConnectedIntegrations } from '../../integrations/connectedIntegrations';
@@ -69,7 +69,7 @@ const IntegrationsPage: React.FC<Props> = ({
           </Typography>
           <AddIntegrations
             user={user}
-            category="data"
+            category={IntegrationCategories.DATA}
             supportedIntegrations={SupportedIntegrations}
           />
           <Typography variant="h6" marginY={2}>
@@ -77,7 +77,7 @@ const IntegrationsPage: React.FC<Props> = ({
           </Typography>
           <AddIntegrations
             user={user}
-            category="compute"
+            category={IntegrationCategories.COMPUTE}
             supportedIntegrations={SupportedIntegrations}
           />
         </Box>

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -247,7 +247,7 @@ const logoBucket =
 const integrationLogosBucket =
   'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations';
 
-const IntegrationCategories = {
+export const IntegrationCategories = {
   DATA: 'data',
   COMPUTE: 'compute',
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Remove data section for compute integrations because compute integrations don't store data.
Updated categories in integrations page so they are not hardcoded strings.

## Related issue number (if any)
ENG 2061

## Demo
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/30596854/208735302-6a819ad1-d4c9-4aca-a307-d5059ac92046.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


