### PR TITLE
[2/3] Implements triggering target workflows at end of run execution

### DIFF
--- a/src/golang/cmd/executor/executor/workflow.go
+++ b/src/golang/cmd/executor/executor/workflow.go
@@ -108,7 +108,7 @@ func (ex *WorkflowExecutor) Run(ctx context.Context) error {
 // TriggerCascadingFlows triggers a new Workflow run for all Workflows (if any)
 // that are scheduled to run after this Workflow.
 func (ex *WorkflowExecutor) TriggerCascadingFlows(ctx context.Context) error {
-	targetIDs, err := ex.WorkflowRepo.GetCascadingTargets(ctx, ex.WorkflowID, ex.Database)
+	targetIDs, err := ex.WorkflowRepo.GetTargets(ctx, ex.WorkflowID, ex.Database)
 	if err != nil {
 		return err
 	}

--- a/src/golang/cmd/executor/executor/workflow.go
+++ b/src/golang/cmd/executor/executor/workflow.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/param"
 	"github.com/aqueducthq/aqueduct/lib/engine"
 	"github.com/aqueducthq/aqueduct/lib/job"
+	"github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
 	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
 	"github.com/google/uuid"
@@ -18,7 +19,7 @@ const pollingIntervalMS = time.Millisecond * 500
 type WorkflowExecutor struct {
 	*BaseExecutor
 
-	WorkflowId    uuid.UUID
+	WorkflowID    uuid.UUID
 	GithubManager github.Manager
 	Engine        engine.Engine
 
@@ -28,7 +29,7 @@ type WorkflowExecutor struct {
 }
 
 func NewWorkflowExecutor(spec *job.WorkflowSpec, base *BaseExecutor) (*WorkflowExecutor, error) {
-	workflowId, err := uuid.Parse(spec.WorkflowId)
+	workflowID, err := uuid.Parse(spec.WorkflowId)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +55,7 @@ func NewWorkflowExecutor(spec *job.WorkflowSpec, base *BaseExecutor) (*WorkflowE
 
 	return &WorkflowExecutor{
 		BaseExecutor:  base,
-		WorkflowId:    workflowId,
+		WorkflowID:    workflowID,
 		GithubManager: githubManager,
 		Engine:        eng,
 		Parameters:    spec.Parameters,
@@ -77,7 +78,7 @@ func (ex *WorkflowExecutor) Run(ctx context.Context) error {
 
 	status, err := ex.Engine.ExecuteWorkflow(
 		ctx,
-		ex.WorkflowId,
+		ex.WorkflowID,
 		&engine.AqueductTimeConfig{
 			OperatorPollInterval: pollingIntervalMS,
 			ExecTimeout:          engine.DefaultExecutionTimeout,
@@ -90,9 +91,44 @@ func (ex *WorkflowExecutor) Run(ctx context.Context) error {
 	}
 
 	log.WithFields(log.Fields{
-		"WorkflowId": ex.WorkflowId,
+		"WorkflowId": ex.WorkflowID,
 		"Parameters": ex.Parameters,
 	}).Infof("Workflow run completed with status: %v", status)
+
+	if err := ex.TriggerCascadingFlows(ctx); err != nil {
+		log.WithFields(log.Fields{
+			"WorkflowId": ex.WorkflowID,
+		}).Error("Unable to trigger cascading Workflows")
+		return err
+	}
+
+	return nil
+}
+
+// TriggerCascadingFlows triggers a new Workflow run for all Workflows (if any)
+// that are scheduled to run after this Workflow.
+func (ex *WorkflowExecutor) TriggerCascadingFlows(ctx context.Context) error {
+	targetIDs, err := ex.WorkflowRepo.GetCascadingTargets(ctx, ex.WorkflowID, ex.Database)
+	if err != nil {
+		return err
+	}
+
+	for _, targetID := range targetIDs {
+		_, err := ex.Engine.TriggerWorkflow(
+			ctx,
+			targetID,
+			lib_utils.AppendPrefix(targetID.String()),
+			&engine.AqueductTimeConfig{
+				OperatorPollInterval: engine.DefaultPollIntervalMillisec,
+				ExecTimeout:          engine.DefaultExecutionTimeout,
+				CleanupTimeout:       engine.DefaultCleanupTimeout,
+			},
+			nil, /*parameters*/
+		)
+		if err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -14,6 +14,7 @@ import (
 	mdl_utils "github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/vault"
+	"github.com/aqueducthq/aqueduct/lib/workflow"
 	dag_utils "github.com/aqueducthq/aqueduct/lib/workflow/dag"
 	operator_utils "github.com/aqueducthq/aqueduct/lib/workflow/operator"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
@@ -132,6 +133,21 @@ func (h *RegisterWorkflowHandler) Prepare(r *http.Request) (interface{}, int, er
 		} else {
 			return nil, http.StatusBadRequest, err
 		}
+	}
+
+	validateScheduleCode, err := workflow.ValidateSchedule(
+		r.Context(),
+		dagSummary.Dag.Metadata.Schedule,
+		dagSummary.Dag.EngineConfig.Type,
+		h.ArtifactRepo,
+		h.DAGRepo,
+		h.DAGEdgeRepo,
+		h.OperatorRepo,
+		h.WorkflowRepo,
+		h.Database,
+	)
+	if err != nil {
+		return nil, validateScheduleCode, err
 	}
 
 	return &registerWorkflowArgs{

--- a/src/golang/lib/workflow/validate.go
+++ b/src/golang/lib/workflow/validate.go
@@ -1,0 +1,77 @@
+package workflow
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/aqueducthq/aqueduct/lib/collections/shared"
+	"github.com/aqueducthq/aqueduct/lib/collections/workflow"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/repos"
+	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
+	"github.com/dropbox/godropbox/errors"
+)
+
+const (
+	internalValidationErrMsg = "Internal system error occurred while validating Workflow schedule."
+)
+
+// ValidateSchedule validates the provided schedule. The following conditions are
+// not allowed:
+// - Having a CascadingUpdateTrigger where SourceID is for a Workflow that is
+// running on a non self-orchestrated engine, such as Airflow. This is not allowed
+// since Aqueduct cannot trigger Workflow runs at the end of execution on an
+// engine that is not self-orchestrated.
+// It returns an HTTP status code and a client-friendly error, if any.
+func ValidateSchedule(
+	ctx context.Context,
+	schedule workflow.Schedule,
+	engineType shared.EngineType,
+	artifactRepo repos.Artifact,
+	dagRepo repos.DAG,
+	dagEdgeRepo repos.DAGEdge,
+	operatorRepo repos.Operator,
+	workflowRepo repos.Workflow,
+	DB database.Database,
+) (int, error) {
+	if schedule.Trigger != workflow.CascadingUpdateTrigger {
+		// Only CascadingUpdateTriggers require validation
+		return http.StatusOK, nil
+	}
+
+	if engineType == shared.AirflowEngineType {
+		// TODO ENG-2202: Support cascading updates for Airflow target workflows
+		return http.StatusBadRequest, errors.New(
+			"We currently do not support providing a source Workflow for a Workflow running on Airflow.",
+		)
+	}
+
+	exists, err := workflowRepo.Exists(ctx, schedule.SourceID, DB)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, internalValidationErrMsg)
+	}
+
+	if !exists {
+		return http.StatusBadRequest, errors.New("The specified source Workflow does not exist.")
+	}
+
+	dag, err := utils.ReadLatestDAGFromDatabase(
+		ctx,
+		schedule.SourceID,
+		workflowRepo,
+		dagRepo,
+		operatorRepo,
+		artifactRepo,
+		dagEdgeRepo,
+		DB,
+	)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, internalValidationErrMsg)
+	}
+
+	if dag.EngineConfig.Type == shared.AirflowEngineType {
+		return http.StatusBadRequest, errors.New("Cannot use Workflows running on Airflow for the source.")
+	}
+
+	return http.StatusOK, nil
+}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds support for triggering target workflows at the end of each workflow run. This is necessary to support cascading updates.

## Related issue number (if any)
ENG 82

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


