### PR TITLE
ENG-2176 Show version number on bottom of navigation bar.

### DIFF
--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -263,7 +263,7 @@ const MenuSidebar: React.FC<{
             </Link>
           </Tooltip>
         </Box>
-        <Box marginLeft="16px">
+        <Box marginLeft="14px" marginBottom="16px">
           <Typography variant="caption" sx={{ color: 'white' }}>
             {versionNumber.length > 0 ? `v${versionNumber}` : ''}
           </Typography>

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -128,19 +128,16 @@ const MenuSidebar: React.FC<{
 
   useEffect(() => {
     async function fetchVersionNumber() {
-      const res = await fetch(`${apiAddress}/api/version`, { method: 'GET', headers: { 'api-key': user.apiKey } });
+      const res = await fetch(`${apiAddress}/api/version`, {
+        method: 'GET',
+        headers: { 'api-key': user.apiKey },
+      });
       const versionNumberResponse = await res.json();
-
-      if (!res.ok) {
-        console.log('error getting version number', versionNumberResponse.error);
-      }
-
-      console.log('versionNumberResponse: ', versionNumberResponse);
       setVersionNumber(versionNumberResponse.version);
     }
 
     fetchVersionNumber();
-  }, [])
+  }, [user.apiKey]);
 
   const pathPrefix = getPathPrefix();
   return (
@@ -267,7 +264,9 @@ const MenuSidebar: React.FC<{
           </Tooltip>
         </Box>
         <Box marginLeft="16px">
-          <Typography variant="caption" sx={{ color: 'white' }}>v{versionNumber}</Typography>
+          <Typography variant="caption" sx={{ color: 'white' }}>
+            {versionNumber.length > 0 ? `v${versionNumber}` : ''}
+          </Typography>
         </Box>
       </Box>
     </Box>

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -13,9 +13,11 @@ import Divider from '@mui/material/Divider';
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
+import UserProfile from 'src/utils/auth';
 
 import { AppDispatch } from '../../stores/store';
 import { getPathPrefix } from '../../utils/getPathPrefix';
+import { apiAddress } from '../hooks/useAqueductConsts';
 import {
   menuSidebar,
   menuSidebarContent,
@@ -113,14 +115,32 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
  */
 const MenuSidebar: React.FC<{
   onSidebarItemClicked?: (name: string) => void;
-}> = ({ onSidebarItemClicked }) => {
+  user: UserProfile;
+}> = ({ onSidebarItemClicked, user }) => {
   const dispatch: AppDispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(undefined);
+  const [versionNumber, setVersionNumber] = useState('');
   const location = useLocation();
 
   useEffect(() => {
     setCurrentPage(location.pathname);
   }, [dispatch, location.pathname]);
+
+  useEffect(() => {
+    async function fetchVersionNumber() {
+      const res = await fetch(`${apiAddress}/api/version`, { method: 'GET', headers: { 'api-key': user.apiKey } });
+      const versionNumberResponse = await res.json();
+
+      if (!res.ok) {
+        console.log('error getting version number', versionNumberResponse.error);
+      }
+
+      console.log('versionNumberResponse: ', versionNumberResponse);
+      setVersionNumber(versionNumberResponse.version);
+    }
+
+    fetchVersionNumber();
+  }, [])
 
   const pathPrefix = getPathPrefix();
   return (
@@ -245,6 +265,9 @@ const MenuSidebar: React.FC<{
               />
             </Link>
           </Tooltip>
+        </Box>
+        <Box marginLeft="16px">
+          <Typography variant="caption" sx={{ color: 'white' }}>v{versionNumber}</Typography>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a small text showing the server's current version number in the bottom of the menu sidebar.

## Related issue number (if any)
ENG-2176

## Loom demo (if any)
Screenshot:
<img width="1486" alt="image" src="https://user-images.githubusercontent.com/1031759/210452694-6e8a8d0a-1df5-494a-8803-8fb05fe6ff50.png">

<img width="90" alt="image" src="https://user-images.githubusercontent.com/1031759/210452742-25fda577-8460-4f29-92a6-50d7e66539ee.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


