### PR TITLE
ENG-2290: Fix bug where workflow details page renders over and over.

### DIFF
--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -35,10 +35,11 @@ export const DefaultLayout: React.FC<Props> = ({
 }) => {
   const dispatch: AppDispatch = useDispatch();
   useEffect(() => {
+    console.log('useEffect handleFetchNotifications');
     if (user) {
       dispatch(handleFetchNotifications({ user }));
     }
-  }, []);
+  }, [dispatch, user]);
 
   return (
     <Box

--- a/src/ui/common/src/components/layouts/default.tsx
+++ b/src/ui/common/src/components/layouts/default.tsx
@@ -35,7 +35,6 @@ export const DefaultLayout: React.FC<Props> = ({
 }) => {
   const dispatch: AppDispatch = useDispatch();
   useEffect(() => {
-    console.log('useEffect handleFetchNotifications');
     if (user) {
       dispatch(handleFetchNotifications({ user }));
     }

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -59,8 +59,6 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
       state.workflowDagResultsReducer.results[workflowDagResultId]
   );
 
-  const workflow = useSelector((state: RootState) => state.workflowReducer);
-
   const operator = (workflowDagResultWithLoadingStatus?.result?.operators ??
     {})[metricOperatorId];
 

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -550,9 +550,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;
@@ -628,7 +627,6 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   ]);
 
   useEffect(() => {
-    console.log('setWorkflowStatusItems useEffect');
     setWorkflowStatusItems(normalizeWorkflowStatusItems());
   }, [
     workflow,

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -158,7 +158,9 @@ const ActiveWorkflowStatusTab: React.FC<ActiveWorkflowStatusTabProps> = ({
       }}
     >
       {listItems.map((listItem, index) => {
-        const key = listItem.nodeId.length > 0 ? listItem.nodeId : index;
+        // It's possible to have multiple events from the same node, so we give it an extra index field to avoid key collisions.
+        const key =
+          listItem.nodeId.length > 0 ? listItem.nodeId + '-' + index : index;
         return (
           <Box
             key={key}
@@ -278,18 +280,13 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   // List of the workflow status items filtered out by category: errors, warnings, logs and checks passed.
   const [listItems, setListItems] = useState<WorkflowStatusItem[]>([]);
 
-  // Ignore Parameters from list of workflow status items
-  // const shouldShowStatusItem = (statusItem: WorkflowStatusItem) => {
-  //   return statusItem.type !== 'paramOp';
-  // };
-
-  const itemsToShow: WorkflowStatusItem[] = workflowStatusItems.filter(
-    (statusItem: WorkflowStatusItem) => {
-      return statusItem.type !== 'paramOp';
-    }
-  );
-
   useEffect(() => {
+    const itemsToShow: WorkflowStatusItem[] = workflowStatusItems.filter(
+      (statusItem: WorkflowStatusItem) => {
+        return statusItem.type !== 'paramOp';
+      }
+    );
+
     const filteredErrors: WorkflowStatusItem[] = itemsToShow.filter(
       (workflowStatusItem) => {
         return workflowStatusItem.level === WorkflowStatusTabs.Errors;
@@ -393,7 +390,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
     setNumWarnings(filteredWarnings.length);
     setNumWorkflowLogs(filteredLogs.length);
     setNumWorkflowChecksPassed(filteredChecks.length);
-  }, [workflowStatusItems, activeWorkflowStatusTab, itemsToShow]);
+  }, [workflowStatusItems, activeWorkflowStatusTab]);
 
   const selectTab = (tab: WorkflowStatusTabs) => {
     dispatch(setWorkflowStatusBarOpenState(true));
@@ -631,6 +628,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
   ]);
 
   useEffect(() => {
+    console.log('setWorkflowStatusItems useEffect');
     setWorkflowStatusItems(normalizeWorkflowStatusItems());
   }, [
     workflow,

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -550,8 +550,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -69,8 +69,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
     }
   };
 
-  // TODO: useLayoutEffect here. May want to figure out some way to debounce as it gets called quite quickly when resizing.
-  // useEffect(getContainerSize, [currentNode]);
+  // TODO (ENG-2302): useLayoutEffect here. May want to figure out some way to debounce as it gets called quite quickly when resizing.
   window.addEventListener('resize', getContainerSize);
 
   const [showRunWorkflowDialog, setShowRunWorkflowDialog] = useState(false);

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -111,7 +111,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-    WorkflowUpdateTrigger.Periodic &&
+      WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -59,7 +59,6 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   const narrowView = containerWidth < ContainerWidthBreakpoint;
 
   const getContainerSize = () => {
-    console.log('getContainerSize useEffect');
     const container = document.getElementById(WorkflowPageContentId);
 
     if (!container) {

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -7,7 +7,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import TextField from '@mui/material/TextField';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { useSelector } from 'react-redux';
 import { useDispatch } from 'react-redux';
@@ -59,6 +59,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   const narrowView = containerWidth < ContainerWidthBreakpoint;
 
   const getContainerSize = () => {
+    console.log('getContainerSize useEffect');
     const container = document.getElementById(WorkflowPageContentId);
 
     if (!container) {
@@ -69,7 +70,8 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
     }
   };
 
-  useEffect(getContainerSize, [currentNode]);
+  // TODO: useLayoutEffect here. May want to figure out some way to debounce as it gets called quite quickly when resizing.
+  // useEffect(getContainerSize, [currentNode]);
   window.addEventListener('resize', getContainerSize);
 
   const [showRunWorkflowDialog, setShowRunWorkflowDialog] = useState(false);
@@ -111,7 +113,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-      WorkflowUpdateTrigger.Periodic &&
+    WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes bug where the workflow details page keeps rendering over and over again, causing a MaximumUpdateDepth error message to appear in the browser console.

## Related issue number (if any)
ENG-2290

## Loom demo (if any)
https://www.loom.com/share/790bedef491e4179b56c41d1d0d5b0c1
## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


