### PR TITLE
[1/2] Refactor Integration Tests in preparation for S3 Data Integration Tests

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/checks_test.py
+++ b/integration_tests/sdk/aqueduct_tests/checks_test.py
@@ -6,7 +6,8 @@ from aqueduct.error import AqueductError, ArtifactNotFoundException, InvalidUser
 from aqueduct import check
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract, publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
+from .extract import extract
 from .test_functions.simple.model import dummy_sentiment_model
 from .test_metrics.constant.model import constant_metric
 

--- a/integration_tests/sdk/aqueduct_tests/conftest.py
+++ b/integration_tests/sdk/aqueduct_tests/conftest.py
@@ -1,6 +1,13 @@
 import pytest
 from aqueduct.constants.enums import ServiceType
 
+from .data_validator import DataValidator
+
+
+@pytest.fixture(scope="function")
+def data_validator(client, data_integration):
+    return DataValidator(client, data_integration)
+
 
 @pytest.fixture(autouse=True)
 def enable_only_for_data_integration_type(request, client, data_integration):

--- a/integration_tests/sdk/aqueduct_tests/data_integration_test.py
+++ b/integration_tests/sdk/aqueduct_tests/data_integration_test.py
@@ -2,7 +2,7 @@ import pytest
 from aqueduct.error import InvalidIntegrationException
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 from .save import save
 from .test_functions.simple.model import dummy_sentiment_model
 

--- a/integration_tests/sdk/aqueduct_tests/data_validator.py
+++ b/integration_tests/sdk/aqueduct_tests/data_validator.py
@@ -1,0 +1,58 @@
+import uuid
+from typing import Any
+
+import pandas as pd
+from aqueduct.models.integration import Integration
+
+from aqueduct import Client, Flow
+
+from ..shared.globals import artifact_id_to_saved_identifier
+from ..shared.validation import fetch_and_validate_saved_object_identifier
+from .extract import extract
+
+
+class DataValidator:
+    """Tests can request an instance of this class as a fixture, and use it to validate published flow runs."""
+
+    _client: Client
+    _integration: Integration
+
+    def __init__(self, client: Client, integration: Integration):
+        self._client = client
+        self._integration = integration
+
+    def check_saved_artifact_data(
+        self, flow: Flow, artifact_id: uuid.UUID, expected_data: Any
+    ) -> None:
+        """Checks that the given artifact was saved by the flow, and the data integration has the expected data.
+
+        The exact destination of the artifact is tracked internally by the test suite.
+        """
+        assert expected_data is not None
+        saved_object_identifier = fetch_and_validate_saved_object_identifier(
+            self._integration, flow, artifact_id
+        )
+
+        # Verify the artifact's actual data state in the data integration.
+        saved_data = extract(self._integration, saved_object_identifier).get()
+        if not isinstance(saved_data, pd.DataFrame):
+            raise Exception(
+                "This method is expected to only deal with pandas Dataframe types."
+                "For more extensive third-party type coverage, please write data integration "
+                "tests instead."
+            )
+        assert isinstance(saved_data, pd.DataFrame)
+        if not saved_data.equals(expected_data):
+            print("Expected data: ", expected_data)
+            print("Actual data: ", saved_data)
+            raise Exception("Mismatch between expected and actual saved data.")
+
+    def check_saved_artifact_data_does_not_exist(self, artifact_id: uuid.UUID) -> None:
+        """Checks that the data integration no longer has the artifact's data stored."""
+        saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
+        try:
+            extract(self._integration, saved_object_identifier)
+        except Exception:
+            return
+
+        raise Exception("Artifact %s is expected to no longer exist, but does." % artifact_id)

--- a/integration_tests/sdk/aqueduct_tests/error_handling_test.py
+++ b/integration_tests/sdk/aqueduct_tests/error_handling_test.py
@@ -5,7 +5,7 @@ import aqueduct
 from aqueduct import op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 
 
 @aqueduct.op()

--- a/integration_tests/sdk/aqueduct_tests/extract.py
+++ b/integration_tests/sdk/aqueduct_tests/extract.py
@@ -1,0 +1,32 @@
+from typing import Optional, Union
+
+from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.constants.enums import ArtifactType
+from aqueduct.integrations.s3_integration import S3Integration
+from aqueduct.integrations.sql_integration import RelationalDBIntegration
+
+from sdk.shared.data_objects import DataObject
+
+
+def extract(
+    integration,
+    obj_identifier: Union[DataObject, str],
+    op_name: Optional[str] = None,
+    lazy: bool = False,
+) -> BaseArtifact:
+    """Reads the specified object in from the integration and returns it as an artifact.
+
+    Assumption: the object is a pandas dataframe, serialized in a particular fashion in each integration.
+    This serialization method should match what is done in `save()`.
+    """
+    if isinstance(obj_identifier, DataObject):
+        obj_identifier = obj_identifier.value
+
+    assert isinstance(obj_identifier, str)
+    if isinstance(integration, RelationalDBIntegration):
+        return integration.sql(query="SELECT * from %s" % obj_identifier, name=op_name, lazy=lazy)
+    elif isinstance(integration, S3Integration):
+        return integration.file(
+            obj_identifier, ArtifactType.TABLE, "parquet", name=op_name, lazy=lazy
+        )
+    raise Exception("Unexpected data integration type provided in test: %s", type(integration))

--- a/integration_tests/sdk/aqueduct_tests/lazy_execution_test.py
+++ b/integration_tests/sdk/aqueduct_tests/lazy_execution_test.py
@@ -10,7 +10,8 @@ from aqueduct.error import InvalidUserArgumentException
 from aqueduct import check, global_config, metric, op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract, publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
+from .extract import extract
 from .save import save
 
 
@@ -217,7 +218,7 @@ def test_lazy_artifacts_with_custom_parameters(client):
     assert doubled._get_content() is None  # do not manifest the contents!
 
 
-def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, validator):
+def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, data_validator):
     reviews = extract(data_integration, DataObject.SENTIMENT)
 
     @op()
@@ -234,6 +235,6 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, va
         name=flow_name(),
         engine=engine,
     )
-    validator.check_saved_artifact_data(
+    data_validator.check_saved_artifact_data(
         flow, review_copied.id(), expected_data=copy_field.local(reviews)
     )

--- a/integration_tests/sdk/aqueduct_tests/load_test.py
+++ b/integration_tests/sdk/aqueduct_tests/load_test.py
@@ -1,12 +1,14 @@
 from aqueduct.constants.enums import LoadUpdateMode
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract, generate_table_name, publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
+from ..shared.naming import generate_table_name
+from .extract import extract
 from .save import save
 
 
 def test_multiple_artifacts_saved_to_same_integration(
-    client, flow_name, data_integration, engine, validator
+    client, flow_name, data_integration, engine, data_validator
 ):
     table_1_save_name = generate_table_name()
     table_2_save_name = generate_table_name()
@@ -23,5 +25,5 @@ def test_multiple_artifacts_saved_to_same_integration(
         engine=engine,
     )
 
-    validator.check_saved_artifact_data(flow, table_1.id(), expected_data=table_1.get())
-    validator.check_saved_artifact_data(flow, table_2.id(), expected_data=table_2.get())
+    data_validator.check_saved_artifact_data(flow, table_1.id(), expected_data=table_1.get())
+    data_validator.check_saved_artifact_data(flow, table_2.id(), expected_data=table_2.get())

--- a/integration_tests/sdk/aqueduct_tests/local_test.py
+++ b/integration_tests/sdk/aqueduct_tests/local_test.py
@@ -2,8 +2,8 @@ from pandas import DataFrame
 from pandas._testing import assert_frame_equal
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
 from .checks_test import success_on_single_table_input
+from .extract import extract
 from .test_functions.simple.model import dummy_sentiment_model, dummy_sentiment_model_multiple_input
 from .test_metrics.constant.model import constant_metric
 

--- a/integration_tests/sdk/aqueduct_tests/metrics_test.py
+++ b/integration_tests/sdk/aqueduct_tests/metrics_test.py
@@ -5,7 +5,8 @@ from aqueduct.error import AqueductError
 from aqueduct import metric
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract, publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
+from .extract import extract
 from .test_metrics.constant.model import constant_metric
 
 

--- a/integration_tests/sdk/aqueduct_tests/mixed_compute_test.py
+++ b/integration_tests/sdk/aqueduct_tests/mixed_compute_test.py
@@ -4,7 +4,8 @@ from aqueduct.constants.enums import ServiceType
 from aqueduct import op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract, publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
+from .extract import extract
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)

--- a/integration_tests/sdk/aqueduct_tests/multiple_output_test.py
+++ b/integration_tests/sdk/aqueduct_tests/multiple_output_test.py
@@ -3,7 +3,7 @@ from aqueduct.error import AqueductError
 
 from aqueduct import op
 
-from ..shared.utils import publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
 
 
 def test_multiple_outputs(client, flow_name, engine):

--- a/integration_tests/sdk/aqueduct_tests/naming_test.py
+++ b/integration_tests/sdk/aqueduct_tests/naming_test.py
@@ -2,7 +2,7 @@ import pytest
 from aqueduct.error import ArtifactNotFoundException, InvalidUserActionException
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 from .test_functions.simple.model import (
     dummy_model,
     dummy_model_2,

--- a/integration_tests/sdk/aqueduct_tests/no_input_test.py
+++ b/integration_tests/sdk/aqueduct_tests/no_input_test.py
@@ -3,7 +3,7 @@ import pandas as pd
 from aqueduct import op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 
 
 @op

--- a/integration_tests/sdk/aqueduct_tests/no_return_test.py
+++ b/integration_tests/sdk/aqueduct_tests/no_return_test.py
@@ -1,6 +1,6 @@
 from aqueduct import op
 
-from ..shared.utils import publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
 
 
 @op

--- a/integration_tests/sdk/aqueduct_tests/operator_hierarchy_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_hierarchy_test.py
@@ -4,7 +4,7 @@ from aqueduct.error import InvalidUserActionException
 from aqueduct import check, metric, op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 
 
 @check()

--- a/integration_tests/sdk/aqueduct_tests/operator_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_test.py
@@ -4,7 +4,7 @@ from aqueduct import op
 from sdk.aqueduct_tests.test_function import dummy_sentiment_model_function
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 
 
 def test_to_operator_local_function(client, data_integration):

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -15,8 +15,9 @@ from pandas._testing import assert_frame_equal
 from aqueduct import metric, op
 
 from ..shared.data_objects import DataObject
+from ..shared.flow_helpers import publish_flow_test, trigger_flow_test
 from ..shared.relational import all_relational_DBs
-from ..shared.utils import extract, publish_flow_test, trigger_flow_test
+from .extract import extract
 
 
 @metric

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -6,7 +6,7 @@ from aqueduct.error import AqueductError, InvalidDependencyFilePath, InvalidFunc
 from aqueduct import global_config, op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 from .test_functions.simple.file_dependency_model import (
     model_with_file_dependency,
     model_with_improper_dependency_path,

--- a/integration_tests/sdk/aqueduct_tests/resources_test.py
+++ b/integration_tests/sdk/aqueduct_tests/resources_test.py
@@ -6,7 +6,7 @@ from aqueduct.error import AqueductError, InvalidUserArgumentException
 
 from aqueduct import global_config, op
 
-from ..shared.utils import publish_flow_test
+from ..shared.flow_helpers import publish_flow_test
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)

--- a/integration_tests/sdk/aqueduct_tests/save.py
+++ b/integration_tests/sdk/aqueduct_tests/save.py
@@ -8,7 +8,7 @@ from aqueduct.integrations.sql_integration import RelationalDBIntegration
 from aqueduct import LoadUpdateMode
 
 from ..shared.globals import artifact_id_to_saved_identifier, use_deprecated_code_paths
-from ..shared.utils import generate_table_name
+from ..shared.naming import generate_table_name
 
 
 def save(

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -6,7 +6,7 @@ import pandas as pd
 from aqueduct import op
 
 from ..shared.data_objects import DataObject
-from ..shared.utils import extract
+from .extract import extract
 
 
 def test_great_expectations_check(client, data_integration):

--- a/integration_tests/sdk/aqueduct_tests/type_enforcement_test.py
+++ b/integration_tests/sdk/aqueduct_tests/type_enforcement_test.py
@@ -6,7 +6,7 @@ from aqueduct.error import AqueductError
 
 from aqueduct import op
 
-from ..shared.utils import publish_flow_test, trigger_flow_test
+from ..shared.flow_helpers import publish_flow_test, trigger_flow_test
 
 
 @op

--- a/integration_tests/sdk/data_integration_tests/conftest.py
+++ b/integration_tests/sdk/data_integration_tests/conftest.py
@@ -6,7 +6,11 @@ import pytest
 # If a disallowed data integration is used, all tests in the file will be skipped.
 from aqueduct.constants.enums import ServiceType
 
-allowed_data_integrations_by_file = {"relational_test": [ServiceType.SQLITE, ServiceType.SNOWFLAKE]}
+from sdk.data_integration_tests.flow_manager import FlowManager
+
+allowed_data_integrations_by_file = {
+    "relational_test": [ServiceType.SQLITE, ServiceType.SNOWFLAKE],
+}
 
 
 @pytest.fixture(autouse=True)
@@ -34,3 +38,15 @@ def filter_tests_based_on_data_integrations(request, client, data_integration):
             "Skipped for data integration `%s`, since it is not of type `%s`."
             % (data_integration._metadata.name, ",".join(allowed_data_integrations))
         )
+
+
+@pytest.fixture
+def flow_manager(client, flow_name, engine):
+    """This a purely a convenience fixture to package some flow-related fields together that
+    data integration tests usually don't care about.
+
+    This allows test cases in this suite to import one fixture in order to publish flows,
+    instead of three. Data Integration tests usually don't care about how flows are published,
+    as it is mostly a mechanism by which data can be saved.
+    """
+    return FlowManager(client, flow_name, engine)

--- a/integration_tests/sdk/data_integration_tests/flow_manager.py
+++ b/integration_tests/sdk/data_integration_tests/flow_manager.py
@@ -1,0 +1,52 @@
+from typing import Callable, List, Optional, Union
+
+from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.constants.enums import ExecutionStatus
+
+from aqueduct import Client, Flow
+from sdk.shared.flow_helpers import publish_flow_test
+
+
+class FlowManager:
+    """This is a convenience class that packages a couple of flow-specific fields together.
+
+    It abstracts away the publishing of flows from data integration test cases, which usually
+    don't care about things like flow name and engine, and just want to publish flows as the
+    only mechanism for saving data. It is imported into test cases as a fixture, to simplify
+    the test signature.
+    """
+
+    _client: Client
+    _flow_name_fn: Callable[..., str]
+    _engine: Optional[str]
+
+    def __init__(self, client, flow_name, engine):
+        self._client = client
+        self._flow_name_fn = flow_name
+        self._engine = engine
+
+    def publish_flow_test(
+        self,
+        artifacts: Union[BaseArtifact, List[BaseArtifact]],
+        expected_statuses: Union[
+            ExecutionStatus, List[ExecutionStatus]
+        ] = ExecutionStatus.SUCCEEDED,
+        existing_flow: Optional[Flow] = None,
+    ) -> Flow:
+        """This is a simplified wrapper around `publish_flow_test()`, built with data integration test in mind."""
+        if existing_flow is not None:
+            return publish_flow_test(
+                self._client,
+                artifacts=artifacts,
+                expected_statuses=expected_statuses,
+                existing_flow=existing_flow,
+                engine=self._engine,
+            )
+        else:
+            return publish_flow_test(
+                self._client,
+                name=self._flow_name_fn(),
+                artifacts=artifacts,
+                expected_statuses=expected_statuses,
+                engine=self._engine,
+            )

--- a/integration_tests/sdk/data_integration_tests/relational_data_validator.py
+++ b/integration_tests/sdk/data_integration_tests/relational_data_validator.py
@@ -1,0 +1,83 @@
+import uuid
+from typing import Any, List, Tuple
+
+import pandas as pd
+from aqueduct.constants.enums import LoadUpdateMode
+from aqueduct.integrations.sql_integration import RelationalDBIntegration
+from aqueduct.models.operators import RelationalDBLoadParams
+
+from aqueduct import Client, Flow
+
+from ..shared.validation import fetch_and_validate_saved_object_identifier
+
+
+class RelationalDataValidator:
+    """Tests can request an instance of this class as a fixture, and use it to validate published flow runs."""
+
+    _client: Client
+    _integration: RelationalDBIntegration
+
+    def __init__(self, client: Client, integration: RelationalDBIntegration):
+        self._client = client
+        self._integration = integration
+
+    def check_saved_artifact_data(
+        self, flow: Flow, artifact_id: uuid.UUID, expected_data: Any
+    ) -> None:
+        """Checks that the given artifact was saved by the flow, and the data integration has the expected data.
+
+        The exact destination of the artifact is tracked internally by the test suite.
+        """
+        assert expected_data is not None
+        saved_object_identifier = fetch_and_validate_saved_object_identifier(
+            self._integration, flow, artifact_id
+        )
+
+        # Verify the artifact's actual data state in the data integration.
+        saved_data = self._integration.sql(query="SELECT * from %s" % saved_object_identifier).get()
+        assert isinstance(saved_data, pd.DataFrame)
+        if not saved_data.equals(expected_data):
+            print("Expected data: ", expected_data)
+            print("Actual data: ", saved_data)
+            raise Exception("Mismatch between expected and actual saved data.")
+
+    def check_saved_update_mode_changes(
+        self,
+        flow: Flow,
+        expected_updates: List[Tuple[str, LoadUpdateMode]],
+        order_matters: bool = True,
+    ):
+        """Checks the exact result of flow.list_saved_objects().
+
+        When `order_matters=True`, the provided `expected_updates` list must match the fetched result exactly.
+        Note that the updates are typically ordered from most to least recent.
+        """
+        data = self._client.flow(flow.id()).list_saved_objects()
+
+        # Check all objects were saved to the same integration.
+        assert len(data.keys()) == 1
+        integration_name = list(data.keys())[0]
+        assert integration_name == self._integration._metadata.name
+
+        assert len(data[integration_name]) == len(expected_updates)
+        saved_objects = data[integration_name]
+
+        assert all(
+            isinstance(saved_object.spec.parameters, RelationalDBLoadParams)
+            for saved_object in saved_objects
+        )
+        actual_updates = [
+            (saved_objects[i].spec.parameters.table, saved_objects[i].spec.parameters.update_mode)
+            for i, (name, _) in enumerate(expected_updates)
+        ]
+
+        if order_matters:
+            assert expected_updates == actual_updates, "Expected %s, got %s." % (
+                expected_updates,
+                actual_updates,
+            )
+        else:
+            assert all(actual_update in expected_updates for actual_update in actual_updates)
+
+        # Check that mapping can be accessed by integration object too.
+        assert data[self._integration] == data[integration_name]

--- a/integration_tests/sdk/data_integration_tests/relational_test.py
+++ b/integration_tests/sdk/data_integration_tests/relational_test.py
@@ -12,7 +12,6 @@ from aqueduct.models.operators import RelationalDBExtractParams
 from aqueduct import LoadUpdateMode, metric, op
 
 from ..shared.demo_db import demo_db_tables
-from ..shared.flow_helpers import publish_flow_test
 from ..shared.naming import generate_table_name
 from ..shared.relational import SHORT_SENTIMENT_SQL_QUERY
 from ..shared.validation import check_artifact_was_computed

--- a/integration_tests/sdk/data_integration_tests/save.py
+++ b/integration_tests/sdk/data_integration_tests/save.py
@@ -3,11 +3,14 @@ from aqueduct.artifacts.base_artifact import BaseArtifact
 from ..shared.globals import artifact_id_to_saved_identifier
 
 
-def save(integration, artifact: BaseArtifact, *args):
+def save(integration, artifact: BaseArtifact, *args, **kwargs):
     """Wrapper around integration.save() that also register's the save with the test suite,
     so that `validator.check_saved_artifact()` can be performed later.
     """
-    integration.save(artifact, *args)
+    assert (
+        len(args) > 0
+    ), "We assume the first non-keyword argument is the object identifier, so one must be supplied."
+    integration.save(artifact, *args, **kwargs)
 
     # The assumption across all our integration.save() methods is that the identifier
     # is always the argument immediately following the artifact.

--- a/integration_tests/sdk/data_integration_tests/validation_helpers.py
+++ b/integration_tests/sdk/data_integration_tests/validation_helpers.py
@@ -1,0 +1,17 @@
+from aqueduct.constants.enums import ArtifactType
+
+
+def check_hotel_reviews_table_artifact(hotel_reviews_artifact):
+    """Use to validate hotel_reviews table data is correct across all data integrations."""
+    assert hotel_reviews_artifact.type() == ArtifactType.TABLE
+    check_hotel_reviews_table_data(hotel_reviews_artifact.get())
+
+
+def check_hotel_reviews_table_data(hotel_reviews_data):
+    assert list(hotel_reviews_data) == [
+        "hotel_name",
+        "review_date",
+        "reviewer_nationality",
+        "review",
+    ]
+    assert hotel_reviews_data.shape[0] == 100

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -1,0 +1,203 @@
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Union
+
+from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.constants.enums import ExecutionStatus
+
+import aqueduct
+from aqueduct import Flow
+from sdk.shared.globals import flow_name_to_id
+
+
+def publish_flow_test(
+    client: aqueduct.Client,
+    artifacts: Union[BaseArtifact, List[BaseArtifact]],
+    engine: Optional[str],
+    expected_statuses: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
+    name: Optional[str] = None,
+    existing_flow: Optional[Flow] = None,
+    metrics: Optional[List[BaseArtifact]] = None,
+    checks: Optional[List[BaseArtifact]] = None,
+    schedule: str = "",
+    source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
+    should_block: bool = True,
+) -> Flow:
+    """Publishes a flow and waits for a specified number of runs with specified statuses to complete.
+
+    Args:
+        artifacts:
+            These are fed directly into client.publish_flow()
+        engine:
+            The engine to publish against.
+        expected_statuses:
+            The expected outcomes of the published flow's runs. This method will not return until these
+            are all satisfied or violated. It can be supplied as either a single status or a list of them.
+            When supplied as a list, the statuses are interpreted in chronologically ascending order. Eg.
+            [SUCCEEDED, FAILED} means I expect one successful run, followed by an unsuccessful one.
+
+            If publishing against a flow that already exists, previous runs will be disregarded. These
+            statuses are expectations about future runs of the flow.
+        name:
+            This is fed directly into client.publish_flow(). This is also registered with `flow_name_to_id`
+            for cleanup purposes.
+        existing_flow:
+            If we are publishing against a flow that already exists, that flow object must be provided.
+            Otherwise, `name` must be supplied.
+        metrics:
+        checks:
+        schedule:
+        source_flow:
+            These are fed directly into `publish_flow()`.
+        should_block:
+            When true (default), we return immediately after publishing, without waiting for the flows to complete.
+            Currently, the only reason this is ever false is if you need to spin up two flows at exactly the same
+            time, and then wait for both of them to complete afterwards.
+    """
+    assert (name or existing_flow) and not (
+        name and existing_flow
+    ), "Either `name` or `existing_flow` must be set (not both or neither)."
+
+    if existing_flow is not None:
+        name = existing_flow.name()
+    assert isinstance(name, str), "Flow name must be string, not %s type." % type(name)
+
+    # Check that if a new flow name is provided, the flow really does not exist.
+    if existing_flow is None:
+        flow_dicts = client.list_flows()
+        assert all(
+            flow_dict["name"] != name for flow_dict in flow_dicts
+        ), "You are publishing with a flow name that has already been published, please supply `existing_flow` instead."
+
+    num_prev_runs = len(existing_flow.list_runs()) if existing_flow is not None else 0
+    flow = client.publish_flow(
+        name=name,
+        artifacts=artifacts,
+        metrics=metrics,
+        checks=checks,
+        schedule=schedule,
+        engine=engine,
+        source_flow=source_flow,
+    )
+    print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
+
+    # Necessary so that the flow is cleaned up at the end of the test.
+    flow_name_to_id[name] = flow.id()
+
+    if should_block:
+        wait_for_flow_runs(
+            client,
+            flow.id(),
+            num_prev_runs=num_prev_runs,
+            expected_statuses=[expected_statuses]
+            if isinstance(expected_statuses, ExecutionStatus)
+            else expected_statuses,
+        )
+    return flow
+
+
+def trigger_flow_test(
+    client: aqueduct.Client,
+    flow: Flow,
+    expected_status: Union[ExecutionStatus, List[ExecutionStatus]] = ExecutionStatus.SUCCEEDED,
+    parameters: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Triggers the given flow, and waits for the expected runs to complete with expected statuses.
+
+    `expected_status` is interpreted the same way as in `publish_flow_test()` above.
+    """
+    num_prev_runs = len(flow.list_runs())
+    client.trigger(flow.id(), parameters=parameters)
+
+    wait_for_flow_runs(
+        client,
+        flow.id(),
+        num_prev_runs=num_prev_runs,
+        expected_statuses=[expected_status]
+        if isinstance(expected_status, ExecutionStatus)
+        else expected_status,
+    )
+
+
+def wait_for_flow_runs(
+    client: aqueduct.Client,
+    flow_id: uuid.UUID,
+    expected_statuses: List[ExecutionStatus],
+    num_prev_runs: int = 0,
+) -> None:
+    """Waits for a flow to complete len(expected_statuses) runs, with the expected statuses.
+
+    Statuses are sorted in chronologically ascending order. `num_prev_runs` denotes the number of
+    previous runs of the flow to ignore when checking new run statuses.
+
+    NOTE: This should only ever directly be used by a test when `publish_flow_test(..., should_block=True)`.
+          Otherwise, just use the publish and trigger helpers directly, instead of calling this.
+    """
+
+    def stop_condition(
+        client: aqueduct.Client,
+        flow_id: uuid.UUID,
+        expected_statuses: List[ExecutionStatus],
+        num_prev_runs: int,
+    ) -> bool:
+        if all(str(flow_id) != flow_dict["flow_id"] for flow_dict in client.list_flows()):
+            return False
+
+        flow = client.flow(flow_id)
+
+        # Last run is prepended to this list. We need to reverse it in order to compare with expected statuses,
+        # which is sorted in chronologically ascending order.
+        flow_runs = list(reversed(flow.list_runs()))[num_prev_runs:]
+        if len(flow_runs) < len(expected_statuses):
+            return False
+
+        statuses = [flow_run["status"] for flow_run in flow_runs]
+
+        # Continue checking as long as there are still runs pending.
+        if any(status == ExecutionStatus.PENDING for status in statuses):
+            return False
+
+        expect_status_strs = [status.value for status in expected_statuses]
+        assert statuses == expect_status_strs, (
+            "Unexpected workflow run status(es). In ascending chronological order (latest last), expected %s, got %s. "
+            % (expect_status_strs, statuses)
+        )
+
+        print(
+            "Workflow %s was created and ran successfully at least %s times!"
+            % (flow_id, len(flow_runs))
+        )
+        return True
+
+    polling(
+        lambda: stop_condition(client, flow_id, expected_statuses, num_prev_runs),
+        timeout=300,
+        poll_threshold=1,
+        timeout_comment="Timed out waiting for workflow run to complete.",
+    )
+
+
+def delete_flow(client: aqueduct.Client, workflow_id: uuid.UUID) -> None:
+    try:
+        client.delete_flow(str(workflow_id))
+    except Exception as e:
+        print("Error deleting workflow %s with exception: %s" % (workflow_id, e))
+    else:
+        print("Successfully deleted workflow %s" % (workflow_id))
+
+
+def polling(
+    stop_condition_fn,
+    timeout=60,
+    poll_threshold=5,
+    timeout_comment="Timed out waiting for workflow run to complete.",
+):
+    begin = time.time()
+
+    while True:
+        assert time.time() - begin < timeout, timeout_comment
+
+        if stop_condition_fn():
+            break
+        else:
+            time.sleep(poll_threshold)

--- a/integration_tests/sdk/shared/naming.py
+++ b/integration_tests/sdk/shared/naming.py
@@ -1,0 +1,14 @@
+import uuid
+
+
+def generate_new_flow_name() -> str:
+    return "test_" + uuid.uuid4().hex
+
+
+def generate_table_name() -> str:
+    return "test_table_" + uuid.uuid4().hex[:24]
+
+
+def generate_object_name() -> str:
+    """For non-relational data integrations."""
+    return "test_object_" + uuid.uuid4().hex[:24]

--- a/integration_tests/sdk/shared/validation.py
+++ b/integration_tests/sdk/shared/validation.py
@@ -1,0 +1,26 @@
+import uuid
+
+from aqueduct.models.integration import Integration
+
+from aqueduct import Client, Flow
+from sdk.shared.globals import artifact_id_to_saved_identifier
+
+"""These helpers are shared across both integration test suites."""
+
+
+def fetch_and_validate_saved_object_identifier(
+    data_integration: Integration, flow: Flow, artifact_id: uuid.UUID
+) -> str:
+    """Validates that the saved object exists according to the Flow API."""
+    all_saved_objects = flow.list_saved_objects()[data_integration._metadata.name]
+    all_saved_object_identifiers = [item.spec.identifier() for item in all_saved_objects]
+
+    saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
+    assert saved_object_identifier in all_saved_object_identifiers
+    return saved_object_identifier
+
+
+def check_artifact_was_computed(flow: Flow, name: str):
+    """Checks only for the artifact computed in the latest flow run."""
+    artifact = flow.latest().artifact(name)
+    assert artifact is not None


### PR DESCRIPTION
## Describe your changes and why you are making these changes
As I was building the S3 data integration tests, I realized there were some additional improvements I could make to make our lives way easier, described below:

- Moved the Validator class from `shared/` into the test suites themselves. Having a single shared validator in `shared/validator.py` is incorrect between the two test suites make different assumptions about the data integrations. For example, the old Validator would only perform extracts in a very specific way - this didn't matter for relational databases since it's all SQL, but it does not take into consideration the many data formats and types that could be stored in S3. So, now the Aqueduct Tests have a DataValidator that all the tests share, and each Data Integration in the Data Integration Tests can have it's own custom DataValidator scoped to just that particular data integration(s).
- Renamed the concept of a Validator to DataValidator, which is more specific.
- Adds the `FlowManager` fixture to the data integration tests. This is to abstract away the publishing of flows from these tests, which usually don't care about *how* a flow is published, they just need to publish flows in order to save data into integrations. The benefit of this class being that test case signatures can be simplified, since only `flow_manager` is required, instead of `client`, `engine`, and `flow_name`.
- The DataValidator continues to be a fixture in Aqueduct tests, but I realized it can just be constructed on the fly in data integration tests, since the Validator is different in each file.
- Split `shared/utils.py` into more specific helper files.

## Related issue number (if any)
ENG-2113

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


