### PR TITLE
Adds SDK support for scheduling a workflow to run after a source

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -207,7 +207,7 @@ def test_publish_with_schedule_and_source_flow(client, flow_name, data_integrati
     with pytest.raises(InvalidUserArgumentException):
         publish_flow_test(
             client,
-            name=flow_name(),
+            name=generate_new_flow_name(),
             artifacts=output_artifact,
             engine=engine,
             schedule=aqueduct.daily(),

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -159,6 +159,7 @@ def test_publish_with_schedule(client, flow_name, data_integration, engine):
         expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
     )
 
+
 def test_publish_flow_with_cascading_trigger(client, flow_name, data_integration, engine):
     """Tests publishing a flow that is set to run on a cascading trigger."""
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
@@ -196,6 +197,22 @@ def test_publish_flow_with_cascading_trigger(client, flow_name, data_integration
         flow.id(),
         expected_statuses=[ExecutionStatus.SUCCEEDED, ExecutionStatus.SUCCEEDED],
     )
+
+
+def test_publish_with_schedule_and_source_flow(client, flow_name, data_integration, engine):
+    """Tests publishing an invalid flow that has both a schedule and a source flow."""
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+    output_artifact = dummy_sentiment_model(table_artifact)
+
+    with pytest.raises(InvalidUserArgumentException):
+        publish_flow_test(
+            client,
+            name=flow_name(),
+            artifacts=output_artifact,
+            engine=engine,
+            schedule=aqueduct.daily(),
+            source_flow=uuid.uuid4(),
+        )
 
 
 def test_invalid_flow(client):

--- a/integration_tests/sdk/shared/utils.py
+++ b/integration_tests/sdk/shared/utils.py
@@ -32,6 +32,7 @@ def publish_flow_test(
     metrics: Optional[List[BaseArtifact]] = None,
     checks: Optional[List[BaseArtifact]] = None,
     schedule: str = "",
+    source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
     should_block: bool = True,
 ) -> Flow:
     """Publishes a flow and waits for a specified number of runs with specified statuses to complete.
@@ -58,6 +59,7 @@ def publish_flow_test(
         metrics:
         checks:
         schedule:
+        source_flow:
             These are fed directly into `publish_flow()`.
         should_block:
             When true (default), we return immediately after publishing, without waiting for the flows to complete.
@@ -87,6 +89,7 @@ def publish_flow_test(
         checks=checks,
         schedule=schedule,
         engine=engine,
+        source_flow=source_flow,
     )
     print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
 

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -422,7 +422,7 @@ class Client:
 
         if source_flow and schedule != "":
             raise InvalidUserArgumentException(
-                "Cannot create a flow with a schedule and a source flow, pick one."
+                "Cannot create a flow with both a schedule and a source flow, pick one."
             )
 
         if (

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -46,7 +46,6 @@ from aqueduct.utils.utils import (
     generate_flow_schedule,
     generate_ui_url,
     parse_user_supplied_id,
-    parse_user_supplied_id_as_uuid,
 )
 
 from aqueduct import globals
@@ -423,14 +422,19 @@ class Client:
                 "`artifacts` argument must either be an artifact or a list of artifacts."
             )
 
-        if not isinstance(source_flow, Flow) and not isinstance(source_flow, str) and not isinstance(source_flow, uuid.UUID):
+        if (
+            source_flow and 
+            not isinstance(source_flow, Flow) and
+            not isinstance(source_flow, str) and
+            not isinstance(source_flow, uuid.UUID)
+        ):
             raise InvalidUserArgumentException(
                 "`source_flow` argument must either be a flow, str, or uuid."
             )
         
         source_flow_id = None
         if isinstance(source_flow, Flow):
-            source_flow_id = source_flow.id
+            source_flow_id = source_flow.id()
         elif isinstance(source_flow, str):
             # Check if there is a flow with the name `source_flow`
             for workflow in globals.__GLOBAL_API_CLIENT__.list_workflows():
@@ -442,8 +446,7 @@ class Client:
                 # No flow with name `source_flow` was found so try to convert
                 # the str to a uuid
                 source_flow_id = uuid.UUID(source_flow)
-        else:
-            # `source_flow` is of type uuid
+        elif isinstance(source_flow, uuid.UUID):
             source_flow_id = source_flow
 
 

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -372,9 +372,7 @@ class Client:
                     Runs outside of this bound are deleted. Defaults to persisting all runs.
             source_flow:
                 Used to identify the source flow for this flow. This can be identified
-                via an object (Flow), name (str), or id (str or uuid). 
-                If not empty, `schedule` will be ignored and this flow will only 
-                run after each successful run of the source flow.
+                via an object (Flow), name (str), or id (str or uuid).
 
         Raises:
             InvalidUserArgumentException:
@@ -420,6 +418,11 @@ class Client:
         ):
             raise InvalidUserArgumentException(
                 "`artifacts` argument must either be an artifact or a list of artifacts."
+            )
+        
+        if source_flow and schedule != "":
+            raise InvalidUserArgumentException(
+                "Cannot create a flow with a schedule and a source flow, pick one."
             )
 
         if (

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -419,22 +419,22 @@ class Client:
             raise InvalidUserArgumentException(
                 "`artifacts` argument must either be an artifact or a list of artifacts."
             )
-        
+
         if source_flow and schedule != "":
             raise InvalidUserArgumentException(
                 "Cannot create a flow with a schedule and a source flow, pick one."
             )
 
         if (
-            source_flow and 
-            not isinstance(source_flow, Flow) and
-            not isinstance(source_flow, str) and
-            not isinstance(source_flow, uuid.UUID)
+            source_flow
+            and not isinstance(source_flow, Flow)
+            and not isinstance(source_flow, str)
+            and not isinstance(source_flow, uuid.UUID)
         ):
             raise InvalidUserArgumentException(
                 "`source_flow` argument must either be a flow, str, or uuid."
             )
-        
+
         source_flow_id = None
         if isinstance(source_flow, Flow):
             source_flow_id = source_flow.id()
@@ -444,14 +444,13 @@ class Client:
                 if workflow.name == source_flow:
                     source_flow_id = workflow.id
                     break
-            
+
             if not source_flow_id:
                 # No flow with name `source_flow` was found so try to convert
                 # the str to a uuid
                 source_flow_id = uuid.UUID(source_flow)
         elif isinstance(source_flow, uuid.UUID):
             source_flow_id = source_flow
-
 
         # If metrics and/or checks are explicitly included, add them to the artifacts list,
         # but don't include them implicitly.

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -50,6 +50,7 @@ class OperatorType(Enum, metaclass=MetaEnum):
 class TriggerType(Enum, metaclass=MetaEnum):
     MANUAL = "manual"
     PERIODIC = "periodic"
+    CASCADE = "cascade"
 
 
 class ServiceType(str, Enum, metaclass=MetaEnum):

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -28,6 +28,7 @@ class Schedule(BaseModel):
     trigger: Optional[TriggerType] = None
     cron_schedule: str = ""
     disable_manual_trigger: bool = False
+    source_id: Optional[uuid.UUID] = None
 
 
 class RetentionPolicy(BaseModel):

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -28,6 +28,8 @@ class Schedule(BaseModel):
     trigger: Optional[TriggerType] = None
     cron_schedule: str = ""
     disable_manual_trigger: bool = False
+    # source_id refers to the source flow for this schedule when
+    # the trigger is TriggerType.CASCADE
     source_id: Optional[uuid.UUID] = None
 
 

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -70,7 +70,13 @@ def is_string_valid_uuid(value: str) -> bool:
         return False
 
 
-def schedule_from_cron_string(schedule_str: str) -> Schedule:
+def generate_flow_schedule(
+    schedule_str: str, source_flow_id: Optional[uuid.UUID] = None
+) -> Schedule:
+    """Generates a flow schedule using the provided cron string and the source flow ID if present."""
+    if source_flow_id:
+        return Schedule(trigger=TriggerType.CASCADE, source_id=source_flow_id)
+
     if len(schedule_str) == 0:
         return Schedule(trigger=TriggerType.MANUAL)
 
@@ -101,6 +107,16 @@ def parse_user_supplied_id(id: Union[str, uuid.UUID]) -> str:
 
     if isinstance(id, uuid.UUID):
         return str(id)
+    return id
+
+
+def parse_user_supplied_id_as_uuid(id: Union[str, uuid.UUID]) -> uuid.UUID:
+    """Verifies that a user-defined id is of the expected types, returning the UUID version of the id."""
+    if not isinstance(id, str) and not isinstance(id, uuid.UUID):
+        raise InvalidUserArgumentException("Provided id must be either str or uuid.")
+
+    if isinstance(id, str):
+        return uuid.UUID(id)
     return id
 
 

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -73,7 +73,7 @@ def is_string_valid_uuid(value: str) -> bool:
 def generate_flow_schedule(
     schedule_str: str, source_flow_id: Optional[uuid.UUID] = None
 ) -> Schedule:
-    """Generates a flow schedule using the provided cron string and the source flow ID if present."""
+    """Generates a flow schedule using the provided cron string and the source flow id if present."""
     if source_flow_id:
         return Schedule(trigger=TriggerType.CASCADE, source_id=source_flow_id)
 
@@ -107,16 +107,6 @@ def parse_user_supplied_id(id: Union[str, uuid.UUID]) -> str:
 
     if isinstance(id, uuid.UUID):
         return str(id)
-    return id
-
-
-def parse_user_supplied_id_as_uuid(id: Union[str, uuid.UUID]) -> uuid.UUID:
-    """Verifies that a user-defined id is of the expected types, returning the UUID version of the id."""
-    if not isinstance(id, str) and not isinstance(id, uuid.UUID):
-        raise InvalidUserArgumentException("Provided id must be either str or uuid.")
-
-    if isinstance(id, str):
-        return uuid.UUID(id)
     return id
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds support for scheduling a workflow to run based on a cascading update. The `publish_flow` API is changed to now allow users to set a `source_flow_id`. If this field is set then the cron schedule is ignored.

## Related issue number (if any)
ENG 2179

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


