### PR TITLE
Fullwidth artifact, check, metric pages

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -207,7 +207,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={!sideSheetMode ? '800px' : 'auto'}>
+      <Box width={sideSheetMode ? '800px' : 'auto'}>
         <Box width="100%">
           {!sideSheetMode && (
             <Box width="100%" display="flex" alignItems="center">

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -220,7 +220,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={!sideSheetMode ? '800px' : 'auto'}>
+      <Box width={sideSheetMode ? '800px' : 'auto'}>
         {!sideSheetMode && (
           <Box width="100%">
             <DetailsPageHeader

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -180,7 +180,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={!sideSheetMode ? '800px' : 'auto'}>
+      <Box width={sideSheetMode ? '800px' : 'auto'}>
         <Box width="100%" mb={3}>
           {!sideSheetMode && (
             <Box width="100%">


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Make the detail sheets full width.

Encountered errors retrieving contents due to storage issues (Object does not exist in storage.) but that is an unrelated issue.

## Related issue number (if any)
ENG-2132,  ENG-2135, ENG-2134, ENG-2133

## Loom demo (if any)
Before:
Check
<img width="1440" alt="check before" src="https://user-images.githubusercontent.com/30596854/209222660-186dd343-82e5-414c-8f3d-33be0a32aa06.png">
Metric
<img width="1438" alt="metric before" src="https://user-images.githubusercontent.com/30596854/209222665-a8818456-c81f-4513-af3b-11c5de8c4f6d.png">
Artifact
<img width="1440" alt="artifact before" src="https://user-images.githubusercontent.com/30596854/209222670-91f7a0eb-b37a-42b4-a8bf-be822f16547e.png">

After:
<img width="1439" alt="check after" src="https://user-images.githubusercontent.com/30596854/209222788-89dccc7f-5088-4b4d-b169-7e73e7f6a0f5.png">
<img width="1439" alt="metric after" src="https://user-images.githubusercontent.com/30596854/209222792-6715a97b-a735-42d3-9c25-4773f4c17660.png">
<img width="1438" alt="artifact after" src="https://user-images.githubusercontent.com/30596854/209222796-930c4f1c-4d3b-46d8-9d2f-63efb7062070.png">


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


