### PR TITLE
Implement basic usage stats collection and reporting

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: python3 scripts/install_local.py --gobinary --sdk --executor
 
       - name: Start the server again
-        run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
+        run: (aqueduct start --disable-usage-stats --verbose > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install packages needed for testing
         run: python3 -m pip install nltk matplotlib pytest-xdist

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: python3 scripts/install_local.py --gobinary --sdk --executor
 
       - name: Start the server again
-        run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
+        run: (aqueduct start --disable-usage-stats --verbose > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install packages needed for testing
         run: python3 -m pip install nltk matplotlib pytest-xdist

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -62,7 +62,7 @@ jobs:
         run: python3 scripts/install_local.py --gobinary --sdk --executor
 
       - name: Start the server again
-        run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
+        run: (aqueduct start --disable-usage-stats --verbose > $SERVER_LOGS_FILE 2>&1 &)
 
       - name: Install Packages needed by the notebooks
         run: python3 -m pip install scikit-learn transformers torch

--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -19,10 +19,11 @@ var (
 		"",
 		"The path to .yml config file",
 	)
-	expose        = flag.Bool("expose", false, "Whether the server will be exposed to the public.")
-	verbose       = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal, with filepaths and line numbers.")
-	port          = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
-	serverLogPath = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
+	expose             = flag.Bool("expose", false, "Whether the server will be exposed to the public.")
+	verbose            = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal, with filepaths and line numbers.")
+	port               = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
+	serverLogPath      = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
+	disableUsageReport = flag.Bool("disable-usage-report", false, "Whether to disable usage statistics reporting.")
 )
 
 func main() {
@@ -77,7 +78,7 @@ func main() {
 		log.Fatalf("Failed to initialize server config: %v", err)
 	}
 
-	s := server.NewAqServer()
+	s := server.NewAqServer(*disableUsageReport)
 
 	err := s.StartWorkflowRetentionJob(config.RetentionJobPeriod())
 	if err != nil {

--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -19,11 +19,11 @@ var (
 		"",
 		"The path to .yml config file",
 	)
-	expose             = flag.Bool("expose", false, "Whether the server will be exposed to the public.")
-	verbose            = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal, with filepaths and line numbers.")
-	port               = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
-	serverLogPath      = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
-	disableUsageReport = flag.Bool("disable-usage-report", false, "Whether to disable usage statistics reporting.")
+	expose            = flag.Bool("expose", false, "Whether the server will be exposed to the public.")
+	verbose           = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal, with filepaths and line numbers.")
+	port              = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
+	serverLogPath     = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
+	disableUsageStats = flag.Bool("disable-usage-stats", false, "Whether to disable usage statistics reporting.")
 )
 
 func main() {
@@ -78,7 +78,7 @@ func main() {
 		log.Fatalf("Failed to initialize server config: %v", err)
 	}
 
-	s := server.NewAqServer(*disableUsageReport)
+	s := server.NewAqServer(*disableUsageStats)
 
 	err := s.StartWorkflowRetentionJob(config.RetentionJobPeriod())
 	if err != nil {

--- a/src/golang/cmd/server/main.go
+++ b/src/golang/cmd/server/main.go
@@ -23,7 +23,10 @@ var (
 	verbose           = flag.Bool("verbose", false, "Whether all logs will be shown in the terminal, with filepaths and line numbers.")
 	port              = flag.Int("port", connection.ServerInternalPort, "The port that the server listens to.")
 	serverLogPath     = filepath.Join(os.Getenv("HOME"), ".aqueduct", "server", "logs", "server")
+	environment       = flag.String("env", "prod", "The environment in which the Aqueduct server is operating.")
 	disableUsageStats = flag.Bool("disable-usage-stats", false, "Whether to disable usage statistics reporting.")
+
+	allowedEnvironments = map[string]bool{"dev": true, "test": true, "prod": true}
 )
 
 func main() {
@@ -78,7 +81,12 @@ func main() {
 		log.Fatalf("Failed to initialize server config: %v", err)
 	}
 
-	s := server.NewAqServer(*disableUsageStats)
+	_, ok := allowedEnvironments[*environment]
+	if !ok {
+		log.Fatalf("Unsupported environment: %v", *environment)
+	}
+
+	s := server.NewAqServer(*environment, *disableUsageStats)
 
 	err := s.StartWorkflowRetentionJob(config.RetentionJobPeriod())
 	if err != nil {

--- a/src/golang/cmd/server/middleware/usage/constants.go
+++ b/src/golang/cmd/server/middleware/usage/constants.go
@@ -1,0 +1,10 @@
+package usage
+
+const (
+	schemaVersion int    = 1
+	obfuscated    string = "***"
+	delimiter     string = "/"
+	hashKey       string = "aqueduct"
+	// This is the Grafana Loki server address
+	logURL string = "https://355951:eyJrIjoiYjgyNTFhMjk4NTcxOGViYjk0MDRmYjM4OTdmMDZlNWNmZmM1MmI1ZCIsIm4iOiJhcXVlZHVjdF8wIiwiaWQiOjc3MDAzMH0=@logs-prod-017.grafana.net/loki/api/v1/push"
+)

--- a/src/golang/cmd/server/middleware/usage/models.go
+++ b/src/golang/cmd/server/middleware/usage/models.go
@@ -1,0 +1,24 @@
+package usage
+
+type Labels struct {
+	SchemaVersion int    `json:"schema_version"`
+	Environment   string `json:"environment"`
+	StatusCode    int    `json:"status_code"`
+	Route         string `json:"route"`
+}
+
+type Payload struct {
+	ID      string `json:"id"`
+	Latency int64  `json:"latency"`
+	Labels
+}
+
+// These fields and json label names for Stream and Streams are required by Loki.
+type Stream struct {
+	Labels Labels     `json:"stream"`
+	Values [][]string `json:"values"`
+}
+
+type Streams struct {
+	Streams []Stream `json:"streams"`
+}

--- a/src/golang/cmd/server/middleware/usage/usage.go
+++ b/src/golang/cmd/server/middleware/usage/usage.go
@@ -4,30 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/denisbrodbeck/machineid"
+	"github.com/go-chi/chi/middleware"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	obfuscated string = "***"
-	delimiter  string = "/"
-	hashKey    string = "aqueduct"
-	// This is the Grafana Loki server address
-	logURL string = "http://34.25.83.71:9090/loki/api/v1/push"
-)
-
-type UsageStats struct {
-	ID      string `json:"id"`
-	Route   string `json:"route"`
-	Latency int64  `json:"latency"`
-}
-
-func reportUsage(startTime time.Time, r *http.Request) {
-	pathToken := strings.Split(r.URL.Path, delimiter)
+func reportUsage(startTime time.Time, environment string, statusCode int, urlPath string) {
+	pathToken := strings.Split(urlPath, delimiter)
 	for i, token := range pathToken {
 		if _, err := uuid.Parse(token); err == nil {
 			pathToken[i] = obfuscated
@@ -42,21 +30,53 @@ func reportUsage(startTime time.Time, r *http.Request) {
 		return
 	}
 
-	usage := UsageStats{
-		ID:      machineID,
-		Route:   strings.Join(pathToken, delimiter),
-		Latency: time.Since(startTime).Milliseconds(),
+	startTimeUnix := startTime.UnixNano()
+
+	// Loki creates indexes for labels to speed up searching. Each label should have a bounded number
+	// of distinct values to prevent the index from getting too large. That's why fields such as ID
+	// and Latency should not be included as labels.
+	labels := Labels{
+		SchemaVersion: schemaVersion,
+		Environment:   environment,
+		StatusCode:    statusCode,
+		Route:         strings.Join(pathToken, delimiter),
 	}
 
-	log.Errorf("This request took %d ms, request URL path: %s, machine id: %s.", usage.Latency, usage.Route, usage.ID)
+	payload := Payload{
+		ID:      machineID,
+		Latency: time.Since(startTime).Milliseconds(),
+		Labels:  labels,
+	}
 
-	payload, err := json.Marshal(usage)
+	payloadJson, err := json.Marshal(payload)
 	if err != nil {
-		log.Errorf("Failed to marshal usage stats: %v", err)
+		log.Errorf("Failed to marshal payload: %v", err)
 		return
 	}
 
-	req, err := http.NewRequest("POST", logURL, bytes.NewBuffer(payload))
+	streams := Streams{
+		Streams: []Stream{
+			{
+				Labels: labels,
+				// According to Loki's requirement, the first field should be the timestamp in ns,
+				// and the second field should be the payload in its json form.
+				Values: [][]string{
+					{
+						strconv.FormatInt(startTimeUnix, 10),
+						string(payloadJson),
+					},
+				},
+			},
+		},
+	}
+
+	streamsJson, err := json.Marshal(streams)
+	if err != nil {
+		log.Errorf("Failed to marshal streams: %v", err)
+		return
+	}
+
+	req, err := http.NewRequest("POST", logURL, bytes.NewBuffer(streamsJson))
 	if err != nil {
 		log.Errorf("Failed to initialize usage stats POST request: %v", err)
 		return
@@ -67,20 +87,25 @@ func reportUsage(startTime time.Time, r *http.Request) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
+		log.Errorf("Failed to send request to loki: %v", err)
 		panic(err)
 	}
 	defer resp.Body.Close()
 }
 
-func WithUsageStats() func(http.Handler) http.Handler {
+func WithUsageStats(environment string) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The reason we need this wrapper is so that we can get the status of the response via
+			// ww.Status().
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
 			startTime := time.Now()
 			defer func() {
-				go reportUsage(startTime, r)
+				go reportUsage(startTime, environment, ww.Status(), r.URL.Path)
 			}()
 
-			h.ServeHTTP(w, r)
+			h.ServeHTTP(ww, r)
 		})
 	}
 }

--- a/src/golang/cmd/server/middleware/usage/usage.go
+++ b/src/golang/cmd/server/middleware/usage/usage.go
@@ -1,0 +1,84 @@
+package usage
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	obfuscated string = "***"
+	delimiter  string = "/"
+	hashKey    string = "aqueduct"
+	// This is the Grafana Loki server address
+	logURL string = "http://34.25.83.71:9090/loki/api/v1/push"
+)
+
+type UsageStats struct {
+	ID      string `json:"id"`
+	Route   string `json:"route"`
+	Latency int64  `json:"latency"`
+}
+
+func reportUsage(startTime time.Time, r *http.Request) {
+	pathToken := strings.Split(r.URL.Path, delimiter)
+	for i, token := range pathToken {
+		if _, err := uuid.Parse(token); err == nil {
+			pathToken[i] = obfuscated
+		}
+	}
+
+	machineID, err := machineid.ProtectedID(hashKey)
+	if err != nil {
+		log.Errorf("Failed to generate device ID: %v", err)
+		return
+	}
+
+	usage := UsageStats{
+		ID:      machineID,
+		Route:   strings.Join(pathToken, delimiter),
+		Latency: time.Since(startTime).Milliseconds(),
+	}
+
+	log.Errorf("This request took %d ms, request URL path: %s, machine id: %s.", usage.Latency, usage.Route, usage.ID)
+
+	payload, err := json.Marshal(usage)
+	if err != nil {
+		log.Errorf("Failed to marshal usage stats: %v", err)
+		return
+	}
+
+	req, err := http.NewRequest("POST", logURL, bytes.NewBuffer(payload))
+	if err != nil {
+		log.Errorf("Failed to initialize usage stats POST request: %v", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+}
+
+func WithUsageStats() func(http.Handler) http.Handler {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			startTime := time.Now()
+			defer func() {
+				go reportUsage(startTime, r)
+			}()
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}

--- a/src/golang/cmd/server/middleware/usage/usage.go
+++ b/src/golang/cmd/server/middleware/usage/usage.go
@@ -34,9 +34,11 @@ func reportUsage(startTime time.Time, r *http.Request) {
 		}
 	}
 
+	// This call generates a unique hash of the host device in a privacy-preserving fashion.
+	// Details can be found here: https://github.com/denisbrodbeck/machineid
 	machineID, err := machineid.ProtectedID(hashKey)
 	if err != nil {
-		log.Errorf("Failed to generate device ID: %v", err)
+		log.Errorf("Failed to generate obfuscated device ID: %v", err)
 		return
 	}
 

--- a/src/golang/cmd/server/server/aqueduct_server.go
+++ b/src/golang/cmd/server/server/aqueduct_server.go
@@ -63,10 +63,10 @@ type AqServer struct {
 	// are no more active requests.
 	RequestMutex sync.RWMutex
 
-	DisableUsageReport bool
+	DisableUsageStats bool
 }
 
-func NewAqServer(disableUsageReport bool) *AqServer {
+func NewAqServer(disableUsageStats bool) *AqServer {
 	ctx := context.Background()
 	aqPath := config.AqueductPath()
 
@@ -90,12 +90,12 @@ func NewAqServer(disableUsageReport bool) *AqServer {
 	}
 
 	s := &AqServer{
-		Router:             chi.NewRouter(),
-		Database:           db,
-		Repos:              CreateRepos(),
-		UnderMaintenance:   atomic.Value{},
-		RequestMutex:       sync.RWMutex{},
-		DisableUsageReport: disableUsageReport,
+		Router:            chi.NewRouter(),
+		Database:          db,
+		Repos:             CreateRepos(),
+		UnderMaintenance:  atomic.Value{},
+		RequestMutex:      sync.RWMutex{},
+		DisableUsageStats: disableUsageStats,
 	}
 	s.UnderMaintenance.Store(false)
 
@@ -244,7 +244,7 @@ func (s *AqServer) StartWorkflowRetentionJob(period string) error {
 func (s *AqServer) AddHandler(route string, handlerObj handler.Handler) {
 	middleware := alice.New()
 
-	if !s.DisableUsageReport {
+	if !s.DisableUsageStats {
 		middleware = middleware.Append(usage.WithUsageStats())
 	}
 

--- a/src/golang/go.mod
+++ b/src/golang/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.33
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dropbox/godropbox v0.0.0-20200228041828-52ad444d3502
+	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.0
 	github.com/go-co-op/gocron v1.13.0

--- a/src/golang/go.mod
+++ b/src/golang/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.25.0
 	github.com/apache/airflow-client-go/airflow v0.0.0-20220509204651-4f1b26e4a5d0
 	github.com/aws/aws-sdk-go v1.40.33
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dropbox/godropbox v0.0.0-20200228041828-52ad444d3502
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-chi/cors v1.2.0

--- a/src/golang/go.sum
+++ b/src/golang/go.sum
@@ -136,6 +136,8 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
+github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/cors v1.2.0 h1:tV1g1XENQ8ku4Bq3K9ub2AtgG+p16SmzeMSGTwrOKdE=

--- a/src/golang/go.sum
+++ b/src/golang/go.sum
@@ -114,6 +114,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dropbox/godropbox v0.0.0-20200228041828-52ad444d3502 h1:tEkxjWg9OqJbkpgLaYbBjFO45+XygMJAEhOS62s+jLY=
 github.com/dropbox/godropbox v0.0.0-20200228041828-52ad444d3502/go.mod h1:Bv2UWEUnUi8YN4834GVjZlRcJbeOAUPp7QjRU2LhBqI=

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -43,6 +43,9 @@ welcome_message = """
 Your API Key: %s
 
 The Web UI and the backend server (v%s) are accessible at: http://%s:%d/login?apiKey=%s
+
+Aqueduct collects usage data to improve its services.
+Usage data collection is enabled by default, and can be disabled by running `aqueduct start` with `--disable-usage-report`.
 ***************************************************
 """
 
@@ -370,7 +373,7 @@ def is_port_in_use(port: int) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
-def start(expose, port, verbose):
+def start(expose, port, verbose, disable_usage_report):
     update()
 
     if port is None:
@@ -399,6 +402,9 @@ def start(expose, port, verbose):
     
     if verbose:
         command.append("--verbose")
+
+    if disable_usage_report:
+        command.append("--disable-usage-report")
 
     popen_handle = execute_command_nonblocking(command)
     return popen_handle, server_port
@@ -603,6 +609,13 @@ if __name__ == "__main__":
     start_args.add_argument(
         "--port", dest="port", help="Specify the port on which the Aqueduct server runs."
     )
+    start_args.add_argument(
+        "--disable-usage-report",
+        default=False,
+        action="store_true",
+        dest="disable_usage_report",
+        help="If set to true, usage statistics report will be disabled",
+    )
 
     install_args = subparsers.add_parser(
         "install",
@@ -667,7 +680,7 @@ if __name__ == "__main__":
 
     if args.command == "start":
         try:
-            popen_handle, server_port = start(args.expose, args.port, args.verbose)
+            popen_handle, server_port = start(args.expose, args.port, args.verbose, args.disable_usage_report)
             time.sleep(1)
             terminated = popen_handle.poll()
             if terminated:

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -44,7 +44,8 @@ Your API Key: %s
 
 The Web UI and the backend server (v%s) are accessible at: http://%s:%d/login?apiKey=%s
 
-Aqueduct collects usage data to improve its services.
+Aqueduct collects non sensitive usage data to improve its services.
+Please refer to https://docs.aqueducthq.com/usage for more details.
 Usage data collection is enabled by default, and can be disabled by running `aqueduct start` with `--disable-usage-stats`.
 ***************************************************
 """

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -373,7 +373,7 @@ def is_port_in_use(port: int) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
-def start(expose, port, verbose, disable_usage_stats):
+def start(expose, port, verbose, env, disable_usage_stats):
     update()
 
     if port is None:
@@ -395,6 +395,8 @@ def start(expose, port, verbose, disable_usage_stats):
         os.path.join(server_directory, "config", "config.yml"),
         "--port",
         str(server_port),
+        "--env",
+        env,
     ]
 
     if expose:
@@ -610,6 +612,12 @@ if __name__ == "__main__":
         "--port", dest="port", help="Specify the port on which the Aqueduct server runs."
     )
     start_args.add_argument(
+        "--env",
+        default="prod",
+        dest="env",
+        help="Specify the environment in which the Aqueduct server is operating.",
+    )
+    start_args.add_argument(
         "--disable-usage-stats",
         default=False,
         action="store_true",
@@ -680,7 +688,7 @@ if __name__ == "__main__":
 
     if args.command == "start":
         try:
-            popen_handle, server_port = start(args.expose, args.port, args.verbose, args.disable_usage_stats)
+            popen_handle, server_port = start(args.expose, args.port, args.verbose, args.env, args.disable_usage_stats)
             time.sleep(1)
             terminated = popen_handle.poll()
             if terminated:

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -45,7 +45,7 @@ Your API Key: %s
 The Web UI and the backend server (v%s) are accessible at: http://%s:%d/login?apiKey=%s
 
 Aqueduct collects usage data to improve its services.
-Usage data collection is enabled by default, and can be disabled by running `aqueduct start` with `--disable-usage-report`.
+Usage data collection is enabled by default, and can be disabled by running `aqueduct start` with `--disable-usage-stats`.
 ***************************************************
 """
 
@@ -373,7 +373,7 @@ def is_port_in_use(port: int) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
-def start(expose, port, verbose, disable_usage_report):
+def start(expose, port, verbose, disable_usage_stats):
     update()
 
     if port is None:
@@ -403,8 +403,8 @@ def start(expose, port, verbose, disable_usage_report):
     if verbose:
         command.append("--verbose")
 
-    if disable_usage_report:
-        command.append("--disable-usage-report")
+    if disable_usage_stats:
+        command.append("--disable-usage-stats")
 
     popen_handle = execute_command_nonblocking(command)
     return popen_handle, server_port
@@ -610,11 +610,11 @@ if __name__ == "__main__":
         "--port", dest="port", help="Specify the port on which the Aqueduct server runs."
     )
     start_args.add_argument(
-        "--disable-usage-report",
+        "--disable-usage-stats",
         default=False,
         action="store_true",
-        dest="disable_usage_report",
-        help="If set to true, usage statistics report will be disabled",
+        dest="disable_usage_stats",
+        help="If set to true, usage statistics reporting will be disabled",
     )
 
     install_args = subparsers.add_parser(
@@ -680,7 +680,7 @@ if __name__ == "__main__":
 
     if args.command == "start":
         try:
-            popen_handle, server_port = start(args.expose, args.port, args.verbose, args.disable_usage_report)
+            popen_handle, server_port = start(args.expose, args.port, args.verbose, args.disable_usage_stats)
             time.sleep(1)
             terminated = popen_handle.poll()
             if terminated:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR enables basic usage stats collection and reporting. Currently, for each request, we collect 1) a privacy-preserving ID of the user's host machine, 2) the name of the route being hit (any uuid in the route is being stripped away), and 3) the latency of the request. We can add more stats as necessary. This usage data is then sent to a Loki server, which is a log aggregation system that I've been playing around with.

Usage data collection is enabled by default, and can be disabled by running `aqueduct start` with `--disable-usage-report`.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


