### PR TITLE
Don't panic when error sending stats to Loki

### DIFF
--- a/src/golang/cmd/server/middleware/usage/usage.go
+++ b/src/golang/cmd/server/middleware/usage/usage.go
@@ -88,7 +88,7 @@ func reportUsage(startTime time.Time, environment string, statusCode int, urlPat
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Errorf("Failed to send request to loki: %v", err)
-		panic(err)
+		return
 	}
 	defer resp.Body.Close()
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
When we panic, it kills the whole server, which is not what we want. Now we just log the error and return, so the server keeps running.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


