### PR TITLE
Fixes bug where saving to relational DBs failed for large string cols

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/relational.py
@@ -97,7 +97,7 @@ class RelationalConnector(connector.DataConnector):
 
         # Map of only string columns to their SQL type
         # If a column is not in this map, we rely on Panda's default mapping
-        dtype_to_sql = self._map_object_dtype_to_varchar(df)
+        col_to_type = self._map_object_dtype_to_varchar(df)
 
         # NOTE (saurav): df._to_sql has known performance issues. Using `method="multi"` helps incrementally,
         # since pandas will pass multiple rows in a single INSERT. If this still remains an issue, we can pass in a
@@ -108,6 +108,6 @@ class RelationalConnector(connector.DataConnector):
             con=self.engine,
             if_exists=params.update_mode.value,
             index=False,
-            dtype=dtype_to_sql,
+            dtype=col_to_type,
             method="multi",
         )

--- a/src/python/aqueduct_executor/operators/connectors/data/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/relational.py
@@ -57,7 +57,7 @@ class RelationalConnector(connector.DataConnector):
             )
         return results
 
-    def _map_object_dtype_to_varchar(df: pd.DataFrame) -> Dict[str, VARCHAR]:
+    def _map_object_dtype_to_varchar(self, df: pd.DataFrame) -> Dict[str, VARCHAR]:
         """Given a DataFrame, for each string column (i.e. object dtype), it
         returns a mapping of column name to the appropriate SQL type VARCHAR(N),
         where N is large enough for all values in the column. Non-string
@@ -69,20 +69,20 @@ class RelationalConnector(connector.DataConnector):
             # Use powers of 2 to determine how large the column needs to be
             # in terms of number of characters
             if max_size < 256:
-                col_to_type[col] = 256
+                col_to_type[col] = VARCHAR(256)
             elif max_size < 512:
-                col_to_type[col] = 512
+                col_to_type[col] = VARCHAR(512)
             elif max_size < 1024:
-                col_to_type[col] = 1024
+                col_to_type[col] = VARCHAR(1024)
             elif max_size < 4096:
-                col_to_type[col] = 4096
+                col_to_type[col] = VARCHAR(4096)
             elif max_size < 16384:
-                col_to_type[col] = 16384
+                col_to_type[col] = VARCHAR(16384)
             elif max_size < 32768:
-                col_to_type[col] = 32768
+                col_to_type[col] = VARCHAR(32768)
             elif max_size < 65536:
                 # The max VARCHAR size supported by many RDBMS is 65535 (2^16 - 1)
-                col_to_type[col] = 65535
+                col_to_type[col] = VARCHAR(65535)
             else:
                 raise Exception(
                     "Cannot support saving string columns with length greater than 65535 bytes"

--- a/src/python/aqueduct_executor/operators/connectors/data/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/relational.py
@@ -8,6 +8,7 @@ from aqueduct_executor.operators.utils.utils import delete_object
 from sqlalchemy import MetaData, engine, inspect
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.types import VARCHAR
 
 
 class RelationalConnector(connector.DataConnector):
@@ -56,11 +57,48 @@ class RelationalConnector(connector.DataConnector):
             )
         return results
 
+    def _map_object_dtype_to_varchar(df: pd.DataFrame) -> Dict[str, VARCHAR]:
+        """Given a DataFrame, for each string column (i.e. object dtype), it
+        returns a mapping of column name to the appropriate SQL type VARCHAR(N),
+        where N is large enough for all values in the column. Non-string
+        columns will not be included in the returned map.
+        """
+        col_to_type = {}
+        for col in df.select_dtypes(include=["object"]):
+            max_size = df[col].astype(str).str.len().max()
+            # Use powers of 2 to determine how large the column needs to be
+            # in terms of number of characters
+            if max_size < 256:
+                col_to_type[col] = 256
+            elif max_size < 512:
+                col_to_type[col] = 512
+            elif max_size < 1024:
+                col_to_type[col] = 1024
+            elif max_size < 4096:
+                col_to_type[col] = 4096
+            elif max_size < 16384:
+                col_to_type[col] = 16384
+            elif max_size < 32768:
+                col_to_type[col] = 32768
+            elif max_size < 65536:
+                # The max VARCHAR size supported by many RDBMS is 65535 (2^16 - 1)
+                col_to_type[col] = 65535
+            else:
+                raise Exception(
+                    "Cannot support saving string columns with length greater than 65535 bytes"
+                )
+        return col_to_type
+
     def load(
         self, params: load.RelationalParams, df: pd.DataFrame, artifact_type: ArtifactType
     ) -> None:
         if artifact_type != ArtifactType.TABLE:
             raise Exception("The data being loaded must be of type table, found %s" % artifact_type)
+
+        # Map of only string columns to their SQL type
+        # If a column is not in this map, we rely on Panda's default mapping
+        dtype_to_sql = self._map_object_dtype_to_varchar(df)
+
         # NOTE (saurav): df._to_sql has known performance issues. Using `method="multi"` helps incrementally,
         # since pandas will pass multiple rows in a single INSERT. If this still remains an issue, we can pass in a
         # callable function for `method` that does bulk loading.
@@ -70,5 +108,6 @@ class RelationalConnector(connector.DataConnector):
             con=self.engine,
             if_exists=params.update_mode.value,
             index=False,
+            dtype=dtype_to_sql,
             method="multi",
         )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where saving artifacts to relational DBs (specifically Postgres and Redshift) was failing for columns with large strings. The fix is to manually determine the appropriate VARCHAR size instead of letting Pandas default it to `255` bytes for all columns.

## Related issue number (if any)
ENG 2319

## Tests
Confirmed that all data_integration tests pass for SQLite, Snowflake, S3.

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


