### PR TITLE
Changes target workflow trigger to manual when source workflow is deleted

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
@@ -43,7 +43,7 @@ def test_delete_source_workflow(client, flow_name, data_integration, engine):
     )
 
     # Delete source flow
-    client.delete_flow(flow.id())
+    client.delete_flow(source_flow.id())
 
 
 def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integration, engine):


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds support for changing the schedule trigger of a target workflow to `MANUAL` when its source workflow is deleted.

## Related issue number (if any)
ENG 2197

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


