### PR TITLE
Prevents cycles in cascading workflows

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
@@ -3,10 +3,47 @@ import pytest
 from aqueduct.constants.enums import LoadUpdateMode
 from aqueduct.error import InvalidRequestError, InvalidUserArgumentException
 
+import aqueduct
+from aqueduct import op
+
 from ..shared.data_objects import DataObject
 from ..shared.relational import SHORT_SENTIMENT_SQL_QUERY, all_relational_DBs
 from ..shared.utils import extract, generate_table_name, publish_flow_test
 from .save import save
+
+
+def test_delete_source_workflow(client, flow_name, data_integration, engine):
+    """Tests deleting a flow that is the source of another flow that has a cascading trigger."""
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+
+    @op
+    def noop(input):
+        return input
+
+    output_artifact = noop(table_artifact)
+
+    # Create a source flow
+    source_name = flow_name()
+    source_flow = publish_flow_test(
+        client,
+        name=source_name,
+        artifacts=output_artifact,
+        engine=engine,
+        schedule=aqueduct.daily(),
+    )
+
+    # Create a flow that is set to run after the above source_flow
+    name = flow_name()
+    flow = publish_flow_test(
+        client,
+        name=name,
+        artifacts=output_artifact,
+        engine=engine,
+        source_flow=source_flow,
+    )
+
+    # Delete source flow
+    client.delete_flow(source_flow.id())
 
 
 def test_delete_workflow_invalid_saved_objects(client, flow_name, data_integration, engine):

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -137,6 +137,8 @@ func (h *RegisterWorkflowHandler) Prepare(r *http.Request) (interface{}, int, er
 
 	validateScheduleCode, err := workflow.ValidateSchedule(
 		r.Context(),
+		isUpdate,
+		dagSummary.Dag.WorkflowID,
 		dagSummary.Dag.Metadata.Schedule,
 		dagSummary.Dag.EngineConfig.Type,
 		h.ArtifactRepo,

--- a/src/golang/lib/graph/directed.go
+++ b/src/golang/lib/graph/directed.go
@@ -1,0 +1,45 @@
+package graph
+
+import "github.com/google/uuid"
+
+type Directed struct {
+	nodes map[uuid.UUID]*node
+}
+
+// NewDirected returns an empty directed graph.
+func NewDirected() *Directed {
+	return &Directed{
+		nodes: make(map[uuid.UUID]*node),
+	}
+}
+
+// AddNode adds a new node. It does nothing if the node already exists.
+func (g *Directed) AddNode(nodeID uuid.UUID) {
+	if _, ok := g.nodes[nodeID]; !ok {
+		g.nodes[nodeID] = &node{id: nodeID}
+	}
+}
+
+// AddEdge adds a directed edge from node fromID to node toID.
+func (g *Directed) AddEdge(fromID uuid.UUID, toID uuid.UUID) {
+	g.nodes[fromID].edges = append(g.nodes[fromID].edges, toID)
+}
+
+// HasPath returns whether there is a path from root to dest.
+func (g *Directed) HasPath(root uuid.UUID, dest uuid.UUID) bool {
+	var queue []uuid.UUID
+	queue = append(queue, g.nodes[root].edges...)
+
+	for len(queue) > 0 {
+		root = queue[0]
+		queue = queue[1:]
+
+		if root == dest {
+			return true
+		}
+
+		queue = append(queue, g.nodes[root].edges...)
+	}
+
+	return false
+}

--- a/src/golang/lib/graph/node.go
+++ b/src/golang/lib/graph/node.go
@@ -1,0 +1,8 @@
+package graph
+
+import "github.com/google/uuid"
+
+type node struct {
+	id    uuid.UUID
+	edges []uuid.UUID
+}

--- a/src/golang/lib/repos/sqlite/workflow.go
+++ b/src/golang/lib/repos/sqlite/workflow.go
@@ -68,6 +68,22 @@ func (*workflowReader) GetByOwnerAndName(ctx context.Context, ownerID uuid.UUID,
 	return getWorkflow(ctx, DB, query, args...)
 }
 
+func (*workflowReader) GetByScheduleTrigger(
+	ctx context.Context,
+	trigger workflow.UpdateTrigger,
+	DB database.Database,
+) ([]models.Workflow, error) {
+	query := fmt.Sprintf(
+		`SELECT %s FROM workflow WHERE
+			json_extract(schedule, '$.trigger') = $1;
+		`,
+		models.WorkflowCols(),
+	)
+	args := []interface{}{trigger}
+
+	return getWorkflows(ctx, DB, query, args...)
+}
+
 func (*workflowReader) GetTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error) {
 	query := `
 		SELECT id FROM workflow

--- a/src/golang/lib/repos/workflow.go
+++ b/src/golang/lib/repos/workflow.go
@@ -33,6 +33,9 @@ type workflowReader interface {
 	// It returns a database.ErrNoRows if no rows are found.
 	GetByOwnerAndName(ctx context.Context, ownerID uuid.UUID, name string, DB database.Database) (*models.Workflow, error)
 
+	// GetByScheduleTrigger returns all Workflows where Schedule.Trigger is equal to trigger.
+	GetByScheduleTrigger(ctx context.Context, trigger workflow.UpdateTrigger, DB database.Database) ([]models.Workflow, error)
+
 	// GetTargets returns the ID of each Workflow where Schedule.SourceID
 	// is equal to ID.
 	GetTargets(ctx context.Context, ID uuid.UUID, DB database.Database) ([]uuid.UUID, error)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR prevents cycles in cascading workflows.

## Related issue number (if any)
ENG 2198

Testing: I manually tested to ensure that an error is returned on the SDK when a user forms a cycle. I am currently adding integration test cases for this (and also add unit tests for the graph cycle detection code).

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


