### PR TITLE
Add convenience integration test running script

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,15 +73,10 @@ jobs:
           echo "apikey: $(aqueduct apikey)" >> test-config.yml
           echo "address: localhost:8080" >> test-config.yml
 
-      - name: Run the SDK Aqueduct Integration Tests
-        timeout-minutes: 30
+      - name: Run the SDK Integration Tests
+        timeout-minutes: 40
         working-directory: integration_tests/sdk
-        run: pytest aqueduct_tests/ -rP -n 5
-
-      - name: Run the SDK Data Integration Tests
-        timeout-minutes: 10
-        working-directory: integration_tests/sdk
-        run: pytest data_integration_tests/ -rP -n 5
+        run: python3 run_tests.py -n 5
 
       - name: Run the No-Concurrency Integration Tests
         timeout-minutes: 10

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -69,18 +69,16 @@ jobs:
       - name: Fetch the API key
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
-      - name: Set up the SDK Integration Tests Config File
+      - name: Set up the SDK Integration Tests
         working-directory: integration_tests/sdk
         run: |
           echo "apikey: $(aqueduct apikey)" >> test-config.yml
           echo "address: localhost:8080" >> test-config.yml
 
-      - name: Run the Integration Tests
-        timeout-minutes: 30
+      - name: Run the SDK Integration Tests
+        timeout-minutes: 40
         working-directory: integration_tests/sdk
-        env:
-          SERVER_ADDRESS: localhost:8080
-        run: pytest aqueduct_tests/ -rP -n ${{ matrix.concurrency }}
+        run: python3 run_tests.py -n 5
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -31,14 +31,14 @@ see `aqueduct_tests/conftest.py` and  `data_integration_tests/conftest.py`.
 
 ## Commands
 
-To run all SDK Integration Tests:
+To run all SDK Integration Tests, from the `integration_tests/sdk` directory, run:
 `python3 run_tests.py [-lf] [-n CONCURRENCY]`
 
 To run just one of the test suites:
 - `python3 run_tests.py --aqueduct [-lf] [-n CONCURRENCY]`
 - `python3 run_tests.py --data-integration [-lf] [-n CONCURRENCY]`
 
-The run tests with concurrency > 1, `pytest-xdist` must be installed.
+To run tests with concurrency > 1, `pytest-xdist` must be installed.
 
 ## Useful Pytest Command Flags 
 

--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -31,21 +31,23 @@ see `aqueduct_tests/conftest.py` and  `data_integration_tests/conftest.py`.
 
 ## Commands
 
-From this directory, to run the Aqueduct Tests:
-`pytest aqueduct_tests/ -rP -vv`
+To run all SDK Integration Tests:
+`python3 run_tests.py [-lf] [-n CONCURRENCY]`
 
-To run the Data Integration Tests:
-`pytest data_integration_tests/ -rP -vv`
+To run just one of the test suites:
+- `python3 run_tests.py --aqueduct [-lf] [-n CONCURRENCY]`
+- `python3 run_tests.py --data-integration [-lf] [-n CONCURRENCY]`
 
+The run tests with concurrency > 1, `pytest-xdist` must be installed.
 
 ## Useful Pytest Command Flags 
+
+The above script simply runs the following pytest commands:
+- `pytest aqueduct_tests/ -rP -vv [-lf] [-n CONCURRENCY]`
+- `pytest data_integration_tests/ -rP -vv [-lf] [-n CONCURRENCY]`
 
 Running all the tests in a single file:
 - `pytest <path to test file> -rP -vv`
 
 Running a specific test:
 - `pytest <specific test directory> -rP -vv -k '<specific test name>'`
-
-Running tests in parallel, with concurrency 5:
-- Install pytest-xdist
-- `pytest <specific test directory> -rP -vv -n 5`

--- a/integration_tests/sdk/run_tests.py
+++ b/integration_tests/sdk/run_tests.py
@@ -13,9 +13,9 @@ def _execute_command(args, cwd=None) -> None:
 
 def _run_tests(dir_name: str, concurrency: int, rerun_failed: bool) -> None:
     if rerun_failed:
-        _execute_command(["pytest", dir_name, ".", "-lf", "-rP", "-vv", "-n", str(concurrency)])
+        _execute_command(["pytest", dir_name, "-lf", "-rP", "-vv", "-n", str(concurrency)])
     else:
-        _execute_command(["pytest", dir_name, ".", "-rP", "-vv", "-n", str(concurrency)])
+        _execute_command(["pytest", dir_name, "-rP", "-vv", "-n", str(concurrency)])
 
 
 if __name__ == "__main__":

--- a/integration_tests/sdk/run_tests.py
+++ b/integration_tests/sdk/run_tests.py
@@ -1,0 +1,74 @@
+import argparse
+import os
+import subprocess
+import sys
+
+
+def _execute_command(args, cwd=None) -> None:
+    with subprocess.Popen(args, stdout=sys.stdout, stderr=sys.stderr, cwd=cwd) as proc:
+        proc.communicate()
+        if proc.returncode != 0:
+            raise Exception("Error executing command: %s" % args)
+
+
+def _run_tests(dir_name: str, concurrency: int, rerun_failed: bool) -> None:
+    if rerun_failed:
+        _execute_command(["pytest", dir_name, ".", "-lf", "-rP", "-vv", "-n", str(concurrency)])
+    else:
+        _execute_command(["pytest", dir_name, ".", "-rP", "-vv", "-n", str(concurrency)])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--data-integration",
+        dest="data_integration_tests",
+        default=False,
+        action="store_true",
+        help="Run the SDK Data Integration tests.",
+    )
+
+    parser.add_argument(
+        "--aqueduct",
+        dest="aqueduct_tests",
+        default=False,
+        action="store_true",
+        help="Run the SDK Aqueduct tests.",
+    )
+
+    parser.add_argument(
+        "-lf",
+        dest="rerun_failed",
+        default=False,
+        action="store_true",
+        help="Run only the tests in the suite that failed during the last run.",
+    )
+
+    parser.add_argument(
+        "-n",
+        dest="concurrency",
+        default=8,
+        action="store",
+        help="The concurrency to run the test suite with.",
+    )
+
+    args = parser.parse_args()
+
+    if not (args.aqueduct_tests or args.data_integration_tests):
+        args.aqueduct_tests = True
+        args.data_integration_tests = True
+
+    cwd = os.getcwd()
+    if not cwd.endswith("integration_tests/sdk"):
+        print("Current directory should be the SDK integration test directory.")
+        print("Your working directory is %s" % cwd)
+        exit(1)
+
+    if args.aqueduct_tests:
+        print("Running Aqueduct Tests...")
+        _run_tests("aqueduct_tests/", args.concurrency, args.rerun_failed)
+
+    if args.data_integration_tests:
+        print("Running Data Integration Tests...")
+        _run_tests("data_integration_tests/", args.concurrency, args.rerun_failed)

--- a/manual_qa_tests/workflows/succeed_parameters.py
+++ b/manual_qa_tests/workflows/succeed_parameters.py
@@ -1,5 +1,6 @@
-import aqueduct as aq
 import time
+
+import aqueduct as aq
 
 NAME = "succeed_parameters"
 DESCRIPTION = """* Workflows Page: should succeed.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Similar to how `run_linters.py` made our lives easier, `run_tests.py` does the same thing for our SDK Integration Tests in the test directory.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


