### PR TITLE
ENG-2130 Remove Settings Account Popover

### DIFF
--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -1,4 +1,4 @@
-import { faBell, faGear } from '@fortawesome/free-solid-svg-icons';
+import { faBell, faSliders } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { AppBar, Breadcrumbs, Link, Toolbar, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -162,7 +162,7 @@ const NavBar: React.FC<{
         <Box sx={{ cursor: 'pointer', marginLeft: '16px' }}>
           <FontAwesomeIcon
             className={styles['navbar-icon']}
-            icon={faGear}
+            icon={faSliders}
             onClick={() => {
               navigate('/account');
             }}

--- a/src/ui/common/src/components/layouts/NavBar.tsx
+++ b/src/ui/common/src/components/layouts/NavBar.tsx
@@ -1,22 +1,10 @@
-import {
-  faBell,
-  faCircleUser,
-  faGear,
-} from '@fortawesome/free-solid-svg-icons';
+import { faBell, faGear } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  AppBar,
-  Breadcrumbs,
-  Link,
-  Menu,
-  MenuItem,
-  Toolbar,
-  Typography,
-} from '@mui/material';
+import { AppBar, Breadcrumbs, Link, Toolbar, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 
 import { RootState } from '../../stores/store';
 import { theme } from '../../styles/theme/theme';
@@ -69,10 +57,8 @@ const NavBar: React.FC<{
   breadcrumbs: BreadcrumbLink[];
   onBreadCrumbClicked?: (name: string) => void;
 }> = ({ user, breadcrumbs, onBreadCrumbClicked = null }) => {
-  const [userPopoverAnchorEl, setUserPopoverAnchorEl] = useState(null);
+  const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState(null);
-
-  const userPopoverOpen = Boolean(userPopoverAnchorEl);
   const open = Boolean(anchorEl);
 
   const numUnreadNotifications = useSelector(
@@ -84,14 +70,6 @@ const NavBar: React.FC<{
       ).length
   );
 
-  const handleUserPopoverClick = (event: React.MouseEvent) => {
-    setUserPopoverAnchorEl(event.currentTarget);
-  };
-
-  const handleCloseUserPopover = () => {
-    setUserPopoverAnchorEl(null);
-  };
-
   const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -101,7 +79,6 @@ const NavBar: React.FC<{
   };
 
   const notificationsPopoverId = open ? 'simple-popover' : undefined;
-  const userPopoverId = userPopoverOpen ? 'user-popover' : undefined;
 
   return (
     <AppBar
@@ -186,33 +163,10 @@ const NavBar: React.FC<{
           <FontAwesomeIcon
             className={styles['navbar-icon']}
             icon={faGear}
-            onClick={handleUserPopoverClick}
-          />
-          <Menu
-            id={userPopoverId}
-            anchorEl={userPopoverAnchorEl}
-            onClose={handleCloseUserPopover}
-            open={userPopoverOpen}
-            PaperProps={{
-              sx: {
-                mt: 1.5,
-              },
+            onClick={() => {
+              navigate('/account');
             }}
-          >
-            <Link
-              to={`${pathPrefix}/account`}
-              underline="none"
-              sx={{ color: 'blue.900' }}
-              component={RouterLink}
-            >
-              <MenuItem sx={{ width: '190px' }} disableRipple>
-                <Box sx={{ fontSize: '20px', mr: 1 }}>
-                  <FontAwesomeIcon icon={faCircleUser} />
-                </Box>
-                Account
-              </MenuItem>
-            </Link>
-          </Menu>
+          />
         </Box>
       </Toolbar>
     </AppBar>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR removes the Account popover in the navigation bar that appeared when users clicked the settings gear.
Users can now navigate to the Account page simply by clicking the settings gear.

## Related issue number (if any)
ENG-2130

## Loom demo (if any)
https://www.loom.com/share/de15a7714f1c4570ab48236b16f18844

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


