### PR TITLE
[3/3] Run SDK Integration Tests against S3 [UI Fix]

### DIFF
--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -50,6 +50,7 @@ import {
   getNextUpdateTime,
   PeriodUnit,
 } from '../../utils/cron';
+import { UpdateMode } from '../../utils/operators';
 import ExecutionStatus, { LoadingStatusEnum } from '../../utils/shared';
 import {
   getSavedObjectIdentifier,
@@ -491,7 +492,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
         [{integration}] <b>{name}</b>
       </Typography>
 
-      {/* Objects saved into S3 are currently expected to have update_mode === "replace". */}
+      {/* Objects saved into S3 are currently expected to have update_mode === UpdateMode.replace */}
       {sortedObjects && (
         <Typography
           style={{
@@ -504,7 +505,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           Update Mode:{' '}
           {sortedObjects
             .map(
-              (object) => `${object.spec.parameters.update_mode || 'replace'}`
+              (object) =>
+                `${object.spec.parameters.update_mode || UpdateMode.replace}`
             )
             .join(', ')}
           {sortedObjects.length > 1 && ' (active)'}

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -62,7 +62,6 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import { LoadingButton } from '../primitives/LoadingButton.styles';
 import StorageSelector from './storageSelector';
-import {RelationalDBLoadParams} from "../../utils/operators";
 
 type PeriodicScheduleSelectorProps = {
   cronString: string;
@@ -503,7 +502,11 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           display="inline"
         >
           Update Mode:{' '}
-          {sortedObjects.map((object) => `${object.spec.parameters.update_mode || "replace"}`).join(', ')}
+          {sortedObjects
+            .map(
+              (object) => `${object.spec.parameters.update_mode || 'replace'}`
+            )
+            .join(', ')}
           {sortedObjects.length > 1 && ' (active)'}
         </Typography>
       )}
@@ -535,7 +538,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                   {displayObject(
                     savedObjectsList[0].integration_name,
                     getSavedObjectIdentifier(savedObjectsList[0]),
-                    sortedObjects,
+                    sortedObjects
                   )}
                 </Box>
               }

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -52,6 +52,7 @@ import {
 } from '../../utils/cron';
 import ExecutionStatus, { LoadingStatusEnum } from '../../utils/shared';
 import {
+  getSavedObjectIdentifier,
   RetentionPolicy,
   SavedObject,
   WorkflowDag,
@@ -61,6 +62,7 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import { LoadingButton } from '../primitives/LoadingButton.styles';
 import StorageSelector from './storageSelector';
+import {RelationalDBLoadParams} from "../../utils/operators";
 
 type PeriodicScheduleSelectorProps = {
   cronString: string;
@@ -489,6 +491,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
       <Typography variant="body1">
         [{integration}] <b>{name}</b>
       </Typography>
+
+      {/* Objects saved into S3 are currently expected to have update_mode === "replace". */}
       {sortedObjects && (
         <Typography
           style={{
@@ -499,7 +503,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           display="inline"
         >
           Update Mode:{' '}
-          {sortedObjects.map((object) => `${object.update_mode}`).join(', ')}
+          {sortedObjects.map((object) => `${object.spec.parameters.update_mode || "replace"}`).join(', ')}
           {sortedObjects.length > 1 && ' (active)'}
         </Typography>
       )}
@@ -513,6 +517,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
           const sortedObjects = [...savedObjectsList].sort((object) =>
             Date.parse(object.modified_at)
           );
+
           // Cannot align the checkbox to the top of a multi-line label.
           // Using a weird marginTop workaround.
           return (
@@ -529,8 +534,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                 <Box sx={{ paddingTop: '24px' }}>
                   {displayObject(
                     savedObjectsList[0].integration_name,
-                    savedObjectsList[0].object_name,
-                    sortedObjects
+                    getSavedObjectIdentifier(savedObjectsList[0]),
+                    sortedObjects,
                   )}
                 </Box>
               }

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -13,7 +13,7 @@ import {
 import {
   GetOperatorResultResponse,
   Operator,
-  OperatorType, RelationalDBLoadParams, S3LoadParams, ServiceType,
+  OperatorType,
 } from '../utils/operators';
 import {
   getArtifactNode,
@@ -24,7 +24,8 @@ import {
 import { isSucceeded, LoadingStatus, LoadingStatusEnum } from '../utils/shared';
 import { ExecutionStatus } from '../utils/shared';
 import {
-  DeleteWorkflowResponse, getSavedObjectIdentifier,
+  DeleteWorkflowResponse,
+  getSavedObjectIdentifier,
   GetWorkflowResponse,
   ListWorkflowSavedObjectsResponse,
   normalizeGetWorkflowResponse,
@@ -283,10 +284,12 @@ export const handleDeleteWorkflow = createAsyncThunk<
     selectedObjects.forEach((object) => {
       if (data['external_delete'][object.integration_name]) {
         data['external_delete'][object.integration_name].push(
-          object.object_name
+          JSON.stringify(object.spec)
         );
       } else {
-        data['external_delete'][object.integration_name] = [object.object_name];
+        data['external_delete'][object.integration_name] = [
+          JSON.stringify(object.spec),
+        ];
       }
     });
 
@@ -585,8 +588,10 @@ export const workflowSlice = createSlice({
         // this altogether.
         if (!!response.object_details) {
           response.object_details.map((object: SavedObject) => {
-
-            const key = String([object.integration_name, getSavedObjectIdentifier(object)]);
+            const key = String([
+              object.integration_name,
+              getSavedObjectIdentifier(object),
+            ]);
             if (savedObjects[key]) {
               savedObjects[key].push(object);
             } else {

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -13,7 +13,7 @@ import {
 import {
   GetOperatorResultResponse,
   Operator,
-  OperatorType,
+  OperatorType, RelationalDBLoadParams, S3LoadParams, ServiceType,
 } from '../utils/operators';
 import {
   getArtifactNode,
@@ -24,7 +24,7 @@ import {
 import { isSucceeded, LoadingStatus, LoadingStatusEnum } from '../utils/shared';
 import { ExecutionStatus } from '../utils/shared';
 import {
-  DeleteWorkflowResponse,
+  DeleteWorkflowResponse, getSavedObjectIdentifier,
   GetWorkflowResponse,
   ListWorkflowSavedObjectsResponse,
   normalizeGetWorkflowResponse,
@@ -584,8 +584,9 @@ export const workflowSlice = createSlice({
         // Only run this code if there are saved objects. If there are none, then just skip
         // this altogether.
         if (!!response.object_details) {
-          response.object_details.map((object) => {
-            const key = String([object.integration_name, object.object_name]);
+          response.object_details.map((object: SavedObject) => {
+
+            const key = String([object.integration_name, getSavedObjectIdentifier(object)]);
             if (savedObjects[key]) {
               savedObjects[key].push(object);
             } else {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -126,6 +126,12 @@ export type Extract = {
   parameters: ExtractParameters;
 };
 
+export enum UpdateMode {
+  append = 'append',
+  replace = 'replace',
+  fail = 'fail',
+}
+
 export type LoadParameters =
   | RelationalDBLoadParams
   | GoogleSheetsLoadParams
@@ -133,7 +139,7 @@ export type LoadParameters =
 
 export type RelationalDBLoadParams = {
   table: string;
-  update_mode: string;
+  update_mode: UpdateMode;
 };
 
 export type GoogleSheetsLoadParams = {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -70,9 +70,29 @@ export type Check = {
 export enum ServiceType {
   Postgres = 'Postgres',
   Snowflake = 'Snowflake',
-  S3 = 'S3',
+  MySQL = 'MySQL',
+  Redshift = 'Redshift',
+  MariaDB = 'MariaDB',
+  SQLServer = 'SQL Server',
+  BigQuery = 'BigQuery',
   AqueductDemo = 'Aqueduct Demo',
+  SQLite = 'SQLite',
+  Athena = 'Athena',
+  S3 = 'S3',
   Github = 'Github',
+}
+
+export enum RelationalDBServices {
+  Postgres = 'Postgres',
+  Snowflake = 'Snowflake',
+  MySQL = 'MySQL',
+  Redshift = 'Redshift',
+  MariaDB = 'MariaDB',
+  SQLServer = 'SQL Server',
+  BigQuery = 'BigQuery',
+  AqueductDemo = 'Aqueduct Demo',
+  SQLite = 'SQLite',
+  Athena = 'Athena',
 }
 
 export type ExtractParameters =

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -70,6 +70,7 @@ export type Check = {
 export enum ServiceType {
   Postgres = 'Postgres',
   Snowflake = 'Snowflake',
+  S3 = 'S3',
   AqueductDemo = 'Aqueduct Demo',
   Github = 'Github',
 }
@@ -105,7 +106,7 @@ export type Extract = {
   parameters: ExtractParameters;
 };
 
-export type LoadParameters = RelationalDBLoadParams | GoogleSheetsLoadParams;
+export type LoadParameters = RelationalDBLoadParams | GoogleSheetsLoadParams | S3LoadParams;
 
 export type RelationalDBLoadParams = {
   table: string;
@@ -115,6 +116,17 @@ export type RelationalDBLoadParams = {
 export type GoogleSheetsLoadParams = {
   filepath: string;
   save_mode: string;
+};
+
+export enum S3TableFormat {
+  Csv = 'CSV',
+  Json = 'JSON',
+  Parquet = 'Parquet',
+}
+
+export type S3LoadParams = {
+   filepath: string;
+   format: S3TableFormat;
 };
 
 export type Load = {

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -106,7 +106,10 @@ export type Extract = {
   parameters: ExtractParameters;
 };
 
-export type LoadParameters = RelationalDBLoadParams | GoogleSheetsLoadParams | S3LoadParams;
+export type LoadParameters =
+  | RelationalDBLoadParams
+  | GoogleSheetsLoadParams
+  | S3LoadParams;
 
 export type RelationalDBLoadParams = {
   table: string;
@@ -125,8 +128,8 @@ export enum S3TableFormat {
 }
 
 export type S3LoadParams = {
-   filepath: string;
-   format: S3TableFormat;
+  filepath: string;
+  format: S3TableFormat;
 };
 
 export type Load = {

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -5,7 +5,9 @@ import {
   normalizeOperator,
   Operator,
   RelationalDBLoadParams,
+  RelationalDBServices,
   S3LoadParams,
+  ServiceType,
 } from './operators';
 import ExecutionStatus, { ExecState } from './shared';
 import { StorageConfig } from './storage';
@@ -142,10 +144,11 @@ export type GetWorkflowResponse = {
 };
 
 export function getSavedObjectIdentifier(savedObject: SavedObject): string {
-  if ('format' in savedObject.spec.parameters) {
-    return (savedObject.spec.parameters as S3LoadParams).filepath;
-  } else if ('table' in savedObject.spec.parameters) {
+  const serviceString: string = savedObject.spec.service;
+  if (Object.values<string>(RelationalDBServices).includes(serviceString)) {
     return (savedObject.spec.parameters as RelationalDBLoadParams).table;
+  } else if (savedObject.spec.service == ServiceType.S3) {
+    return (savedObject.spec.parameters as S3LoadParams).filepath;
   } else {
     return '';
   }

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -1,6 +1,12 @@
 import { Artifact } from './artifacts';
 import { EngineConfig } from './engine';
-import {Load, normalizeOperator, Operator, RelationalDBLoadParams, S3LoadParams} from './operators';
+import {
+  Load,
+  normalizeOperator,
+  Operator,
+  RelationalDBLoadParams,
+  S3LoadParams,
+} from './operators';
 import ExecutionStatus, { ExecState } from './shared';
 import { StorageConfig } from './storage';
 
@@ -136,12 +142,12 @@ export type GetWorkflowResponse = {
 };
 
 export function getSavedObjectIdentifier(savedObject: SavedObject): string {
-  if (savedObject.spec.parameters as S3LoadParams !== undefined) {
-    return (savedObject.spec.parameters as S3LoadParams).filepath
-  } else if (savedObject.spec.parameters as RelationalDBLoadParams !== undefined) {
-    return (savedObject.spec.parameters as RelationalDBLoadParams).table
+  if ('format' in savedObject.spec.parameters) {
+    return (savedObject.spec.parameters as S3LoadParams).filepath;
+  } else if ('table' in savedObject.spec.parameters) {
+    return (savedObject.spec.parameters as RelationalDBLoadParams).table;
   } else {
-    return "";
+    return '';
   }
 }
 
@@ -150,9 +156,6 @@ export type SavedObject = {
   modified_at: string;
   integration_name: string;
   spec: Load;
-
-  // TODO: REMOVE
-  object_name: string; // Used in delete_workflow
 };
 
 export type ListWorkflowSavedObjectsResponse = {

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -1,6 +1,6 @@
 import { Artifact } from './artifacts';
 import { EngineConfig } from './engine';
-import { normalizeOperator, Operator } from './operators';
+import {Load, normalizeOperator, Operator, RelationalDBLoadParams, S3LoadParams} from './operators';
 import ExecutionStatus, { ExecState } from './shared';
 import { StorageConfig } from './storage';
 
@@ -135,14 +135,24 @@ export type GetWorkflowResponse = {
   workflow_dag_results: WorkflowDagResultSummary[];
 };
 
+export function getSavedObjectIdentifier(savedObject: SavedObject): string {
+  if (savedObject.spec.parameters as S3LoadParams !== undefined) {
+    return (savedObject.spec.parameters as S3LoadParams).filepath
+  } else if (savedObject.spec.parameters as RelationalDBLoadParams !== undefined) {
+    return (savedObject.spec.parameters as RelationalDBLoadParams).table
+  } else {
+    return "";
+  }
+}
+
 export type SavedObject = {
   operator_name: string;
   modified_at: string;
   integration_name: string;
-  integration_id: string;
-  service: string;
-  object_name: string;
-  update_mode: string;
+  spec: Load;
+
+  // TODO: REMOVE
+  object_name: string; // Used in delete_workflow
 };
 
 export type ListWorkflowSavedObjectsResponse = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The backend bug fixes in https://github.com/aqueducthq/aqueduct/pull/833 caused two backend routes used by the UI to change, specifically `delete_workflow.go` and `list_workflow_objects`. This PR updates the UI to be compatible with the new backend, and ensures that we can now display objects in S3 and delete them.

## Related issue number (if any)
ENG-2110

## Loom demo (if any)
https://www.loom.com/share/4e581cde84d34856b05f23e42923c4d4

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


