### PR TITLE
Eng 2137 make integrations page full width

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -32,7 +32,7 @@ const AddIntegrations: React.FC<Props> = ({
   const [showMigrationDialog, setShowMigrationDialog] = useState(false);
 
   return (
-    <Box sx={{ maxWidth: '616px' }}>
+    <Box>
       {showMigrationDialog && (
         <Alert
           onClose={() => {
@@ -44,7 +44,7 @@ const AddIntegrations: React.FC<Props> = ({
           {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
         </Alert>
       )}
-      <Grid container spacing={1} sx={{ width: '100%' }} columns={4}>
+      <Box sx={{ width: '100%', display: 'flex', flexWrap: 'wrap' }}>
         {Object.entries(supportedIntegrations)
           .filter(([svc]) => svc !== 'Aqueduct Demo')
           .map(([svc, integration]) => {
@@ -62,7 +62,7 @@ const AddIntegrations: React.FC<Props> = ({
               />
             );
           })}
-      </Grid>
+      </Box>
     </Box>
   );
 };
@@ -105,6 +105,7 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
       sx={{
         width: '160px',
         height: '128px',
+        m: 1,
         px: 2,
         py: 2,
         borderRadius: 2,
@@ -135,7 +136,7 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
   );
 
   return (
-    <Grid container item xs={4} key={service}>
+    <Box key={service}>
       <Box>
         {iconWrapper}
         {showDialog && (
@@ -169,7 +170,7 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
           {`Successfully connected to ${service}!`}
         </Alert>
       </Snackbar>
-    </Grid>
+    </Box>
   );
 };
 

--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
 import Snackbar from '@mui/material/Snackbar';
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -86,7 +86,7 @@ const IntegrationsPage: React.FC<Props> = ({
         </Box>
 
         <Box marginY={3}>
-          <Divider sx={{ width: '950px' }} />
+          <Divider />
         </Box>
 
         <Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The issue with using Grid which keeps the column count constant and resized the elements within the columns. However, our elements (integration icons) are constant size so it looks strange. I switched to using a flexbox. Now the grid of integrations will be one row if the screen is wide enough.

## Related issue number (if any)
ENG-2137

## Loom demo (if any)
I show how the page performs on different screen sizes by zooming in and zooming out of the page. As you can see, as the screen grows larger (zooming out) there are more columns in the grid until there is just one row.

https://user-images.githubusercontent.com/30596854/210420400-258035a1-0bd3-4cea-81a7-0f06bf97cb46.mov

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


