### PR TITLE
ENG 2173 Metric Details Page does not show Workflow Name in Header

### DIFF
--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -76,7 +76,10 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
   const breadcrumbs = [
     BreadcrumbLink.HOME,
     BreadcrumbLink.WORKFLOWS,
-    new BreadcrumbLink(workflowLink, workflow.selectedDag?.metadata.name),
+    new BreadcrumbLink(
+      workflowLink,
+      workflowDagResultWithLoadingStatus?.result?.name ?? 'Workflow'
+    ),
     new BreadcrumbLink(path, operator ? operator.name : 'Metric'),
   ];
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Changed the metric details page to get the workflow name from the same place as check, operator, and artifact details page.

## Related issue number (if any)
ENG 2173

## Loom demo (if any)
Bug

https://user-images.githubusercontent.com/30596854/212381175-6971d8f7-de08-401d-afc9-bac9d44de444.mov

Bugfix

https://user-images.githubusercontent.com/30596854/212381156-6ced0457-827f-40a3-b8e5-aa748fde4d82.mov

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


