### PR TITLE
ENG-2121: Use dark logo for Aqueduct engine.

### DIFF
--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -253,7 +253,7 @@ export const IntegrationCategories = {
 };
 
 export const ServiceLogos: ServiceLogo = {
-  ['Aqueduct']: `${logoBucket}/aqueduct-logo-light/1x/logo_light_blue.png`,
+  ['Aqueduct']: `${logoBucket}/aqueduct-logo-dark/small/2x/aqueduct-logo-dark-small%402x.png`,
   ['Postgres']: `${integrationLogosBucket}/440px-Postgresql_elephant.svg.png`,
   ['Snowflake']: `${integrationLogosBucket}/51-513957_periscope-data-partners-snowflake-computing-logo.png`,
   ['Redshift']: `${integrationLogosBucket}/amazon-redshift.png`,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -253,7 +253,8 @@ export const IntegrationCategories = {
 };
 
 export const ServiceLogos: ServiceLogo = {
-  ['Aqueduct']: `${logoBucket}/aqueduct-logo-dark/small/2x/aqueduct-logo-dark-small%402x.png`,
+  //['Aqueduct']: `${logoBucket}/aqueduct-logo-dark/small/2x/aqueduct-logo-dark-small%402x.png`,
+  ['Aqueduct']: `${logoBucket}/aqueduct-logo-two-tone/small/2x/aqueduct-logo-two-tone-small%402x.png`,
   ['Postgres']: `${integrationLogosBucket}/440px-Postgresql_elephant.svg.png`,
   ['Snowflake']: `${integrationLogosBucket}/51-513957_periscope-data-partners-snowflake-computing-logo.png`,
   ['Redshift']: `${integrationLogosBucket}/amazon-redshift.png`,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -253,7 +253,6 @@ export const IntegrationCategories = {
 };
 
 export const ServiceLogos: ServiceLogo = {
-  //['Aqueduct']: `${logoBucket}/aqueduct-logo-dark/small/2x/aqueduct-logo-dark-small%402x.png`,
   ['Aqueduct']: `${logoBucket}/aqueduct-logo-two-tone/small/2x/aqueduct-logo-two-tone-small%402x.png`,
   ['Postgres']: `${integrationLogosBucket}/440px-Postgresql_elephant.svg.png`,
   ['Snowflake']: `${integrationLogosBucket}/51-513957_periscope-data-partners-snowflake-computing-logo.png`,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR replaces the light logo being used in the engine column with the dark logo.

## Related issue number (if any)
ENG-2121

## Loom demo (if any)
Screenshot:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/1031759/210285004-0a858361-f61b-4a18-8871-a0fdfd659393.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


