### PR TITLE
ENG-1961 Hide Parameters in Workflow Status Bar

### DIFF
--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -280,37 +280,43 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
 
   // Ignore Parameters from list of workflow status items
   const shouldShowStatusItem = (statusItem: WorkflowStatusItem) => {
-    console.log('statusItem type: ', statusItem.type);
-
-    if (statusItem.type === 'paramOp') {
-      console.log('statusItem type is parameter')
-    }
     return statusItem.type !== 'paramOp';
-  }
+  };
 
   useEffect(() => {
     const filteredErrors: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Errors;
+        return (
+          shouldShowStatusItem(workflowStatusItem) &&
+          workflowStatusItem.level === WorkflowStatusTabs.Errors
+        );
       }
     );
 
     const filteredWarnings: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Warnings;
+        return (
+          shouldShowStatusItem(workflowStatusItem) &&
+          workflowStatusItem.level === WorkflowStatusTabs.Warnings
+        );
       }
     );
 
     const filteredLogs: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Logs;
+        return (
+          shouldShowStatusItem(workflowStatusItem) &&
+          workflowStatusItem.level === WorkflowStatusTabs.Logs
+        );
       }
     );
 
     const filteredChecks: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-
-        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Checks;
+        return (
+          shouldShowStatusItem(workflowStatusItem) &&
+          workflowStatusItem.level === WorkflowStatusTabs.Checks
+        );
       }
     );
 
@@ -553,8 +559,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -278,28 +278,39 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   // List of the workflow status items filtered out by category: errors, warnings, logs and checks passed.
   const [listItems, setListItems] = useState<WorkflowStatusItem[]>([]);
 
+  // Ignore Parameters from list of workflow status items
+  const shouldShowStatusItem = (statusItem: WorkflowStatusItem) => {
+    console.log('statusItem type: ', statusItem.type);
+
+    if (statusItem.type === 'paramOp') {
+      console.log('statusItem type is parameter')
+    }
+    return statusItem.type !== 'paramOp';
+  }
+
   useEffect(() => {
     const filteredErrors: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return workflowStatusItem.level === WorkflowStatusTabs.Errors;
+        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Errors;
       }
     );
 
     const filteredWarnings: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return workflowStatusItem.level === WorkflowStatusTabs.Warnings;
+        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Warnings;
       }
     );
 
     const filteredLogs: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return workflowStatusItem.level === WorkflowStatusTabs.Logs;
+        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Logs;
       }
     );
 
     const filteredChecks: WorkflowStatusItem[] = workflowStatusItems.filter(
       (workflowStatusItem) => {
-        return workflowStatusItem.level === WorkflowStatusTabs.Checks;
+
+        return shouldShowStatusItem(workflowStatusItem) && workflowStatusItem.level === WorkflowStatusTabs.Checks;
       }
     );
 
@@ -542,9 +553,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -279,44 +279,38 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   const [listItems, setListItems] = useState<WorkflowStatusItem[]>([]);
 
   // Ignore Parameters from list of workflow status items
-  const shouldShowStatusItem = (statusItem: WorkflowStatusItem) => {
-    return statusItem.type !== 'paramOp';
-  };
+  // const shouldShowStatusItem = (statusItem: WorkflowStatusItem) => {
+  //   return statusItem.type !== 'paramOp';
+  // };
+
+  const itemsToShow: WorkflowStatusItem[] = workflowStatusItems.filter(
+    (statusItem: WorkflowStatusItem) => {
+      return statusItem.type !== 'paramOp';
+    }
+  );
 
   useEffect(() => {
-    const filteredErrors: WorkflowStatusItem[] = workflowStatusItems.filter(
+    const filteredErrors: WorkflowStatusItem[] = itemsToShow.filter(
       (workflowStatusItem) => {
-        return (
-          shouldShowStatusItem(workflowStatusItem) &&
-          workflowStatusItem.level === WorkflowStatusTabs.Errors
-        );
+        return workflowStatusItem.level === WorkflowStatusTabs.Errors;
       }
     );
 
-    const filteredWarnings: WorkflowStatusItem[] = workflowStatusItems.filter(
+    const filteredWarnings: WorkflowStatusItem[] = itemsToShow.filter(
       (workflowStatusItem) => {
-        return (
-          shouldShowStatusItem(workflowStatusItem) &&
-          workflowStatusItem.level === WorkflowStatusTabs.Warnings
-        );
+        return workflowStatusItem.level === WorkflowStatusTabs.Warnings;
       }
     );
 
-    const filteredLogs: WorkflowStatusItem[] = workflowStatusItems.filter(
+    const filteredLogs: WorkflowStatusItem[] = itemsToShow.filter(
       (workflowStatusItem) => {
-        return (
-          shouldShowStatusItem(workflowStatusItem) &&
-          workflowStatusItem.level === WorkflowStatusTabs.Logs
-        );
+        return workflowStatusItem.level === WorkflowStatusTabs.Logs;
       }
     );
 
-    const filteredChecks: WorkflowStatusItem[] = workflowStatusItems.filter(
+    const filteredChecks: WorkflowStatusItem[] = itemsToShow.filter(
       (workflowStatusItem) => {
-        return (
-          shouldShowStatusItem(workflowStatusItem) &&
-          workflowStatusItem.level === WorkflowStatusTabs.Checks
-        );
+        return workflowStatusItem.level === WorkflowStatusTabs.Checks;
       }
     );
 
@@ -399,7 +393,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
     setNumWarnings(filteredWarnings.length);
     setNumWorkflowLogs(filteredLogs.length);
     setNumWorkflowChecksPassed(filteredChecks.length);
-  }, [workflowStatusItems, activeWorkflowStatusTab]);
+  }, [workflowStatusItems, activeWorkflowStatusTab, itemsToShow]);
 
   const selectTab = (tab: WorkflowStatusTabs) => {
     dispatch(setWorkflowStatusBarOpenState(true));
@@ -559,9 +553,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -553,8 +553,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR hides status items of type 'Parameter' in the Workflow Status Bar.

## Related issue number (if any)
ENG-1961

## Loom demo (if any)
https://www.loom.com/share/b2b96345e81c42edbc0a26b31f6f9d6d

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


