### PR TITLE
Fix a bug where operator execution fails when running on k8s

### DIFF
--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -183,6 +183,9 @@ func (j *k8sJobManager) Poll(ctx context.Context, name string) (shared.Execution
 	} else {
 		pod, err := k8s.GetPod(ctx, name, j.k8sClient)
 		if err != nil {
+			if err == k8s.ErrNoPodExists {
+				return shared.PendingExecutionStatus, nil
+			}
 			return shared.FailedExecutionStatus, systemError(err)
 		}
 

--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -183,7 +183,7 @@ func (j *k8sJobManager) Poll(ctx context.Context, name string) (shared.Execution
 	} else {
 		pod, err := k8s.GetPod(ctx, name, j.k8sClient)
 		if err != nil {
-			if err == k8s.ErrNoPodExists {
+			if err == errors.New("No pod exists") {
 				return shared.PendingExecutionStatus, nil
 			}
 			return shared.FailedExecutionStatus, systemError(err)

--- a/src/golang/lib/k8s/jobs.go
+++ b/src/golang/lib/k8s/jobs.go
@@ -12,8 +12,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var ErrNoPodExists = errors.New("No pod exists")
-
 // A helper function that takes in the name of a job, a container image, and
 // other configuration parameters. It uses this information to generate a new
 // job and run the job.
@@ -114,7 +112,7 @@ func GetPod(ctx context.Context, name string, k8sClient *kubernetes.Clientset) (
 
 	if len(podList.Items) == 0 {
 		log.Infof("No pod has been created from job %s yet...", name)
-		return nil, ErrNoPodExists
+		return nil, errors.New("No pod exists")
 	}
 
 	if len(podList.Items) != 1 {

--- a/src/golang/lib/k8s/jobs.go
+++ b/src/golang/lib/k8s/jobs.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 
 	"github.com/dropbox/godropbox/errors"
+	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+var ErrNoPodExists = errors.New("No pod exists")
 
 // A helper function that takes in the name of a job, a container image, and
 // other configuration parameters. It uses this information to generate a new
@@ -107,6 +110,11 @@ func GetPod(ctx context.Context, name string, k8sClient *kubernetes.Clientset) (
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if len(podList.Items) == 0 {
+		log.Infof("No pod has been created from job %s yet...", name)
+		return nil, ErrNoPodExists
 	}
 
 	if len(podList.Items) != 1 {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This was because there's a small time gap between launching a job and spinning up a pod. We capture this case and return a pending status, so that the next time we poll, the pod will be created. I tested manually and it worked, so hopefully it will fix the issue @kenxu95 you ran into as well.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


