### PR TITLE
ENG-1857 Resets workflow settings dialog changes on close if changes are not saved.

### DIFF
--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -275,6 +275,16 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     retentionPolicy.k_latest_runs !==
     workflowDag.metadata?.retention_policy?.k_latest_runs;
 
+  const initialSettings = {
+    name: workflowDag.metadata?.name,
+    description: workflowDag.metadata?.description,
+    triggerType: workflowDag.metadata.schedule.trigger,
+    schedule: workflowDag.metadata.schedule.cron_schedule,
+    paused: workflowDag.metadata.schedule.paused,
+    // TODO: figure out what to do with retentionPolicyUpdated.
+    retentionPolicy: workflowDag.metadata?.retention_policy,
+  };
+
   const settingsChanged =
     name !== workflowDag.metadata?.name || // The workflow name has been changed.
     description !== workflowDag.metadata?.description || // The workflow description has changed.
@@ -537,7 +547,9 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const deleteDialog = (
     <Dialog
       open={showDeleteDialog}
-      onClose={() => setShowDeleteDialog(false)}
+      onClose={() => {
+        setShowDeleteDialog(false);
+      }}
       fullWidth
     >
       <DialogTitle>
@@ -776,7 +788,19 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
 
             <FontAwesomeIcon
               icon={faXmark}
-              onClick={onClose}
+              onClick={() => {
+                setName(initialSettings.name);
+                setDescription(initialSettings.description);
+                setTriggerType(initialSettings.triggerType);
+                setSchedule(initialSettings.schedule);
+                setPaused(initialSettings.paused);
+                setRetentionPolicy(initialSettings.retentionPolicy);
+
+                // Finally close the dialog
+                if (onClose) {
+                  onClose();
+                }
+              }}
               style={{ cursor: 'pointer' }}
             />
           </Box>

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -281,7 +281,6 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     triggerType: workflowDag.metadata.schedule.trigger,
     schedule: workflowDag.metadata.schedule.cron_schedule,
     paused: workflowDag.metadata.schedule.paused,
-    // TODO: figure out what to do with retentionPolicyUpdated.
     retentionPolicy: workflowDag.metadata?.retention_policy,
   };
 

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -357,10 +357,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
           <WorkflowSettings
             user={user}
             open={showSettings}
-            onClose={() => {
-              console.log('WorkflowHeader workflowSettings onClose()');
-              setShowSettings(false);
-            }}
+            onClose={() => setShowSettings(false)}
             workflowDag={workflowDag}
           />
         </Box>

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -357,7 +357,10 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
           <WorkflowSettings
             user={user}
             open={showSettings}
-            onClose={() => setShowSettings(false)}
+            onClose={() => {
+              console.log('WorkflowHeader workflowSettings onClose()');
+              setShowSettings(false);
+            }}
             workflowDag={workflowDag}
           />
         </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Resets state of workflow settings dialog back to initial state on dialog close when user does not save changes

## Related issue number (if any)
ENG-1857

## Loom demo (if any)
https://www.loom.com/share/de75aeec569345e7a756520e4fbf2ece

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


