### PR TITLE
Fix bug where the UI keeps hitting the notification route

### DIFF
--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -38,7 +38,7 @@ export const DefaultLayout: React.FC<Props> = ({
     if (user) {
       dispatch(handleFetchNotifications({ user }));
     }
-  });
+  }, []);
 
   return (
     <Box

--- a/src/ui/common/src/utils/notifications.ts
+++ b/src/ui/common/src/utils/notifications.ts
@@ -43,6 +43,7 @@ export async function listNotifications(
   user: UserProfile
 ): Promise<[Notification[], string]> {
   try {
+    console.log("list notification: calling notification route!");
     const res = await fetch(`${apiAddress}/api/notifications`, {
       method: 'GET',
       headers: { 'api-key': user.apiKey },
@@ -65,6 +66,7 @@ export async function archiveNotification(
   id: string
 ): Promise<string> {
   try {
+    console.log("archive notification: calling notification route!");
     const res = await fetch(`${apiAddress}/api/notifications/${id}/archive`, {
       method: 'POST',
       headers: { 'api-key': user.apiKey },

--- a/src/ui/common/src/utils/notifications.ts
+++ b/src/ui/common/src/utils/notifications.ts
@@ -43,7 +43,6 @@ export async function listNotifications(
   user: UserProfile
 ): Promise<[Notification[], string]> {
   try {
-    console.log("list notification: calling notification route!");
     const res = await fetch(`${apiAddress}/api/notifications`, {
       method: 'GET',
       headers: { 'api-key': user.apiKey },
@@ -66,7 +65,6 @@ export async function archiveNotification(
   id: string
 ): Promise<string> {
   try {
-    console.log("archive notification: calling notification route!");
     const res = await fetch(`${apiAddress}/api/notifications/${id}/archive`, {
       method: 'POST',
       headers: { 'api-key': user.apiKey },


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This was happening because we forgot to put an empty dependency array to `useEffect`, so it keeps calling the route every time the UI re-renders. By putting the empty dependency array, it only calls the route when the component mounts.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


