### PR TITLE
[2/3] Add Data Integration Test Suite coverage for SQLite and Snowflake

### DIFF
--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -20,7 +20,11 @@ To run the Data Integration Tests:
 `API_KEY=<your api key> SERVER_ADDRESS=<your server's address> INTEGRATION=aqueduct_demo pytest data_integration_tests/ -rP -vv
 
 The test suite also has a variety of other custom flags, please inspect the `conftest.py` files in both this directory and subdirectories
-to find their descriptions.
+to find their descriptions. Flags shared by both suites are:
+* `--data`: The integration name of the data integration to run against.
+* `--engine`: The integration of the engine to run compute on.
+* `--keep-flows`: Does not delete any flows created by the test run. Useful for debugging.
+* `--deprecated`: Runs against any deprecated API that still exists in the SDK.
 
 Running all the tests in a single file:
 - `<your env variables> pytest <path to test file> -rP -vv`

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -403,3 +403,15 @@ def test_publish_with_redundant_config_fields(client):
             k_latest_runs=10,
             config=FlowConfig(k_latest_runs=123),
         )
+
+
+def test_flow_list_saved_objects_none(client, flow_name, engine):
+    """Check that flow.list_saved_objects() works when no objects were actually saved."""
+
+    @op
+    def noop():
+        return 123
+
+    output = noop()
+    flow = publish_flow_test(client, artifacts=output, name=flow_name(), engine=engine)
+    assert len(flow.list_saved_objects()) == 0

--- a/integration_tests/sdk/data_integration_tests/conftest.py
+++ b/integration_tests/sdk/data_integration_tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+
+# Maps the test files in this directory to the allowed data integrations for that file.
+# If a disallowed data integration is used, all tests in the file will be skipped.
+from aqueduct.constants.enums import ServiceType
+
+allowed_data_integrations_by_file = {"relational_test": [ServiceType.SQLITE]}
+
+
+@pytest.fixture(autouse=True)
+def filter_tests_based_on_data_integrations(request, client, data_integration):
+    """Does the same thing as `enable_only_for_data_integration_type()`, only over entire files.
+
+    This is because the data integration tests are grouped such that each file is only relevant for
+    a specific integration(s).
+
+    All that is required is that every file define a `REQUIRED_INTEGRATION=...` variable, so we know
+    which data integrations to skip.
+    """
+    test_file_name = os.path.splitext(os.path.basename(request.fspath))[
+        0
+    ]  # The extension is stripped out.
+
+    assert test_file_name in allowed_data_integrations_by_file, (
+        "%s.py has not specified what data integrations it's allowed to run with, please add those "
+        "to the dict in `data_integration_tests/conftest.py`" % test_file_name
+    )
+
+    allowed_data_integrations = allowed_data_integrations_by_file[test_file_name]
+    if data_integration._metadata.service not in allowed_data_integrations:
+        pytest.skip(
+            "Skipped for data integration `%s`, since it is not of type `%s`."
+            % (data_integration._metadata.name, ",".join(allowed_data_integrations))
+        )

--- a/integration_tests/sdk/data_integration_tests/conftest.py
+++ b/integration_tests/sdk/data_integration_tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 # If a disallowed data integration is used, all tests in the file will be skipped.
 from aqueduct.constants.enums import ServiceType
 
-allowed_data_integrations_by_file = {"relational_test": [ServiceType.SQLITE]}
+allowed_data_integrations_by_file = {"relational_test": [ServiceType.SQLITE, ServiceType.SNOWFLAKE]}
 
 
 @pytest.fixture(autouse=True)

--- a/integration_tests/sdk/data_integration_tests/relational_test.py
+++ b/integration_tests/sdk/data_integration_tests/relational_test.py
@@ -123,7 +123,7 @@ def test_sql_integration_list_tables(client, data_integration):
     tables = data_integration.list_tables()
 
     for expected_table in demo_db_tables():
-        assert expected_table in tables["name"].unique()
+        assert tables["tablename"].str.contains(expected_table, case=False).sum() > 0
 
 
 def test_sql_today_tag(client, data_integration):

--- a/integration_tests/sdk/data_integration_tests/relational_test.py
+++ b/integration_tests/sdk/data_integration_tests/relational_test.py
@@ -1,0 +1,316 @@
+from typing import List
+
+import pandas as pd
+import pytest
+from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.artifacts.generic_artifact import GenericArtifact
+from aqueduct.constants.enums import ExecutionStatus
+from aqueduct.error import AqueductError, InvalidUserActionException, InvalidUserArgumentException
+from aqueduct.models.operators import RelationalDBExtractParams
+
+from aqueduct import LoadUpdateMode, metric, op
+
+from ..shared.demo_db import demo_db_tables
+from ..shared.relational import SHORT_SENTIMENT_SQL_QUERY
+from ..shared.utils import generate_table_name, publish_flow_test
+from .save import save
+
+
+def _create_successful_sql_artifacts(
+    client,
+    data_integration,
+    wrap_query_in_extract_params_struct: bool = False,
+) -> List[BaseArtifact]:
+    """Tests and returns artifacts for two types of sql queries: basic and chained.
+
+    Every artifact is saved to a random table with update_mode='replace'.
+    """
+    hotel_reviews_query = "SELECT * FROM hotel_reviews"
+    chained_query = [
+        "SELECT * FROM hotel_reviews",
+        "SELECT review, review_date FROM $ WHERE reviewer_nationality ='{{nationality}}'",
+        "SELECT review FROM $",
+    ]
+
+    if wrap_query_in_extract_params_struct:
+        hotel_reviews_query = RelationalDBExtractParams(query=hotel_reviews_query)
+        chained_query = RelationalDBExtractParams(queries=chained_query)
+
+    # Test a successful basic sql query.
+    hotel_reviews_table = data_integration.sql(hotel_reviews_query)
+    assert list(hotel_reviews_table.get()) == [
+        "hotel_name",
+        "review_date",
+        "reviewer_nationality",
+        "review",
+    ]
+    assert hotel_reviews_table.get().shape[0] == 100
+
+    # Test a successful chain query.
+    client.create_param("nationality", default=" United Kingdom ")
+    chained_query_result = data_integration.sql(chained_query)
+    expected_chained_query_result = data_integration.sql(
+        "SELECT review FROM hotel_reviews WHERE reviewer_nationality=' United Kingdom '",
+    )
+    assert expected_chained_query_result.get().equals(chained_query_result.get())
+
+    artifacts = [hotel_reviews_table, chained_query_result]
+    for artifact in artifacts:
+        save(data_integration, artifact, generate_table_name(), LoadUpdateMode.REPLACE)
+    return artifacts
+
+
+def _publish_saves_and_check(client, flow_name, validator, artifacts: List[BaseArtifact]):
+    flow = publish_flow_test(
+        client,
+        artifacts,
+        name=flow_name(),
+        engine=None,
+    )
+    for artifact in artifacts:
+        validator.check_saved_artifact_data(flow, artifact.id(), expected_data=artifact.get())
+
+
+def test_sql_integration_query_and_save(client, flow_name, data_integration, validator):
+    artifacts = _create_successful_sql_artifacts(client, data_integration)
+    _publish_saves_and_check(client, flow_name, validator, artifacts)
+
+
+def test_sql_integration_query_and_save_relationaldbextractparams(
+    client, flow_name, data_integration, validator
+):
+    artifacts = _create_successful_sql_artifacts(
+        client, data_integration, wrap_query_in_extract_params_struct=True
+    )
+    _publish_saves_and_check(client, flow_name, validator, artifacts)
+
+
+def test_sql_integration_artifact_with_custom_metadata(
+    client, flow_name, data_integration, validator
+):
+    # TODO: validate custom descriptions once we can fetch descriptions easily.
+    artifact = data_integration.sql(
+        "SELECT * FROM hotel_reviews", name="Test Artifact", description="This is a description"
+    )
+    assert artifact.name() == "Test Artifact artifact"
+
+    flow = publish_flow_test(client, artifact, name=flow_name(), engine=None)
+    validator.check_artifact_was_computed(flow, "Test Artifact artifact")
+
+
+def test_sql_integration_failed_query(client, data_integration):
+    # Sql query is malformed.
+    with pytest.raises(AqueductError, match="Preview Execution Failed"):
+        data_integration.sql("SELECT * FROM ")
+
+    # SQL error happens at execution time (table missing).
+    with pytest.raises(AqueductError, match="Preview Execution Failed"):
+        data_integration.sql("SELECT * FROM missing_table")
+
+
+def test_sql_integration_table_retrieval(client, data_integration):
+    df = data_integration.table(name="hotel_reviews")
+    assert len(df) == 100
+    assert list(df) == [
+        "hotel_name",
+        "review_date",
+        "reviewer_nationality",
+        "review",
+    ]
+
+
+def test_sql_integration_list_tables(client, data_integration):
+    tables = data_integration.list_tables()
+
+    for expected_table in demo_db_tables():
+        assert expected_table in tables["name"].unique()
+
+
+def test_sql_today_tag(client, data_integration):
+    table_artifact_today = data_integration.sql(
+        query="select * from hotel_reviews where review_date = {{today}}"
+    )
+    assert table_artifact_today.get().empty
+    table_artifact_not_today = data_integration.sql(
+        query="select * from hotel_reviews where review_date < {{today}}"
+    )
+    assert len(table_artifact_not_today.get()) == 100
+
+
+def test_sql_query_with_parameter(client, data_integration):
+    # Missing parameters.
+    with pytest.raises(InvalidUserArgumentException):
+        _ = data_integration.sql(query="select * from {{missing_parameter}}")
+
+    # The parameter is not a string type.
+    _ = client.create_param("table_name", default=1234)
+    with pytest.raises(InvalidUserArgumentException):
+        _ = data_integration.sql(query="select * from {{ table_name }}")
+
+    client.create_param("table_name", default="hotel_reviews")
+    table_artifact = data_integration.sql(query="select * from {{ table_name }}")
+
+    expected_table_artifact = data_integration.sql(query="select * from hotel_reviews")
+    assert table_artifact.get().equals(expected_table_artifact.get())
+    expected_table_artifact = data_integration.sql(query="select * from customer_activity")
+    assert table_artifact.get(parameters={"table_name": "customer_activity"}).equals(
+        expected_table_artifact.get()
+    )
+
+    # Trigger the parameter with invalid values.
+    with pytest.raises(InvalidUserArgumentException):
+        _ = table_artifact.get(parameters={"table_name": ["this is the incorrect type"]})
+    with pytest.raises(InvalidUserArgumentException):
+        _ = table_artifact.get(parameters={"non-existant parameter": "blah"})
+
+
+def test_sql_query_with_multiple_parameters(client, flow_name, data_integration, engine):
+    _ = client.create_param("table_name", default="hotel_reviews")
+    nationality = client.create_param(
+        "reviewer-nationality", default="United Kingdom"
+    )  # check that dashes work.
+    table_artifact = data_integration.sql(
+        query="select * from {{ table_name }} where reviewer_nationality='{{ reviewer-nationality }}' and review_date < {{ today}}"
+    )
+    expected_table_artifact = data_integration.sql(
+        "select * from hotel_reviews where reviewer_nationality='United Kingdom' and review_date < {{today}}"
+    )
+    assert table_artifact.get().equals(expected_table_artifact.get())
+    expected_table_artifact = data_integration.sql(
+        "select * from hotel_reviews where reviewer_nationality='Australia' and review_date < {{today}}"
+    )
+    assert table_artifact.get(parameters={"reviewer-nationality": "Australia"}).equals(
+        expected_table_artifact.get()
+    )
+
+    # Use the parameters in another operator.
+    @metric
+    def noop(sql_output, param):
+        return len(param)
+
+    result = noop(table_artifact, nationality)
+    assert result.get() == len(nationality.get())
+    assert result.get(parameters={"reviewer-nationality": "Australia"}) == len("Australia")
+
+    publish_flow_test(client, name=flow_name(), artifacts=[result], engine=engine)
+
+
+def test_sql_query_user_vs_builtin_precedence(client, data_integration):
+    """If a user defines an expansion that collides with a built-in one, the user-defined one should take precedence."""
+    table_artifact = data_integration.sql(
+        query="select * from hotel_reviews where review_date > {{today}}"
+    )
+    builtin_result = table_artifact.get()
+
+    datestring = "'2016-01-01'"
+    _ = client.create_param("today", datestring)
+    table_artifact = data_integration.sql(
+        query="select * from hotel_reviews where review_date > {{today}}"
+    )
+    user_param_result = table_artifact.get()
+    assert not builtin_result.equals(user_param_result)
+
+    expected_table_artifact = data_integration.sql(
+        query="select * from hotel_reviews where review_date > %s" % datestring
+    )
+    assert user_param_result.equals(expected_table_artifact.get())
+
+
+def test_sql_integration_save_wrong_data_type(client, flow_name, data_integration):
+    # Try to save a numeric artifact.
+    num_param = client.create_param("number", default=123)
+    with pytest.raises(
+        InvalidUserActionException,
+        match="Unable to save non-relational data into relational data store",
+    ):
+        save(data_integration, num_param, generate_table_name(), LoadUpdateMode.REPLACE)
+
+    # Save a generic artifact that is actually a string. This won't fail at save() time,
+    # but instead when the flow is published.
+    @op
+    def foo():
+        return "asdf"
+
+    string_artifact = foo.lazy()
+    assert isinstance(string_artifact, GenericArtifact)
+    save(data_integration, string_artifact, generate_table_name(), LoadUpdateMode.REPLACE)
+    publish_flow_test(
+        client,
+        string_artifact,
+        name=flow_name(),
+        engine=None,
+        expected_statuses=ExecutionStatus.FAILED,
+    )
+
+
+def test_sql_integration_save_with_different_update_modes(
+    client, flow_name, data_integration, engine, validator
+):
+    table_1_save_name = generate_table_name()
+    table_2_save_name = generate_table_name()
+
+    table = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    extracted_table_data = table.get()
+    save(data_integration, table, table_1_save_name, LoadUpdateMode.REPLACE)
+
+    # This will create the table.
+    flow = publish_flow_test(
+        client,
+        name=flow_name(),
+        artifacts=table,
+        engine=engine,
+    )
+    validator.check_saved_artifact_data(flow, table.id(), expected_data=extracted_table_data)
+
+    # Change to append mode.
+    save(data_integration, table, table_1_save_name, LoadUpdateMode.APPEND)
+    publish_flow_test(
+        client,
+        existing_flow=flow,
+        artifacts=table,
+        engine=engine,
+    )
+    validator.check_saved_artifact_data(
+        flow,
+        table.id(),
+        expected_data=pd.concat([extracted_table_data, extracted_table_data], ignore_index=True),
+    )
+
+    # Redundant append mode change
+    save(data_integration, table, table_1_save_name, LoadUpdateMode.APPEND)
+    publish_flow_test(
+        client,
+        existing_flow=flow,
+        artifacts=table,
+        engine=engine,
+    )
+    validator.check_saved_artifact_data(
+        flow,
+        table.id(),
+        expected_data=pd.concat(
+            [extracted_table_data, extracted_table_data, extracted_table_data], ignore_index=True
+        ),
+    )
+
+    # Create a different table from the same artifact.
+    save(data_integration, table, table_2_save_name, LoadUpdateMode.REPLACE)
+    publish_flow_test(
+        client,
+        existing_flow=flow,
+        artifacts=table,
+        engine=engine,
+    )
+    validator.check_saved_artifact_data(
+        flow,
+        table.id(),
+        expected_data=extracted_table_data,
+    )
+
+    validator.check_saved_update_mode_changes(
+        flow,
+        expected_updates=[
+            (table_2_save_name, LoadUpdateMode.REPLACE),
+            (table_1_save_name, LoadUpdateMode.APPEND),
+            (table_1_save_name, LoadUpdateMode.REPLACE),
+        ],
+    )

--- a/integration_tests/sdk/data_integration_tests/save.py
+++ b/integration_tests/sdk/data_integration_tests/save.py
@@ -1,0 +1,14 @@
+from aqueduct.artifacts.base_artifact import BaseArtifact
+
+from ..shared.globals import artifact_id_to_saved_identifier
+
+
+def save(integration, artifact: BaseArtifact, *args):
+    """Wrapper around integration.save() that also register's the save with the test suite,
+    so that `validator.check_saved_artifact()` can be performed later.
+    """
+    integration.save(artifact, *args)
+
+    # The assumption across all our integration.save() methods is that the identifier
+    # is always the argument immediately following the artifact.
+    artifact_id_to_saved_identifier[str(artifact.id())] = args[0]

--- a/integration_tests/sdk/shared/demo_db.py
+++ b/integration_tests/sdk/shared/demo_db.py
@@ -11,5 +11,4 @@ def demo_db_tables() -> List[str]:
         "wine",
         "diabetes",
         "house_prices",
-        "pred_churn",
     ]

--- a/integration_tests/sdk/shared/utils.py
+++ b/integration_tests/sdk/shared/utils.py
@@ -66,7 +66,7 @@ def publish_flow_test(
     """
     assert (
         name or existing_flow and not (name and existing_flow)
-    ), "Either `name` or `existing_flow` can be set, but not both."
+    ), "Either `name` or `existing_flow` must be set (not both or neither)."
 
     if existing_flow is not None:
         name = existing_flow.name()

--- a/sdk/aqueduct/backend/response_models.py
+++ b/sdk/aqueduct/backend/response_models.py
@@ -242,7 +242,7 @@ class ListWorkflowSavedObjectsResponse(BaseModel):
             List of objects written by the workflow.
     """
 
-    object_details: List[SavedObjectUpdate]
+    object_details: Optional[List[SavedObjectUpdate]]
 
 
 class GetVersionResponse(BaseModel):

--- a/sdk/aqueduct/flow.py
+++ b/sdk/aqueduct/flow.py
@@ -123,7 +123,12 @@ class Flow:
         Returns:
             A dictionary mapping the integration id to the list of table names/storage path.
         """
+        object_mapping: DefaultDict[str, List[SavedObjectUpdate]] = defaultdict(list)
+
         workflow_objects = globals.__GLOBAL_API_CLIENT__.list_saved_objects(self._id).object_details
+        if workflow_objects is None:
+            return object_mapping  # Empty map
+
         object_mapping = defaultdict(list)
         for item in workflow_objects:
             object_mapping[item.integration_name].append(item)

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -89,7 +89,7 @@ BUILT_IN_EXPANSIONS = {
 
 class RelationalDBIntegration(Integration):
     """
-    Class for RealtionalDB integrations.
+    Class for Relational integrations.
     """
 
     def __init__(self, dag: DAG, metadata: IntegrationInfo):

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -34,7 +34,7 @@ LIST_TABLES_QUERY_SQLSERVER = (
 )
 LIST_TABLES_QUERY_BIGQUERY = "SELECT schema_name FROM information_schema.schemata;"
 GET_TABLE_QUERY = "select * from %s"
-LIST_TABLES_QUERY_SQLITE = "SELECT name FROM sqlite_master WHERE type='table';"
+LIST_TABLES_QUERY_SQLITE = "SELECT name AS tablename FROM sqlite_master WHERE type='table';"
 LIST_TABLES_QUERY_ATHENA = "AQUEDUCT_ATHENA_LIST_TABLE"
 
 # Regular Expression that matches any substring appearance with
@@ -98,7 +98,7 @@ class RelationalDBIntegration(Integration):
 
     def list_tables(self) -> pd.DataFrame:
         """
-        Lists the tables available in the RealtionalDB integration.
+        Lists the tables available in the RelationalDB integration.
 
         Returns:
             pd.DataFrame of available tables.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Initializes the SDK data integration test suite and adds test coverage for relational databases, tested and allowed for SQLite and Snowflake.

The point of SDK Data Integration Tests is to test the SDK Integration API with *completeness*. Our Aqueduct Tests can be too generic to cover all the edge cases for our Integration API, which is different for each integration type.

The Data Integration Tests are organized such that each test file is responsible for testing a particular integration type. See `integration_tests/sdk/data_integration_tests/conftest.py` for how this is enforced. Both Aqueduct and Data Integration Tests shared the fixtures and configurations in `integration_tests/sdk/conftest.py`.

## Related issue number (if any)
ENG-2113

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


