### PR TITLE
[1/2][Backend] Eng 2191 add slack integration to backend

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -329,6 +329,10 @@ func ValidateConfig(
 		return validateEmailConfig(config)
 	}
 
+	if service == integration.Slack {
+		return validateSlackConfig(config)
+	}
+
 	jobName := fmt.Sprintf("authenticate-operator-%s", uuid.New().String())
 	if service == integration.Conda {
 		return validateConda()
@@ -628,6 +632,19 @@ func validateEmailConfig(config auth.Config) (int, error) {
 	return http.StatusOK, nil
 }
 
+func validateSlackConfig(config auth.Config) (int, error) {
+	slackConfig, err := lib_utils.ParseSlackConfig(config)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+
+	if err := notification.AuthenticateSlack(slackConfig); err != nil {
+		return http.StatusBadRequest, err
+	}
+
+	return http.StatusOK, nil
+}
+
 // ValidatePrerequisites validates if the integration for the given service can be connected at all.
 // For now, it checks if an integration already exists for unique integrations including
 // conda, email, and slack.
@@ -663,16 +680,17 @@ func ValidatePrerequisites(
 		return http.StatusOK, nil
 	}
 
-	if svc == integration.Email {
-		emailIntegrations, err := integrationRepo.GetByServiceAndUser(ctx, svc, userID, DB)
+	// These integrations should be unique.
+	if svc == integration.Email || svc == integration.Slack {
+		integrations, err := integrationRepo.GetByServiceAndUser(ctx, svc, userID, DB)
 		if err != nil {
 			return http.StatusInternalServerError, errors.Wrap(err, "Unable to verify if email is connected.")
 		}
 
-		if len(emailIntegrations) > 0 {
+		if len(integrations) > 0 {
 			return http.StatusBadRequest, errors.Newf(
 				"You already have an email integration %s connected.",
-				emailIntegrations[0].Name,
+				integrations[0].Name,
 			)
 		}
 

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -689,7 +689,8 @@ func ValidatePrerequisites(
 
 		if len(integrations) > 0 {
 			return http.StatusBadRequest, errors.Newf(
-				"You already have an email integration %s connected.",
+				"You already have an %s integration %s connected.",
+				svc,
 				integrations[0].Name,
 			)
 		}

--- a/src/golang/go.mod
+++ b/src/golang/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.12
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sirupsen/logrus v1.8.1
+	github.com/slack-go/slack v0.12.1
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 	google.golang.org/api v0.103.0
@@ -57,6 +58,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.0 // indirect

--- a/src/golang/go.sum
+++ b/src/golang/go.sum
@@ -127,6 +127,8 @@ github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -175,6 +177,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v40 v40.0.0 h1:oBPVDaIhdUmwDWRRH8XJ/dZG+Rn755i08+Hp1uJHlR0=
@@ -210,6 +213,7 @@ github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyyc
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 h1:f0n1xnMSmBLzVfsMMvriDyA75NB/oBgILX2GcHXIQzY=
 github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75/go.mod h1:g2644b03hfBX9Ov0ZBDgXXens4rxSxmqFBbhvKv2yVA=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -342,6 +346,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/slack-go/slack v0.12.1 h1:X97b9g2hnITDtNsNe5GkGx6O2/Sz/uC20ejRZN6QxOw=
+github.com/slack-go/slack v0.12.1/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/src/golang/lib/collections/integration/constants.go
+++ b/src/golang/lib/collections/integration/constants.go
@@ -31,6 +31,7 @@ const (
 	Conda        Service = "Conda"
 	Databricks   Service = "Databricks"
 	Email        Service = "Email"
+	Slack        Service = "Slack"
 
 	DemoDbIntegrationName = "aqueduct_demo"
 )
@@ -39,7 +40,29 @@ const (
 func ParseService(s string) (Service, error) {
 	svc := Service(s)
 	switch svc {
-	case Postgres, Snowflake, MySql, Redshift, MariaDb, SqlServer, BigQuery, GoogleSheets, Salesforce, S3, Athena, AqueductDemo, Github, Sqlite, Airflow, Kubernetes, GCS, Lambda, MongoDB, Conda, Databricks, Email:
+	case Postgres,
+		Snowflake,
+		MySql,
+		Redshift,
+		MariaDb,
+		SqlServer,
+		BigQuery,
+		GoogleSheets,
+		Salesforce,
+		S3,
+		Athena,
+		AqueductDemo,
+		Github,
+		Sqlite,
+		Airflow,
+		Kubernetes,
+		GCS,
+		Lambda,
+		MongoDB,
+		Conda,
+		Databricks,
+		Email,
+		Slack:
 		return svc, nil
 	default:
 		return "", errors.Newf("Unknown service: %s", s)

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -122,12 +122,12 @@ func ParseEmailConfig(conf auth.Config) (*shared.EmailConfig, error) {
 	}
 
 	var c struct {
-		User              string                   `json:"user" yaml:"user"`
-		Password          string                   `json:"password" yaml:"password"`
-		Host              string                   `json:"host" yaml:"host"`
-		Port              string                   `json:"port" yaml:"port"`
-		TargetsSerialized string                   `json:"targets_serialized" yaml:"targets_serialized"`
-		Level             shared.NotificationLevel `json:"level" yaml:"level"`
+		User              string                   `json:"user"`
+		Password          string                   `json:"password"`
+		Host              string                   `json:"host"`
+		Port              string                   `json:"port"`
+		TargetsSerialized string                   `json:"targets_serialized"`
+		Level             shared.NotificationLevel `json:"level"`
 	}
 	if err := json.Unmarshal(data, &c); err != nil {
 		return nil, err
@@ -154,9 +154,9 @@ func ParseSlackConfig(conf auth.Config) (*shared.SlackConfig, error) {
 	}
 
 	var c struct {
-		Token              string                   `json:"token" yaml:"token"`
-		ChannelsSerialized string                   `json:"channels_serialized" yaml:"channels_serialized"`
-		Level              shared.NotificationLevel `json:"level" yaml:"level"`
+		Token              string                   `json:"token"`
+		ChannelsSerialized string                   `json:"channels_serialized"`
+		Level              shared.NotificationLevel `json:"level"`
 	}
 	if err := json.Unmarshal(data, &c); err != nil {
 		return nil, err

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -146,3 +146,30 @@ func ParseEmailConfig(conf auth.Config) (*shared.EmailConfig, error) {
 		Targets:  targets,
 	}, nil
 }
+
+func ParseSlackConfig(conf auth.Config) (*shared.SlackConfig, error) {
+	data, err := conf.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	var c struct {
+		Token              string                   `json:"token" yaml:"token"`
+		ChannelsSerialized string                   `json:"channels_serialized" yaml:"channels_serialized"`
+		Level              shared.NotificationLevel `json:"level" yaml:"level"`
+	}
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+
+	var channels []string
+	if err := json.Unmarshal([]byte(c.ChannelsSerialized), &channels); err != nil {
+		return nil, err
+	}
+
+	return &shared.SlackConfig{
+		Token:    c.Token,
+		Channels: channels,
+		Level:    c.Level,
+	}, nil
+}

--- a/src/golang/lib/models/shared/integration_config.go
+++ b/src/golang/lib/models/shared/integration_config.go
@@ -53,6 +53,12 @@ type EmailConfig struct {
 	Level    NotificationLevel `json:"level" yaml:"level"`
 }
 
+type SlackConfig struct {
+	Token    string            `json:"token" yaml:"token"`
+	Channels []string          `json:"channels" yaml:"channels"`
+	Level    NotificationLevel `json:"level" yaml:"level"`
+}
+
 func (c *EmailConfig) FullHost() string {
 	return fmt.Sprintf("%s:%s", c.Host, c.Port)
 }

--- a/src/golang/lib/models/shared/integration_config.go
+++ b/src/golang/lib/models/shared/integration_config.go
@@ -45,19 +45,19 @@ type K8sIntegrationConfig struct {
 }
 
 type EmailConfig struct {
-	User     string `json:"user" yaml:"user"`
-	Password string `json:"password" yaml:"password"`
-	Host     string `json:"host" yaml:"host"`
-	Port     string `json:"port" yaml:"port"`
+	User     string `json:"user"`
+	Password string `json:"password"`
+	Host     string `json:"host"`
+	Port     string `json:"port"`
 	// Targets are email addresses for receivers.
-	Targets []string          `json:"targets" yaml:"targets"`
-	Level   NotificationLevel `json:"level" yaml:"level"`
+	Targets []string          `json:"targets"`
+	Level   NotificationLevel `json:"level"`
 }
 
 type SlackConfig struct {
-	Token    string            `json:"token" yaml:"token"`
-	Channels []string          `json:"channels" yaml:"channels"`
-	Level    NotificationLevel `json:"level" yaml:"level"`
+	Token    string            `json:"token"`
+	Channels []string          `json:"channels"`
+	Level    NotificationLevel `json:"level"`
 }
 
 func (c *EmailConfig) FullHost() string {

--- a/src/golang/lib/notification/slack.go
+++ b/src/golang/lib/notification/slack.go
@@ -1,0 +1,12 @@
+package notification
+
+import (
+	"github.com/aqueducthq/aqueduct/lib/models/shared"
+	"github.com/slack-go/slack"
+)
+
+func AuthenticateSlack(conf *shared.SlackConfig) error {
+	client := slack.New(conf.Token)
+	_, err := client.AuthTest()
+	return err
+}

--- a/src/golang/lib/workflow/operator/connector/auth/static_config.go
+++ b/src/golang/lib/workflow/operator/connector/auth/static_config.go
@@ -31,6 +31,7 @@ func (sc *StaticConfig) PublicConfig() map[string]string {
 	sensitiveKeys := []string{
 		"auth_uri",                    // MongoDB config.
 		"password",                    // most integration configs have this field.
+		"token",                       // slack config
 		"service_account_credentials", // S3 config.
 		"config_file_content",         // S3 config.
 	}

--- a/src/ui/common/src/components/integrations/cards/card.tsx
+++ b/src/ui/common/src/components/integrations/cards/card.tsx
@@ -24,6 +24,7 @@ import { MySqlCard } from './mysqlCard';
 import { PostgresCard } from './postgresCard';
 import { RedshiftCard } from './redshiftCard';
 import { S3Card } from './s3Card';
+import { SlackCard } from './slackCard';
 import { SnowflakeCard } from './snowflakeCard';
 
 type DataProps = {
@@ -141,6 +142,9 @@ export const IntegrationCard: React.FC<IntegrationProps> = ({
       break;
     case 'Email':
       serviceCard = <EmailCard integration={integration} />;
+      break;
+    case 'Slack':
+      serviceCard = <SlackCard integration={integration} />;
       break;
     default:
       serviceCard = null;

--- a/src/ui/common/src/components/integrations/cards/detailCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/detailCard.tsx
@@ -18,6 +18,7 @@ import { MySqlCard } from './mysqlCard';
 import { PostgresCard } from './postgresCard';
 import { RedshiftCard } from './redshiftCard';
 import { S3Card } from './s3Card';
+import { SlackCard } from './slackCard';
 import { SnowflakeCard } from './snowflakeCard';
 
 type DetailIntegrationCardProps = {
@@ -65,6 +66,9 @@ export const DetailIntegrationCard: React.FC<DetailIntegrationCardProps> = ({
       break;
     case 'Email':
       serviceCard = <EmailCard integration={integration} />;
+      break;
+    case 'Slack':
+      serviceCard = <SlackCard integration={integration} />;
       break;
     default:
       serviceCard = null;

--- a/src/ui/common/src/components/integrations/cards/slackCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/slackCard.tsx
@@ -1,0 +1,30 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
+import { Integration, SlackConfig } from '../../../utils/integrations';
+
+type Props = {
+  integration: Integration;
+};
+
+export const SlackCard: React.FC<Props> = ({ integration }) => {
+  const config = integration.config as SlackConfig;
+  const channels = JSON.parse(config.channels_serialized) as string[];
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography variant="body2">
+        {channels.length > 1 ? (
+          <strong>Channel: </strong>
+        ) : (
+          <strong>Channels:</strong>
+        )}{' '}
+        {channels.join(', ')}
+      </Typography>
+      <Typography variant="body2">
+        <strong>Level: </strong>
+        {config.level.toUpperCase()}
+      </Typography>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -40,6 +40,7 @@ import {
   RedshiftConfig,
   S3Config,
   Service,
+  SlackConfig,
   SnowflakeConfig,
   SQLiteConfig,
   SupportedIntegrations,
@@ -61,6 +62,7 @@ import { MysqlDialog } from './mysqlDialog';
 import { PostgresDialog } from './postgresDialog';
 import { RedshiftDialog } from './redshiftDialog';
 import { isS3ConfigComplete, S3Dialog } from './s3Dialog';
+import { SlackDialog } from './slackDialog';
 import { SnowflakeDialog } from './snowflakeDialog';
 import { SQLiteDialog } from './sqliteDialog';
 
@@ -318,6 +320,14 @@ const IntegrationDialog: React.FC<Props> = ({
         <EmailDialog
           onUpdateField={setConfigField}
           value={config as EmailConfig}
+        />
+      );
+      break;
+    case 'Slack':
+      serviceDialog = (
+        <SlackDialog
+          onUpdateField={setConfigField}
+          value={config as SlackConfig}
         />
       );
       break;

--- a/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
@@ -1,0 +1,79 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React, { useState } from 'react';
+import { NotificationLogLevel } from 'src';
+
+import { SlackConfig } from '../../../utils/integrations';
+import NotificationLevelSelector from '../../notifications/NotificationLevelSelector';
+import { IntegrationTextInputField } from './IntegrationTextInputField';
+
+const Placeholders = {
+  token: '*****',
+  channel: 'my_channel',
+  level: 'succeeded',
+};
+
+type Props = {
+  onUpdateField: (field: keyof SlackConfig, value: string) => void;
+  value?: SlackConfig;
+};
+
+export const SlackDialog: React.FC<Props> = ({ onUpdateField, value }) => {
+  const [channels, setChannels] = useState(
+    value?.channels_serialized
+      ? (JSON.parse(value?.channels_serialized) as string[]).join(',')
+      : ''
+  );
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={false}
+        label="Bot Token *"
+        description="The slack bot token. Please make sure this token has the permissions to send messages to channels you specified."
+        placeholder={Placeholders.token}
+        type="password"
+        onChange={(event) => {
+          if (!!event.target.value) {
+            onUpdateField('token', event.target.value);
+          }
+        }}
+        value={value?.token ?? null}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={true}
+        label="Channels *"
+        description="The channel(s) to send notifications. Use comma to separate different channels."
+        placeholder={Placeholders.channel}
+        onChange={(event) => {
+          setChannels(event.target.value);
+          const channelsList = event.target.value
+            .split(',')
+            .map((r) => r.trim());
+          onUpdateField('channels_serialized', JSON.stringify(channelsList));
+        }}
+        value={channels ?? null}
+      />
+
+      <Box sx={{ mt: 2 }}>
+        <Box sx={{ my: 1 }}>
+          <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+            Level *
+          </Typography>
+          <Typography variant="body2" sx={{ color: 'darkGray' }}>
+            The notification levels at which to send a slack notification. This
+            applies to all workflows unless separately specified in workflow
+            settings.
+          </Typography>
+        </Box>
+        <NotificationLevelSelector
+          level={value?.level as NotificationLogLevel}
+          onSelectLevel={(level) => onUpdateField('level', level)}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -83,7 +83,9 @@ const IntegrationsPage: React.FC<Props> = ({
             category={IntegrationCategories.COMPUTE}
             supportedIntegrations={SupportedIntegrations}
           />
-          <Typography variant="h6" marginY={2}>
+          {
+            // TODO: Enable this once notification are fully implemented.
+            /*<Typography variant="h6" marginY={2}>
             Notifications
           </Typography>
           <Typography variant="h6" marginY={2}>
@@ -92,7 +94,8 @@ const IntegrationsPage: React.FC<Props> = ({
               category={IntegrationCategories.NOTIFICATION}
               supportedIntegrations={SupportedIntegrations}
             />
-          </Typography>
+  </Typography>*/
+          }
         </Box>
 
         <Box marginY={3}>

--- a/src/ui/common/src/index.tsx
+++ b/src/ui/common/src/index.tsx
@@ -17,6 +17,7 @@ import { MySqlCard } from './components/integrations/cards/mysqlCard';
 import { PostgresCard } from './components/integrations/cards/postgresCard';
 import { RedshiftCard } from './components/integrations/cards/redshiftCard';
 import { S3Card } from './components/integrations/cards/s3Card';
+import { SlackCard } from './components/integrations/cards/slackCard';
 import { SnowflakeCard } from './components/integrations/cards/snowflakeCard';
 import { ConnectedIntegrations } from './components/integrations/connectedIntegrations';
 import AddTableDialog from './components/integrations/dialogs/addTableDialog';
@@ -35,6 +36,7 @@ import { MysqlDialog } from './components/integrations/dialogs/mysqlDialog';
 import { PostgresDialog } from './components/integrations/dialogs/postgresDialog';
 import { RedshiftDialog } from './components/integrations/dialogs/redshiftDialog';
 import { S3Dialog } from './components/integrations/dialogs/s3Dialog';
+import { SlackDialog } from './components/integrations/dialogs/slackDialog';
 import { SnowflakeDialog } from './components/integrations/dialogs/snowflakeDialog';
 import { Card } from './components/layouts/card';
 import DefaultLayout from './components/layouts/default';
@@ -364,6 +366,8 @@ export {
   setWorkflowStatusBarOpenState,
   // TODO: Refactor to remove sidesheet state
   sideSheetSwitcher,
+  SlackCard,
+  SlackDialog,
   SnowflakeCard,
   SnowflakeDialog,
   StatusChip as Status,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -168,6 +168,12 @@ export type EmailConfig = {
   level: string;
 };
 
+export type SlackConfig = {
+  token: string;
+  channels_serialized: string;
+  level: string;
+};
+
 export type IntegrationConfig =
   | PostgresConfig
   | SnowflakeConfig
@@ -187,7 +193,8 @@ export type IntegrationConfig =
   | LambdaConfig
   | CondaConfig
   | DatabricksConfig
-  | EmailConfig;
+  | EmailConfig
+  | SlackConfig;
 
 export type Service =
   | 'Postgres'
@@ -209,7 +216,8 @@ export type Service =
   | 'MongoDB'
   | 'Conda'
   | 'Databricks'
-  | 'Email';
+  | 'Email'
+  | 'Slack';
 
 export type Info = {
   logo: string;
@@ -292,6 +300,7 @@ export const ServiceLogos: ServiceLogo = {
   ['Conda']: `${integrationLogosBucket}/conda.png`,
   ['Databricks']: `${integrationLogosBucket}/databricks_logo.png`,
   ['Email']: `${integrationLogosBucket}/email.png`,
+  ['Slack']: `${integrationLogosBucket}/slack.png`,
 
   // TODO(ENG-2301): Once task is addressed, remove this duplicate entry.
   ['K8s']: `${integrationLogosBucket}/kubernetes.png`,
@@ -385,6 +394,11 @@ export const SupportedIntegrations: ServiceInfoMap = {
   },
   ['Email']: {
     logo: ServiceLogos['Email'],
+    activated: true,
+    category: IntegrationCategories.NOTIFICATION,
+  },
+  ['Slack']: {
+    logo: ServiceLogos['Slack'],
     activated: true,
     category: IntegrationCategories.NOTIFICATION,
   },


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds backend changes for slack integration. It's very similar to #898 , and covers the necessary auth check when connecting to slack.

A follow up task is https://linear.app/aqueducthq/issue/ENG-2315/[m3]-detect-if-slack-token-has-channel-access-on-auth-time , that we will add checks to ensure the token has permission to all specified channels. We decide to do this later as we will explore slack go APIs more heavily in the next milestone.
 
## Related issue number (if any)
ENG-2191

## Loom demo (if any)
See #910 

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


