### PR TITLE
[1/3] Run SDK Integration Tests against S3 [Backend Bugfix]

### DIFF
--- a/integration_tests/backend/test_reads.py
+++ b/integration_tests/backend/test_reads.py
@@ -96,11 +96,21 @@ class TestBackend:
                 ("table_2", "replace"),
             ]
         )
-        assert set([(item["object_name"], item["update_mode"]) for item in data]) == data_set
+
+        print(data)
+        assert (
+            set(
+                [
+                    (item["spec"]["parameters"]["table"], item["spec"]["parameters"]["update_mode"])
+                    for item in data
+                ]
+            )
+            == data_set
+        )
 
         # Check all in same integration
         assert len(set([item["integration_name"] for item in data])) == 1
-        assert len(set([item["service"] for item in data])) == 1
+        assert len(set([item["spec"]["service"] for item in data])) == 1
 
     def test_endpoint_delete_integration(self):
         integration_name = f"test_delete_integration_{uuid.uuid4().hex[:8]}"

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -2,10 +2,10 @@ import pandas as pd
 import pytest
 from aqueduct.constants.enums import CheckSeverity
 from aqueduct.error import AqueductError, ArtifactNotFoundException, InvalidUserActionException
-from constants import CHURN_SQL_QUERY, SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_functions.simple.model import dummy_sentiment_model
 from test_metrics.constant.model import constant_metric
-from utils import publish_flow_test
+from utils import extract, publish_flow_test
 
 from aqueduct import check
 
@@ -35,8 +35,8 @@ def success_on_multiple_mixed_inputs(metric, df):
 
 def test_check_on_table(client, flow_name, data_integration, engine):
     """Test check on a function operator."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    check_artifact = success_on_single_table_input(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    check_artifact = success_on_single_table_input(table_artifact)
     assert check_artifact.get()
 
     publish_flow_test(
@@ -49,8 +49,8 @@ def test_check_on_table(client, flow_name, data_integration, engine):
 
 def test_check_on_metric(client, flow_name, data_integration, engine):
     """Test check on a metric operator."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    metric = constant_metric(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    metric = constant_metric(table_artifact)
 
     check_artifact = success_on_single_metric_input(metric)
     assert check_artifact.get()
@@ -65,11 +65,11 @@ def test_check_on_metric(client, flow_name, data_integration, engine):
 
 def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, engine):
     """Test check on multiple tables and metrics."""
-    sql_artifact1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    metric = constant_metric(sql_artifact1)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    metric = constant_metric(table_artifact1)
 
-    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    table = dummy_sentiment_model(sql_artifact2)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
+    table = dummy_sentiment_model(table_artifact2)
 
     check_artifact = success_on_multiple_mixed_inputs(metric, table)
     assert check_artifact.get()
@@ -84,20 +84,20 @@ def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, eng
 
 def test_edit_check(client, data_integration):
     """Test that checks can be edited by replacing with the same name."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @check()
     def check_op(df):
         return False
 
-    failed_check = check_op(sql_artifact)
+    failed_check = check_op(table_artifact)
     assert not failed_check.get()
 
     @check()
     def check_op(df):
         return True
 
-    success_check = check_op(sql_artifact)
+    success_check = check_op(table_artifact)
     assert success_check.get()
 
     # Attempting to fetch the previous check artifact should fail, since its been overwritten!
@@ -107,17 +107,17 @@ def test_edit_check(client, data_integration):
 
 def test_delete_check(client, data_integration):
     """Test that checks can be deleted by name."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(InvalidUserActionException):
-        sql_artifact.remove_check(name="nonexistant_check")
+        table_artifact.remove_check(name="nonexistant_check")
 
-    check_artifact_on_sql = success_on_single_table_input(sql_artifact)
-    sql_artifact.remove_check(name="success_on_single_table_input")
+    check_artifact_on_sql = success_on_single_table_input(table_artifact)
+    table_artifact.remove_check(name="success_on_single_table_input")
     with pytest.raises(ArtifactNotFoundException):
         check_artifact_on_sql.get()
 
-    metric_artifact = constant_metric(sql_artifact)
+    metric_artifact = constant_metric(table_artifact)
     check_artifact_on_metric = success_on_single_metric_input(metric_artifact)
     metric_artifact.remove_check(name="success_on_single_metric_input")
     with pytest.raises(ArtifactNotFoundException):
@@ -125,42 +125,42 @@ def test_delete_check(client, data_integration):
 
 
 def test_check_wrong_input_type(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     # User function receives a dataframe when it's expecting a metric.
     with pytest.raises(AqueductError):
-        check_artifact = success_on_single_metric_input(sql_artifact)
+        check_artifact = success_on_single_metric_input(table_artifact)
 
     # TODO(ENG-862): the following code should not surface an internal error,
     #  since its the user's fault.
     # Running a function operator on a check output, which is not allowed.
-    check_artifact = success_on_single_table_input(sql_artifact)
+    check_artifact = success_on_single_table_input(table_artifact)
     with pytest.raises(Exception):
         dummy_sentiment_model(check_artifact)
 
 
 def test_check_wrong_number_of_inputs(client, data_integration):
-    sql_artifact1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
     # TODO(ENG-863): Do we want a more specific error here?
     with pytest.raises(AqueductError):
-        success_on_single_table_input(sql_artifact1, sql_artifact2)
+        success_on_single_table_input(table_artifact1, table_artifact2)
 
 
 def test_check_with_numpy_bool_output(client, data_integration):
-    sql_artifact = data_integration.sql(query=CHURN_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.CHURN)
 
     @check()
     def success_check_return_numpy_bool(df):
         return df["total_charges"].mean() < 2500
 
-    check_artifact = success_check_return_numpy_bool(sql_artifact)
+    check_artifact = success_check_return_numpy_bool(table_artifact)
     assert check_artifact.get()
 
 
 def test_check_with_series_output(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @check()
     def success_check_return_series_of_booleans(df):
@@ -170,22 +170,22 @@ def test_check_with_series_output(client, flow_name, data_integration, engine):
     def failure_check_return_series_of_booleans(df):
         return pd.Series([True, False, True])
 
-    passed = success_check_return_series_of_booleans(sql_artifact)
+    passed = success_check_return_series_of_booleans(table_artifact)
     assert passed.get()
 
-    failed = failure_check_return_series_of_booleans(sql_artifact)
+    failed = failure_check_return_series_of_booleans(table_artifact)
     assert not failed.get()
 
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[sql_artifact, passed, failed],
+        artifacts=[table_artifact, passed, failed],
         engine=engine,
     )
 
 
 def test_check_failure_with_varying_severity(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     # An error check will fail the workflow, but a warning check will not.
     @check(severity=CheckSeverity.WARNING)
@@ -196,15 +196,15 @@ def test_check_failure_with_varying_severity(client, flow_name, data_integration
     def failure_blocking_check(df):
         return False
 
-    nonblocking_check = failure_nonblocking_check(sql_artifact)
+    nonblocking_check = failure_nonblocking_check(table_artifact)
 
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[sql_artifact, nonblocking_check],
+        artifacts=[table_artifact, nonblocking_check],
         engine=engine,
     )
 
     # In eager execution, this check should fail before we can publish the flow.
     with pytest.raises(AqueductError):
-        failure_blocking_check(sql_artifact)
+        failure_blocking_check(table_artifact)

--- a/integration_tests/sdk/constants.py
+++ b/integration_tests/sdk/constants.py
@@ -1,9 +1,0 @@
-# Parameters for the sentiment dataset.
-SENTIMENT_SQL_QUERY = "select * from hotel_reviews"
-# This is to speed up the database writes.
-SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
-
-# Parameters for the churn dataset.
-CHURN_SQL_QUERY = "select * from customer_activity"
-
-WINE_SQL_QUERY = "select * from wine"

--- a/integration_tests/sdk/data_objects.py
+++ b/integration_tests/sdk/data_objects.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class DataObject(str, Enum):
+    SENTIMENT = "hotel_reviews"
+    CHURN = "customer_activity"
+    WINE = "wine"
+    CUSTOMERS = "customers"

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -2,11 +2,13 @@ import pandas as pd
 import pytest
 from aqueduct.constants.enums import LoadUpdateMode
 from aqueduct.error import InvalidRequestError
-from constants import SHORT_SENTIMENT_SQL_QUERY
+from data_objects import DataObject
+from relational import SHORT_SENTIMENT_SQL_QUERY, all_relational_DBs
 from utils import (
     check_flow_doesnt_exist,
     check_table_doesnt_exist,
     check_table_exists,
+    extract,
     generate_table_name,
     publish_flow_test,
     save,
@@ -15,7 +17,7 @@ from utils import (
 
 def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integration, engine):
     """Check the flow cannot delete an object it had not saved."""
-    table = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     save(data_integration, table)
 
     flow = publish_flow_test(
@@ -26,8 +28,9 @@ def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integrati
     )
 
     tables = client.flow(flow.id()).list_saved_objects()
-    tables[data_integration][0].object_name = "I_DON_T_EXIST"
-    tables[data_integration] = [tables[data_integration][0]]
+    table_saved_object_update = tables[data_integration][0]
+    table_saved_object_update.spec.set_identifier("I_DONT_EXIST")
+    tables[data_integration] = [table_saved_object_update]
 
     # Cannot delete a flow if the saved objects specified had not been saved by the flow.
     with pytest.raises(InvalidRequestError):
@@ -37,7 +40,10 @@ def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integrati
     client.flow(flow.id())
 
 
-def test_delete_workflow_saved_objects(client, flow_name, data_integration, engine, validator):
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
+def test_force_delete_workflow_saved_objects(
+    client, flow_name, data_integration, engine, validator
+):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     table_name = generate_table_name()
     table = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
@@ -66,7 +72,7 @@ def test_delete_workflow_saved_objects(client, flow_name, data_integration, engi
     )
 
     tables = client.flow(flow.id()).list_saved_objects()
-    assert table_name in [item.object_name for item in tables[data_integration]]
+    assert table_name in [item.spec.identifier() for item in tables[data_integration]]
 
     # Doesn't work if don't force because it is created in append mode.
     with pytest.raises(InvalidRequestError):
@@ -80,6 +86,7 @@ def test_delete_workflow_saved_objects(client, flow_name, data_integration, engi
     check_table_doesnt_exist(data_integration, table_name)
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_delete_workflow_saved_objects_twice(
     client, flow_name, data_integration, engine, validator
 ):
@@ -122,11 +129,11 @@ def test_delete_workflow_saved_objects_twice(
     check_table_exists(data_integration, table_name)
 
     tables = client.flow(flow1.id()).list_saved_objects()
-    tables_1 = set([item.object_name for item in tables[data_integration]])
+    tables_1 = set([item.spec.identifier() for item in tables[data_integration]])
     assert table_name in tables_1
 
     tables = client.flow(flow2.id()).list_saved_objects()
-    tables_2 = set([item.object_name for item in tables[data_integration]])
+    tables_2 = set([item.spec.identifier() for item in tables[data_integration]])
     assert table_name in tables_2
 
     assert tables_1 == tables_2

--- a/integration_tests/sdk/error_handling_test.py
+++ b/integration_tests/sdk/error_handling_test.py
@@ -1,5 +1,8 @@
 import pytest
 from aqueduct.error import AqueductError, InvalidUserArgumentException
+from data_objects import DataObject
+from relational import all_relational_DBs
+from utils import extract
 
 import aqueduct
 from aqueduct import op
@@ -19,18 +22,19 @@ TIP_EXTRACT = "We couldn't execute the provided query. Please double check your 
 TIP_OP_EXECUTION = "Error executing operator. Please refer to the stack trace for fix."
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_handle_relational_query_error(client, data_integration):
     try:
-        sql_artifact = data_integration.sql(query=BAD_QUERY)
+        _ = data_integration.sql(query=BAD_QUERY)
     except AqueductError as e:
         assert TIP_EXTRACT in e.message
 
 
 def test_handle_bad_op_error(client, data_integration):
-    sql_artifact = data_integration.sql(query=GOOD_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     try:
-        bad_op(sql_artifact)
+        bad_op(table_artifact)
     except AqueductError as e:
         assert TIP_OP_EXECUTION in e.message
 

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -8,7 +8,7 @@ from aqueduct.error import InvalidUserArgumentException
 from aqueduct.integrations.airflow_integration import AirflowIntegration
 from aqueduct.models.config import FlowConfig
 from aqueduct.models.integration import IntegrationInfo
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_functions.sentiment.model import sentiment_model
 from test_functions.simple.model import (
     dummy_model,
@@ -17,6 +17,7 @@ from test_functions.simple.model import (
 )
 from test_metrics.constant.model import constant_metric
 from utils import (
+    extract,
     generate_new_flow_name,
     generate_table_name,
     publish_flow_test,
@@ -30,8 +31,8 @@ from aqueduct import check, metric, op
 
 
 def test_basic_flow(client, flow_name, data_integration, engine, validator):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -40,13 +41,14 @@ def test_basic_flow(client, flow_name, data_integration, engine, validator):
         name=flow_name(),
         engine=engine,
     )
+
     validator.check_saved_artifact(flow, output_artifact.id(), expected_data=output_artifact.get())
 
 
 def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
     """Actually run the full sentiment model (with nltk dependency)."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -59,10 +61,10 @@ def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
 
 
 def test_complex_flow(client, flow_name, data_integration, engine, validator):
-    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
-    fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact1, sql_artifact2)
+    fn_artifact = dummy_sentiment_model_multiple_input(table_artifact1, table_artifact2)
     output_artifact = dummy_model(fn_artifact)
     save(data_integration, output_artifact)
 
@@ -115,11 +117,11 @@ def test_complex_flow(client, flow_name, data_integration, engine, validator):
 
 
 def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
-    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
-    fn_artifact1 = dummy_sentiment_model(sql_artifact1)
-    fn_artifact2 = dummy_model(sql_artifact2)
+    fn_artifact1 = dummy_sentiment_model(table_artifact1)
+    fn_artifact2 = dummy_model(table_artifact2)
     save(data_integration, fn_artifact1)
     save(data_integration, fn_artifact2)
 
@@ -132,8 +134,8 @@ def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
 
 
 def test_publish_with_schedule(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     # Execute the flow 1 minute from now.
@@ -165,8 +167,8 @@ def test_invalid_flow(client):
 
 def test_publish_flow_with_same_name(client, flow_name, data_integration, engine):
     """Tests flow editing behavior."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
 
     name = flow_name()
     flow = publish_flow_test(
@@ -191,8 +193,8 @@ def test_publish_flow_with_same_name(client, flow_name, data_integration, engine
 
 
 def test_refresh_flow(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -211,8 +213,8 @@ def test_refresh_flow(client, flow_name, data_integration, engine):
 
 
 def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -228,8 +230,8 @@ def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
 
 
 def test_get_artifact_reuse_for_computation(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -245,9 +247,9 @@ def test_get_artifact_reuse_for_computation(client, flow_name, data_integration,
 
 
 def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact_2 = dummy_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
+    output_artifact_2 = dummy_model(table_artifact)
 
     flow_1 = publish_flow_test(
         client,
@@ -280,7 +282,7 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
 
 
 def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
-    # Write a new table into the demo db.
+    # Write a new table into the data integration.
     initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
 
     @op
@@ -288,8 +290,8 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return initial_table
 
     table = generate_initial_table()
-    table_name = generate_table_name()
-    save(data_integration, table, name=table_name)
+    saved_table_identifier = generate_table_name()
+    save(data_integration, table, name=saved_table_identifier)
 
     setup_flow = publish_flow_test(
         client,
@@ -303,7 +305,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return df
 
     # Create a new flow that extracts this data.
-    output = data_integration.sql("SELECT * FROM %s" % table_name, name="Test Table Query")
+    output = extract(data_integration, saved_table_identifier, op_name="Test Table Query")
     assert output.get().equals(initial_table)
 
     flow = publish_flow_test(
@@ -319,7 +321,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
     table = generate_new_table()
-    save(data_integration, table, name=table_name)
+    save(data_integration, table, name=saved_table_identifier)
     publish_flow_test(
         client,
         artifacts=table,

--- a/integration_tests/sdk/local_test.py
+++ b/integration_tests/sdk/local_test.py
@@ -1,49 +1,51 @@
 from checks_test import success_on_single_table_input
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from pandas import DataFrame
 from pandas._testing import assert_frame_equal
 from test_functions.simple.model import dummy_sentiment_model, dummy_sentiment_model_multiple_input
 from test_metrics.constant.model import constant_metric
+from utils import extract
 
 
 def test_local_operator(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     output_cloud = output_artifact.get()
 
-    output_local = dummy_sentiment_model.local(sql_artifact)
+    output_local = dummy_sentiment_model.local(table_artifact)
     assert output_cloud.count()[0] == output_local.count()[0]
     assert_frame_equal(output_cloud, output_local)
 
 
 def test_local_metric(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric = constant_metric(sql_artifact)
+    metric = constant_metric(table_artifact)
     assert metric.get() == 17.5
-    assert constant_metric.local(sql_artifact) == 17.5
+    assert constant_metric.local(table_artifact) == 17.5
 
 
 def test_local_check(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+
     check = success_on_single_table_input
-    assert check(sql_artifact)
-    assert check.local(sql_artifact)
+    assert check(table_artifact)
+    assert check.local(table_artifact)
 
 
 def test_local_dataframe_input(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_cloud = dummy_sentiment_model(sql_artifact).get()
-    output_local = dummy_sentiment_model.local(sql_artifact.get())
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_cloud = dummy_sentiment_model(table_artifact).get()
+    output_local = dummy_sentiment_model.local(table_artifact.get())
     assert type(output_local) is DataFrame
     assert_frame_equal(output_cloud, output_local)
 
 
 def test_local_on_multiple_inputs(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_cloud = dummy_sentiment_model_multiple_input(sql_artifact, sql_artifact2).get()
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
-    output_local = dummy_sentiment_model_multiple_input.local(sql_artifact, sql_artifact2)
+    output_cloud = dummy_sentiment_model_multiple_input(table_artifact, table_artifact2).get()
+    output_local = dummy_sentiment_model_multiple_input.local(table_artifact, table_artifact2)
     assert type(output_local) is DataFrame
     assert_frame_equal(output_cloud, output_local)

--- a/integration_tests/sdk/metrics_test.py
+++ b/integration_tests/sdk/metrics_test.py
@@ -1,24 +1,24 @@
 import pandas as pd
 import pytest
 from aqueduct.error import AqueductError
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_metrics.constant.model import constant_metric
-from utils import publish_flow_test
+from utils import extract, publish_flow_test
 
 from aqueduct import metric
 
 
 def test_basic_metric(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric = constant_metric(sql_artifact)
+    metric = constant_metric(table_artifact)
     assert metric.get() == 17.5
 
 
 def test_metric_bound(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric = constant_metric(sql_artifact)
+    metric = constant_metric(table_artifact)
     check_artifact = metric.bound(upper=100)
     assert check_artifact.get()
 
@@ -39,12 +39,13 @@ def test_metric_bound(client, data_integration):
 
 
 def test_register_metric(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    metric_artifact = constant_metric(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+
+    metric_artifact = constant_metric(table_artifact)
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[sql_artifact, metric_artifact],
+        artifacts=[table_artifact, metric_artifact],
         engine=engine,
     )
 
@@ -62,8 +63,8 @@ def metric_with_multiple_inputs(df1, m, df2):
 
 
 def test_metric_mixed_inputs(client, flow_name, data_integration, engine):
-    sql1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql1 = extract(data_integration, DataObject.SENTIMENT)
+    sql2 = extract(data_integration, DataObject.SENTIMENT)
     metric_input = constant_metric(sql1)
 
     metric_output = metric_with_multiple_inputs(sql1, metric_input, sql2)

--- a/integration_tests/sdk/mixed_compute_test.py
+++ b/integration_tests/sdk/mixed_compute_test.py
@@ -1,14 +1,15 @@
 import pytest
 from aqueduct.constants.enums import ServiceType
-from constants import SENTIMENT_SQL_QUERY
-from utils import publish_flow_test
+from data_objects import DataObject
+from utils import extract, publish_flow_test
 
 from aqueduct import op
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
 def test_flow_with_multiple_compute_using_op_spec(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    """Runs a workflow both Aqueduct and a third-party compute engine."""
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @op
     def noop(input):
@@ -19,5 +20,5 @@ def test_flow_with_multiple_compute_using_op_spec(client, flow_name, data_integr
         return input
 
     # Only `noop_on_third_party` is run on outside compute.
-    output = noop_on_third_party(noop(sql_artifact))
+    output = noop_on_third_party(noop(table_artifact))
     publish_flow_test(client, output, engine=None)

--- a/integration_tests/sdk/naming_test.py
+++ b/integration_tests/sdk/naming_test.py
@@ -1,24 +1,25 @@
 import pytest
 from aqueduct.error import ArtifactNotFoundException, InvalidUserActionException
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_functions.simple.model import (
     dummy_model,
     dummy_model_2,
     dummy_sentiment_model,
     dummy_sentiment_model_multiple_input,
 )
+from utils import extract
 
 
 def test_extract_with_default_name_collision(client, data_integration):
     # In the case where no explicit name is supplied, we expect new extract
     # operators to always be created.
-    sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact_1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact_2 = extract(data_integration, DataObject.SENTIMENT)
 
-    assert sql_artifact_1.name() == "%s query 1 artifact" % data_integration._metadata.name
-    assert sql_artifact_2.name() == "%s query 2 artifact" % data_integration._metadata.name
+    assert table_artifact_1.name() == "%s query 1 artifact" % data_integration._metadata.name
+    assert table_artifact_2.name() == "%s query 2 artifact" % data_integration._metadata.name
 
-    fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact_1, sql_artifact_2)
+    fn_artifact = dummy_sentiment_model_multiple_input(table_artifact_1, table_artifact_2)
     fn_df = fn_artifact.get()
     assert list(fn_df) == [
         "hotel_name",
@@ -33,12 +34,12 @@ def test_extract_with_default_name_collision(client, data_integration):
 
 def test_extract_with_explicit_name_collision(client, data_integration):
     # In the case where an explicit name is supplied, we will overwrite any colliding ops.
-    sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    table_artifact_1 = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
-    fn_artifact = dummy_sentiment_model(sql_artifact_1)
+    fn_artifact = dummy_sentiment_model(table_artifact_1)
 
-    sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
-    assert sql_artifact_2.name() == "sql query artifact"
+    table_artifact_2 = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
+    assert table_artifact_2.name() == "sql query artifact"
 
     # Cannot preview an artifact with a dependency that has been deleted,
     # since it itself would have been removed from the dag.
@@ -47,9 +48,9 @@ def test_extract_with_explicit_name_collision(client, data_integration):
 
     # Cannot run a function on an artifact that has already been overwritten.
     with pytest.raises(ArtifactNotFoundException):
-        _ = dummy_sentiment_model(sql_artifact_1)
+        _ = dummy_sentiment_model(table_artifact_1)
 
-    fn_artifact = dummy_sentiment_model(sql_artifact_2)
+    fn_artifact = dummy_sentiment_model(table_artifact_2)
     fn_df = fn_artifact.get()
     assert list(fn_df) == [
         "hotel_name",
@@ -63,12 +64,12 @@ def test_extract_with_explicit_name_collision(client, data_integration):
 
 def test_function_with_name_collision(client, data_integration):
     """Colliding functions are always overwritten."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
     # There's not an easy way to programmatically change the function, so lets
     # just run the same function twice and check that the latest one wins.
-    dummy_fn_artifact_old = dummy_model(sql_artifact)
-    dummy_fn_artifact_new = dummy_model(sql_artifact)
+    dummy_fn_artifact_old = dummy_model(table_artifact)
+    dummy_fn_artifact_new = dummy_model(table_artifact)
 
     with pytest.raises(ArtifactNotFoundException):
         dummy_fn_artifact_old.get()
@@ -86,23 +87,23 @@ def test_function_with_name_collision(client, data_integration):
 
 def test_naming_collision_with_different_types(client, data_integration):
     # An overwrite is invalid because the operators are of different types.
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
     # Function collides with existing sql artifact
-    _ = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="dummy_model")
+    _ = extract(data_integration, DataObject.SENTIMENT, op_name="dummy_model")
     with pytest.raises(InvalidUserActionException):
-        dummy_model(sql_artifact)
+        dummy_model(table_artifact)
 
     # SQL collides with existing function
-    _ = dummy_sentiment_model(sql_artifact)
+    _ = dummy_sentiment_model(table_artifact)
     with pytest.raises(InvalidUserActionException):
-        _ = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="dummy_sentiment_model")
+        _ = extract(data_integration, DataObject.SENTIMENT, op_name="dummy_sentiment_model")
 
 
 def test_naming_collision_with_dependency(client, data_integration):
     # Overwrite is invalid when the operator being replaced is an upstream dependency.
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sentiment_model")
-    dummy_model_output = dummy_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sentiment_model")
+    dummy_model_output = dummy_model(table_artifact)
     dummy_model_2_output = dummy_model_2(dummy_model_output)
 
     with pytest.raises(InvalidUserActionException):

--- a/integration_tests/sdk/no_input_test.py
+++ b/integration_tests/sdk/no_input_test.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from data_objects import DataObject
+from utils import extract
 
 from aqueduct import op
 
@@ -21,7 +23,7 @@ def test_basic_no_input_function(client):
 
 
 def test_flow_with_no_input_function(client, data_integration):
-    customers_table = data_integration.sql(query="SELECT * FROM customers;")
+    customers_table = extract(data_integration, DataObject.CUSTOMERS)
 
     result = join(no_input(), customers_table)
     expected = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})

--- a/integration_tests/sdk/operator_hierarchy_test.py
+++ b/integration_tests/sdk/operator_hierarchy_test.py
@@ -1,6 +1,7 @@
 import pytest
 from aqueduct.error import InvalidUserActionException
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
+from utils import extract
 
 from aqueduct import check, metric, op
 
@@ -32,9 +33,9 @@ def regular_function(args):
 
 def test_check_artifact_restriction(client, data_integration):
     """Test that an artifact produced by a check operator cannot be used as an argument to any operator types."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    check_artifact = produce_check_artifact(sql_artifact)
+    check_artifact = produce_check_artifact(table_artifact)
     with pytest.raises(InvalidUserActionException):
         check_function(check_artifact)
     with pytest.raises(InvalidUserActionException):
@@ -45,8 +46,8 @@ def test_check_artifact_restriction(client, data_integration):
 
 def test_metric_artifact_restriction(client, data_integration):
     """Test that an artifact produced by a metric operator cannot be used as an argument to function operator."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric_artifact = produce_metric_artifact(sql_artifact)
+    metric_artifact = produce_metric_artifact(table_artifact)
     with pytest.raises(InvalidUserActionException):
         regular_function(metric_artifact)

--- a/integration_tests/sdk/operator_test.py
+++ b/integration_tests/sdk/operator_test.py
@@ -1,12 +1,13 @@
 from aqueduct.decorator import to_operator
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_function import dummy_sentiment_model_function
+from utils import extract
 
 from aqueduct import op
 
 
 def test_to_operator_local_function(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @op
     def dummy_sentiment_model(df):
@@ -17,25 +18,25 @@ def test_to_operator_local_function(client, data_integration):
         df["positivity"] = 123
         return df
 
-    output_artifact_from_decorator = dummy_sentiment_model(sql_artifact)
+    output_artifact_from_decorator = dummy_sentiment_model(table_artifact)
     df_normal = output_artifact_from_decorator.get()
-    output_artifact_from_to_operator = to_operator(dummy_sentiment_model_func)(sql_artifact)
+    output_artifact_from_to_operator = to_operator(dummy_sentiment_model_func)(table_artifact)
     df_func = output_artifact_from_to_operator.get()
 
     assert df_normal["positivity"].equals(df_func["positivity"])
 
 
 def test_to_operator_imported_function(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @op(file_dependencies=["test_function.py"])
     def decorated_func(df):
         df = dummy_sentiment_model_function(df)
         return df
 
-    df_decorate = decorated_func(sql_artifact).get()
+    df_decorate = decorated_func(table_artifact).get()
     df_function = to_operator(
         dummy_sentiment_model_function, file_dependencies=["test_function.py"]
-    )(sql_artifact).get()
+    )(table_artifact).get()
 
     assert df_decorate["positivity"].equals(df_function["positivity"])

--- a/integration_tests/sdk/relational.py
+++ b/integration_tests/sdk/relational.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from aqueduct.constants.enums import RelationalDBServices, ServiceType
+
+# We limit the number of rows to speed up a database writes a littel bit.
+SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
+
+
+def all_relational_DBs() -> List[ServiceType]:
+    return [ServiceType(relational_service.value) for relational_service in RelationalDBServices]

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -1,12 +1,14 @@
 import pytest
 from aqueduct.error import InvalidIntegrationException, InvalidUserArgumentException
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
+from relational import all_relational_DBs
 from test_functions.simple.model import dummy_sentiment_model
-from utils import publish_flow_test, save
+from utils import extract, publish_flow_test, save
 
 from aqueduct import metric
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_integration_load_table(client, data_integration):
     df = data_integration.table(name="hotel_reviews")
     assert len(df) == 100
@@ -24,25 +26,27 @@ def test_invalid_source_integration(client):
 
 
 def test_invalid_destination_integration(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
 
     with pytest.raises(InvalidIntegrationException):
         data_integration._metadata.name = "bad name"
         save(data_integration, output_artifact)
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_today_tag(client, data_integration):
-    sql_artifact_today = data_integration.sql(
+    table_artifact_today = data_integration.sql(
         query="select * from hotel_reviews where review_date = {{today}}"
     )
-    assert sql_artifact_today.get().empty
-    sql_artifact_not_today = data_integration.sql(
+    assert table_artifact_today.get().empty
+    table_artifact_not_today = data_integration.sql(
         query="select * from hotel_reviews where review_date < {{today}}"
     )
-    assert len(sql_artifact_not_today.get()) == 100
+    assert len(table_artifact_not_today.get()) == 100
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_query_with_parameter(client, data_integration):
     # Missing parameters.
     with pytest.raises(InvalidUserArgumentException):
@@ -54,39 +58,40 @@ def test_sql_query_with_parameter(client, data_integration):
         _ = data_integration.sql(query="select * from {{ table_name }}")
 
     client.create_param("table_name", default="hotel_reviews")
-    sql_artifact = data_integration.sql(query="select * from {{ table_name }}")
+    table_artifact = data_integration.sql(query="select * from {{ table_name }}")
 
-    expected_sql_artifact = data_integration.sql(query="select * from hotel_reviews")
-    assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = data_integration.sql(query="select * from customer_activity")
-    assert sql_artifact.get(parameters={"table_name": "customer_activity"}).equals(
-        expected_sql_artifact.get()
+    expected_table_artifact = data_integration.sql(query="select * from hotel_reviews")
+    assert table_artifact.get().equals(expected_table_artifact.get())
+    expected_table_artifact = data_integration.sql(query="select * from customer_activity")
+    assert table_artifact.get(parameters={"table_name": "customer_activity"}).equals(
+        expected_table_artifact.get()
     )
 
     # Trigger the parameter with invalid values.
     with pytest.raises(InvalidUserArgumentException):
-        _ = sql_artifact.get(parameters={"table_name": ["this is the incorrect type"]})
+        _ = table_artifact.get(parameters={"table_name": ["this is the incorrect type"]})
     with pytest.raises(InvalidUserArgumentException):
-        _ = sql_artifact.get(parameters={"non-existant parameter": "blah"})
+        _ = table_artifact.get(parameters={"non-existant parameter": "blah"})
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_query_with_multiple_parameters(client, flow_name, data_integration, engine):
     _ = client.create_param("table_name", default="hotel_reviews")
     nationality = client.create_param(
         "reviewer-nationality", default="United Kingdom"
     )  # check that dashes work.
-    sql_artifact = data_integration.sql(
+    table_artifact = data_integration.sql(
         query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer-nationality }}' and review_date < {{ today}}"
     )
-    expected_sql_artifact = data_integration.sql(
+    expected_table_artifact = data_integration.sql(
         "select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}"
     )
-    assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = data_integration.sql(
+    assert table_artifact.get().equals(expected_table_artifact.get())
+    expected_table_artifact = data_integration.sql(
         "select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}"
     )
-    assert sql_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
-        expected_sql_artifact.get()
+    assert table_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
+        expected_table_artifact.get()
     )
 
     # Use the parameters in another operator.
@@ -94,34 +99,36 @@ def test_sql_query_with_multiple_parameters(client, flow_name, data_integration,
     def noop(sql_output, param):
         return len(param)
 
-    result = noop(sql_artifact, nationality)
+    result = noop(table_artifact, nationality)
     assert result.get() == len(nationality.get())
     assert result.get(parameters={"reviewer-nationality": "Australia"}) == len("Australia")
 
     publish_flow_test(client, name=flow_name(), artifacts=[result], engine=engine)
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_query_user_vs_builtin_precedence(client, data_integration):
     """If a user defines an expansion that collides with a built-in one, the user-defined one should take precedence."""
-    sql_artifact = data_integration.sql(
+    table_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > {{today}}"
     )
-    builtin_result = sql_artifact.get()
+    builtin_result = table_artifact.get()
 
     datestring = "'2016-01-01'"
     _ = client.create_param("today", datestring)
-    sql_artifact = data_integration.sql(
+    table_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > {{today}}"
     )
-    user_param_result = sql_artifact.get()
+    user_param_result = table_artifact.get()
     assert not builtin_result.equals(user_param_result)
 
-    expected_sql_artifact = data_integration.sql(
+    expected_table_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > %s" % datestring
     )
-    assert user_param_result.equals(expected_sql_artifact.get())
+    assert user_param_result.equals(expected_table_artifact.get())
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_chained_sql_query(client):
     client.create_param("nationality", default=" United Kingdom ")
     warehouse = client.integration(name="aqueduct_demo")

--- a/integration_tests/sdk/table_artifact_test.py
+++ b/integration_tests/sdk/table_artifact_test.py
@@ -2,24 +2,23 @@ import math
 import time
 
 import pandas as pd
-from constants import SENTIMENT_SQL_QUERY, WINE_SQL_QUERY
+from data_objects import DataObject
+from utils import extract
 
 from aqueduct import op
 
 
 def test_great_expectations_check(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     ge_check = table.validate_with_expectation(
         "expect_column_values_to_be_unique", {"column": "fixed_acidity"}
     )
-
-    assert ge_check.get() == False
+    assert not ge_check.get()
 
     ge_check = table.validate_with_expectation(
         "expect_column_values_to_not_be_null", {"column": "fixed_acidity"}
     )
-
-    assert ge_check.get() == True
+    assert ge_check.get()
 
 
 @op
@@ -47,7 +46,7 @@ def mem_intensive_function(table: pd.DataFrame) -> pd.DataFrame:
 
 
 def test_system_runtime_metric(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     timed_table = timed_function(table)
 
     runtime_metric = timed_table.system_metric("runtime")
@@ -56,7 +55,7 @@ def test_system_runtime_metric(client, data_integration):
 
 
 def test_system_max_memory_metric(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     timed_table = mem_intensive_function(table)
 
     max_mem_metric = timed_table.system_metric("max_memory")
@@ -65,7 +64,7 @@ def test_system_max_memory_metric(client, data_integration):
 
 
 def test_number_of_missing_values(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_missing_values(column_id="hotel_name")
     assert missing_metric.get() == 0
 
@@ -78,7 +77,7 @@ def test_number_of_missing_values(client, data_integration):
 
 
 def test_number_of_rows(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_rows()
     assert missing_metric.get() == 100
 
@@ -88,7 +87,7 @@ def test_number_of_rows(client, data_integration):
 
 
 def test_max(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.max(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 15.8999, rel_tol=1e-3)
 
@@ -97,7 +96,7 @@ def test_max(client, data_integration):
 
 
 def test_min(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.min(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 3.7999, rel_tol=1e-3)
 
@@ -106,7 +105,7 @@ def test_min(client, data_integration):
 
 
 def test_mean(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.mean(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 7.2153, rel_tol=1e-3)
 
@@ -115,7 +114,7 @@ def test_mean(client, data_integration):
 
 
 def test_std(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.std(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 1.2964, rel_tol=1e-3)
 
@@ -124,7 +123,7 @@ def test_std(client, data_integration):
 
 
 def test_head_standard(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     assert table.get().shape[0] == 100
 
     table_head = table.head()

--- a/sdk/aqueduct/backend/response_models.py
+++ b/sdk/aqueduct/backend/response_models.py
@@ -10,7 +10,7 @@ from aqueduct.constants.enums import (
 )
 from aqueduct.models.artifact import ArtifactMetadata
 from aqueduct.models.dag import Metadata
-from aqueduct.models.operators import Operator
+from aqueduct.models.operators import LoadSpec, Operator
 from aqueduct.utils.utils import human_readable_timestamp
 from pydantic import BaseModel
 
@@ -231,10 +231,7 @@ class SavedObjectUpdate(BaseModel):
     operator_name: str
     modified_at: str
     integration_name: str
-    integration_id: uuid.UUID
-    service: ServiceType
-    object_name: str
-    update_mode: str
+    spec: LoadSpec
 
 
 class ListWorkflowSavedObjectsResponse(BaseModel):

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -77,6 +77,8 @@ class ServiceType(str, Enum, metaclass=MetaEnum):
 
 
 class RelationalDBServices(str, Enum, metaclass=MetaEnum):
+    """Must match the corresponding entries in `ServiceType` exactly."""
+
     POSTGRES = "Postgres"
     SNOWFLAKE = "Snowflake"
     MYSQL = "MySQL"

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -73,6 +73,7 @@ class ServiceType(str, Enum, metaclass=MetaEnum):
     LAMBDA = "Lambda"
     MONGO_DB = "MongoDB"
     CONDA = "Conda"
+    AQUEDUCT_ENGINE = "Aqueduct Engine"
 
 
 class RelationalDBServices(str, Enum, metaclass=MetaEnum):

--- a/sdk/aqueduct/error.py
+++ b/sdk/aqueduct/error.py
@@ -98,6 +98,11 @@ class InvalidUserArgumentException(Error):
     pass
 
 
+# Exception raised when the user does something that is explicitly unsupported right now.
+class UnsupportedFeatureException(Error):
+    pass
+
+
 # Exception raised when user attempts to use an invalid file name as a file dependency.
 class ReservedFileNameException(Error):
     pass

--- a/sdk/aqueduct/models/operators.py
+++ b/sdk/aqueduct/models/operators.py
@@ -15,7 +15,7 @@ from aqueduct.constants.enums import (
     SerializationType,
     ServiceType,
 )
-from aqueduct.error import AqueductError
+from aqueduct.error import AqueductError, UnsupportedFeatureException
 from aqueduct.models.config import EngineConfig
 from aqueduct.models.integration import IntegrationInfo
 from pydantic import BaseModel, Extra
@@ -133,6 +133,27 @@ class LoadSpec(BaseModel):
     service: ServiceType
     integration_id: uuid.UUID
     parameters: UnionLoadParams
+
+    def identifier(self) -> str:
+        if isinstance(self.parameters, RelationalDBLoadParams):
+            return self.parameters.table
+        elif isinstance(self.parameters, S3LoadParams):
+            return self.parameters.filepath
+        raise UnsupportedFeatureException(
+            "identifier() is currently unsupported for data integration type %s."
+            % self.service.value
+        )
+
+    def set_identifier(self, new_obj_identifier: str) -> None:
+        if isinstance(self.parameters, RelationalDBLoadParams):
+            self.parameters.table = new_obj_identifier
+        elif isinstance(self.parameters, S3LoadParams):
+            self.parameters.filepath = new_obj_identifier
+        else:
+            raise UnsupportedFeatureException(
+                "set_identifier() is currently unsupported for data integration type %s."
+                % self.service.value
+            )
 
 
 class EntryPoint(BaseModel):

--- a/src/golang/cmd/server/handler/list_workflow_objects.go
+++ b/src/golang/cmd/server/handler/list_workflow_objects.go
@@ -86,7 +86,7 @@ func (h *ListWorkflowObjectsHandler) Perform(ctx context.Context, interfaceArgs 
 	// Get all specs for the workflow.
 	operatorList, err := h.OperatorRepo.GetDistinctLoadOPsByWorkflow(ctx, args.workflowId, h.Database)
 	if err != nil {
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving workflow.")
+		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving workflow objects.")
 	}
 
 	return ListWorkflowObjectsResponse{

--- a/src/golang/lib/collections/operator/connector/load.go
+++ b/src/golang/lib/collections/operator/connector/load.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/integration"
+	"github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 )
@@ -71,4 +72,8 @@ func (l *Load) UnmarshalJSON(data []byte) error {
 
 	l.Parameters = params
 	return nil
+}
+
+func (l *Load) Scan(value interface{}) error {
+	return utils.ScanJSONB(value, l)
 }

--- a/src/golang/lib/models/views/operator.go
+++ b/src/golang/lib/models/views/operator.go
@@ -3,20 +3,18 @@ package views
 import (
 	"time"
 
-	"github.com/aqueducthq/aqueduct/lib/collections/integration"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
+	"github.com/aqueducthq/aqueduct/lib/collections/operator/connector"
 	"github.com/google/uuid"
 )
 
 // LoadOperator contains metadata about a Load Operator
 type LoadOperator struct {
-	OperatorName    string              `db:"operator_name" json:"operator_name"`
-	ModifiedAt      time.Time           `db:"modified_at" json:"modified_at"`
-	IntegrationName string              `db:"integration_name" json:"integration_name"`
-	IntegrationID   uuid.UUID           `db:"integration_id" json:"integration_id"`
-	Service         integration.Service `db:"service" json:"service"`
-	TableName       string              `db:"table_name" json:"object_name"`
-	UpdateMode      string              `db:"update_mode" json:"update_mode"`
+	OperatorName    string    `db:"operator_name" json:"operator_name"`
+	ModifiedAt      time.Time `db:"modified_at" json:"modified_at"`
+	IntegrationName string    `db:"integration_name" json:"integration_name"`
+
+	Spec *connector.Load `db:"spec" json:"spec"`
 }
 
 // LoadOperatorSpec is a wrapper around a Load Operator's spec and other metadata

--- a/src/golang/lib/models/views/operator.go
+++ b/src/golang/lib/models/views/operator.go
@@ -10,11 +10,10 @@ import (
 
 // LoadOperator contains metadata about a Load Operator
 type LoadOperator struct {
-	OperatorName    string    `db:"operator_name" json:"operator_name"`
-	ModifiedAt      time.Time `db:"modified_at" json:"modified_at"`
-	IntegrationName string    `db:"integration_name" json:"integration_name"`
-
-	Spec *connector.Load `db:"spec" json:"spec"`
+	OperatorName    string         `db:"operator_name" json:"operator_name"`
+	ModifiedAt      time.Time      `db:"modified_at" json:"modified_at"`
+	IntegrationName string         `db:"integration_name" json:"integration_name"`
+	Spec            connector.Load `db:"spec" json:"spec"`
 }
 
 // LoadOperatorSpec is a wrapper around a Load Operator's spec and other metadata

--- a/src/golang/lib/repos/tests/operator.go
+++ b/src/golang/lib/repos/tests/operator.go
@@ -1,12 +1,12 @@
 package tests
 
 import (
-	"github.com/aqueducthq/aqueduct/lib/models"
-	"github.com/aqueducthq/aqueduct/lib/models/views"
-	"github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/connector"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/function"
+	"github.com/aqueducthq/aqueduct/lib/models"
+	"github.com/aqueducthq/aqueduct/lib/models/utils"
+	"github.com/aqueducthq/aqueduct/lib/models/views"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -72,19 +72,18 @@ func (ts *TestSuite) TestOperator_GetDistinctLoadOPsByWorkflow() {
 	for _, expectedLoadOperator := range expectedOperators {
 		load := expectedLoadOperator.Spec.Load()
 		loadParams := load.Parameters
-		relationalLoad, ok := connector.CastToRelationalDBLoadParams(loadParams)
-		require.True(ts.T(), ok)
 		integration, err := ts.integration.Get(ts.ctx, load.IntegrationId, ts.DB)
 		require.Nil(ts.T(), err)
-					
+
 		expectedLoadOperators = append(expectedLoadOperators, views.LoadOperator{
-			OperatorName: expectedLoadOperator.Name,
-			ModifiedAt: dag.CreatedAt,
+			OperatorName:    expectedLoadOperator.Name,
+			ModifiedAt:      dag.CreatedAt,
 			IntegrationName: integration.Name,
-			IntegrationID: integration.ID,
-			Service: testIntegrationService,
-			TableName: relationalLoad.Table,
-			UpdateMode: relationalLoad.UpdateMode,
+			Spec: &connector.Load{
+				Service:       testIntegrationService,
+				IntegrationId: integration.ID,
+				Parameters:    loadParams,
+			},
 		})
 	}
 
@@ -162,9 +161,9 @@ func (ts *TestSuite) TestOperator_Create() {
 		function.Function{},
 	)
 	expectedOperator := &models.Operator{
-		Name: name,
+		Name:        name,
 		Description: description,
-		Spec: *spec,
+		Spec:        *spec,
 		ExecutionEnvironmentID: utils.NullUUID{
 			IsNull: true,
 		},
@@ -216,8 +215,8 @@ func (ts *TestSuite) TestOperator_Update() {
 		function.Function{},
 	)
 	changes := map[string]interface{}{
-		models.OperatorName:        name,
-		models.OperatorSpec:        spec,
+		models.OperatorName: name,
+		models.OperatorSpec: spec,
 	}
 
 	newOperator, err := ts.operator.Update(ts.ctx, operators[0].ID, changes, ts.DB)

--- a/src/golang/lib/repos/tests/operator.go
+++ b/src/golang/lib/repos/tests/operator.go
@@ -79,7 +79,7 @@ func (ts *TestSuite) TestOperator_GetDistinctLoadOPsByWorkflow() {
 			OperatorName:    expectedLoadOperator.Name,
 			ModifiedAt:      dag.CreatedAt,
 			IntegrationName: integration.Name,
-			Spec: &connector.Load{
+			Spec: connector.Load{
 				Service:       testIntegrationService,
 				IntegrationId: integration.ID,
 				Parameters:    loadParams,

--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -89,16 +89,15 @@ def run(spec: Spec) -> None:
 
 
 def _execute(spec: Spec, storage: Storage, exec_state: ExecutionState) -> None:
-
-    if isinstance(spec.connector_name, dict):
+    if spec.type == JobType.DELETESAVEDOBJECTS:
         run_delete_saved_objects(spec, storage, exec_state)
-    else:
-        # Because constructing certain connectors (eg. Postgres) can also involve authentication,
-        # we do both in `run_authenticate()`, and give a more helpful error message on failure.
-        if spec.type == JobType.AUTHENTICATE:
-            run_authenticate(spec, exec_state, is_demo=(spec.name == AQUEDUCT_DEMO_NAME))
-            return
 
+    # Because constructing certain connectors (eg. Postgres) can also involve authentication,
+    # we do both in `run_authenticate()`, and give a more helpful error message on failure.
+    elif spec.type == JobType.AUTHENTICATE:
+        run_authenticate(spec, exec_state, is_demo=(spec.name == AQUEDUCT_DEMO_NAME))
+
+    else:
         op = setup_connector(spec.connector_name, spec.connector_config)
         if spec.type == JobType.EXTRACT:
             run_extract(spec, op, storage, exec_state)

--- a/src/python/aqueduct_executor/operators/connectors/data/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/s3.py
@@ -146,7 +146,7 @@ class S3Connector(connector.DataConnector):
         if artifact_type == ArtifactType.TABLE:
             if params.format is None:
                 raise Exception("You must specify a file format for table data.")
-            buf = io.BytesIO(data)
+            buf = io.BytesIO()
             if params.format == common.S3TableFormat.CSV:
                 data.to_csv(buf, index=False)
             elif params.format == common.S3TableFormat.JSON:
@@ -181,6 +181,7 @@ class S3Connector(connector.DataConnector):
         self.s3.Object(self.bucket, params.filepath).put(Body=serialized_data)
 
     def _delete_object(self, name: str, context: Optional[Dict[str, Any]] = None) -> None:
+        """`name` is expected to be the S3 FilePath, found in S3Params."""
         self.s3.Object(self.bucket, name).delete()
 
     def delete(self, objects: List[str]) -> List[SavedObjectDelete]:

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -233,7 +233,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
 
   const dispatch: AppDispatch = useDispatch();
 
-  useCallback(() => {
+  useEffect(() => {
     dispatch(
       handleListWorkflowSavedObjects({
         apiKey: user.apiKey,


### PR DESCRIPTION
Lead reviewers: @cw75 and @likawind 

## Describe your changes and why you are making these changes
A number of backend bugs were discovered while attempting to get our integration test suite working against S3.

- In `data/s3.py`, we were initialize a bytes buffer with non-bytes data, causing the code to crash.
- In `sqlite/operators.go`, we were writing read queries that assumed the load operators would be to relational databases. Since S3 was not relational, these queries would not detect such load operators, causing the `list_workflow_objects` endpoint to omit those operators incorrectly. Fixing up those queries necessitated a cascade of other downstream changes:
     - `list_workflow_objects` still returns a LoadOperator, but this struct contains a Load spec instead of flattened fields now, which generalizes to different integrations better. This means that changes had to be made to the SDK's `flow.list_saved_objects()`  user-facing method, as well as the UI [addressed in a follow-up PR].
     - `delete_workflow` had to be altered to take in this new Load spec variant, since it is expected that a user use the output of `list_saved_objects()` to feed into `delete_workflow`. This also has a UI component to it [addressed in a follow-up PR].

## Related issue number (if any)
ENG-2110

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


