### PR TITLE
Delete external data during test teardown in SDK Integration Tests

### DIFF
--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -9,7 +9,7 @@ from sdk.setup_integration import (
     setup_data_integrations,
 )
 from sdk.shared import globals as test_globals
-from sdk.shared.utils import delete_flow, generate_new_flow_name
+from sdk.shared.utils import generate_new_flow_name
 from sdk.shared.validator import Validator
 
 
@@ -134,7 +134,17 @@ def flow_name(client, request, pytestconfig):
     def cleanup_flows():
         if not pytestconfig.getoption("keep_flows"):
             for flow_name in flow_names:
-                delete_flow(client, test_globals.flow_name_to_id[flow_name])
+                flow_id = test_globals.flow_name_to_id[flow_name]
+
+                try:
+                    client.delete_flow(
+                        str(flow_id),
+                        saved_objects_to_delete=client.flow(flow_id).list_saved_objects(),
+                    )
+                except Exception as e:
+                    print("Error deleting workflow %s with exception: %s" % (flow_id, e))
+                else:
+                    print("Successfully deleted workflow %s" % flow_id)
 
     request.addfinalizer(cleanup_flows)
     return get_new_flow_name

--- a/integration_tests/sdk/shared/utils.py
+++ b/integration_tests/sdk/shared/utils.py
@@ -213,15 +213,6 @@ def extract(
     raise Exception("Unexpected data integration type provided in test: %s", type(integration))
 
 
-def delete_flow(client: aqueduct.Client, workflow_id: uuid.UUID) -> None:
-    try:
-        client.delete_flow(str(workflow_id))
-    except Exception as e:
-        print("Error deleting workflow %s with exception: %s" % (workflow_id, e))
-    else:
-        print("Successfully deleted workflow %s" % (workflow_id))
-
-
 def polling(
     stop_condition_fn,
     timeout=60,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
See title. Pretty easy fix.

Tested by running against Snowflake and checking that no new tables were left behind.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


