### PR TITLE
[SDK] Add some convenience get helpers to our SDK Integration Class

### DIFF
--- a/integration_tests/backend/test_reads.py
+++ b/integration_tests/backend/test_reads.py
@@ -146,7 +146,7 @@ class TestBackend:
         assert integration_name not in set([integration["name"] for integration in data])
 
     def test_endpoint_test_integration(self):
-        resp = self.get_response(self.GET_TEST_INTEGRATION_TEMPLATE % self.integration._metadata.id)
+        resp = self.get_response(self.GET_TEST_INTEGRATION_TEMPLATE % self.integration.id())
         assert resp.ok
 
     def test_endpoint_get_workflow_dag_result_with_failure(self):

--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -18,10 +18,10 @@ This file contains:
 2) The server's address.
 3) The connection configuration information for each of the data integrations to run against. The test suites
 will automatically run against each of the data integrations specified in this file, unless a `--data` argument
-is supplied.
+is supplied, whereby the tests will filter down to just that data integration.
 
 Both these test suites share a collection of command line flags:
-* `--data`: The integration name of the data integration to run all tests against.
+* `--data`: The integration name of the data integration to run all tests against. 
 * `--engine`: The integration of the engine to compute all tests on.
 * `--keep-flows`: If set, we will not delete any flows created by the test run. This is useful for debugging.
 * `--deprecated`: Runs against any deprecated API that still exists in the SDK. Such code paths should be eventually deleted after some time, but this ensures backwards compatibility.

--- a/integration_tests/sdk/aqueduct_tests/conftest.py
+++ b/integration_tests/sdk/aqueduct_tests/conftest.py
@@ -26,8 +26,8 @@ def enable_only_for_data_integration_type(request, client, data_integration):
             isinstance(data_type, ServiceType) for data_type in enabled_data_integration_types
         ), "Arguments to `enable_only_for_data_integration_type()` must be of type ServiceType"
 
-        if data_integration._metadata.service not in enabled_data_integration_types:
+        if data_integration.type() not in enabled_data_integration_types:
             pytest.skip(
                 "Skipped for data integration `%s`, since it is not of type `%s`."
-                % (data_integration._metadata.name, ",".join(enabled_data_integration_types))
+                % (data_integration.name(), ",".join(enabled_data_integration_types))
             )

--- a/integration_tests/sdk/aqueduct_tests/naming_test.py
+++ b/integration_tests/sdk/aqueduct_tests/naming_test.py
@@ -17,8 +17,8 @@ def test_extract_with_default_name_collision(client, data_integration):
     table_artifact_1 = extract(data_integration, DataObject.SENTIMENT)
     table_artifact_2 = extract(data_integration, DataObject.SENTIMENT)
 
-    assert table_artifact_1.name() == "%s query 1 artifact" % data_integration._metadata.name
-    assert table_artifact_2.name() == "%s query 2 artifact" % data_integration._metadata.name
+    assert table_artifact_1.name() == "%s query 1 artifact" % data_integration.name()
+    assert table_artifact_2.name() == "%s query 2 artifact" % data_integration.name()
 
     fn_artifact = dummy_sentiment_model_multiple_input(table_artifact_1, table_artifact_2)
     fn_df = fn_artifact.get()

--- a/integration_tests/sdk/data_integration_tests/conftest.py
+++ b/integration_tests/sdk/data_integration_tests/conftest.py
@@ -34,10 +34,10 @@ def filter_tests_based_on_data_integrations(request, client, data_integration):
     )
 
     allowed_data_integrations = allowed_data_integrations_by_file[test_file_name]
-    if data_integration._metadata.service not in allowed_data_integrations:
+    if data_integration.type() not in allowed_data_integrations:
         pytest.skip(
             "Skipped for data integration `%s`, since it is not of type `%s`."
-            % (data_integration._metadata.name, ",".join(allowed_data_integrations))
+            % (data_integration.name(), ",".join(allowed_data_integrations))
         )
 
 

--- a/integration_tests/sdk/data_integration_tests/relational_data_validator.py
+++ b/integration_tests/sdk/data_integration_tests/relational_data_validator.py
@@ -57,7 +57,7 @@ class RelationalDataValidator:
         # Check all objects were saved to the same integration.
         assert len(data.keys()) == 1
         integration_name = list(data.keys())[0]
-        assert integration_name == self._integration._metadata.name
+        assert integration_name == self._integration.name()
 
         assert len(data[integration_name]) == len(expected_updates)
         saved_objects = data[integration_name]

--- a/integration_tests/sdk/shared/validation.py
+++ b/integration_tests/sdk/shared/validation.py
@@ -12,7 +12,7 @@ def fetch_and_validate_saved_object_identifier(
     data_integration: Integration, flow: Flow, artifact_id: uuid.UUID
 ) -> str:
     """Validates that the saved object exists according to the Flow API."""
-    all_saved_objects = flow.list_saved_objects()[data_integration._metadata.name]
+    all_saved_objects = flow.list_saved_objects()[data_integration.name()]
     all_saved_object_identifiers = [item.spec.identifier() for item in all_saved_objects]
 
     saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]

--- a/integration_tests/sdk/shared/validator.py
+++ b/integration_tests/sdk/shared/validator.py
@@ -25,7 +25,7 @@ class Validator:
 
     def _fetch_saved_object_identifier(self, flow: Flow, artifact_id: uuid.UUID) -> str:
         """Also validates that the saved object exists according to the Flow API."""
-        all_saved_objects = flow.list_saved_objects()[self._integration._metadata.name]
+        all_saved_objects = flow.list_saved_objects()[self._integration.name()]
         all_saved_object_identifiers = [item.spec.identifier() for item in all_saved_objects]
 
         saved_object_identifier = artifact_id_to_saved_identifier[str(artifact_id)]
@@ -88,7 +88,7 @@ class Validator:
         # Check all objects were saved to the same integration.
         assert len(data.keys()) == 1
         integration_name = list(data.keys())[0]
-        assert integration_name == self._integration._metadata.name
+        assert integration_name == self._integration.name()
 
         assert len(data[integration_name]) == len(expected_updates)
         saved_objects = data[integration_name]

--- a/sdk/aqueduct/integrations/mongodb_integration.py
+++ b/sdk/aqueduct/integrations/mongodb_integration.py
@@ -58,7 +58,7 @@ class MongoDBCollectionIntegration(Integration):
             lazy:
                 Whether to run this operator lazily. See https://docs.aqueducthq.com/operators/lazy-vs.-eager-execution .
         """
-        op_name = name or self._dag.get_unclaimed_op_name(prefix="%s query" % self._metadata.name)
+        op_name = name or self._dag.get_unclaimed_op_name(prefix="%s query" % self.name())
         if globals.__GLOBAL_CONFIG__.lazy:
             lazy = True
         execution_mode = ExecutionMode.EAGER if not lazy else ExecutionMode.LAZY
@@ -102,8 +102,8 @@ class MongoDBCollectionIntegration(Integration):
                         description=description,
                         spec=OperatorSpec(
                             extract=ExtractSpec(
-                                service=self._metadata.service,
-                                integration_id=self._metadata.id,
+                                service=self.type(),
+                                integration_id=self.id(),
                                 parameters=mongo_extract_params,
                             )
                         ),

--- a/sdk/aqueduct/integrations/s3_integration.py
+++ b/sdk/aqueduct/integrations/s3_integration.py
@@ -199,7 +199,7 @@ class S3Integration(Integration):
         if artifact.type() == ArtifactType.TABLE and format is None:
             raise InvalidUserArgumentException(
                 "You must supply a file format when saving tabular data into S3 integration `%s`."
-                % self._metadata.name,
+                % self.name(),
             )
         elif (
             artifact.type() != ArtifactType.TABLE

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -103,23 +103,23 @@ class RelationalDBIntegration(Integration):
         Returns:
             pd.DataFrame of available tables.
         """
-        if self._metadata.service in [
+        if self.type() in [
             ServiceType.POSTGRES,
             ServiceType.AQUEDUCTDEMO,
             ServiceType.REDSHIFT,
         ]:
             list_tables_query = LIST_TABLES_QUERY_PG
-        elif self._metadata.service == ServiceType.SNOWFLAKE:
+        elif self.type() == ServiceType.SNOWFLAKE:
             list_tables_query = LIST_TABLES_QUERY_SNOWFLAKE
-        elif self._metadata.service in [ServiceType.MYSQL, ServiceType.MARIADB]:
+        elif self.type() in [ServiceType.MYSQL, ServiceType.MARIADB]:
             list_tables_query = LIST_TABLES_QUERY_MYSQL
-        elif self._metadata.service == ServiceType.SQLSERVER:
+        elif self.type() == ServiceType.SQLSERVER:
             list_tables_query = LIST_TABLES_QUERY_SQLSERVER
-        elif self._metadata.service == ServiceType.BIGQUERY:
+        elif self.type() == ServiceType.BIGQUERY:
             list_tables_query = LIST_TABLES_QUERY_BIGQUERY
-        elif self._metadata.service == ServiceType.SQLITE:
+        elif self.type() == ServiceType.SQLITE:
             list_tables_query = LIST_TABLES_QUERY_SQLITE
-        elif self._metadata.service == ServiceType.ATHENA:
+        elif self.type() == ServiceType.ATHENA:
             list_tables_query = LIST_TABLES_QUERY_ATHENA
 
         sql_artifact = self.sql(query=list_tables_query)
@@ -175,7 +175,7 @@ class RelationalDBIntegration(Integration):
         # overwrite the existing one.
         sql_op_name = name
         if sql_op_name is None:
-            sql_op_name = self._dag.get_unclaimed_op_name(prefix="%s query" % integration_info.name)
+            sql_op_name = self._dag.get_unclaimed_op_name(prefix="%s query" % self.name())
 
         extract_params = query
         if isinstance(extract_params, str):
@@ -239,8 +239,8 @@ class RelationalDBIntegration(Integration):
                         description=description,
                         spec=OperatorSpec(
                             extract=ExtractSpec(
-                                service=integration_info.service,
-                                integration_id=integration_info.id,
+                                service=self.type(),
+                                integration_id=self.id(),
                                 parameters=extract_params,
                             )
                         ),
@@ -284,10 +284,9 @@ class RelationalDBIntegration(Integration):
             "`integration.config()` is deprecated. Please use `integration.save()` directly instead."
         )
 
-        if self._metadata.service == ServiceType.ATHENA:
+        if self.type() == ServiceType.ATHENA:
             raise InvalidUserActionException(
-                "Save operation is not supported for integration type %s."
-                % self._metadata.service.value
+                "Save operation is not supported for integration type %s." % self.type().value
             )
 
         return SaveConfig(

--- a/sdk/aqueduct/models/integration.py
+++ b/sdk/aqueduct/models/integration.py
@@ -43,10 +43,19 @@ class IntegrationInfo(BaseModel):
 
 class Integration(ABC):
     """
-    Abstract class for the various integrations Aqueduct interacts with.
+    Base class for the various integrations Aqueduct interacts with.
     """
 
     _metadata: IntegrationInfo
+
+    def id(self) -> uuid.UUID:
+        return self._metadata.id
+
+    def name(self) -> str:
+        return self._metadata.name
+
+    def type(self) -> ServiceType:
+        return self._metadata.service
 
     def __hash__(self) -> int:
         """An integration is uniquely identified by its name.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
It's pretty annoying to have to do `integration._metadata.name`, `integration._metadata.service` for the name and types of integrations. This PR just makes basic fetches for these, the same way we do on the BaseArtifact class.


## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


