### PR TITLE
Cache server env for usage stats collection

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -98,6 +98,11 @@ if __name__ == "__main__":
     if not os.path.isdir(preview_outputs_directory):
         os.mkdir(preview_outputs_directory)
 
+    # Force the env to be "dev", so that we don't have to manually set the env when starting the server.
+    env_file_path = os.path.join(server_directory, "config", "env")
+    with open(env_file_path, "w") as f:
+        f.write("dev")
+
     # Install the local SDK.
     if args.update_sdk:
         print("Updating the Python SDK...")

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -46,11 +46,12 @@ The Web UI and the backend server (v%s) are accessible at: http://%s:%d/login?ap
 
 Aqueduct collects non sensitive usage data to improve its services.
 Please refer to https://docs.aqueducthq.com/usage for more details.
-Usage data collection is enabled by default, and can be disabled by running `aqueduct start` with `--disable-usage-stats`.
+Usage data collection is enabled by default, and can be disabled via `aqueduct start --disable-usage-stats`.
 ***************************************************
 """
 
 conda_cmd_prefix = "conda"
+env_file_path = os.path.join(os.environ["HOME"], ".aqueduct", "server", "config", "env")
 
 
 def update_config_yaml(file):
@@ -374,6 +375,12 @@ def is_port_in_use(port: int) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
+def cache_env(env):
+    if env:
+        with open(env_file_path, "w") as f:
+            f.write(env)
+
+
 def start(expose, port, verbose, env, disable_usage_stats):
     update()
 
@@ -390,14 +397,14 @@ def start(expose, port, verbose, env, disable_usage_stats):
         server_port = int(port)
         print("Server will use the user-specified port %d" % server_port)
 
+    cache_env(env)
+
     command = [
         os.path.join(server_directory, "bin", "server"),
         "--config",
         os.path.join(server_directory, "config", "config.yml"),
         "--port",
         str(server_port),
-        "--env",
-        env,
     ]
 
     if expose:
@@ -614,7 +621,6 @@ if __name__ == "__main__":
     )
     start_args.add_argument(
         "--env",
-        default="prod",
         dest="env",
         help="Specify the environment in which the Aqueduct server is operating.",
     )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When running server with `--env` , we will cache the env into a file, and the user doesn't need to specify the env again in the future. If the user wants to update the env, they will run the server with `--env` again and the cache will be updated. If the cached entry doesn't exist, the `prod` env will be used.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


