### PR TITLE
Removes erroring step from periodic integration test

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -19,11 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # For now, we want to always perform inference in our periodic tests for additional coverage.
-      - name: Remove the requirements.txt file.
-        working-directory: integration_tests/sdk
-        run: rm requirements.txt
-
       - name: Create the logs directory
         run: mkdir -p logs
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Periodic tests have been failing with the [following error](https://github.com/aqueducthq/aqueduct/actions/runs/3884579549/jobs/6627331601#step:4:6):
```

Run rm requirements.txt

rm: cannot remove 'requirements.txt': No such file or directory

Error: Process completed with exit code 1.
```

This removes the step causing the error. Results of this test can be found here: https://github.com/aqueducthq/aqueduct/actions/runs/3895323545/jobs/6650495413
## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


