### PR TITLE
Show option names on the sidesheet and remove the Aqueduct logo on the Home page

### DIFF
--- a/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
+++ b/src/ui/common/src/components/cards/GettingStartedTutorial.tsx
@@ -82,12 +82,6 @@ const GettingStartedTutorial: React.FC<GettingStartedTutorialProps> = ({
         flexDirection: 'column',
       }}
     >
-      <img
-        src="https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/aqueduct-logo-two-tone/1x/aqueduct-logo-two-tone-1x.png"
-        width="300px"
-        style={{ marginTop: '64px' }}
-      />
-
       <Box
         sx={{
           display: 'flex',

--- a/src/ui/common/src/components/layouts/menuSidebar.styles.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.styles.tsx
@@ -18,6 +18,7 @@ export const menuSidebarContent = {
   width: '100%',
   paddingLeft: '8px',
   paddingRight: '8px',
+  marginTop: '8px',
 };
 
 export const menuSidebarFooter = {
@@ -38,8 +39,8 @@ export const menuSidebarLink = {
   minWidth: '64px',
   width: '64px',
   maxWidth: '64px',
-  marginTop: '5px',
-  marginBottom: '5px',
+  marginTop: '8px',
+  marginBottom: '8px',
 };
 
 export const menuSidebarLogoLink = {

--- a/src/ui/common/src/components/layouts/menuSidebar.styles.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.styles.tsx
@@ -38,6 +38,8 @@ export const menuSidebarLink = {
   minWidth: '64px',
   width: '64px',
   maxWidth: '64px',
+  marginTop: '5px',
+  marginBottom: '5px',
 };
 
 export const menuSidebarLogoLink = {

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -6,7 +6,7 @@ import {
   faShareNodes,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link, Tooltip, Typography } from '@mui/material';
+import { Link, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
@@ -218,9 +218,7 @@ const MenuSidebar: React.FC<{
                 onSidebarItemClicked('data');
               }
             }}
-            icon={
-              <FontAwesomeIcon style={menuSidebarIcon} icon={faDatabase} />
-            }
+            icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faDatabase} />}
             text="Data"
             selected={currentPage === '/data'}
           />

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -88,7 +88,7 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
       <Box>{icon}</Box>
       <Box
         sx={{
-          marginTop: '5px',
+          marginTop: '4px',
           fontSize: '12px',
         }}
       >
@@ -223,6 +223,8 @@ const MenuSidebar: React.FC<{
             selected={currentPage === '/data'}
           />
         </Link>
+
+        <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
       </Box>
 
       <Box style={menuSidebarFooter}>

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -88,7 +88,8 @@ const SidebarButton: React.FC<SidebarButtonProps> = ({
       <Box>{icon}</Box>
       <Box
         sx={{
-          marginTop: '8px',
+          marginTop: '5px',
+          fontSize: '12px',
         }}
       >
         {text}
@@ -163,105 +164,99 @@ const MenuSidebar: React.FC<{
       </Link>
 
       <Box sx={{ my: 2 }} style={menuSidebarContent}>
-        <Tooltip title="Workflows" arrow placement="right">
-          <Link
-            to={`${getPathPrefix()}/workflows`}
-            style={menuSidebarLink}
-            underline="none"
-            component={RouterLink}
-          >
-            <SidebarButton
-              onClick={() => {
-                if (onSidebarItemClicked) {
-                  onSidebarItemClicked('workflows');
-                }
-              }}
-              icon={
-                <FontAwesomeIcon style={menuSidebarIcon} icon={faShareNodes} />
+        <Link
+          to={`${getPathPrefix()}/workflows`}
+          style={menuSidebarLink}
+          underline="none"
+          component={RouterLink}
+        >
+          <SidebarButton
+            onClick={() => {
+              if (onSidebarItemClicked) {
+                onSidebarItemClicked('workflows');
               }
-              text=""
-              selected={currentPage === '/workflows'}
-            />
-          </Link>
-        </Tooltip>
+            }}
+            icon={
+              <FontAwesomeIcon style={menuSidebarIcon} icon={faShareNodes} />
+            }
+            text="Workflows"
+            selected={currentPage === '/workflows'}
+          />
+        </Link>
 
-        <Tooltip title="Integrations" arrow placement="right">
-          <Link
-            to={`${getPathPrefix()}/integrations`}
-            style={menuSidebarLink}
-            underline="none"
-            component={RouterLink}
-          >
-            <SidebarButton
-              onClick={() => {
-                if (onSidebarItemClicked) {
-                  onSidebarItemClicked('integrations');
-                }
-              }}
-              icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faPlug} />}
-              text=""
-              selected={currentPage === '/integrations'}
-            />
-          </Link>
-        </Tooltip>
+        <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
 
-        <Tooltip title="Data" placement="right" arrow>
-          <Link
-            to={`${getPathPrefix()}/data`}
-            style={menuSidebarLink}
-            underline="none"
-            component={RouterLink}
-          >
-            <SidebarButton
-              onClick={() => {
-                if (onSidebarItemClicked) {
-                  onSidebarItemClicked('data');
-                }
-              }}
-              icon={
-                <FontAwesomeIcon style={menuSidebarIcon} icon={faDatabase} />
+        <Link
+          to={`${getPathPrefix()}/integrations`}
+          style={menuSidebarLink}
+          underline="none"
+          component={RouterLink}
+        >
+          <SidebarButton
+            onClick={() => {
+              if (onSidebarItemClicked) {
+                onSidebarItemClicked('integrations');
               }
-              text=""
-              selected={currentPage === '/data'}
-            />
-          </Link>
-        </Tooltip>
+            }}
+            icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faPlug} />}
+            text="Integrations"
+            selected={currentPage === '/integrations'}
+          />
+        </Link>
+
+        <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
+
+        <Link
+          to={`${getPathPrefix()}/data`}
+          style={menuSidebarLink}
+          underline="none"
+          component={RouterLink}
+        >
+          <SidebarButton
+            onClick={() => {
+              if (onSidebarItemClicked) {
+                onSidebarItemClicked('data');
+              }
+            }}
+            icon={
+              <FontAwesomeIcon style={menuSidebarIcon} icon={faDatabase} />
+            }
+            text="Data"
+            selected={currentPage === '/data'}
+          />
+        </Link>
       </Box>
 
       <Box style={menuSidebarFooter}>
         <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
         <Box sx={{ my: 2 }}>
-          <Tooltip title="Documentation" placement="right" arrow>
-            <Link href="https://docs.aqueducthq.com" underline="none">
-              <SidebarButton
-                onClick={() => {
-                  if (onSidebarItemClicked) {
-                    onSidebarItemClicked('documentation');
-                  }
-                }}
-                icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faBook} />}
-                text=""
-              />
-            </Link>
-          </Tooltip>
+          <Link href="https://docs.aqueducthq.com" underline="none">
+            <SidebarButton
+              onClick={() => {
+                if (onSidebarItemClicked) {
+                  onSidebarItemClicked('documentation');
+                }
+              }}
+              icon={<FontAwesomeIcon style={menuSidebarIcon} icon={faBook} />}
+              text="Docs"
+            />
+          </Link>
         </Box>
         <Divider sx={{ width: '64px', backgroundColor: 'white' }} />
         <Box sx={{ my: 2 }}>
-          <Tooltip title="Report Issue" placement="right" arrow>
-            <Link href="mailto:support@aqueducthq.com" underline="none">
-              <SidebarButton
-                onClick={() => {
-                  if (onSidebarItemClicked) {
-                    onSidebarItemClicked('report_issue');
-                  }
-                }}
-                icon={
-                  <FontAwesomeIcon style={menuSidebarIcon} icon={faMessage} />
+          <Link href="mailto:support@aqueducthq.com" underline="none">
+            <SidebarButton
+              onClick={() => {
+                if (onSidebarItemClicked) {
+                  onSidebarItemClicked('report_issue');
                 }
-                text=""
-              />
-            </Link>
-          </Tooltip>
+              }}
+              icon={
+                <FontAwesomeIcon style={menuSidebarIcon} icon={faMessage} />
+              }
+              text="Feedback"
+            />
+          </Link>
         </Box>
         <Box marginLeft="14px" marginBottom="16px">
           <Typography variant="caption" sx={{ color: 'white' }}>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
See screenshot below:
![Screen Shot 2023-01-20 at 2 07 37 PM](https://user-images.githubusercontent.com/6820919/213813816-473557fb-f843-4ca5-bb00-e90ceb843dc4.png)



## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


