### PR TITLE
[2/3] Run SDK Integration Tests against S3 [Testing Changes]

### DIFF
--- a/integration_tests/backend/test_reads.py
+++ b/integration_tests/backend/test_reads.py
@@ -96,11 +96,21 @@ class TestBackend:
                 ("table_2", "replace"),
             ]
         )
-        assert set([(item["object_name"], item["update_mode"]) for item in data]) == data_set
+
+        print(data)
+        assert (
+            set(
+                [
+                    (item["spec"]["parameters"]["table"], item["spec"]["parameters"]["update_mode"])
+                    for item in data
+                ]
+            )
+            == data_set
+        )
 
         # Check all in same integration
         assert len(set([item["integration_name"] for item in data])) == 1
-        assert len(set([item["service"] for item in data])) == 1
+        assert len(set([item["spec"]["service"] for item in data])) == 1
 
     def test_endpoint_delete_integration(self):
         integration_name = f"test_delete_integration_{uuid.uuid4().hex[:8]}"

--- a/integration_tests/sdk/checks_test.py
+++ b/integration_tests/sdk/checks_test.py
@@ -2,10 +2,10 @@ import pandas as pd
 import pytest
 from aqueduct.constants.enums import CheckSeverity
 from aqueduct.error import AqueductError, ArtifactNotFoundException, InvalidUserActionException
-from constants import CHURN_SQL_QUERY, SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_functions.simple.model import dummy_sentiment_model
 from test_metrics.constant.model import constant_metric
-from utils import publish_flow_test
+from utils import extract, publish_flow_test
 
 from aqueduct import check
 
@@ -35,8 +35,8 @@ def success_on_multiple_mixed_inputs(metric, df):
 
 def test_check_on_table(client, flow_name, data_integration, engine):
     """Test check on a function operator."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    check_artifact = success_on_single_table_input(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    check_artifact = success_on_single_table_input(table_artifact)
     assert check_artifact.get()
 
     publish_flow_test(
@@ -49,8 +49,8 @@ def test_check_on_table(client, flow_name, data_integration, engine):
 
 def test_check_on_metric(client, flow_name, data_integration, engine):
     """Test check on a metric operator."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    metric = constant_metric(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    metric = constant_metric(table_artifact)
 
     check_artifact = success_on_single_metric_input(metric)
     assert check_artifact.get()
@@ -65,11 +65,11 @@ def test_check_on_metric(client, flow_name, data_integration, engine):
 
 def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, engine):
     """Test check on multiple tables and metrics."""
-    sql_artifact1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    metric = constant_metric(sql_artifact1)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    metric = constant_metric(table_artifact1)
 
-    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    table = dummy_sentiment_model(sql_artifact2)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
+    table = dummy_sentiment_model(table_artifact2)
 
     check_artifact = success_on_multiple_mixed_inputs(metric, table)
     assert check_artifact.get()
@@ -84,20 +84,20 @@ def test_check_on_multiple_mixed_inputs(client, flow_name, data_integration, eng
 
 def test_edit_check(client, data_integration):
     """Test that checks can be edited by replacing with the same name."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @check()
     def check_op(df):
         return False
 
-    failed_check = check_op(sql_artifact)
+    failed_check = check_op(table_artifact)
     assert not failed_check.get()
 
     @check()
     def check_op(df):
         return True
 
-    success_check = check_op(sql_artifact)
+    success_check = check_op(table_artifact)
     assert success_check.get()
 
     # Attempting to fetch the previous check artifact should fail, since its been overwritten!
@@ -107,17 +107,17 @@ def test_edit_check(client, data_integration):
 
 def test_delete_check(client, data_integration):
     """Test that checks can be deleted by name."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(InvalidUserActionException):
-        sql_artifact.remove_check(name="nonexistant_check")
+        table_artifact.remove_check(name="nonexistant_check")
 
-    check_artifact_on_sql = success_on_single_table_input(sql_artifact)
-    sql_artifact.remove_check(name="success_on_single_table_input")
+    check_artifact_on_sql = success_on_single_table_input(table_artifact)
+    table_artifact.remove_check(name="success_on_single_table_input")
     with pytest.raises(ArtifactNotFoundException):
         check_artifact_on_sql.get()
 
-    metric_artifact = constant_metric(sql_artifact)
+    metric_artifact = constant_metric(table_artifact)
     check_artifact_on_metric = success_on_single_metric_input(metric_artifact)
     metric_artifact.remove_check(name="success_on_single_metric_input")
     with pytest.raises(ArtifactNotFoundException):
@@ -125,42 +125,42 @@ def test_delete_check(client, data_integration):
 
 
 def test_check_wrong_input_type(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     # User function receives a dataframe when it's expecting a metric.
     with pytest.raises(AqueductError):
-        check_artifact = success_on_single_metric_input(sql_artifact)
+        check_artifact = success_on_single_metric_input(table_artifact)
 
     # TODO(ENG-862): the following code should not surface an internal error,
     #  since its the user's fault.
     # Running a function operator on a check output, which is not allowed.
-    check_artifact = success_on_single_table_input(sql_artifact)
+    check_artifact = success_on_single_table_input(table_artifact)
     with pytest.raises(Exception):
         dummy_sentiment_model(check_artifact)
 
 
 def test_check_wrong_number_of_inputs(client, data_integration):
-    sql_artifact1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
     # TODO(ENG-863): Do we want a more specific error here?
     with pytest.raises(AqueductError):
-        success_on_single_table_input(sql_artifact1, sql_artifact2)
+        success_on_single_table_input(table_artifact1, table_artifact2)
 
 
 def test_check_with_numpy_bool_output(client, data_integration):
-    sql_artifact = data_integration.sql(query=CHURN_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.CHURN)
 
     @check()
     def success_check_return_numpy_bool(df):
         return df["total_charges"].mean() < 2500
 
-    check_artifact = success_check_return_numpy_bool(sql_artifact)
+    check_artifact = success_check_return_numpy_bool(table_artifact)
     assert check_artifact.get()
 
 
 def test_check_with_series_output(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @check()
     def success_check_return_series_of_booleans(df):
@@ -170,22 +170,22 @@ def test_check_with_series_output(client, flow_name, data_integration, engine):
     def failure_check_return_series_of_booleans(df):
         return pd.Series([True, False, True])
 
-    passed = success_check_return_series_of_booleans(sql_artifact)
+    passed = success_check_return_series_of_booleans(table_artifact)
     assert passed.get()
 
-    failed = failure_check_return_series_of_booleans(sql_artifact)
+    failed = failure_check_return_series_of_booleans(table_artifact)
     assert not failed.get()
 
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[sql_artifact, passed, failed],
+        artifacts=[table_artifact, passed, failed],
         engine=engine,
     )
 
 
 def test_check_failure_with_varying_severity(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     # An error check will fail the workflow, but a warning check will not.
     @check(severity=CheckSeverity.WARNING)
@@ -196,15 +196,15 @@ def test_check_failure_with_varying_severity(client, flow_name, data_integration
     def failure_blocking_check(df):
         return False
 
-    nonblocking_check = failure_nonblocking_check(sql_artifact)
+    nonblocking_check = failure_nonblocking_check(table_artifact)
 
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[sql_artifact, nonblocking_check],
+        artifacts=[table_artifact, nonblocking_check],
         engine=engine,
     )
 
     # In eager execution, this check should fail before we can publish the flow.
     with pytest.raises(AqueductError):
-        failure_blocking_check(sql_artifact)
+        failure_blocking_check(table_artifact)

--- a/integration_tests/sdk/constants.py
+++ b/integration_tests/sdk/constants.py
@@ -1,9 +1,0 @@
-# Parameters for the sentiment dataset.
-SENTIMENT_SQL_QUERY = "select * from hotel_reviews"
-# This is to speed up the database writes.
-SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
-
-# Parameters for the churn dataset.
-CHURN_SQL_QUERY = "select * from customer_activity"
-
-WINE_SQL_QUERY = "select * from wine"

--- a/integration_tests/sdk/data_objects.py
+++ b/integration_tests/sdk/data_objects.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class DataObject(str, Enum):
+    SENTIMENT = "hotel_reviews"
+    CHURN = "customer_activity"
+    WINE = "wine"
+    CUSTOMERS = "customers"

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -10,10 +10,8 @@ from utils import (
     check_table_exists,
     extract,
     generate_table_name,
-    get_object_identifier_from_load_spec,
     publish_flow_test,
     save,
-    set_object_identifier_on_load_spec,
 )
 
 
@@ -31,7 +29,7 @@ def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integrati
 
     tables = client.flow(flow.id()).list_saved_objects()
     table_saved_object_update = tables[data_integration][0]
-    set_object_identifier_on_load_spec(table_saved_object_update.spec, "I_DONT_EXIST")
+    table_saved_object_update.spec.set_identifier("I_DONT_EXIST")
     tables[data_integration] = [table_saved_object_update]
 
     # Cannot delete a flow if the saved objects specified had not been saved by the flow.
@@ -75,7 +73,7 @@ def test_force_delete_workflow_saved_objects(
 
     tables = client.flow(flow.id()).list_saved_objects()
     assert table_name in [
-        get_object_identifier_from_load_spec(item.spec) for item in tables[data_integration]
+        item.spec.identifier() for item in tables[data_integration]
     ]
 
     # Doesn't work if don't force because it is created in append mode.
@@ -134,13 +132,13 @@ def test_delete_workflow_saved_objects_twice(
 
     tables = client.flow(flow1.id()).list_saved_objects()
     tables_1 = set(
-        [get_object_identifier_from_load_spec(item.spec) for item in tables[data_integration]]
+        [item.spec.identifier() for item in tables[data_integration]]
     )
     assert table_name in tables_1
 
     tables = client.flow(flow2.id()).list_saved_objects()
     tables_2 = set(
-        [get_object_identifier_from_load_spec(item.spec) for item in tables[data_integration]]
+        [item.spec.identifier() for item in tables[data_integration]]
     )
     assert table_name in tables_2
 

--- a/integration_tests/sdk/delete_workflow_test.py
+++ b/integration_tests/sdk/delete_workflow_test.py
@@ -72,9 +72,7 @@ def test_force_delete_workflow_saved_objects(
     )
 
     tables = client.flow(flow.id()).list_saved_objects()
-    assert table_name in [
-        item.spec.identifier() for item in tables[data_integration]
-    ]
+    assert table_name in [item.spec.identifier() for item in tables[data_integration]]
 
     # Doesn't work if don't force because it is created in append mode.
     with pytest.raises(InvalidRequestError):
@@ -131,15 +129,11 @@ def test_delete_workflow_saved_objects_twice(
     check_table_exists(data_integration, table_name)
 
     tables = client.flow(flow1.id()).list_saved_objects()
-    tables_1 = set(
-        [item.spec.identifier() for item in tables[data_integration]]
-    )
+    tables_1 = set([item.spec.identifier() for item in tables[data_integration]])
     assert table_name in tables_1
 
     tables = client.flow(flow2.id()).list_saved_objects()
-    tables_2 = set(
-        [item.spec.identifier() for item in tables[data_integration]]
-    )
+    tables_2 = set([item.spec.identifier() for item in tables[data_integration]])
     assert table_name in tables_2
 
     assert tables_1 == tables_2

--- a/integration_tests/sdk/error_handling_test.py
+++ b/integration_tests/sdk/error_handling_test.py
@@ -1,5 +1,8 @@
 import pytest
 from aqueduct.error import AqueductError, InvalidUserArgumentException
+from data_objects import DataObject
+from relational import all_relational_DBs
+from utils import extract
 
 import aqueduct
 from aqueduct import op
@@ -19,18 +22,19 @@ TIP_EXTRACT = "We couldn't execute the provided query. Please double check your 
 TIP_OP_EXECUTION = "Error executing operator. Please refer to the stack trace for fix."
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_handle_relational_query_error(client, data_integration):
     try:
-        sql_artifact = data_integration.sql(query=BAD_QUERY)
+        _ = data_integration.sql(query=BAD_QUERY)
     except AqueductError as e:
         assert TIP_EXTRACT in e.message
 
 
 def test_handle_bad_op_error(client, data_integration):
-    sql_artifact = data_integration.sql(query=GOOD_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     try:
-        bad_op(sql_artifact)
+        bad_op(table_artifact)
     except AqueductError as e:
         assert TIP_OP_EXECUTION in e.message
 

--- a/integration_tests/sdk/flow_test.py
+++ b/integration_tests/sdk/flow_test.py
@@ -8,7 +8,7 @@ from aqueduct.error import InvalidUserArgumentException
 from aqueduct.integrations.airflow_integration import AirflowIntegration
 from aqueduct.models.config import FlowConfig
 from aqueduct.models.integration import IntegrationInfo
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_functions.sentiment.model import sentiment_model
 from test_functions.simple.model import (
     dummy_model,
@@ -17,6 +17,7 @@ from test_functions.simple.model import (
 )
 from test_metrics.constant.model import constant_metric
 from utils import (
+    extract,
     generate_new_flow_name,
     generate_table_name,
     publish_flow_test,
@@ -30,8 +31,8 @@ from aqueduct import check, metric, op
 
 
 def test_basic_flow(client, flow_name, data_integration, engine, validator):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -40,13 +41,14 @@ def test_basic_flow(client, flow_name, data_integration, engine, validator):
         name=flow_name(),
         engine=engine,
     )
+
     validator.check_saved_artifact(flow, output_artifact.id(), expected_data=output_artifact.get())
 
 
 def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
     """Actually run the full sentiment model (with nltk dependency)."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -59,10 +61,10 @@ def test_sentiment_flow(client, flow_name, data_integration, engine, validator):
 
 
 def test_complex_flow(client, flow_name, data_integration, engine, validator):
-    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
-    fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact1, sql_artifact2)
+    fn_artifact = dummy_sentiment_model_multiple_input(table_artifact1, table_artifact2)
     output_artifact = dummy_model(fn_artifact)
     save(data_integration, output_artifact)
 
@@ -115,11 +117,11 @@ def test_complex_flow(client, flow_name, data_integration, engine, validator):
 
 
 def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
-    sql_artifact1 = data_integration.sql(name="Query 1", query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(name="Query 2", query=SENTIMENT_SQL_QUERY)
+    table_artifact1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
-    fn_artifact1 = dummy_sentiment_model(sql_artifact1)
-    fn_artifact2 = dummy_model(sql_artifact2)
+    fn_artifact1 = dummy_sentiment_model(table_artifact1)
+    fn_artifact2 = dummy_model(table_artifact2)
     save(data_integration, fn_artifact1)
     save(data_integration, fn_artifact2)
 
@@ -132,8 +134,8 @@ def test_multiple_output_artifacts(client, flow_name, data_integration, engine):
 
 
 def test_publish_with_schedule(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     # Execute the flow 1 minute from now.
@@ -165,8 +167,8 @@ def test_invalid_flow(client):
 
 def test_publish_flow_with_same_name(client, flow_name, data_integration, engine):
     """Tests flow editing behavior."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
 
     name = flow_name()
     flow = publish_flow_test(
@@ -191,8 +193,8 @@ def test_publish_flow_with_same_name(client, flow_name, data_integration, engine
 
 
 def test_refresh_flow(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -211,8 +213,8 @@ def test_refresh_flow(client, flow_name, data_integration, engine):
 
 
 def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -228,8 +230,8 @@ def test_get_artifact_from_flow(client, flow_name, data_integration, engine):
 
 
 def test_get_artifact_reuse_for_computation(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     save(data_integration, output_artifact)
 
     flow = publish_flow_test(
@@ -245,9 +247,9 @@ def test_get_artifact_reuse_for_computation(client, flow_name, data_integration,
 
 
 def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
-    output_artifact_2 = dummy_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
+    output_artifact_2 = dummy_model(table_artifact)
 
     flow_1 = publish_flow_test(
         client,
@@ -280,7 +282,7 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
 
 
 def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
-    # Write a new table into the demo db.
+    # Write a new table into the data integration.
     initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
 
     @op
@@ -288,8 +290,8 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return initial_table
 
     table = generate_initial_table()
-    table_name = generate_table_name()
-    save(data_integration, table, name=table_name)
+    saved_table_identifier = generate_table_name()
+    save(data_integration, table, name=saved_table_identifier)
 
     setup_flow = publish_flow_test(
         client,
@@ -303,7 +305,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return df
 
     # Create a new flow that extracts this data.
-    output = data_integration.sql("SELECT * FROM %s" % table_name, name="Test Table Query")
+    output = extract(data_integration, saved_table_identifier, op_name="Test Table Query")
     assert output.get().equals(initial_table)
 
     flow = publish_flow_test(
@@ -319,7 +321,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
         return pd.DataFrame([9, 9, 9, 9, 9, 9], columns=["numbers"])
 
     table = generate_new_table()
-    save(data_integration, table, name=table_name)
+    save(data_integration, table, name=saved_table_identifier)
     publish_flow_test(
         client,
         artifacts=table,

--- a/integration_tests/sdk/local_test.py
+++ b/integration_tests/sdk/local_test.py
@@ -1,49 +1,51 @@
 from checks_test import success_on_single_table_input
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from pandas import DataFrame
 from pandas._testing import assert_frame_equal
 from test_functions.simple.model import dummy_sentiment_model, dummy_sentiment_model_multiple_input
 from test_metrics.constant.model import constant_metric
+from utils import extract
 
 
 def test_local_operator(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
     output_cloud = output_artifact.get()
 
-    output_local = dummy_sentiment_model.local(sql_artifact)
+    output_local = dummy_sentiment_model.local(table_artifact)
     assert output_cloud.count()[0] == output_local.count()[0]
     assert_frame_equal(output_cloud, output_local)
 
 
 def test_local_metric(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric = constant_metric(sql_artifact)
+    metric = constant_metric(table_artifact)
     assert metric.get() == 17.5
-    assert constant_metric.local(sql_artifact) == 17.5
+    assert constant_metric.local(table_artifact) == 17.5
 
 
 def test_local_check(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+
     check = success_on_single_table_input
-    assert check(sql_artifact)
-    assert check.local(sql_artifact)
+    assert check(table_artifact)
+    assert check.local(table_artifact)
 
 
 def test_local_dataframe_input(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_cloud = dummy_sentiment_model(sql_artifact).get()
-    output_local = dummy_sentiment_model.local(sql_artifact.get())
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_cloud = dummy_sentiment_model(table_artifact).get()
+    output_local = dummy_sentiment_model.local(table_artifact.get())
     assert type(output_local) is DataFrame
     assert_frame_equal(output_cloud, output_local)
 
 
 def test_local_on_multiple_inputs(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_cloud = dummy_sentiment_model_multiple_input(sql_artifact, sql_artifact2).get()
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact2 = extract(data_integration, DataObject.SENTIMENT)
 
-    output_local = dummy_sentiment_model_multiple_input.local(sql_artifact, sql_artifact2)
+    output_cloud = dummy_sentiment_model_multiple_input(table_artifact, table_artifact2).get()
+    output_local = dummy_sentiment_model_multiple_input.local(table_artifact, table_artifact2)
     assert type(output_local) is DataFrame
     assert_frame_equal(output_cloud, output_local)

--- a/integration_tests/sdk/metrics_test.py
+++ b/integration_tests/sdk/metrics_test.py
@@ -1,24 +1,24 @@
 import pandas as pd
 import pytest
 from aqueduct.error import AqueductError
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_metrics.constant.model import constant_metric
-from utils import publish_flow_test
+from utils import extract, publish_flow_test
 
 from aqueduct import metric
 
 
 def test_basic_metric(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric = constant_metric(sql_artifact)
+    metric = constant_metric(table_artifact)
     assert metric.get() == 17.5
 
 
 def test_metric_bound(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric = constant_metric(sql_artifact)
+    metric = constant_metric(table_artifact)
     check_artifact = metric.bound(upper=100)
     assert check_artifact.get()
 
@@ -39,12 +39,13 @@ def test_metric_bound(client, data_integration):
 
 
 def test_register_metric(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    metric_artifact = constant_metric(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+
+    metric_artifact = constant_metric(table_artifact)
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[sql_artifact, metric_artifact],
+        artifacts=[table_artifact, metric_artifact],
         engine=engine,
     )
 
@@ -62,8 +63,8 @@ def metric_with_multiple_inputs(df1, m, df2):
 
 
 def test_metric_mixed_inputs(client, flow_name, data_integration, engine):
-    sql1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    sql1 = extract(data_integration, DataObject.SENTIMENT)
+    sql2 = extract(data_integration, DataObject.SENTIMENT)
     metric_input = constant_metric(sql1)
 
     metric_output = metric_with_multiple_inputs(sql1, metric_input, sql2)

--- a/integration_tests/sdk/mixed_compute_test.py
+++ b/integration_tests/sdk/mixed_compute_test.py
@@ -1,14 +1,15 @@
 import pytest
 from aqueduct.constants.enums import ServiceType
-from constants import SENTIMENT_SQL_QUERY
-from utils import publish_flow_test
+from data_objects import DataObject
+from utils import extract, publish_flow_test
 
 from aqueduct import op
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
 def test_flow_with_multiple_compute_using_op_spec(client, flow_name, data_integration, engine):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    """Runs a workflow both Aqueduct and a third-party compute engine."""
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @op
     def noop(input):
@@ -19,5 +20,5 @@ def test_flow_with_multiple_compute_using_op_spec(client, flow_name, data_integr
         return input
 
     # Only `noop_on_third_party` is run on outside compute.
-    output = noop_on_third_party(noop(sql_artifact))
+    output = noop_on_third_party(noop(table_artifact))
     publish_flow_test(client, output, engine=None)

--- a/integration_tests/sdk/naming_test.py
+++ b/integration_tests/sdk/naming_test.py
@@ -1,24 +1,25 @@
 import pytest
 from aqueduct.error import ArtifactNotFoundException, InvalidUserActionException
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_functions.simple.model import (
     dummy_model,
     dummy_model_2,
     dummy_sentiment_model,
     dummy_sentiment_model_multiple_input,
 )
+from utils import extract
 
 
 def test_extract_with_default_name_collision(client, data_integration):
     # In the case where no explicit name is supplied, we expect new extract
     # operators to always be created.
-    sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact_1 = extract(data_integration, DataObject.SENTIMENT)
+    table_artifact_2 = extract(data_integration, DataObject.SENTIMENT)
 
-    assert sql_artifact_1.name() == "%s query 1 artifact" % data_integration._metadata.name
-    assert sql_artifact_2.name() == "%s query 2 artifact" % data_integration._metadata.name
+    assert table_artifact_1.name() == "%s query 1 artifact" % data_integration._metadata.name
+    assert table_artifact_2.name() == "%s query 2 artifact" % data_integration._metadata.name
 
-    fn_artifact = dummy_sentiment_model_multiple_input(sql_artifact_1, sql_artifact_2)
+    fn_artifact = dummy_sentiment_model_multiple_input(table_artifact_1, table_artifact_2)
     fn_df = fn_artifact.get()
     assert list(fn_df) == [
         "hotel_name",
@@ -33,12 +34,12 @@ def test_extract_with_default_name_collision(client, data_integration):
 
 def test_extract_with_explicit_name_collision(client, data_integration):
     # In the case where an explicit name is supplied, we will overwrite any colliding ops.
-    sql_artifact_1 = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    table_artifact_1 = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
-    fn_artifact = dummy_sentiment_model(sql_artifact_1)
+    fn_artifact = dummy_sentiment_model(table_artifact_1)
 
-    sql_artifact_2 = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
-    assert sql_artifact_2.name() == "sql query artifact"
+    table_artifact_2 = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
+    assert table_artifact_2.name() == "sql query artifact"
 
     # Cannot preview an artifact with a dependency that has been deleted,
     # since it itself would have been removed from the dag.
@@ -47,9 +48,9 @@ def test_extract_with_explicit_name_collision(client, data_integration):
 
     # Cannot run a function on an artifact that has already been overwritten.
     with pytest.raises(ArtifactNotFoundException):
-        _ = dummy_sentiment_model(sql_artifact_1)
+        _ = dummy_sentiment_model(table_artifact_1)
 
-    fn_artifact = dummy_sentiment_model(sql_artifact_2)
+    fn_artifact = dummy_sentiment_model(table_artifact_2)
     fn_df = fn_artifact.get()
     assert list(fn_df) == [
         "hotel_name",
@@ -63,12 +64,12 @@ def test_extract_with_explicit_name_collision(client, data_integration):
 
 def test_function_with_name_collision(client, data_integration):
     """Colliding functions are always overwritten."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
     # There's not an easy way to programmatically change the function, so lets
     # just run the same function twice and check that the latest one wins.
-    dummy_fn_artifact_old = dummy_model(sql_artifact)
-    dummy_fn_artifact_new = dummy_model(sql_artifact)
+    dummy_fn_artifact_old = dummy_model(table_artifact)
+    dummy_fn_artifact_new = dummy_model(table_artifact)
 
     with pytest.raises(ArtifactNotFoundException):
         dummy_fn_artifact_old.get()
@@ -86,23 +87,23 @@ def test_function_with_name_collision(client, data_integration):
 
 def test_naming_collision_with_different_types(client, data_integration):
     # An overwrite is invalid because the operators are of different types.
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sql query")
+    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
     # Function collides with existing sql artifact
-    _ = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="dummy_model")
+    _ = extract(data_integration, DataObject.SENTIMENT, op_name="dummy_model")
     with pytest.raises(InvalidUserActionException):
-        dummy_model(sql_artifact)
+        dummy_model(table_artifact)
 
     # SQL collides with existing function
-    _ = dummy_sentiment_model(sql_artifact)
+    _ = dummy_sentiment_model(table_artifact)
     with pytest.raises(InvalidUserActionException):
-        _ = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="dummy_sentiment_model")
+        _ = extract(data_integration, DataObject.SENTIMENT, op_name="dummy_sentiment_model")
 
 
 def test_naming_collision_with_dependency(client, data_integration):
     # Overwrite is invalid when the operator being replaced is an upstream dependency.
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY, name="sentiment_model")
-    dummy_model_output = dummy_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sentiment_model")
+    dummy_model_output = dummy_model(table_artifact)
     dummy_model_2_output = dummy_model_2(dummy_model_output)
 
     with pytest.raises(InvalidUserActionException):

--- a/integration_tests/sdk/no_input_test.py
+++ b/integration_tests/sdk/no_input_test.py
@@ -1,4 +1,6 @@
 import pandas as pd
+from data_objects import DataObject
+from utils import extract
 
 from aqueduct import op
 
@@ -21,7 +23,7 @@ def test_basic_no_input_function(client):
 
 
 def test_flow_with_no_input_function(client, data_integration):
-    customers_table = data_integration.sql(query="SELECT * FROM customers;")
+    customers_table = extract(data_integration, DataObject.CUSTOMERS)
 
     result = join(no_input(), customers_table)
     expected = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})

--- a/integration_tests/sdk/operator_hierarchy_test.py
+++ b/integration_tests/sdk/operator_hierarchy_test.py
@@ -1,6 +1,7 @@
 import pytest
 from aqueduct.error import InvalidUserActionException
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
+from utils import extract
 
 from aqueduct import check, metric, op
 
@@ -32,9 +33,9 @@ def regular_function(args):
 
 def test_check_artifact_restriction(client, data_integration):
     """Test that an artifact produced by a check operator cannot be used as an argument to any operator types."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    check_artifact = produce_check_artifact(sql_artifact)
+    check_artifact = produce_check_artifact(table_artifact)
     with pytest.raises(InvalidUserActionException):
         check_function(check_artifact)
     with pytest.raises(InvalidUserActionException):
@@ -45,8 +46,8 @@ def test_check_artifact_restriction(client, data_integration):
 
 def test_metric_artifact_restriction(client, data_integration):
     """Test that an artifact produced by a metric operator cannot be used as an argument to function operator."""
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    metric_artifact = produce_metric_artifact(sql_artifact)
+    metric_artifact = produce_metric_artifact(table_artifact)
     with pytest.raises(InvalidUserActionException):
         regular_function(metric_artifact)

--- a/integration_tests/sdk/operator_test.py
+++ b/integration_tests/sdk/operator_test.py
@@ -1,12 +1,13 @@
 from aqueduct.decorator import to_operator
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
 from test_function import dummy_sentiment_model_function
+from utils import extract
 
 from aqueduct import op
 
 
 def test_to_operator_local_function(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @op
     def dummy_sentiment_model(df):
@@ -17,25 +18,25 @@ def test_to_operator_local_function(client, data_integration):
         df["positivity"] = 123
         return df
 
-    output_artifact_from_decorator = dummy_sentiment_model(sql_artifact)
+    output_artifact_from_decorator = dummy_sentiment_model(table_artifact)
     df_normal = output_artifact_from_decorator.get()
-    output_artifact_from_to_operator = to_operator(dummy_sentiment_model_func)(sql_artifact)
+    output_artifact_from_to_operator = to_operator(dummy_sentiment_model_func)(table_artifact)
     df_func = output_artifact_from_to_operator.get()
 
     assert df_normal["positivity"].equals(df_func["positivity"])
 
 
 def test_to_operator_imported_function(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     @op(file_dependencies=["test_function.py"])
     def decorated_func(df):
         df = dummy_sentiment_model_function(df)
         return df
 
-    df_decorate = decorated_func(sql_artifact).get()
+    df_decorate = decorated_func(table_artifact).get()
     df_function = to_operator(
         dummy_sentiment_model_function, file_dependencies=["test_function.py"]
-    )(sql_artifact).get()
+    )(table_artifact).get()
 
     assert df_decorate["positivity"].equals(df_function["positivity"])

--- a/integration_tests/sdk/relational.py
+++ b/integration_tests/sdk/relational.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from aqueduct.constants.enums import RelationalDBServices, ServiceType
+
+# We limit the number of rows to speed up a database writes a littel bit.
+SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
+
+
+def all_relational_DBs() -> List[ServiceType]:
+    return [ServiceType(relational_service.value) for relational_service in RelationalDBServices]

--- a/integration_tests/sdk/sql_integration_test.py
+++ b/integration_tests/sdk/sql_integration_test.py
@@ -1,12 +1,14 @@
 import pytest
 from aqueduct.error import InvalidIntegrationException, InvalidUserArgumentException
-from constants import SENTIMENT_SQL_QUERY
+from data_objects import DataObject
+from relational import all_relational_DBs
 from test_functions.simple.model import dummy_sentiment_model
-from utils import publish_flow_test, save
+from utils import extract, publish_flow_test, save
 
 from aqueduct import metric
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_integration_load_table(client, data_integration):
     df = data_integration.table(name="hotel_reviews")
     assert len(df) == 100
@@ -24,25 +26,27 @@ def test_invalid_source_integration(client):
 
 
 def test_invalid_destination_integration(client, data_integration):
-    sql_artifact = data_integration.sql(query=SENTIMENT_SQL_QUERY)
-    output_artifact = dummy_sentiment_model(sql_artifact)
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
 
     with pytest.raises(InvalidIntegrationException):
         data_integration._metadata.name = "bad name"
         save(data_integration, output_artifact)
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_today_tag(client, data_integration):
-    sql_artifact_today = data_integration.sql(
+    table_artifact_today = data_integration.sql(
         query="select * from hotel_reviews where review_date = {{today}}"
     )
-    assert sql_artifact_today.get().empty
-    sql_artifact_not_today = data_integration.sql(
+    assert table_artifact_today.get().empty
+    table_artifact_not_today = data_integration.sql(
         query="select * from hotel_reviews where review_date < {{today}}"
     )
-    assert len(sql_artifact_not_today.get()) == 100
+    assert len(table_artifact_not_today.get()) == 100
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_query_with_parameter(client, data_integration):
     # Missing parameters.
     with pytest.raises(InvalidUserArgumentException):
@@ -54,39 +58,40 @@ def test_sql_query_with_parameter(client, data_integration):
         _ = data_integration.sql(query="select * from {{ table_name }}")
 
     client.create_param("table_name", default="hotel_reviews")
-    sql_artifact = data_integration.sql(query="select * from {{ table_name }}")
+    table_artifact = data_integration.sql(query="select * from {{ table_name }}")
 
-    expected_sql_artifact = data_integration.sql(query="select * from hotel_reviews")
-    assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = data_integration.sql(query="select * from customer_activity")
-    assert sql_artifact.get(parameters={"table_name": "customer_activity"}).equals(
-        expected_sql_artifact.get()
+    expected_table_artifact = data_integration.sql(query="select * from hotel_reviews")
+    assert table_artifact.get().equals(expected_table_artifact.get())
+    expected_table_artifact = data_integration.sql(query="select * from customer_activity")
+    assert table_artifact.get(parameters={"table_name": "customer_activity"}).equals(
+        expected_table_artifact.get()
     )
 
     # Trigger the parameter with invalid values.
     with pytest.raises(InvalidUserArgumentException):
-        _ = sql_artifact.get(parameters={"table_name": ["this is the incorrect type"]})
+        _ = table_artifact.get(parameters={"table_name": ["this is the incorrect type"]})
     with pytest.raises(InvalidUserArgumentException):
-        _ = sql_artifact.get(parameters={"non-existant parameter": "blah"})
+        _ = table_artifact.get(parameters={"non-existant parameter": "blah"})
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_query_with_multiple_parameters(client, flow_name, data_integration, engine):
     _ = client.create_param("table_name", default="hotel_reviews")
     nationality = client.create_param(
         "reviewer-nationality", default="United Kingdom"
     )  # check that dashes work.
-    sql_artifact = data_integration.sql(
+    table_artifact = data_integration.sql(
         query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer-nationality }}' and review_date < {{ today}}"
     )
-    expected_sql_artifact = data_integration.sql(
+    expected_table_artifact = data_integration.sql(
         "select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}"
     )
-    assert sql_artifact.get().equals(expected_sql_artifact.get())
-    expected_sql_artifact = data_integration.sql(
+    assert table_artifact.get().equals(expected_table_artifact.get())
+    expected_table_artifact = data_integration.sql(
         "select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}"
     )
-    assert sql_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
-        expected_sql_artifact.get()
+    assert table_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
+        expected_table_artifact.get()
     )
 
     # Use the parameters in another operator.
@@ -94,34 +99,36 @@ def test_sql_query_with_multiple_parameters(client, flow_name, data_integration,
     def noop(sql_output, param):
         return len(param)
 
-    result = noop(sql_artifact, nationality)
+    result = noop(table_artifact, nationality)
     assert result.get() == len(nationality.get())
     assert result.get(parameters={"reviewer-nationality": "Australia"}) == len("Australia")
 
     publish_flow_test(client, name=flow_name(), artifacts=[result], engine=engine)
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_sql_query_user_vs_builtin_precedence(client, data_integration):
     """If a user defines an expansion that collides with a built-in one, the user-defined one should take precedence."""
-    sql_artifact = data_integration.sql(
+    table_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > {{today}}"
     )
-    builtin_result = sql_artifact.get()
+    builtin_result = table_artifact.get()
 
     datestring = "'2016-01-01'"
     _ = client.create_param("today", datestring)
-    sql_artifact = data_integration.sql(
+    table_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > {{today}}"
     )
-    user_param_result = sql_artifact.get()
+    user_param_result = table_artifact.get()
     assert not builtin_result.equals(user_param_result)
 
-    expected_sql_artifact = data_integration.sql(
+    expected_table_artifact = data_integration.sql(
         query="select * from hotel_reviews where review_date > %s" % datestring
     )
-    assert user_param_result.equals(expected_sql_artifact.get())
+    assert user_param_result.equals(expected_table_artifact.get())
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_chained_sql_query(client):
     client.create_param("nationality", default=" United Kingdom ")
     warehouse = client.integration(name="aqueduct_demo")

--- a/integration_tests/sdk/table_artifact_test.py
+++ b/integration_tests/sdk/table_artifact_test.py
@@ -2,24 +2,23 @@ import math
 import time
 
 import pandas as pd
-from constants import SENTIMENT_SQL_QUERY, WINE_SQL_QUERY
+from data_objects import DataObject
+from utils import extract
 
 from aqueduct import op
 
 
 def test_great_expectations_check(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     ge_check = table.validate_with_expectation(
         "expect_column_values_to_be_unique", {"column": "fixed_acidity"}
     )
-
-    assert ge_check.get() == False
+    assert not ge_check.get()
 
     ge_check = table.validate_with_expectation(
         "expect_column_values_to_not_be_null", {"column": "fixed_acidity"}
     )
-
-    assert ge_check.get() == True
+    assert ge_check.get()
 
 
 @op
@@ -47,7 +46,7 @@ def mem_intensive_function(table: pd.DataFrame) -> pd.DataFrame:
 
 
 def test_system_runtime_metric(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     timed_table = timed_function(table)
 
     runtime_metric = timed_table.system_metric("runtime")
@@ -56,7 +55,7 @@ def test_system_runtime_metric(client, data_integration):
 
 
 def test_system_max_memory_metric(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     timed_table = mem_intensive_function(table)
 
     max_mem_metric = timed_table.system_metric("max_memory")
@@ -65,7 +64,7 @@ def test_system_max_memory_metric(client, data_integration):
 
 
 def test_number_of_missing_values(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_missing_values(column_id="hotel_name")
     assert missing_metric.get() == 0
 
@@ -78,7 +77,7 @@ def test_number_of_missing_values(client, data_integration):
 
 
 def test_number_of_rows(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_rows()
     assert missing_metric.get() == 100
 
@@ -88,7 +87,7 @@ def test_number_of_rows(client, data_integration):
 
 
 def test_max(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.max(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 15.8999, rel_tol=1e-3)
 
@@ -97,7 +96,7 @@ def test_max(client, data_integration):
 
 
 def test_min(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.min(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 3.7999, rel_tol=1e-3)
 
@@ -106,7 +105,7 @@ def test_min(client, data_integration):
 
 
 def test_mean(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.mean(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 7.2153, rel_tol=1e-3)
 
@@ -115,7 +114,7 @@ def test_mean(client, data_integration):
 
 
 def test_std(client, data_integration):
-    table = data_integration.sql(query=WINE_SQL_QUERY)
+    table = extract(data_integration, DataObject.WINE)
     missing_metric = table.std(column_id="fixed_acidity")
     assert math.isclose(missing_metric.get(), 1.2964, rel_tol=1e-3)
 
@@ -124,7 +123,7 @@ def test_std(client, data_integration):
 
 
 def test_head_standard(client, data_integration):
-    table = data_integration.sql(query=SENTIMENT_SQL_QUERY)
+    table = extract(data_integration, DataObject.SENTIMENT)
     assert table.get().shape[0] == 100
 
     table_head = table.head()

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -228,23 +228,6 @@ def extract(
     raise Exception("Unexpected data integration type provided in test: %s", type(integration))
 
 
-def get_object_identifier_from_load_spec(load_spec: LoadSpec) -> str:
-    if isinstance(load_spec.parameters, RelationalDBLoadParams):
-        return load_spec.parameters.table
-    elif isinstance(load_spec.parameters, S3LoadParams):
-        return load_spec.parameters.filepath
-    raise Exception("Unsupported load parameters %s." % type(load_spec.parameters))
-
-
-def set_object_identifier_on_load_spec(load_spec: LoadSpec, new_obj_identifier: str) -> str:
-    if isinstance(load_spec.parameters, RelationalDBLoadParams):
-        load_spec.parameters.table = new_obj_identifier
-    elif isinstance(load_spec.parameters, S3LoadParams):
-        load_spec.parameters.filepath = new_obj_identifier
-    else:
-        raise Exception("Unsupported load parameters %s." % type(load_spec.parameters))
-
-
 def save(
     integration,
     artifact: TableArtifact,

--- a/integration_tests/sdk/utils.py
+++ b/integration_tests/sdk/utils.py
@@ -3,7 +3,12 @@ import uuid
 from typing import Any, Dict, List, Optional, Union
 
 from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.constants.enums import ExecutionStatus, LoadUpdateMode, RelationalDBServices
+from aqueduct.artifacts.table_artifact import TableArtifact
+from aqueduct.constants.enums import ArtifactType, ExecutionStatus, LoadUpdateMode, S3TableFormat
+from aqueduct.integrations.s3_integration import S3Integration
+from aqueduct.integrations.sql_integration import RelationalDBIntegration
+from aqueduct.models.operators import LoadSpec, RelationalDBLoadParams, S3LoadParams
+from data_objects import DataObject
 
 import aqueduct
 from aqueduct import Flow
@@ -199,28 +204,81 @@ def wait_for_flow_runs(
     )
 
 
+def extract(
+    integration,
+    obj_identifier: Union[DataObject, str],
+    op_name: Optional[str] = None,
+    lazy: bool = False,
+) -> BaseArtifact:
+    """Reads the specified object in from the integration and returns it as an artifact.
+
+    Assumption: the object is a pandas dataframe, serialized in a particular fashion in each integration.
+    This serialization method should match what is done in `save()`.
+    """
+    if isinstance(obj_identifier, DataObject):
+        obj_identifier = obj_identifier.value
+
+    assert isinstance(obj_identifier, str)
+    if isinstance(integration, RelationalDBIntegration):
+        return integration.sql(query="SELECT * from %s" % obj_identifier, name=op_name, lazy=lazy)
+    elif isinstance(integration, S3Integration):
+        return integration.file(
+            obj_identifier, ArtifactType.TABLE, "parquet", name=op_name, lazy=lazy
+        )
+    raise Exception("Unexpected data integration type provided in test: %s", type(integration))
+
+
+def get_object_identifier_from_load_spec(load_spec: LoadSpec) -> str:
+    if isinstance(load_spec.parameters, RelationalDBLoadParams):
+        return load_spec.parameters.table
+    elif isinstance(load_spec.parameters, S3LoadParams):
+        return load_spec.parameters.filepath
+    raise Exception("Unsupported load parameters %s." % type(load_spec.parameters))
+
+
+def set_object_identifier_on_load_spec(load_spec: LoadSpec, new_obj_identifier: str) -> str:
+    if isinstance(load_spec.parameters, RelationalDBLoadParams):
+        load_spec.parameters.table = new_obj_identifier
+    elif isinstance(load_spec.parameters, S3LoadParams):
+        load_spec.parameters.filepath = new_obj_identifier
+    else:
+        raise Exception("Unsupported load parameters %s." % type(load_spec.parameters))
+
+
 def save(
     integration,
-    artifact: BaseArtifact,
+    artifact: TableArtifact,
     name: Optional[str] = None,
     update_mode: Optional[LoadUpdateMode] = None,
 ):
-    """NOTE: if `name` is set, make sure that it is set to a globally unique value, since test cases can be run concurrently."""
-    assert (
-        integration._metadata.service in RelationalDBServices
-    ), "Currently, only relational data integrations are supported."
+    """Saves an artifact into the integration.
 
+    If `name` is set, make sure that it is set to a globally unique value, since test cases can be run concurrently.
+
+    Assumption: the artifact represents a pandas dataframe. Each type of integration is serialized in a particular fashion.
+    It should match the deserialization method in extract().
+    """
     if name is None:
         name = generate_table_name()
     if update_mode is None:
         update_mode = LoadUpdateMode.REPLACE
 
-    if use_deprecated_code_path():
-        artifact.save(integration.config(name, update_mode))
-    else:
-        integration.save(artifact, name, update_mode)
+    if isinstance(integration, RelationalDBIntegration):
+        if use_deprecated_code_path():
+            artifact.save(integration.config(name, update_mode))
+        else:
+            integration.save(artifact, name, update_mode)
 
-    # Record exactly where the artifact was saved, so we can validate the data later, after the flow is published.
+    elif isinstance(integration, S3Integration):
+        assert update_mode == LoadUpdateMode.REPLACE, "S3 only supports replacement update."
+        integration.save(artifact, name, S3TableFormat.PARQUET)
+
+        # Record where the artifact was saved, so we can validate the data later, after the flow is published.
+        artifact_id_to_saved_identifier[str(artifact.id())] = name
+    else:
+        raise Exception("Unexpected data integration type provided in test: %s", type(integration))
+
+    # Record where the artifact was saved, so we can validate the data later, after the flow is published.
     artifact_id_to_saved_identifier[str(artifact.id())] = name
 
 

--- a/integration_tests/sdk/validator.py
+++ b/integration_tests/sdk/validator.py
@@ -6,7 +6,7 @@ from aqueduct.constants.enums import LoadUpdateMode
 from aqueduct.integrations.sql_integration import RelationalDBIntegration
 from aqueduct.models.integration import Integration
 from aqueduct.models.operators import RelationalDBLoadParams
-from utils import artifact_id_to_saved_identifier, extract, get_object_identifier_from_load_spec
+from utils import artifact_id_to_saved_identifier, extract
 
 from aqueduct import Client, Flow
 
@@ -31,7 +31,7 @@ class Validator:
         all_saved_objects = flow.list_saved_objects()[self._integration._metadata.name]
 
         all_saved_object_identifiers = [
-            get_object_identifier_from_load_spec(item.spec) for item in all_saved_objects
+            item.spec.identifier() for item in all_saved_objects
         ]
         saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
         assert saved_object_identifier in all_saved_object_identifiers

--- a/integration_tests/sdk/validator.py
+++ b/integration_tests/sdk/validator.py
@@ -1,10 +1,12 @@
 import uuid
 from typing import Any, List, Tuple
 
+import pandas as pd
 from aqueduct.constants.enums import LoadUpdateMode
 from aqueduct.integrations.sql_integration import RelationalDBIntegration
 from aqueduct.models.integration import Integration
-from utils import artifact_id_to_saved_identifier
+from aqueduct.models.operators import RelationalDBLoadParams
+from utils import artifact_id_to_saved_identifier, extract, get_object_identifier_from_load_spec
 
 from aqueduct import Client, Flow
 
@@ -25,18 +27,25 @@ class Validator:
         The exact destination of the artifact is tracked internally by the test suite.
         NOTE: this currently only works against SQL-based integrations.
         """
-        assert isinstance(
-            self._integration, RelationalDBIntegration
-        ), "Currently, only relational data integrations are supported."
-
         # Check that given saved artifacts were indeed saved based on the flow API.
         all_saved_objects = flow.list_saved_objects()[self._integration._metadata.name]
-        all_saved_object_identifiers = [item.object_name for item in all_saved_objects]
+
+        all_saved_object_identifiers = [
+            get_object_identifier_from_load_spec(item.spec) for item in all_saved_objects
+        ]
         saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
         assert saved_object_identifier in all_saved_object_identifiers
 
         # Verify that the actual data was saved.
-        saved_data = self._integration.sql(f"SELECT * FROM {saved_object_identifier}").get()
+        saved_data = extract(self._integration, saved_object_identifier).get()
+        if not isinstance(saved_data, pd.DataFrame):
+            raise Exception(
+                "This test suite is expected to only deal with pandas Dataframe types."
+                "For more extensive third-party type coverage, please write data integration "
+                "tests instead."
+            )
+
+        assert isinstance(saved_data, pd.DataFrame)
         if not saved_data.equals(expected_data):
             print("Expected data: ", expected_data)
             print("Actual data: ", saved_data)
@@ -50,9 +59,15 @@ class Validator:
     ):
         """Checks the exact result of flow.list_saved_objects().
 
+        NOTE: This should only ever be called when checking saves against relational databases!
+
         When `order_matters=True`, the provided `expected_updates` list must match the fetched result exactly.
         Note that the updates are typically ordered from most to least recent.
         """
+        assert isinstance(
+            self._integration, RelationalDBIntegration
+        ), "Currently, only relational data integrations are supported."
+
         data = self._client.flow(flow.id()).list_saved_objects()
 
         # Check all objects were saved to the same integration.
@@ -62,8 +77,13 @@ class Validator:
 
         assert len(data[integration_name]) == len(expected_updates)
         saved_objects = data[integration_name]
+
+        assert all(
+            isinstance(saved_object.spec.parameters, RelationalDBLoadParams)
+            for saved_object in saved_objects
+        )
         actual_updates = [
-            (saved_objects[i].object_name, saved_objects[i].update_mode)
+            (saved_objects[i].spec.parameters.table, saved_objects[i].spec.parameters.update_mode)
             for i, (name, _) in enumerate(expected_updates)
         ]
 

--- a/integration_tests/sdk/validator.py
+++ b/integration_tests/sdk/validator.py
@@ -30,9 +30,7 @@ class Validator:
         # Check that given saved artifacts were indeed saved based on the flow API.
         all_saved_objects = flow.list_saved_objects()[self._integration._metadata.name]
 
-        all_saved_object_identifiers = [
-            item.spec.identifier() for item in all_saved_objects
-        ]
+        all_saved_object_identifiers = [item.spec.identifier() for item in all_saved_objects]
         saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
         assert saved_object_identifier in all_saved_object_identifiers
 

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -77,6 +77,7 @@ class ServiceType(str, Enum, metaclass=MetaEnum):
 
 
 class RelationalDBServices(str, Enum, metaclass=MetaEnum):
+    """Must match the corresponding entries in `ServiceType` exactly."""
     POSTGRES = "Postgres"
     SNOWFLAKE = "Snowflake"
     MYSQL = "MySQL"

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -78,6 +78,7 @@ class ServiceType(str, Enum, metaclass=MetaEnum):
 
 class RelationalDBServices(str, Enum, metaclass=MetaEnum):
     """Must match the corresponding entries in `ServiceType` exactly."""
+
     POSTGRES = "Postgres"
     SNOWFLAKE = "Snowflake"
     MYSQL = "MySQL"

--- a/sdk/aqueduct/error.py
+++ b/sdk/aqueduct/error.py
@@ -98,6 +98,11 @@ class InvalidUserArgumentException(Error):
     pass
 
 
+# Exception raised when the user does something that is explicitly unsupported right now.
+class UnsupportedFeatureException(Error):
+    pass
+
+
 # Exception raised when user attempts to use an invalid file name as a file dependency.
 class ReservedFileNameException(Error):
     pass

--- a/sdk/aqueduct/models/operators.py
+++ b/sdk/aqueduct/models/operators.py
@@ -13,9 +13,9 @@ from aqueduct.constants.enums import (
     S3TableFormat,
     SalesforceExtractType,
     SerializationType,
-    ServiceType,
+    ServiceType, RelationalDBServices,
 )
-from aqueduct.error import AqueductError
+from aqueduct.error import AqueductError, UnsupportedFeatureException
 from aqueduct.models.config import EngineConfig
 from aqueduct.models.integration import IntegrationInfo
 from pydantic import BaseModel, Extra
@@ -133,6 +133,20 @@ class LoadSpec(BaseModel):
     service: ServiceType
     integration_id: uuid.UUID
     parameters: UnionLoadParams
+
+    def identifier(self) -> str:
+        if self.service in RelationalDBServices:
+            return self.parameters.table
+        elif self.service == ServiceType.S3:
+            return self.parameters.filepath
+        raise UnsupportedFeatureException("identifier() is currently unsupported for data integration type %s." % self.service.value)
+
+    def set_identifier(self, new_obj_identifier: str) -> None:
+        if self.service in RelationalDBServices:
+            self.parameters.table = new_obj_identifier
+        elif self.service == ServiceType.S3:
+            self.parameters.filepath = new_obj_identifier
+        raise UnsupportedFeatureException("set_identifier() is currently unsupported for data integration type %s." % self.service.value)
 
 
 class EntryPoint(BaseModel):

--- a/sdk/aqueduct/models/operators.py
+++ b/sdk/aqueduct/models/operators.py
@@ -146,7 +146,8 @@ class LoadSpec(BaseModel):
             self.parameters.table = new_obj_identifier
         elif self.service == ServiceType.S3:
             self.parameters.filepath = new_obj_identifier
-        raise UnsupportedFeatureException("set_identifier() is currently unsupported for data integration type %s." % self.service.value)
+        else:
+            raise UnsupportedFeatureException("set_identifier() is currently unsupported for data integration type %s." % self.service.value)
 
 
 class EntryPoint(BaseModel):

--- a/sdk/aqueduct/models/operators.py
+++ b/sdk/aqueduct/models/operators.py
@@ -10,10 +10,11 @@ from aqueduct.constants.enums import (
     GoogleSheetsSaveMode,
     LoadUpdateMode,
     OperatorType,
+    RelationalDBServices,
     S3TableFormat,
     SalesforceExtractType,
     SerializationType,
-    ServiceType, RelationalDBServices,
+    ServiceType,
 )
 from aqueduct.error import AqueductError, UnsupportedFeatureException
 from aqueduct.models.config import EngineConfig
@@ -135,19 +136,25 @@ class LoadSpec(BaseModel):
     parameters: UnionLoadParams
 
     def identifier(self) -> str:
-        if self.service in RelationalDBServices:
+        if isinstance(self.parameters, RelationalDBLoadParams):
             return self.parameters.table
-        elif self.service == ServiceType.S3:
+        elif isinstance(self.parameters, S3LoadParams):
             return self.parameters.filepath
-        raise UnsupportedFeatureException("identifier() is currently unsupported for data integration type %s." % self.service.value)
+        raise UnsupportedFeatureException(
+            "identifier() is currently unsupported for data integration type %s."
+            % self.service.value
+        )
 
     def set_identifier(self, new_obj_identifier: str) -> None:
-        if self.service in RelationalDBServices:
+        if isinstance(self.parameters, RelationalDBLoadParams):
             self.parameters.table = new_obj_identifier
-        elif self.service == ServiceType.S3:
+        elif isinstance(self.parameters, S3LoadParams):
             self.parameters.filepath = new_obj_identifier
         else:
-            raise UnsupportedFeatureException("set_identifier() is currently unsupported for data integration type %s." % self.service.value)
+            raise UnsupportedFeatureException(
+                "set_identifier() is currently unsupported for data integration type %s."
+                % self.service.value
+            )
 
 
 class EntryPoint(BaseModel):

--- a/sdk/aqueduct/models/operators.py
+++ b/sdk/aqueduct/models/operators.py
@@ -10,7 +10,6 @@ from aqueduct.constants.enums import (
     GoogleSheetsSaveMode,
     LoadUpdateMode,
     OperatorType,
-    RelationalDBServices,
     S3TableFormat,
     SalesforceExtractType,
     SerializationType,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR makes all the changes necessary to run the full suite of SDK integration tests against the S3 data integration: eg. `pytest ... --data data_s3` passes for an S3 integration named "data_s3".

NOTE: an important assumption is that the S3 integration already has the following tables populated (from the demo db).
<img width="405" alt="image" src="https://user-images.githubusercontent.com/6466121/209276945-c6eca45d-2c84-4c17-abe8-ccd7d506ae2f.png">
These dataframes are all serialized in parquet format. Diversity of data format is not what this test suite is responsible for.

There will eventually be a script that populates S3 automatically for you from the demo db if you don't have them there yet. Note that the table name in sqlite matches the filepath of the object in S3 exactly.

Notable changes:
- Introduce an `extract()` helper in our integration tests that returns a TableArtifact from any supported integration (that being Snowflake, Demo, and S3 right now).
- Introduce a `@pytest.mark.enable_only_for_data_integration_type(ServiceType.S3, ...)` marker for our tests. There is already one for engines, so this is very similar.

The rest of the PR is really just applying all these changes to the entire test suite.

## Related issue number (if any)
ENG-2110

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


