### PR TITLE
Bugfix: Fix table row height

### DIFF
--- a/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
@@ -147,8 +147,8 @@ export const CheckItem: React.FC<CheckItemProps> = ({ checks }) => {
       sx={{
         display: 'flex',
         alignItems: 'center',
+        minHeight: '48px',
       }}
-      height="48px"
     >
       {checks.length > 0 ? (
         <Box sx={cellStyling}>

--- a/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
@@ -110,8 +110,8 @@ const MetricItem: React.FC<MetricItemProps> = ({ metrics }) => {
       sx={{
         display: 'flex',
         alignItems: 'center',
+        minHeight: '48px',
       }}
-      height="48px"
     >
       {metrics.length > 0 ? (
         <Box sx={cellStyling}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Updated table row to have a set height but this resulted in a bug that causes the text to overflow when maximizing the checks or metrics list. This bug is resolved by setting the MIN height to that height instead.

## Related issue number (if any)
N/A

## Loom demo (if any)
Before:
<img width="1376" alt="Screen Shot 2023-01-10 at 10 58 44 AM" src="https://user-images.githubusercontent.com/30596854/211639049-940f7e13-4db3-49c0-9ea3-fc36e44de0aa.png">

After:
<img width="1376" alt="Screen Shot 2023-01-10 at 11 02 52 AM" src="https://user-images.githubusercontent.com/30596854/211639042-22f1d2d0-8611-4223-a558-df33ac32e1ac.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


