### PR TITLE
ENG-1880 Hide preview when artifact is cancelled.

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -84,11 +84,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-    isSucceeded(workflowDagResultWithLoadingStatus.status)
+      isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-          workflowDagResultWithLoadingStatus?.result,
-          artifactId
-        )
+        workflowDagResultWithLoadingStatus?.result,
+        artifactId
+      )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -128,9 +128,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${
-          artifact ? artifact.name : 'Artifact Details'
-        } | Aqueduct`;
+        document.title = `${artifact ? artifact.name : 'Artifact Details'
+          } | Aqueduct`;
       }
 
       if (
@@ -247,7 +246,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             )}
           </Box>
 
-          {previewAvailable && (
+          {previewAvailable ? (
             <>
               <Divider sx={{ marginY: '32px' }} />
               <Box width="100%" marginTop="12px">
@@ -264,10 +263,20 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
                   contentWithLoadingStatus={contentWithLoadingStatus}
                 />
               </Box>
+
+              <Divider sx={{ marginY: '32px' }} />
+            </>
+          ) : (
+            <>
+              <Divider sx={{ marginY: '32px' }} />
+
+              <Box marginBottom="32px">
+                <Alert severity="warning">
+                  An upstream operator failed, causing this artifact to not be created.
+                </Alert>
+              </Box>
             </>
           )}
-
-          <Divider sx={{ marginY: '32px' }} />
 
           <Box display="flex" width="100%">
             <MetricsOverview metrics={metrics} />

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -84,11 +84,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-      isSucceeded(workflowDagResultWithLoadingStatus.status)
+    isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-        workflowDagResultWithLoadingStatus?.result,
-        artifactId
-      )
+          workflowDagResultWithLoadingStatus?.result,
+          artifactId
+        )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -128,8 +128,9 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${artifact ? artifact.name : 'Artifact Details'
-          } | Aqueduct`;
+        document.title = `${
+          artifact ? artifact.name : 'Artifact Details'
+        } | Aqueduct`;
       }
 
       if (
@@ -272,7 +273,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
               <Box marginBottom="32px">
                 <Alert severity="warning">
-                  An upstream operator failed, causing this artifact to not be created.
+                  An upstream operator failed, causing this artifact to not be
+                  created.
                 </Alert>
               </Box>
             </>

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -15,13 +15,13 @@ import { AppDispatch, RootState } from '../../../../stores/store';
 import UserProfile from '../../../../utils/auth';
 import { getPathPrefix } from '../../../../utils/getPathPrefix';
 import { OperatorType } from '../../../../utils/operators';
-import {
+import ExecutionStatus, {
   isFailed,
   isInitial,
   isLoading,
   isSucceeded,
 } from '../../../../utils/shared';
-import DefaultLayout from '../../../layouts/default';
+import DefaultLayout, { SidesheetContentWidth } from '../../../layouts/default';
 import ArtifactContent from '../../../workflows/artifact/content';
 import CsvExporter from '../../../workflows/artifact/csvExporter';
 import {
@@ -84,11 +84,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-    isSucceeded(workflowDagResultWithLoadingStatus.status)
+      isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-          workflowDagResultWithLoadingStatus?.result,
-          artifactId
-        )
+        workflowDagResultWithLoadingStatus?.result,
+        artifactId
+      )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -128,9 +128,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${
-          artifact ? artifact.name : 'Artifact Details'
-        } | Aqueduct`;
+        document.title = `${artifact ? artifact.name : 'Artifact Details'
+          } | Aqueduct`;
       }
 
       if (
@@ -205,9 +204,12 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const inputs = mapOperators([artifact.from]);
   const outputs = mapOperators(artifact.to ? artifact.to : []);
 
+  const artifactStatus = artifact?.result?.exec_state?.status;
+  const previewAvailable = artifactStatus && artifactStatus !== ExecutionStatus.Canceled;
+
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
-      <Box width={sideSheetMode ? '800px' : 'auto'}>
+      <Box width={sideSheetMode ? SidesheetContentWidth : '100%'}>
         <Box width="100%">
           {!sideSheetMode && (
             <Box width="100%" display="flex" alignItems="center">
@@ -243,22 +245,27 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             )}
           </Box>
 
-          <Divider sx={{ marginY: '32px' }} />
-
-          <Box width="100%" marginTop="12px">
-            <Typography
-              variant="h6"
-              component="div"
-              marginBottom="8px"
-              fontWeight="normal"
-            >
-              Preview
-            </Typography>
-            <ArtifactContent
-              artifact={artifact}
-              contentWithLoadingStatus={contentWithLoadingStatus}
-            />
-          </Box>
+          {
+            previewAvailable && (
+              <>
+                <Divider sx={{ marginY: '32px' }} />
+                <Box width="100%" marginTop="12px">
+                  <Typography
+                    variant="h6"
+                    component="div"
+                    marginBottom="8px"
+                    fontWeight="normal"
+                  >
+                    Preview
+                  </Typography>
+                  <ArtifactContent
+                    artifact={artifact}
+                    contentWithLoadingStatus={contentWithLoadingStatus}
+                  />
+                </Box>
+              </>
+            )
+          }
 
           <Divider sx={{ marginY: '32px' }} />
 

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -84,11 +84,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const { metrics, checks } =
     !!workflowDagResultWithLoadingStatus &&
-      isSucceeded(workflowDagResultWithLoadingStatus.status)
+    isSucceeded(workflowDagResultWithLoadingStatus.status)
       ? getMetricsAndChecksOnArtifact(
-        workflowDagResultWithLoadingStatus?.result,
-        artifactId
-      )
+          workflowDagResultWithLoadingStatus?.result,
+          artifactId
+        )
       : { metrics: [], checks: [] };
 
   const pathPrefix = getPathPrefix();
@@ -128,8 +128,9 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   useEffect(() => {
     if (!!artifact) {
       if (!sideSheetMode) {
-        document.title = `${artifact ? artifact.name : 'Artifact Details'
-          } | Aqueduct`;
+        document.title = `${
+          artifact ? artifact.name : 'Artifact Details'
+        } | Aqueduct`;
       }
 
       if (
@@ -205,7 +206,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const outputs = mapOperators(artifact.to ? artifact.to : []);
 
   const artifactStatus = artifact?.result?.exec_state?.status;
-  const previewAvailable = artifactStatus && artifactStatus !== ExecutionStatus.Canceled;
+  const previewAvailable =
+    artifactStatus && artifactStatus !== ExecutionStatus.Canceled;
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
@@ -245,27 +247,25 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             )}
           </Box>
 
-          {
-            previewAvailable && (
-              <>
-                <Divider sx={{ marginY: '32px' }} />
-                <Box width="100%" marginTop="12px">
-                  <Typography
-                    variant="h6"
-                    component="div"
-                    marginBottom="8px"
-                    fontWeight="normal"
-                  >
-                    Preview
-                  </Typography>
-                  <ArtifactContent
-                    artifact={artifact}
-                    contentWithLoadingStatus={contentWithLoadingStatus}
-                  />
-                </Box>
-              </>
-            )
-          }
+          {previewAvailable && (
+            <>
+              <Divider sx={{ marginY: '32px' }} />
+              <Box width="100%" marginTop="12px">
+                <Typography
+                  variant="h6"
+                  component="div"
+                  marginBottom="8px"
+                  fontWeight="normal"
+                >
+                  Preview
+                </Typography>
+                <ArtifactContent
+                  artifact={artifact}
+                  contentWithLoadingStatus={contentWithLoadingStatus}
+                />
+              </Box>
+            </>
+          )}
 
           <Divider sx={{ marginY: '32px' }} />
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR hides artifact previews when the artifact is cancelled.

## Related issue number (if any)
ENG-1880

## Loom demo (if any)
https://www.loom.com/share/a78d9b2a5a71457090a417439cbb619a

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


