### PR TITLE
Adds UI support for showing the source workflow in the settings

### DIFF
--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -359,9 +359,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
       )}
 
       {triggerType === WorkflowUpdateTrigger.Cascade && (
-        <>
-          <TriggerSourceSelector workflows={workflows} />
-        </>
+        <TriggerSourceSelector workflows={workflows} />
       )}
     </Box>
   );

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -36,6 +36,7 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import { handleFetchAllWorkflowSummaries } from '../../reducers/listWorkflowSummaries';
 import {
   handleDeleteWorkflow,
   handleListWorkflowSavedObjects,
@@ -63,6 +64,7 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import { LoadingButton } from '../primitives/LoadingButton.styles';
 import StorageSelector from './storageSelector';
+import TriggerSourceSelector from './triggerSourceSelector';
 
 type PeriodicScheduleSelectorProps = {
   cronString: string;
@@ -242,6 +244,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
         workflowId: workflowDag.workflow_id,
       })
     );
+    dispatch(handleFetchAllWorkflowSummaries({ apiKey: user.apiKey }));
   }, [dispatch, user.apiKey, workflowDag.workflow_id]);
 
   const savedObjectsResponse = useSelector(
@@ -257,6 +260,10 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
 
   const dagResults = useSelector(
     (state: RootState) => state.workflowReducer.dagResults
+  );
+
+  const workflows = useSelector(
+    (state: RootState) => state.listWorkflowReducer.workflows
   );
 
   const [name, setName] = useState(workflowDag.metadata?.name);
@@ -284,6 +291,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
     schedule: workflowDag.metadata.schedule.cron_schedule,
     paused: workflowDag.metadata.schedule.paused,
     retentionPolicy: workflowDag.metadata?.retention_policy,
+    sourceId: workflowDag.metadata?.schedule.source_id,
   };
 
   const settingsChanged =
@@ -298,6 +306,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const triggerOptions = [
     { label: 'Update Manually', value: WorkflowUpdateTrigger.Manual },
     { label: 'Update Periodically', value: WorkflowUpdateTrigger.Periodic },
+    { label: 'Update After Source', value: WorkflowUpdateTrigger.Cascade },
   ];
 
   const scheduleSelector = (
@@ -319,6 +328,11 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               sx={{
                 [`& .${formControlLabelClasses.label}`]: { fontSize: '14px' },
               }}
+              // TODO: ENG-2181 Add support for changing source trigger
+              disabled={
+                value === WorkflowUpdateTrigger.Cascade &&
+                triggerType !== WorkflowUpdateTrigger.Cascade
+              }
             />
           );
         })}
@@ -341,6 +355,12 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
               />
             }
           />
+        </>
+      )}
+
+      {triggerType === WorkflowUpdateTrigger.Cascade && (
+        <>
+          <TriggerSourceSelector workflows={workflows} />
         </>
       )}
     </Box>

--- a/src/ui/common/src/components/workflows/triggerSourceSelector.tsx
+++ b/src/ui/common/src/components/workflows/triggerSourceSelector.tsx
@@ -1,0 +1,61 @@
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import MenuItem from '@mui/material/MenuItem';
+import Select from '@mui/material/Select';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { ListWorkflowSummary } from 'src/utils/workflows';
+
+import { RootState } from '../../stores/store';
+
+type Props = {
+  workflows: ListWorkflowSummary[];
+};
+
+export const TriggerSourceSelector: React.FC<Props> = ({ workflows }) => {
+  const workflow = useSelector((state: RootState) => state.workflowReducer);
+
+  const dag = workflow.selectedDag;
+
+  const filteredWorkflows = workflows.filter(
+    (workflow) => workflow.id === dag.metadata?.schedule.source_id
+  );
+  // TODO: ENG-2181 Add support for changing source trigger
+  const selected = filteredWorkflows[0].id;
+
+  const getMenuItems = () => {
+    return filteredWorkflows.map((workflow) => {
+      return (
+        <MenuItem
+          value={workflow.id}
+          key={workflow.id}
+          sx={{ backgroundColor: selected ? 'blueTint' : null }}
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            <Typography>{workflow.name}</Typography>
+          </Box>
+        </MenuItem>
+      );
+    });
+  };
+
+  const menuItems = getMenuItems();
+
+  return (
+    <Box>
+      <FormControl disabled sx={{ minWidth: 120 }} size="small">
+        <Select
+          sx={{ maxHeight: 48 }}
+          id="grouped-select"
+          autoWidth
+          value={selected}
+        >
+          {menuItems}
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+
+export default TriggerSourceSelector;

--- a/src/ui/common/src/utils/workflows.tsx
+++ b/src/ui/common/src/utils/workflows.tsx
@@ -21,6 +21,7 @@ export enum WorkflowUpdateTrigger {
   Manual = 'manual',
   Periodic = 'periodic',
   Airflow = 'airflow',
+  Cascade = 'cascade',
 }
 
 export type WorkflowSchedule = {
@@ -28,6 +29,7 @@ export type WorkflowSchedule = {
   cron_schedule: string;
   disable_manual_trigger: boolean;
   paused: boolean;
+  source_id: string;
 };
 
 export type RetentionPolicy = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds UI support for showing the source workflow in the settings page if the workflow is set to be triggered after a source. Note that this PR is just 1/2 of the UI changes needed for the feature. There is a separate task here that is tracking changes for allowing users to change the workflow schedule to use cascading updates from the UI. This PR is separated just for reviewing purposes.

## Related issue number (if any)
ENG 2180

## Loom demo (if any)
https://www.loom.com/share/4813a0d6239c4dfda62a337f843fa847

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


