### PR TITLE
ENG-2136 Make History List Item Width Consistent

### DIFF
--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -174,7 +174,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
         // Redux object.
         const artifactResult = structuredClone(
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
         );
 
@@ -258,7 +258,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
         <Divider sx={{ my: '32px' }} />
 
-        <Box width="100%" marginTop={sideSheetMode ? '16px' : '40px'}>
+        <Box width={"46.25%"} marginTop={sideSheetMode ? '16px' : '40px'}>
           <CheckHistory
             historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             checkLevel={operator?.spec?.check?.level}

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -174,7 +174,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
         // Redux object.
         const artifactResult = structuredClone(
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
         );
 
@@ -258,7 +258,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
         <Divider sx={{ my: '32px' }} />
 
-        <Box width={"46.25%"} marginTop={sideSheetMode ? '16px' : '40px'}>
+        <Box width={'46.25%'} marginTop={sideSheetMode ? '16px' : '40px'}>
           <CheckHistory
             historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             checkLevel={operator?.spec?.check?.level}

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -220,7 +220,7 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={sideSheetMode ? '800px' : 'auto'}>
+      <Box width={sideSheetMode ? 'auto' : 'auto'}>
         {!sideSheetMode && (
           <Box width="100%">
             <DetailsPageHeader
@@ -258,7 +258,10 @@ const CheckDetailsPage: React.FC<CheckDetailsPageProps> = ({
 
         <Divider sx={{ my: '32px' }} />
 
-        <Box width={'46.25%'} marginTop={sideSheetMode ? '16px' : '40px'}>
+        <Box
+          width={sideSheetMode ? 'auto' : '49.2%'}
+          marginTop={sideSheetMode ? '16px' : '40px'}
+        >
           <CheckHistory
             historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             checkLevel={operator?.spec?.check?.level}

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -137,8 +137,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   useEffect(() => {
     if (!!operator && !sideSheetMode) {
       // this should only be set when the user is viewing this as a full page, not side sheet.
-      document.title = `${operator ? operator.name : 'Operator Details'
-        } | Aqueduct`;
+      document.title = `${
+        operator ? operator.name : 'Operator Details'
+      } | Aqueduct`;
     }
   }, [operator, sideSheetMode]);
 
@@ -170,7 +171,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -217,7 +218,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
           <Divider sx={{ my: '32px' }} />
 
-          <Box width={"49.2%"} marginTop={sideSheetMode ? '16px' : '40px'}>
+          <Box width={'49.2%'} marginTop={sideSheetMode ? '16px' : '40px'}>
             <MetricsHistory
               historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             />

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -180,7 +180,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={sideSheetMode ? '800px' : 'auto'}>
+      <Box width={sideSheetMode ? 'auto' : 'auto'}>
         <Box width="100%" mb={3}>
           {!sideSheetMode && (
             <Box width="100%">
@@ -218,7 +218,10 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
           <Divider sx={{ my: '32px' }} />
 
-          <Box width={'49.2%'} marginTop={sideSheetMode ? '16px' : '40px'}>
+          <Box
+            width={sideSheetMode ? 'auto' : '49.2%'}
+            marginTop={sideSheetMode ? '16px' : '40px'}
+          >
             <MetricsHistory
               historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             />

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -137,9 +137,8 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   useEffect(() => {
     if (!!operator && !sideSheetMode) {
       // this should only be set when the user is viewing this as a full page, not side sheet.
-      document.title = `${
-        operator ? operator.name : 'Operator Details'
-      } | Aqueduct`;
+      document.title = `${operator ? operator.name : 'Operator Details'
+        } | Aqueduct`;
     }
   }, [operator, sideSheetMode]);
 
@@ -171,7 +170,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -218,7 +217,7 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
 
           <Divider sx={{ my: '32px' }} />
 
-          <Box width="100%">
+          <Box width={"49.2%"} marginTop={sideSheetMode ? '16px' : '40px'}>
             <MetricsHistory
               historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
             />

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -72,7 +72,7 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
 
   return (
     <Box mt="32px">
-      <Typography variant="h6" fontWeight="normal">
+      <Typography variant="h6" fontWeight="normal" marginBottom="8px">
         History
       </Typography>
 
@@ -121,11 +121,11 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
               backgroundColor: backgroundColor,
               '&:hover': { backgroundColor: hoverColor },
             }}
-            width="fit-content"
+            width="100%"
           >
             <Box
               sx={{ display: 'flex', alignItems: 'center' }}
-              width="fit-content"
+              width="100%"
             >
               {icon}
 

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -123,10 +123,7 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
             }}
             width="100%"
           >
-            <Box
-              sx={{ display: 'flex', alignItems: 'center' }}
-              width="100%"
-            >
+            <Box sx={{ display: 'flex', alignItems: 'center' }} width="100%">
               {icon}
 
               <Typography sx={{ ml: 1 }} variant="body2">

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -121,9 +121,9 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
               backgroundColor: backgroundColor,
               '&:hover': { backgroundColor: hoverColor },
             }}
-            width="100%"
+            width="auto"
           >
-            <Box sx={{ display: 'flex', alignItems: 'center' }} width="100%">
+            <Box sx={{ display: 'flex', alignItems: 'center' }}>
               {icon}
 
               <Typography sx={{ ml: 1 }} variant="body2">

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -110,7 +110,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
         />
       </Box>
 
-      <Box width="500px" mt="32px">
+      <Box width="100%" mt="32px">
         <Typography variant="h6" fontWeight="normal">
           History
         </Typography>

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -110,7 +110,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
         />
       </Box>
 
-      <Box width="100%" mt="32px">
+      <Box mt="32px">
         <Typography variant="h6" fontWeight="normal">
           History
         </Typography>
@@ -158,6 +158,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
                     : `1px solid ${theme.palette.gray[400]}`,
                 backgroundColor: backgroundColor,
                 '&:hover': { backgroundColor: hoverColor },
+                width: 'auto',
               }}
             >
               <Box sx={{ flex: 1, display: 'flex', alignItems: 'center' }}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR makes the width of the history list consistent for Check and Metric history list items. Please see loom demo for more details.

## Related issue number (if any)
ENG-2136

## Loom demo (if any)
https://www.loom.com/share/9053ee3e1f4f41f180bb7654b2394d3f

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


