### PR TITLE
[1/2] Update SDK Integration Tests to run automagicky against various data integrations

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,18 +67,20 @@ jobs:
       - name: Fetch the API key
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
+      - name: Set up the SDK Integration Tests
+        working-directory: integration_tests/sdk
+        run: |
+          echo "apikey: $(aqueduct apikey)" >> test-config.yml
+          echo "address: localhost:8080" >> test-config.yml
+
       - name: Run the SDK Aqueduct Integration Tests
         timeout-minutes: 30
         working-directory: integration_tests/sdk
-        env:
-          SERVER_ADDRESS: localhost:8080
         run: pytest aqueduct_tests/ -rP -n 5
 
       - name: Run the SDK Data Integration Tests
         timeout-minutes: 10
         working-directory: integration_tests/sdk
-        env:
-          SERVER_ADDRESS: localhost:8080
         run: pytest data_integration_tests/ -rP -n 5
 
       - name: Run the No-Concurrency Integration Tests

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Fetch the API key
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
+      - name: Set up the SDK Integration Tests Config File
+        working-directory: integration_tests/sdk
+        run: |
+          echo "apikey: $(aqueduct apikey)" >> test-config.yml
+          echo "address: localhost:8080" >> test-config.yml
+
       - name: Run the Integration Tests
         timeout-minutes: 30
         working-directory: integration_tests/sdk

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ sdk/docs/build/
 **/*_aqueduct_metric/
 **/*_aqueduct_check/
 **/*_internal_aqueduct_bound_check/
+
+# Integration Configuration - which may have sensitive credentials.
+integration_tests/sdk/test-config.yml

--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -11,15 +11,16 @@ APIs, abilities, and limitations, and Aqueduct Tests are philosophically less su
 to be focused and complete, instead of reusable. They should only use the SDK's Integration API to validate data movement to and from
 our supported third-party integrations.
 
-## Usage
+## Configuration
+For these test suites to run, a configuration file must exist at `test-config.yml`. See `test-config-example.yml` for the format template.
+This file contains:
+1) The apikey to access the server.
+2) The server's address.
+3) The connection configuration information for each of the data integrations to run against. The test suites
+will automatically run against each of the data integrations specified in this file, unless a `--data` argument
+is supplied.
 
-From this directory, to run the Aqueduct Tests:
-`API_KEY=<your api key> SERVER_ADDRESS=<your server's address> pytest aqueduct_tests/ -rP -vv`
-
-To run the Data Integration Tests:
-`API_KEY=<your api key> SERVER_ADDRESS=<your server's address> pytest data_integration_tests/ -rP -vv`
-
-Both these test suites share a collection of configuration flags:
+Both these test suites share a collection of command line flags:
 * `--data`: The integration name of the data integration to run all tests against.
 * `--engine`: The integration of the engine to compute all tests on.
 * `--keep-flows`: If set, we will not delete any flows created by the test run. This is useful for debugging.
@@ -28,14 +29,23 @@ Both these test suites share a collection of configuration flags:
 For additional markers/fixtures/flags, please inspect `conftest.py` in this directory. For test-specific configurations,
 see `aqueduct_tests/conftest.py` and  `data_integration_tests/conftest.py`.
 
-## Useful Pytest Flags 
+## Commands
+
+From this directory, to run the Aqueduct Tests:
+`pytest aqueduct_tests/ -rP -vv`
+
+To run the Data Integration Tests:
+`pytest data_integration_tests/ -rP -vv`
+
+
+## Useful Pytest Command Flags 
 
 Running all the tests in a single file:
-- `<your env variables> pytest <path to test file> -rP -vv`
+- `pytest <path to test file> -rP -vv`
 
 Running a specific test:
-- `<your env variables>  pytest <specific test directory> -rP -vv -k '<specific test name>'`
+- `pytest <specific test directory> -rP -vv -k '<specific test name>'`
 
 Running tests in parallel, with concurrency 5:
 - Install pytest-xdist
-- `<your env variables> pytest <specific test directory> -rP -vv -n 5`
+- `pytest <specific test directory> -rP -vv -n 5`

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -3,7 +3,11 @@ from aqueduct.constants.enums import ServiceType
 from aqueduct.models.dag import DAG, Metadata
 
 from aqueduct import Client, globals
-from sdk.setup_integration import list_data_integrations, setup_data_integration, get_aqueduct_config
+from sdk.setup_integration import (
+    get_aqueduct_config,
+    list_data_integrations,
+    setup_data_integrations,
+)
 from sdk.shared import globals as test_globals
 from sdk.shared.utils import delete_flow, generate_new_flow_name
 from sdk.shared.validator import Validator
@@ -29,6 +33,14 @@ def pytest_configure(config):
     )
 
 
+def pytest_cmdline_main(config):
+    data_integration = config.getoption(f"--data")
+    if data_integration is not None:
+        setup_data_integrations(filter_to=data_integration)
+    else:
+        setup_data_integrations()
+
+
 @pytest.fixture(scope="function")
 def client(pytestconfig):
     # Reset the global dag variable, in case it was dirtied by a previous test,
@@ -44,7 +56,6 @@ def data_integration(request, pytestconfig, client):
         if request.param != cmdline_data_flag:
             pytest.skip("Skipped. Tests are only running against %s." % cmdline_data_flag)
 
-    setup_data_integration(request.param)
     return client.integration(request.param)
 
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -34,6 +34,7 @@ def pytest_configure(config):
 
 
 def pytest_cmdline_main(config):
+    """Gets all the integrations ready for the tests to run. Should only run once, before we even collect any tests."""
     data_integration = config.getoption(f"--data")
     if data_integration is not None:
         setup_data_integrations(filter_to=data_integration)
@@ -51,6 +52,11 @@ def client(pytestconfig):
 
 @pytest.fixture(scope="function", params=list_data_integrations())
 def data_integration(request, pytestconfig, client):
+    """This fixture is parameterized to run every test case against every requested data integration.
+
+    The requested data integrations are all in the test configuration file, but can be overwritten
+    by the `--data` command line flag.
+    """
     cmdline_data_flag = pytestconfig.getoption("data")
     if cmdline_data_flag is not None:
         if request.param != cmdline_data_flag:

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -1,87 +1,24 @@
-from typing import Dict, List, Any, Optional, Tuple, Set
+from typing import Any, Dict, List, Optional, Set, Tuple, cast
 
+import pandas as pd
 import yaml
+from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.artifacts.table_artifact import TableArtifact
+from aqueduct.constants.enums import ArtifactType, ServiceType
+from aqueduct.integrations.s3_integration import S3Integration
+from aqueduct.integrations.sql_integration import RelationalDBIntegration
 from aqueduct.models.integration import Integration
 
 from aqueduct import Client
-from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.constants.enums import ServiceType, LoadUpdateMode
-from aqueduct.integrations.sql_integration import RelationalDBIntegration
+from sdk.aqueduct_tests.save import save
 from sdk.shared.demo_db import demo_db_tables
-from sdk.shared.flow_helpers import publish_flow_test, delete_flow
-from sdk.shared.naming import generate_new_flow_name
+from sdk.shared.flow_helpers import delete_flow, publish_flow_test
+from sdk.shared.naming import generate_object_name
 
 TEST_CONFIG_FILE: str = "test-config-example.yml"
 
 # We only cache the config for the lifecycle of a single test run.
 CACHED_CONFIG: Optional[Dict[str, Any]] = None
-
-# Tracks the integrations that we have already set up for this test run.
-ready_integrations: Set[str] = set()
-
-
-def _sanitize_wine_data(df):
-    """The wine data in our demo db reads out with some unexpected tokens that
-    we need to remove before saving into other databases. The unsanitized version
-    will fail when saved to Snowflake, for example.
-    """
-    import numpy as np
-    return df.replace(r'^\\N$', np.nan, regex=True)
-
-
-def _missing_artifacts(client: Client, existing_names: Set[str]) -> Dict[str, BaseArtifact]:
-    """Given the names of all objects that already exists in an integration, computes
-    the objects that are missing the returns parameter artifacts with the missing data
-    for each of the missing objects.
-
-    All setup data is extracted from the demo db.
-    """
-    needed_names = set(demo_db_tables())
-    already_set_up_names = needed_names.intersection(existing_names)
-
-    missing_names = needed_names.difference(already_set_up_names)
-    if len(missing_names) == 0:
-        return []
-
-    demo = client.integration("aqueduct_demo")
-    artifact_by_name: Dict[str, BaseArtifact] = {}
-    for table_name in missing_names:
-        data = demo.table(table_name)
-        if table_name == "wine":
-            data = _sanitize_wine_data(data)
-
-        artifact_by_name[table_name] = client.create_param("Snowflake %s Data" % table_name, default=data)
-    return artifact_by_name
-
-
-def setup_snowflake_data(client: Client, snowflake: Integration) -> None:
-    assert isinstance(snowflake, RelationalDBIntegration)
-
-    # Check if these tables already exist.
-    existing_tables = set(snowflake.list_tables()["tablename"])
-
-    missing_artifact_by_name = _missing_artifacts(existing_tables)
-    if len(missing_artifact_by_name) == 0:
-        return
-
-    for table_name, artifact in missing_artifact_by_name:
-        snowflake.save(artifact, table_name, LoadUpdateMode.REPLACE)
-
-    flow = publish_flow_test(
-        client,
-        artifacts=list(missing_artifact_by_name.values()),
-        name=generate_new_flow_name(),
-        engine=None,
-    )
-    delete_flow(client, flow.id())
-
-
-def setup_sqlite_data(client):
-    pass
-
-
-def setup_s3_data(client):
-    pass
 
 
 def _parse_config_file() -> Dict[str, Any]:
@@ -93,51 +30,154 @@ def _parse_config_file() -> Dict[str, Any]:
     return CACHED_CONFIG
 
 
-def setup_data_integration(name: str) -> None:
+def _fetch_demo_data(demo: RelationalDBIntegration, table_name: str) -> pd.DataFrame:
+    df = demo.table(table_name)
+
+    # Certain tables in our demo db read out with some unexpected tokens that
+    # we need to remove before saving into other databases. The unsanitized version
+    # will fail when saved to Snowflake, for example.
+    if table_name == "wine" or table_name == "mpg":
+        import numpy as np
+
+        df = df.replace(r"^\\N$", np.nan, regex=True)
+    return df
+
+
+def _generate_setup_flow_name(integration: Integration):
+    return "Setup Data for %s Integration: %s" % (
+        integration._metadata.service,
+        integration._metadata.name,
+    )
+
+
+def _publish_missing_artifacts(
+    client: Client, artifacts: List[BaseArtifact], flow_name: str
+) -> None:
+    flow = publish_flow_test(
+        client,
+        artifacts=artifacts,
+        name=flow_name,
+        engine=None,
+    )
+    delete_flow(client, flow.id())
+
+
+def _add_missing_artifacts(
+    client: Client,
+    integration: Integration,
+    existing_names: Set[str],
+) -> None:
+    """Given the names of all objects that already exists in an integration, computes
+    any objects that are missing and saves them into the integration.
+
+
+    Publishes a workflow in order to do this. The workflow is immediately deleted after one
+    successful run.  All setup data is extracted from the demo db.
+    """
+    # Force name comparisons to be case-insensitive.
+    existing_names = [elem.lower() for elem in existing_names]
+
+    needed_names = set(demo_db_tables())
+    already_set_up_names = needed_names.intersection(existing_names)
+    missing_names = needed_names.difference(already_set_up_names)
+    if len(missing_names) == 0:
+        return
+
+    demo = client.integration("aqueduct_demo")
+    artifacts: List[BaseArtifact] = []
+    for table_name in missing_names:
+        data = _fetch_demo_data(demo, table_name)
+        data_param = client.create_param(generate_object_name(), default=data)
+
+        # We use the generic save() defined in Aqueduct Tests, which dictates
+        # the data format.
+        save(
+            integration,
+            cast(TableArtifact, data_param),
+            name=table_name,
+        )
+        artifacts.append(data_param)
+
+    _publish_missing_artifacts(
+        client,
+        artifacts=artifacts,
+        flow_name=_generate_setup_flow_name(integration),
+    )
+
+
+def _setup_snowflake_data(client: Client, snowflake: RelationalDBIntegration) -> None:
+    # Find all the tables that already exist.
+    existing_table_names = set(snowflake.list_tables()["tablename"])
+
+    _add_missing_artifacts(client, snowflake, existing_table_names)
+
+
+def _setup_s3_data(client: Client, s3: S3Integration):
+
+    # Find all the objects that already exist.
+    existing_names = set()
+    for object_name in demo_db_tables():
+        try:
+            s3.file(object_name, artifact_type=ArtifactType.TABLE, format="parquet")
+            existing_names.add(object_name)
+        except:
+            # Failing to fetch simply means we will need to populate this data.
+            pass
+
+    _add_missing_artifacts(client, s3, existing_names)
+
+
+def setup_data_integrations(filter_to: Optional[str] = None) -> None:
     """Connects to the given integration name if the server hasn't yet. It also ensures
     that the appropriate data is populated.
+
+    If `filter_to` is set, we only connect to that given integration name. Otherwise,
+    we attempt to connect to every integration listed in the config file.
     """
-    if name in ready_integrations:
+    if filter_to is not None:
+        data_integrations = [filter_to]
+    else:
+        data_integrations = list_data_integrations()
+
+    # No need to do any setup for the demo db.
+    if "aqueduct_demo" in data_integrations:
+        data_integrations.remove("aqueduct_demo")
+
+    if len(data_integrations) == 0:
         return
 
     test_config = _parse_config_file()
     assert "data" in test_config
-    assert name in test_config["data"], "Supplied integration %s not found in config file." % name
 
     client = Client(*get_aqueduct_config())
-    connected_integrations = client.list_integrations()
+    for integration_name in data_integrations:
+        integration_config = test_config["data"][integration_name]
+        service_type = integration_config["type"]
 
-    integration_config = test_config["data"][name]
-    service_type = integration_config["type"]
+        # Connect to any integrations that don't exist.
+        connected_integrations = client.list_integrations()
+        if integration_name not in connected_integrations.keys():
 
-    # Connect to any integrations that don't exist.
-    if name not in connected_integrations.keys():
+            # Modifying the config dictionary should be ok, since we only ever process
+            # an entry once.
+            del integration_config["type"]
+            client.connect_integration(integration_name, service_type, integration_config)
 
-        # Modifying the config dictionary should be ok, since we only ever process
-        # an entry once.
-        del integration_config["type"]
-        client.connect_integration(name, service_type, integration_config)
+        integration = client.integration(integration_name)
 
-    integration = client.integration(name)
-
-    # Setup the data in each of these integrations.
-    if service_type == ServiceType.SNOWFLAKE:
-        setup_snowflake_data(client, integration)
-    elif service_type == ServiceType.SQLITE:
-        setup_sqlite_data(client)
-    elif service_type == ServiceType.S3:
-        setup_s3_data(client)
-    else:
-        raise Exception("Test suite does not yet support %s." % service_type)
-
-    ready_integrations.add(name)
+        # Setup the data in each of these integrations.
+        if service_type == ServiceType.SNOWFLAKE:
+            _setup_snowflake_data(client, integration)
+        elif service_type == ServiceType.S3:
+            _setup_s3_data(client, integration)
+        else:
+            raise Exception("Test suite does not yet support %s." % service_type)
 
 
 def list_data_integrations() -> List[str]:
-    """Lists all the data integrations present in the config file. The demo db is always included."""
+    """Get the list of data integrations from the config file."""
     test_config = _parse_config_file()
     assert "data" in test_config
-
     data_integrations = list(test_config["data"].keys())
     data_integrations.insert(0, "aqueduct_demo")
     return data_integrations
@@ -146,5 +186,7 @@ def list_data_integrations() -> List[str]:
 def get_aqueduct_config() -> Tuple[str, str]:
     # Returns the apikey and server address.
     test_config = _parse_config_file()
-    assert "apikey" in test_config and "address" in test_config, "apikey and address must be set in test-config.yml."
+    assert (
+        "apikey" in test_config and "address" in test_config
+    ), "apikey and address must be set in test-config.yml."
     return test_config["apikey"], test_config["address"]

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -177,9 +177,10 @@ def setup_data_integrations(filter_to: Optional[str] = None) -> None:
 def list_data_integrations() -> List[str]:
     """Get the list of data integrations from the config file."""
     test_config = _parse_config_file()
-    assert "data" in test_config
-    data_integrations = list(test_config["data"].keys())
-    data_integrations.insert(0, "aqueduct_demo")
+
+    data_integrations = ["aqueduct_demo"]
+    if "data" in test_config:
+        data_integrations += list(test_config["data"].keys())
     return data_integrations
 
 

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -15,7 +15,7 @@ from sdk.shared.demo_db import demo_db_tables
 from sdk.shared.flow_helpers import delete_flow, publish_flow_test
 from sdk.shared.naming import generate_object_name
 
-TEST_CONFIG_FILE: str = "test-config-example.yml"
+TEST_CONFIG_FILE: str = "test-config.yml"
 
 # We only cache the config for the lifecycle of a single test run.
 CACHED_CONFIG: Optional[Dict[str, Any]] = None

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -33,7 +33,7 @@ def _parse_config_file() -> Dict[str, Any]:
 def _fetch_demo_data(demo: RelationalDBIntegration, table_name: str) -> pd.DataFrame:
     df = demo.table(table_name)
 
-    # Certain tables in our demo db read out with some unexpected tokens that
+    # Certain tables in our demo db read out some unexpected tokens that
     # we need to remove before saving into other databases. The unsanitized version
     # will fail when saved to Snowflake, for example.
     if table_name == "wine" or table_name == "mpg":

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -1,0 +1,78 @@
+from typing import Dict, List, Any, Optional, Tuple
+
+import yaml
+
+from aqueduct import Client
+from aqueduct.constants.enums import ServiceType
+
+TEST_CONFIG_FILE: str = "test-config-example.yml"
+CACHED_CONFIG: Optional[Dict[str, Any]] = None
+
+def setup_snowflake_data(client):
+    pass
+
+
+def setup_sqlite_data(client):
+    pass
+
+
+def setup_s3_data(client):
+    pass
+
+
+def _parse_config_file() -> Dict[str, Any]:
+    global CACHED_CONFIG
+    if CACHED_CONFIG is None:
+        with open(TEST_CONFIG_FILE, "r") as f:
+            CACHED_CONFIG = yaml.safe_load(f)
+
+    return CACHED_CONFIG
+
+
+# TODO: do not require a full setup of the yaml file if you're just trying to run a single integration.
+def setup_data_integrations():
+    """Returns the list of data integrations that we expect the tests to run against.
+
+    This list of integrations is configured by `integrations-config.yml`. This method connects
+    to any integrations that the server doesn't have, and also ensures that the appropriate data
+    is populated in each one.
+    """
+    test_config = _parse_config_file()
+
+    assert "apikey" in test_config
+    assert "address" in test_config
+    assert "data" in test_config
+
+    client = Client(test_config["apikey"], test_config["address"])
+    connected_integrations = client.list_integrations()
+    for name, config in test_config["data"].items():
+        service_type = config["type"]
+
+        # Connect to any integrations that don't exist.
+        if name not in connected_integrations.keys():
+            del config["type"]
+            client.connect_integration(name, service_type, config)
+
+        # Setup the data in each of these integrations.
+        if service_type == ServiceType.SNOWFLAKE:
+            setup_snowflake_data(client)
+        elif service_type == ServiceType.SQLITE:
+            setup_sqlite_data(client)
+        elif service_type == ServiceType.S3:
+            setup_s3_data(client)
+        else:
+            raise Exception("Test suite does not yet support %s." % service_type)
+
+
+def list_data_integrations() -> List[str]:
+    """Assumption is that `setup_data_integrations()` has already run."""
+    test_config = _parse_config_file()
+    data_integrations = list(test_config["data"].keys())
+    data_integrations.insert(0, "aqueduct_demo")
+    return data_integrations
+
+
+def get_aqueduct_config() -> Tuple[str, str]:
+    # Returns the apikey and server address.
+    test_config = _parse_config_file()
+    return test_config["apikey"], test_config["address"]

--- a/integration_tests/sdk/shared/utils.py
+++ b/integration_tests/sdk/shared/utils.py
@@ -171,7 +171,7 @@ def wait_for_flow_runs(
 
         expect_status_strs = [status.value for status in expected_statuses]
         assert statuses == expect_status_strs, (
-            "Unexpected workflow run status(es). In ascending chronological order (latest last), expected %s, got %s. "
+            "Unexpected workflow run status(es). In ascending chronological order, expected %s, got %s. "
             % (expect_status_strs, statuses)
         )
 

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -1,0 +1,17 @@
+# TODO: describe format
+apikey: D2BV8UQY7HJ6GECI03NW5ASTKXOL4MP9
+address: localhost:8080
+data:
+  test_snowflake:
+    type: Snowflake
+    username: AQADMIN
+    password: v&H7Y0lpAzl!fll4x3hi
+    account_identifier: baa81868
+    database: KENNY
+    warehouse: COMPUTE_WH
+  test_s3:
+    type: S3
+    access_key_id: AKIAZAAWG5MFAJY7N5X2
+    secret_access_key: Io0QMH1bK7ITVDPZmZcYeWdoshBZkt9sUG5onHVy
+    bucket: integration-tests-kenny
+    region: us-east-2

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -1,17 +1,29 @@
-apikey: D2BV8UQY7HJ6GECI03NW5ASTKXOL4MP9
-address: localhost:8080
+apikey: <APIKEY>
+address: <SERVER ADDRESS>
 
+# Each integration entry starts with the name of the integration, followed
+# by the list of credentials needed to connect to it.
 data:
   test_snowflake:
     type: Snowflake
-    username: AQADMIN
-    password: v&H7Y0lpAzl!fll4x3hi
-    account_identifier: baa81868
-    database: KENNY
-    warehouse: COMPUTE_WH
+    username:
+    password:
+    account_identifier:
+    database:
+    warehouse:
   test_s3:
     type: S3
-    access_key_id: AKIAZAAWG5MFAJY7N5X2
-    secret_access_key: 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
+
+    # Access Key Credentials
+    access_key_id:
+    secret_access_key:
+    # (Alternative) Config File Credentials
+    # config_file_path:
+    # config_file_content:
+    # config_file_profile:
+
     bucket: integration-tests-kenny
     region: us-east-2
+
+    # Whether to configure this integration as the metadata store too.
+    # use_as_storage:

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -22,8 +22,8 @@ data:
     # config_file_content:
     # config_file_profile:
 
-    bucket: integration-tests-kenny
-    region: us-east-2
+    bucket:
+    region:
 
     # Whether to configure this integration as the metadata store too.
     # use_as_storage:

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -1,6 +1,11 @@
-# TODO: describe format
 apikey: D2BV8UQY7HJ6GECI03NW5ASTKXOL4MP9
 address: localhost:8080
+
+# An integration entry format:
+# <integration name>:
+#    - <integration config field>
+#    - <integration config field>
+#    - ...
 data:
   test_snowflake:
     type: Snowflake

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -1,11 +1,6 @@
 apikey: D2BV8UQY7HJ6GECI03NW5ASTKXOL4MP9
 address: localhost:8080
 
-# An integration entry format:
-# <integration name>:
-#    - <integration config field>
-#    - <integration config field>
-#    - ...
 data:
   test_snowflake:
     type: Snowflake

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -19,7 +19,6 @@ data:
     secret_access_key:
     # (Alternative) Config File Credentials
     # config_file_path:
-    # config_file_content:
     # config_file_profile:
 
     bucket:

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -60,7 +60,6 @@ class S3Config(BaseConnectionConfig):
 
     # Config credentials
     config_file_path: str = ""
-    config_file_content: str = ""
     config_file_profile: str = ""
 
     bucket: str

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -63,10 +63,10 @@ class S3Config(BaseConnectionConfig):
     config_file_content: str = ""
     config_file_profile: str = ""
 
-    bucket: str = ""
+    bucket: str
+    region: str
 
-    region: str = ""
-    use_as_storage: str = ""
+    use_as_storage: str = "false"
 
 
 class AthenaConfig(BaseConnectionConfig):


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There are some significant test behavior changes that arise from this PR:

We finally introduce the concept of a test configuration file, located at `integration_tests/sdk/test-config.yml`. I've supplied an example format for people to copy over in `test-config-example.yml`. I imagine we'll have the full one stored in an S3 bucket somewhere.

This test configuration file will contain the server address and apikey - we'll no longer need to use environmental variables. The configuration file also contains entries for the different data integrations we will run the tests against. Every test case will run against every data integration defined in this file, unless the `--data` command line flag is supplied! 

Follow-up: Update our github actions and documentation to reflect these new changes.

## Related issue number (if any)
ENG-1837

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


