### PR TITLE
ENG-2264 Data List Page Loading Fixes

### DIFF
--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -1,4 +1,4 @@
-import { Link, Typography, CircularProgress } from '@mui/material';
+import { CircularProgress, Link, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -32,16 +32,13 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
 
   useEffect(() => {
     const fetchDataArtifactsAndIntegrations = async () => {
-      console.log('starting to fetch data.');
       setIsLoading(true);
       await dispatch(getDataArtifactPreview({ apiKey }));
       await dispatch(handleLoadIntegrations({ apiKey }));
-      console.log('done fetching data');
       setIsLoading(false);
     };
 
     fetchDataArtifactsAndIntegrations();
-
   }, [apiKey, dispatch]);
 
   const dataCardsInfo = useSelector(
@@ -94,12 +91,9 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
         ? Object.keys(dataCardsInfo.data.latest_versions)
         : [];
 
-    console.log('latestVersions: ', latestVersions);
     tableData = latestVersions.map((version) => {
       const currentVersion =
         dataCardsInfo.data.latest_versions[version.toString()];
-
-      console.log('currentVersion: ', currentVersion);
 
       const artifactId = currentVersion.artifact_id;
       const artifactName = currentVersion.artifact_name;
@@ -116,9 +110,6 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
           latestVersion = version;
         }
       });
-
-      // TODO: Update DataPreviewVersion to have the fields we get back here. (see data.ts)
-      console.log('latestVersion: ', latestVersion);
 
       let checks = [];
       if (latestVersion?.checks?.length > 0) {
@@ -232,19 +223,26 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     return parseInt(savedRowsPerPage);
   };
 
-  console.log('data page render artifactList: ', artifactList);
-
-  console.log('isLoading: ', isLoading);
-
   if (isLoading) {
     return (
-      <Layout breadcrumbs={[BreadcrumbLink.HOME, BreadcrumbLink.DATA]} user={user}>
-        <Box sx={{ display: 'flex', width: '100%', height: '100%', justifyContent: 'center', alignItems: 'center' }}>
+      <Layout
+        breadcrumbs={[BreadcrumbLink.HOME, BreadcrumbLink.DATA]}
+        user={user}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            width: '100%',
+            height: '100%',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
           <Box sx={{ width: '64px', height: '64px' }}>
             <CircularProgress sx={{ width: '100%', height: '100%' }} />
           </Box>
         </Box>
-      </Layout >
+      </Layout>
     );
   }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a loading spinner to the data list page and improves null checking while waiting for data to be fetched.

## Related issue number (if any)
ENG-2264

## Loom demo (if any)
https://www.loom.com/share/8f402aea4e5547d588309e9ea1be4395

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


