### PR TITLE
ENG-2134 Remove Unnecessary Backticks in WorkflowStatusBar Warning list item

### DIFF
--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -459,7 +459,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         newWorkflowStatusItem.level = WorkflowStatusTabs.Warnings;
         newWorkflowStatusItem.title = (
           <>
-            `Non-fatal error occurred for `<b>${artifactName}</b>
+            Non-fatal error occurred for <b>{artifactName}</b>
           </>
         );
         newWorkflowStatusItem.message = artifactExecState.error?.tip;
@@ -536,7 +536,7 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
         newWorkflowStatusItem.level = WorkflowStatusTabs.Warnings;
         newWorkflowStatusItem.title = (
           <>
-            `Warning for `<b>{operatorName}</b>
+            Warning for <b>{operatorName}</b>
           </>
         );
         newWorkflowStatusItem.message = opExecState.error?.tip;
@@ -550,9 +550,8 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
-            err.context ?? ''
-          }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
+            }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;

--- a/src/ui/common/src/components/workflows/StatusBar.tsx
+++ b/src/ui/common/src/components/workflows/StatusBar.tsx
@@ -550,8 +550,9 @@ export const WorkflowStatusBar: React.FC<WorkflowStatusBarProps> = ({
             </>
           );
           const err = opExecState.error;
-          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${err.context ?? ''
-            }`;
+          newWorkflowStatusItem.message = `${err.tip ?? ''}\n${
+            err.context ?? ''
+          }`;
         } else {
           // no error message found, so treat this as a system internal error
           newWorkflowStatusItem.message = `Aqueduct Internal Error`;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR resolves an issue where unnecessary backticks and dollar signs appeared in the WorkflowStatusBar's WarningListItem.

This issue happened due to treating the title as a string and not a react component (we use a component here to support more advanced title styling).

## Related issue number (if any)
ENG-2134

## Loom demo (if any)
<img width="636" alt="image" src="https://user-images.githubusercontent.com/1031759/214449915-a5b962a7-826f-48e7-8fbf-f325f638b2c6.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


