### PR TITLE
[1/3] Adds SourceID field to Workflow.Schedule column

### DIFF
--- a/integration_tests/sdk/shared/utils.py
+++ b/integration_tests/sdk/shared/utils.py
@@ -32,6 +32,7 @@ def publish_flow_test(
     metrics: Optional[List[BaseArtifact]] = None,
     checks: Optional[List[BaseArtifact]] = None,
     schedule: str = "",
+    source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
     should_block: bool = True,
 ) -> Flow:
     """Publishes a flow and waits for a specified number of runs with specified statuses to complete.
@@ -58,6 +59,7 @@ def publish_flow_test(
         metrics:
         checks:
         schedule:
+        source_flow:
             These are fed directly into `publish_flow()`.
         should_block:
             When true (default), we return immediately after publishing, without waiting for the flows to complete.
@@ -87,6 +89,7 @@ def publish_flow_test(
         checks=checks,
         schedule=schedule,
         engine=engine,
+        source_flow=source_flow,
     )
     print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
 

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -43,9 +43,9 @@ from aqueduct.utils.type_inference import infer_artifact_type
 from aqueduct.utils.utils import (
     construct_param_spec,
     generate_engine_config,
+    generate_flow_schedule,
     generate_ui_url,
     parse_user_supplied_id,
-    schedule_from_cron_string,
 )
 
 from aqueduct import globals
@@ -321,6 +321,7 @@ class Client:
         checks: Optional[List[BoolArtifact]] = None,
         k_latest_runs: Optional[int] = None,
         config: Optional[FlowConfig] = None,
+        source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
     ) -> Flow:
         """Uploads and kicks off the given flow in the system.
 
@@ -369,6 +370,9 @@ class Client:
                 - engine: Specify where this flow should run with one of your connected integrations.
                 - k_latest_runs: Number of most-recent runs of this flow that Aqueduct should store.
                     Runs outside of this bound are deleted. Defaults to persisting all runs.
+            source_flow:
+                Used to identify the source flow for this flow. This can be identified
+                via an object (Flow), name (str), or id (str or uuid).
 
         Raises:
             InvalidUserArgumentException:
@@ -416,6 +420,38 @@ class Client:
                 "`artifacts` argument must either be an artifact or a list of artifacts."
             )
 
+        if source_flow and schedule != "":
+            raise InvalidUserArgumentException(
+                "Cannot create a flow with both a schedule and a source flow, pick one."
+            )
+
+        if (
+            source_flow
+            and not isinstance(source_flow, Flow)
+            and not isinstance(source_flow, str)
+            and not isinstance(source_flow, uuid.UUID)
+        ):
+            raise InvalidUserArgumentException(
+                "`source_flow` argument must either be a flow, str, or uuid."
+            )
+
+        source_flow_id = None
+        if isinstance(source_flow, Flow):
+            source_flow_id = source_flow.id()
+        elif isinstance(source_flow, str):
+            # Check if there is a flow with the name `source_flow`
+            for workflow in globals.__GLOBAL_API_CLIENT__.list_workflows():
+                if workflow.name == source_flow:
+                    source_flow_id = workflow.id
+                    break
+
+            if not source_flow_id:
+                # No flow with name `source_flow` was found so try to convert
+                # the str to a uuid
+                source_flow_id = uuid.UUID(source_flow)
+        elif isinstance(source_flow, uuid.UUID):
+            source_flow_id = source_flow
+
         # If metrics and/or checks are explicitly included, add them to the artifacts list,
         # but don't include them implicitly.
         implicitly_include_metrics = True
@@ -432,7 +468,7 @@ class Client:
             artifacts += checks
             implicitly_include_checks = False
 
-        cron_schedule = schedule_from_cron_string(schedule)
+        flow_schedule = generate_flow_schedule(schedule, source_flow_id)
 
         k_latest_runs_from_flow_config = config.k_latest_runs if config else None
         if k_latest_runs and k_latest_runs_from_flow_config:
@@ -466,7 +502,7 @@ class Client:
         dag.metadata = Metadata(
             name=name,
             description=description,
-            schedule=cron_schedule,
+            schedule=flow_schedule,
             retention_policy=retention_policy,
         )
         dag.set_engine_config(

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -50,6 +50,7 @@ class OperatorType(Enum, metaclass=MetaEnum):
 class TriggerType(Enum, metaclass=MetaEnum):
     MANUAL = "manual"
     PERIODIC = "periodic"
+    CASCADE = "cascade"
 
 
 class ServiceType(str, Enum, metaclass=MetaEnum):

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -28,6 +28,9 @@ class Schedule(BaseModel):
     trigger: Optional[TriggerType] = None
     cron_schedule: str = ""
     disable_manual_trigger: bool = False
+    # source_id refers to the source flow for this schedule when
+    # the trigger is TriggerType.CASCADE
+    source_id: Optional[uuid.UUID] = None
 
 
 class RetentionPolicy(BaseModel):

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -70,7 +70,13 @@ def is_string_valid_uuid(value: str) -> bool:
         return False
 
 
-def schedule_from_cron_string(schedule_str: str) -> Schedule:
+def generate_flow_schedule(
+    schedule_str: str, source_flow_id: Optional[uuid.UUID] = None
+) -> Schedule:
+    """Generates a flow schedule using the provided cron string and the source flow id if present."""
+    if source_flow_id:
+        return Schedule(trigger=TriggerType.CASCADE, source_id=source_flow_id)
+
     if len(schedule_str) == 0:
         return Schedule(trigger=TriggerType.MANUAL)
 

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -14,6 +14,7 @@ import (
 	mdl_utils "github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/vault"
+	"github.com/aqueducthq/aqueduct/lib/workflow"
 	dag_utils "github.com/aqueducthq/aqueduct/lib/workflow/dag"
 	operator_utils "github.com/aqueducthq/aqueduct/lib/workflow/operator"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
@@ -132,6 +133,21 @@ func (h *RegisterWorkflowHandler) Prepare(r *http.Request) (interface{}, int, er
 		} else {
 			return nil, http.StatusBadRequest, err
 		}
+	}
+
+	validateScheduleCode, err := workflow.ValidateSchedule(
+		r.Context(),
+		dagSummary.Dag.Metadata.Schedule,
+		dagSummary.Dag.EngineConfig.Type,
+		h.ArtifactRepo,
+		h.DAGRepo,
+		h.DAGEdgeRepo,
+		h.OperatorRepo,
+		h.WorkflowRepo,
+		h.Database,
+	)
+	if err != nil {
+		return nil, validateScheduleCode, err
 	}
 
 	return &registerWorkflowArgs{

--- a/src/golang/lib/collections/workflow/types.go
+++ b/src/golang/lib/collections/workflow/types.go
@@ -23,8 +23,9 @@ type Schedule struct {
 	CronSchedule         CronString    `json:"cron_schedule"`
 	DisableManualTrigger bool          `json:"disable_manual_trigger"`
 	Paused               bool          `json:"paused"`
-	// TriggerIDs are all of the Workflows that trigger this Schedule
-	TriggerIDs []uuid.UUID `json:"trigger_ids"`
+	// SourceID is the source Workflow that triggers this
+	// Workflow upon a successful run
+	SourceID uuid.UUID `json:"source_id"`
 }
 
 func (s *Schedule) Value() (driver.Value, error) {

--- a/src/golang/lib/collections/workflow/types.go
+++ b/src/golang/lib/collections/workflow/types.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 
 	"github.com/aqueducthq/aqueduct/lib/collections/utils"
+	"github.com/google/uuid"
 )
 
 type CronString string
@@ -11,9 +12,10 @@ type CronString string
 type UpdateTrigger string
 
 const (
-	ManualUpdateTrigger   UpdateTrigger = "manual"
-	PeriodicUpdateTrigger UpdateTrigger = "periodic"
-	AirflowUpdateTrigger  UpdateTrigger = "airflow"
+	ManualUpdateTrigger    UpdateTrigger = "manual"
+	PeriodicUpdateTrigger  UpdateTrigger = "periodic"
+	AirflowUpdateTrigger   UpdateTrigger = "airflow"
+	CascadingUpdateTrigger UpdateTrigger = "cascade"
 )
 
 type Schedule struct {
@@ -21,6 +23,8 @@ type Schedule struct {
 	CronSchedule         CronString    `json:"cron_schedule"`
 	DisableManualTrigger bool          `json:"disable_manual_trigger"`
 	Paused               bool          `json:"paused"`
+	// TriggerIDs are all of the Workflows that trigger this Schedule
+	TriggerIDs []uuid.UUID `json:"trigger_ids"`
 }
 
 func (s *Schedule) Value() (driver.Value, error) {

--- a/src/golang/lib/repos/sqlite/workflow.go
+++ b/src/golang/lib/repos/sqlite/workflow.go
@@ -68,15 +68,12 @@ func (*workflowReader) GetByOwnerAndName(ctx context.Context, ownerID uuid.UUID,
 	return getWorkflow(ctx, DB, query, args...)
 }
 
-func (*workflowReader) GetCascadingTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error) {
+func (*workflowReader) GetTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error) {
 	query := `
 		SELECT id FROM workflow
 		WHERE
 			json_extract(schedule, '$.trigger') = $1
-			AND EXISTS (
-				SELECT 1
-				FROM json_each(json_extract(schedule, '$.trigger_ids')) WHERE value = $2
-			)
+			AND json_extract(schedule, '$.source_id') = $2
 		;`
 	args := []interface{}{workflow.CascadingUpdateTrigger, ID}
 

--- a/src/golang/lib/repos/tests/workflow.go
+++ b/src/golang/lib/repos/tests/workflow.go
@@ -42,7 +42,7 @@ func (ts *TestSuite) TestWorkflow_GetByOwnerAndName() {
 	requireDeepEqual(ts.T(), workflow, actualWorkflow)
 }
 
-func (ts *TestSuite) TestWorkflow_GetCascadingTargets() {
+func (ts *TestSuite) TestWorkflow_GetTargets() {
 	triggerWorkflow := ts.seedWorkflow(1)[0]
 
 	// Create 2 Workflows where the schedule is a cascading update after
@@ -55,8 +55,8 @@ func (ts *TestSuite) TestWorkflow_GetCascadingTargets() {
 			randString(10),
 			randString(15),
 			&workflow.Schedule{
-				Trigger:    workflow.CascadingUpdateTrigger,
-				TriggerIDs: []uuid.UUID{triggerWorkflow.ID},
+				Trigger:  workflow.CascadingUpdateTrigger,
+				SourceID: triggerWorkflow.ID,
 			},
 			&workflow.RetentionPolicy{
 				KLatestRuns: 5,
@@ -68,7 +68,7 @@ func (ts *TestSuite) TestWorkflow_GetCascadingTargets() {
 		expectedIDs = append(expectedIDs, workflow.ID)
 	}
 
-	actualIDs, err := ts.workflow.GetCascadingTargets(ts.ctx, triggerWorkflow.ID, ts.DB)
+	actualIDs, err := ts.workflow.GetTargets(ts.ctx, triggerWorkflow.ID, ts.DB)
 	require.Nil(ts.T(), err)
 	require.ElementsMatch(ts.T(), expectedIDs, actualIDs)
 }

--- a/src/golang/lib/repos/tests/workflow.go
+++ b/src/golang/lib/repos/tests/workflow.go
@@ -42,6 +42,37 @@ func (ts *TestSuite) TestWorkflow_GetByOwnerAndName() {
 	requireDeepEqual(ts.T(), workflow, actualWorkflow)
 }
 
+func (ts *TestSuite) TestWorkflow_GetCascadingTargets() {
+	triggerWorkflow := ts.seedWorkflow(1)[0]
+
+	// Create 2 Workflows where the schedule is a cascading update after
+	// `triggerWorkflow` completes
+	expectedIDs := make([]uuid.UUID, 0, 2)
+	for i := 0; i < 2; i++ {
+		workflow, err := ts.workflow.Create(
+			ts.ctx,
+			triggerWorkflow.UserID,
+			randString(10),
+			randString(15),
+			&workflow.Schedule{
+				Trigger:    workflow.CascadingUpdateTrigger,
+				TriggerIDs: []uuid.UUID{triggerWorkflow.ID},
+			},
+			&workflow.RetentionPolicy{
+				KLatestRuns: 5,
+			},
+			ts.DB,
+		)
+		require.Nil(ts.T(), err)
+
+		expectedIDs = append(expectedIDs, workflow.ID)
+	}
+
+	actualIDs, err := ts.workflow.GetCascadingTargets(ts.ctx, triggerWorkflow.ID, ts.DB)
+	require.Nil(ts.T(), err)
+	require.ElementsMatch(ts.T(), expectedIDs, actualIDs)
+}
+
 func (ts *TestSuite) TestWorkflow_GetLatestStatusesByOrg() {
 	// TODO: Implement once DAG, DAGRun, and DAGResult collections are refactored
 }

--- a/src/golang/lib/repos/workflow.go
+++ b/src/golang/lib/repos/workflow.go
@@ -33,6 +33,10 @@ type workflowReader interface {
 	// It returns a database.ErrNoRows if no rows are found.
 	GetByOwnerAndName(ctx context.Context, ownerID uuid.UUID, name string, DB database.Database) (*models.Workflow, error)
 
+	// GetCascadingTargets returns an ID for each Workflow that should be triggered
+	// after the Workflow specified.
+	GetCascadingTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error)
+
 	// GetLastRunByEngine returns a WorkflowLastRun for each Workflow where the latest
 	// DAGResult created is associated with a DAG running on engine.
 	GetLastRunByEngine(ctx context.Context, engine shared.EngineType, DB database.Database) ([]views.WorkflowLastRun, error)

--- a/src/golang/lib/repos/workflow.go
+++ b/src/golang/lib/repos/workflow.go
@@ -33,9 +33,9 @@ type workflowReader interface {
 	// It returns a database.ErrNoRows if no rows are found.
 	GetByOwnerAndName(ctx context.Context, ownerID uuid.UUID, name string, DB database.Database) (*models.Workflow, error)
 
-	// GetCascadingTargets returns an ID for each Workflow that should be triggered
-	// after the Workflow specified.
-	GetCascadingTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error)
+	// GetTargets returns the ID of each Workflow where Schedule.SourceID
+	// is equal to ID.
+	GetTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error)
 
 	// GetLastRunByEngine returns a WorkflowLastRun for each Workflow where the latest
 	// DAGResult created is associated with a DAG running on engine.

--- a/src/golang/lib/workflow/validate.go
+++ b/src/golang/lib/workflow/validate.go
@@ -1,0 +1,77 @@
+package workflow
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/repos"
+	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
+	"github.com/dropbox/godropbox/errors"
+)
+
+const (
+	internalValidationErrMsg = "Internal system error occurred while validating Workflow schedule."
+)
+
+// ValidateSchedule validates the provided schedule. The following conditions are
+// not allowed:
+// - Having a CascadingUpdateTrigger where SourceID is for a Workflow that is
+// running on a non self-orchestrated engine, such as Airflow. This is not allowed
+// since Aqueduct cannot trigger Workflow runs at the end of execution on an
+// engine that is not self-orchestrated.
+// It returns an HTTP status code and a client-friendly error, if any.
+func ValidateSchedule(
+	ctx context.Context,
+	schedule workflow.Schedule,
+	engineType shared.EngineType,
+	artifactRepo repos.Artifact,
+	dagRepo repos.DAG,
+	dagEdgeRepo repos.DAGEdge,
+	operatorRepo repos.Operator,
+	workflowRepo repos.Workflow,
+	DB database.Database,
+) (int, error) {
+	if schedule.Trigger != workflow.CascadingUpdateTrigger {
+		// Only CascadingUpdateTriggers require validation
+		return http.StatusOK, nil
+	}
+
+	if engineType == shared.AirflowEngineType {
+		// TODO ENG-2202: Support cascading updates for Airflow target workflows
+		return http.StatusBadRequest, errors.New(
+			"We currently do not support providing a source Workflow for a Workflow running on Airflow.",
+		)
+	}
+
+	exists, err := workflowRepo.Exists(ctx, schedule.SourceID, DB)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, internalValidationErrMsg)
+	}
+
+	if !exists {
+		return http.StatusBadRequest, errors.New("The specified source Workflow does not exist.")
+	}
+
+	dag, err := utils.ReadLatestDAGFromDatabase(
+		ctx,
+		schedule.SourceID,
+		workflowRepo,
+		dagRepo,
+		operatorRepo,
+		artifactRepo,
+		dagEdgeRepo,
+		DB,
+	)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, internalValidationErrMsg)
+	}
+
+	if dag.EngineConfig.Type == shared.AirflowEngineType {
+		return http.StatusBadRequest, errors.New("Cannot use Workflows running on Airflow for the source.")
+	}
+
+	return http.StatusOK, nil
+}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds the `SourceID` field to the `Workflow.Schedule` column. This is necessary to support cascading updates. It also adds a method in the `Workflow` repo to get all target workflows for a given workflow. This is used to perform cascading updates at the end of workflow execution.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


