### PR TITLE
[2/2][UI] Eng 2191 Allow user to connect to slack integration

### DIFF
--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -24,6 +24,7 @@ import { MySqlCard } from './mysqlCard';
 import { PostgresCard } from './postgresCard';
 import { RedshiftCard } from './redshiftCard';
 import { S3Card } from './s3Card';
+import { SlackCard } from './slackCard';
 import { SnowflakeCard } from './snowflakeCard';
 
 type DataProps = {
@@ -141,6 +142,9 @@ export const IntegrationCard: React.FC<IntegrationProps> = ({
       break;
     case 'Email':
       serviceCard = <EmailCard integration={integration} />;
+      break;
+    case 'Slack':
+      serviceCard = <SlackCard integration={integration} />;
       break;
     default:
       serviceCard = null;

--- a/src/ui/common/src/components/integrations/cards/detailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/detailCard.tsx
@@ -18,6 +18,7 @@ import { MySqlCard } from './mysqlCard';
 import { PostgresCard } from './postgresCard';
 import { RedshiftCard } from './redshiftCard';
 import { S3Card } from './s3Card';
+import { SlackCard } from './slackCard';
 import { SnowflakeCard } from './snowflakeCard';
 
 type DetailIntegrationCardProps = {
@@ -65,6 +66,9 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
       break;
     case 'Email':
       serviceCard = <EmailCard integration={integration} />;
+      break;
+    case 'Slack':
+      serviceCard = <SlackCard integration={integration} />;
       break;
     default:
       serviceCard = null;

--- a/src/ui/common/src/components/integrations/cards/slackCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/slackCard.tsx
@@ -1,0 +1,30 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { Integration, SlackConfig } from '../../../utils/integrations';
+
+type Props = {
+  integration: Integration;
+};
+
+export const SlackCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as SlackConfig;
+  const channels = JSON.parse(config.channels_serialized) as string[];
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body2">
+        {channels.length > 1 ? (
+          <strong>Channel: </strong>
+        ) : (
+          <strong>Channels:</strong>
+        )}{' '}
+        {channels.join(', ')}
+      </Typography>
+      <Typography variant="body2">
+        <strong>Level: </strong>
+        {config.level.toUpperCase()}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -40,6 +40,7 @@ import {
   RedshiftConfig,
   S3Config,
   Service,
+  SlackConfig,
   SnowflakeConfig,
   SQLiteConfig,
   SupportedIntegrations,
@@ -61,6 +62,7 @@ import { MysqlDialog } from './mysqlDialog';
 import { PostgresDialog } from './postgresDialog';
 import { RedshiftDialog } from './redshiftDialog';
 import { isS3ConfigComplete, S3Dialog } from './s3Dialog';
+import { SlackDialog } from './slackDialog';
 import { SnowflakeDialog } from './snowflakeDialog';
 import { SQLiteDialog } from './sqliteDialog';
 
@@ -318,6 +320,14 @@ const IntegrationDialog: React.FC<Props> = ({
         <EmailDialog
           onUpdateField={setConfigField}
           value={config as EmailConfig}
+        />
+      );
+      break;
+    case 'Slack':
+      serviceDialog = (
+        <SlackDialog
+          onUpdateField={setConfigField}
+          value={config as SlackConfig}
         />
       );
       break;

--- a/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
@@ -1,0 +1,79 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React, { useState } from 'react';
+import { NotificationLogLevel } from 'src';
+
+import { SlackConfig } from '../../../utils/integrations';
+import NotificationLevelSelector from '../../notifications/NotificationLevelSelector';
+import { IntegrationTextInputField } from './IntegrationTextInputField';
+
+const Placeholders = {
+  token: '*****',
+  channel: 'my_channel',
+  level: 'succeeded',
+};
+
+type Props = {
+  onUpdateField: (field: keyof SlackConfig, value: string) => void;
+  value?: SlackConfig;
+};
+
+export const SlackDialog: React.FC<Props> = ({ onUpdateField, value }) => {
+  const [channels, setChannels] = useState(
+    value?.channels_serialized
+      ? (JSON.parse(value?.channels_serialized) as string[]).join(',')
+      : ''
+  );
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={false}
+        label="Bot Token *"
+        description="The slack bot token. Please make sure this token has the permissions to send messages to channels you specified."
+        placeholder={Placeholders.token}
+        type="password"
+        onChange={(event) => {
+          if (!!event.target.value) {
+            onUpdateField('token', event.target.value);
+          }
+        }}
+        value={value?.token ?? null}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Channels *"
+        description="The channel(s) to send notifications. Use comma to separate different channels."
+        placeholder={Placeholders.channel}
+        onChange={(event) => {
+          setChannels(event.target.value);
+          const channelsList = event.target.value
+            .split(',')
+            .map((r) => r.trim());
+          onUpdateField('channels_serialized', JSON.stringify(channelsList));
+        }}
+        value={channels ?? null}
+      />
+
+      <Box sx={{ mt: 2 }}>
+        <Box sx={{ my: 1 }}>
+          <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+            Level *
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'darkGray' }}>
+            The notification levels at which to send a slack notification. This
+            applies to all workflows unless separately specified in workflow
+            settings.
+          </Typography>
+        </Box>
+        <NotificationLevelSelector
+          level={value?.level as NotificationLogLevel}
+          onSelectLevel={(level) => onUpdateField('level', level)}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -83,7 +83,9 @@ const IntegrationsPage: React.FC<Props> = ({
             category={IntegrationCategories.COMPUTE}
             supportedIntegrations={SupportedIntegrations}
           />
-          <Typography variant="h6" marginY={2}>
+          {
+            // TODO: Enable this once notification are fully implemented.
+            /*<Typography variant="h6" marginY={2}>
             Notifications
           </Typography>
           <Typography variant="h6" marginY={2}>
@@ -92,7 +94,8 @@ const IntegrationsPage: React.FC<Props> = ({
               category={IntegrationCategories.NOTIFICATION}
               supportedIntegrations={SupportedIntegrations}
             />
-          </Typography>
+  </Typography>*/
+          }
         </Box>
 
         <Box marginY={3}>

--- a/src/ui/common/src/index.tsx
+++ b/src/ui/common/src/index.tsx
@@ -17,6 +17,7 @@ import { MySqlCard } from './components/integrations/cards/mysqlCard';
 import { PostgresCard } from './components/integrations/cards/postgresCard';
 import { RedshiftCard } from './components/integrations/cards/redshiftCard';
 import { S3Card } from './components/integrations/cards/s3Card';
+import { SlackCard } from './components/integrations/cards/slackCard';
 import { SnowflakeCard } from './components/integrations/cards/snowflakeCard';
 import { ConnectedIntegrations } from './components/integrations/connectedIntegrations';
 import AddTableDialog from './components/integrations/dialogs/addTableDialog';
@@ -35,6 +36,7 @@ import { MysqlDialog } from './components/integrations/dialogs/mysqlDialog';
 import { PostgresDialog } from './components/integrations/dialogs/postgresDialog';
 import { RedshiftDialog } from './components/integrations/dialogs/redshiftDialog';
 import { S3Dialog } from './components/integrations/dialogs/s3Dialog';
+import { SlackDialog } from './components/integrations/dialogs/slackDialog';
 import { SnowflakeDialog } from './components/integrations/dialogs/snowflakeDialog';
 import { Card } from './components/layouts/card';
 import DefaultLayout from './components/layouts/default';
@@ -364,6 +366,8 @@ export {
   setWorkflowStatusBarOpenState,
   // TODO: Refactor to remove sidesheet state
   sideSheetSwitcher,
+  SlackCard,
+  SlackDialog,
   SnowflakeCard,
   SnowflakeDialog,
   StatusChip as Status,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -168,6 +168,12 @@ export type EmailConfig = {
   level: string;
 };
 
+export type SlackConfig = {
+  token: string;
+  channels_serialized: string;
+  level: string;
+};
+
 export type IntegrationConfig =
   | PostgresConfig
   | SnowflakeConfig
@@ -187,7 +193,8 @@ export type IntegrationConfig =
   | LambdaConfig
   | CondaConfig
   | DatabricksConfig
-  | EmailConfig;
+  | EmailConfig
+  | SlackConfig;
 
 export type Service =
   | 'Postgres'
@@ -209,7 +216,8 @@ export type Service =
   | 'MongoDB'
   | 'Conda'
   | 'Databricks'
-  | 'Email';
+  | 'Email'
+  | 'Slack';
 
 export type Info = {
   logo: string;
@@ -292,6 +300,7 @@ export const ServiceLogos: ServiceLogo = {
   ['Conda']: `${integrationLogosBucket}/conda.png`,
   ['Databricks']: `${integrationLogosBucket}/databricks_logo.png`,
   ['Email']: `${integrationLogosBucket}/email.png`,
+  ['Slack']: `${integrationLogosBucket}/slack.png`,
 };
 
 export const SupportedIntegrations: ServiceInfoMap = {
@@ -382,6 +391,11 @@ export const SupportedIntegrations: ServiceInfoMap = {
   },
   ['Email']: {
     logo: ServiceLogos['Email'],
+    activated: true,
+    category: IntegrationCategories.NOTIFICATION,
+  },
+  ['Slack']: {
+    logo: ServiceLogos['Slack'],
     activated: true,
     category: IntegrationCategories.NOTIFICATION,
   },


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds all required UI work to allow user connecting to slack integration. it's very similar to  #897 and reuses the notification level selector.

Tested the following features are working properly:
* connect
* test-connect
* edit
* delete

## Related issue number (if any)
ENG-2191

## Loom demo (if any)
Integration list page:
![Screenshot 2023-01-23 at 9 49 04 PM](https://user-images.githubusercontent.com/10411887/214221800-a83bb2f7-62f5-4be9-969e-903bb35f72a7.png)

Connect dialog:
![Screenshot 2023-01-23 at 9 48 56 PM](https://user-images.githubusercontent.com/10411887/214221828-1c9b69d4-1403-49f8-b3b4-08189203130e.png)

Integration detail page:
![Screenshot 2023-01-23 at 9 50 22 PM](https://user-images.githubusercontent.com/10411887/214221907-11e5978e-dfa6-4e04-ac37-557c8405d9d9.png)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


