### PR TITLE
Add release scripts for helm updates and doc updates

### DIFF
--- a/scripts/release/doc.sh
+++ b/scripts/release/doc.sh
@@ -1,3 +1,4 @@
+# usage: Run this script to generate docs for gitbook repo.
 GITBOOK_REPO=$HOME/gitbook
 
 cd ~/aqueduct/sdk

--- a/scripts/release/doc.sh
+++ b/scripts/release/doc.sh
@@ -1,0 +1,19 @@
+GITBOOK_REPO=$HOME/gitbook
+
+cd ~/aqueduct/sdk
+
+bash ../scripts/generate_docs.sh 
+cp -r docs/* $GITBOOK_REPO/api-reference/sdk-reference/package-aqueduct
+rm -r docs/
+
+cd ~/aqueduct
+python3 scripts/convert_nb_to_md.py --input="examples/churn_prediction/Customer Churn Prediction.ipynb" --output=$GITBOOK_REPO/example-workflows/customer-churn-predictor.md
+python3 scripts/convert_nb_to_md.py --input="examples/sentiment-analysis/Sentiment Model.ipynb" --output=$GITBOOK_REPO/example-workflows/sentiment-analysis.md
+python3 scripts/convert_nb_to_md.py --input="examples/wine-ratings-prediction/Predict Missing Wine Ratings.ipynb" --output=$GITBOOK_REPO/example-workflows/wine-ratings-predictor.md
+python3 scripts/convert_nb_to_md.py --input="examples/house-price-prediction/House Price Prediction.ipynb" --output=$GITBOOK_REPO/example-workflows/house-price-prediction.md
+python3 scripts/convert_nb_to_md.py --input="examples/mpg-regressor/Predicting MPG.ipynb" --output=$GITBOOK_REPO/example-workflows/mpg-regressor.md
+python3 scripts/convert_nb_to_md.py --input="examples/diabetes-classifier/Classifying Diabetes Risk.ipynb" --output=$GITBOOK_REPO/example-workflows/diabetes-classifier.md
+python3 scripts/convert_nb_to_md.py --input="examples/tutorials/Quickstart Tutorial.ipynb" --output=$GITBOOK_REPO/example-workflows/quickstart-tutorial.md
+python3 scripts/convert_nb_to_md.py --input="examples/tutorials/Parameters Tutorial.ipynb" --output=$GITBOOK_REPO/example-workflows/parameters-tutorial.md
+
+echo "Please commit changes and publish a PR for gitbook repo"

--- a/scripts/release/update_helm.sh
+++ b/scripts/release/update_helm.sh
@@ -1,0 +1,16 @@
+VERSION=$1
+GH_PAGES_BRANCH=gh_pages_$VERSION
+
+cd ~
+helm package aqueduct-helm/
+
+cd ~/aqueduct-helm/
+git checkout gh-pages && git pull origin gh-pages
+git branch $GH_PAGES_BRANCH && git checkout $GH_PAGES_BRANCH
+mv ~/aqueduct-$VERSION.tgz .
+
+cd ~ && helm repo index aqueduct-helm/ --url https://aqueducthq.github.io/aqueduct-helm/
+cd ~/aqueduct-helm
+git add --all && git commit -m "prepare gh page for release"
+echo "Please make a PR to merge the following branch to gh-pages:"
+echo $GH_PAGES_BRANCH

--- a/scripts/release/update_helm.sh
+++ b/scripts/release/update_helm.sh
@@ -1,3 +1,6 @@
+# usage: run with `sh update_helm.sh <VERSION>`
+# Please change `~` to the root of your aqueduct repos if they are not
+# located in `~`. 
 VERSION=$1
 GH_PAGES_BRANCH=gh_pages_$VERSION
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds release scripts to automate help and doc updates. These scripts does not depend on where they run (since working dir is modified internally) so that it's easier to integrate into larger scripts in the future.

Reference to old steps https://www.notion.so/aqueducthq/Runbook-Cutting-an-OSS-Release-b72400b7584845f0b0b4ff84bab4aedc . See deprecated contents for helm and doc updates

Usage (also reflected in new release checklist: https://www.notion.so/aqueducthq/Template-Release-Version-Checklist-9d694d4857634ce5918b0a0971c17e79):
```
sh update_helm.sh <VERSION NUMBER>
sh doc.sh
```
## Related issue number (if any)
ENG-2217 ENG-2218

## Tests
Corresponding parts for v0.1.9 release are done using these two scripts

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


