### PR TITLE
ENG-2158 Persist number of rows between page refreshes on workflows page and data page tables.

### DIFF
--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -183,22 +183,18 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   );
 
   const onChangeRowsPerPage = (rowsPerPage) => {
-    // Set the rows per page in localStorage here.
-    console.log('data page onChangeRowsPerPage: ', rowsPerPage);
-    localStorage.setItem('dataTableRowsPerPage', rowsPerPage)
-  }
+    localStorage.setItem('dataTableRowsPerPage', rowsPerPage);
+  };
 
   const getRowsPerPage = () => {
     const savedRowsPerPage = localStorage.getItem('dataTableRowsPerPage');
-    console.log('dataTableRowsPerPage', savedRowsPerPage);
 
     if (!savedRowsPerPage) {
-      console.log('savedRowsPerPage not found, returning default');
       return 5; // return default rows per page value.
     }
 
     return parseInt(savedRowsPerPage);
-  }
+  };
 
   return (
     <Layout

--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -182,6 +182,24 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     </Typography>
   );
 
+  const onChangeRowsPerPage = (rowsPerPage) => {
+    // Set the rows per page in localStorage here.
+    console.log('data page onChangeRowsPerPage: ', rowsPerPage);
+    localStorage.setItem('dataTableRowsPerPage', rowsPerPage)
+  }
+
+  const getRowsPerPage = () => {
+    const savedRowsPerPage = localStorage.getItem('dataTableRowsPerPage');
+    console.log('dataTableRowsPerPage', savedRowsPerPage);
+
+    if (!savedRowsPerPage) {
+      console.log('savedRowsPerPage not found, returning default');
+      return 5; // return default rows per page value.
+    }
+
+    return parseInt(savedRowsPerPage);
+  }
+
   return (
     <Layout
       breadcrumbs={[BreadcrumbLink.HOME, BreadcrumbLink.DATA]}
@@ -192,6 +210,8 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
           data={artifactList}
           searchEnabled={true}
           onGetColumnValue={onGetColumnValue}
+          onChangeRowsPerPage={onChangeRowsPerPage}
+          savedRowsPerPage={getRowsPerPage()}
         />
       ) : (
         <Box>{noItemsMessage}</Box>

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -169,6 +169,10 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     return value;
   };
 
+  const onChangeRowsPerPage = (rowsPerPage) => {
+    console.log('workflowsPage onChangeRowsPerPage: ', rowsPerPage);
+  }
+
   return (
     <Layout
       breadcrumbs={[BreadcrumbLink.HOME, BreadcrumbLink.WORKFLOWS]}
@@ -179,6 +183,7 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
           data={workflowTableData}
           searchEnabled={true}
           onGetColumnValue={onGetColumnValue}
+          onChangeRowsPerPage={onChangeRowsPerPage}
         />
       ) : (
         <Box>{noItemsMessage}</Box>

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -170,8 +170,18 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   };
 
   const onChangeRowsPerPage = (rowsPerPage) => {
-    console.log('workflowsPage onChangeRowsPerPage: ', rowsPerPage);
-  }
+    localStorage.setItem('workflowsTableRowsPerPage', rowsPerPage);
+  };
+
+  const getRowsPerPage = () => {
+    const savedRowsPerPage = localStorage.getItem('workflowsTableRowsPerPage');
+
+    if (!savedRowsPerPage) {
+      return 5; // return default rows per page value.
+    }
+
+    return parseInt(savedRowsPerPage);
+  };
 
   return (
     <Layout
@@ -184,6 +194,7 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
           searchEnabled={true}
           onGetColumnValue={onGetColumnValue}
           onChangeRowsPerPage={onChangeRowsPerPage}
+          savedRowsPerPage={getRowsPerPage()}
         />
       ) : (
         <Box>{noItemsMessage}</Box>

--- a/src/ui/common/src/components/tables/PaginatedSearchTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedSearchTable.tsx
@@ -36,6 +36,8 @@ export interface PaginatedSearchTableProps {
   searchEnabled?: boolean;
   onGetColumnValue?: (row, column) => PaginatedSearchTableElement;
   onShouldInclude?: (rowItem, searchQuery, searchColumn) => boolean;
+  onChangeRowsPerPage?: (rowsPerPage) => void;
+  savedRowsPerPage?: number;
 }
 
 export const PaginatedSearchTable: React.FC<PaginatedSearchTableProps> = ({
@@ -43,9 +45,11 @@ export const PaginatedSearchTable: React.FC<PaginatedSearchTableProps> = ({
   onGetColumnValue,
   searchEnabled = false,
   onShouldInclude,
+  onChangeRowsPerPage,
+  savedRowsPerPage
 }) => {
   const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(5);
+  const [rowsPerPage, setRowsPerPage] = React.useState(savedRowsPerPage ? savedRowsPerPage : 5);
   const [searchQuery, setSearchQuery] = React.useState('');
   // TODO: Add dropdown to select which column to search the table on.
   // TODO: add setSearchColumn to the array below.
@@ -98,6 +102,10 @@ export const PaginatedSearchTable: React.FC<PaginatedSearchTableProps> = ({
   const handleChangeRowsPerPage = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
+    if (onChangeRowsPerPage) {
+      // Call the callback here and set the appropriate stuff in localstorage.
+      onChangeRowsPerPage(+event.target.value);
+    }
     setRowsPerPage(+event.target.value);
     setPage(0);
   };

--- a/src/ui/common/src/components/tables/PaginatedSearchTable.tsx
+++ b/src/ui/common/src/components/tables/PaginatedSearchTable.tsx
@@ -46,10 +46,12 @@ export const PaginatedSearchTable: React.FC<PaginatedSearchTableProps> = ({
   searchEnabled = false,
   onShouldInclude,
   onChangeRowsPerPage,
-  savedRowsPerPage
+  savedRowsPerPage,
 }) => {
   const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(savedRowsPerPage ? savedRowsPerPage : 5);
+  const [rowsPerPage, setRowsPerPage] = React.useState(
+    savedRowsPerPage ? savedRowsPerPage : 5
+  );
   const [searchQuery, setSearchQuery] = React.useState('');
   // TODO: Add dropdown to select which column to search the table on.
   // TODO: add setSearchColumn to the array below.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR saves the selected number of rows for the workflows page table and the data page table. When users refresh the page, they will see that the number of rows selected persists.

## Related issue number (if any)
ENG-2158

## Loom demo (if any)
https://www.loom.com/share/74cdeaf29ee6431e912b77c0c304d801

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


