### PR TITLE
Fix integration tests with sqlalchemy hack

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,9 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
+  push:
+    branches:
+      - fix_integration_test_with_hack
 
 jobs:
   run-tests:
@@ -39,13 +42,8 @@ jobs:
       - name: Install aqueduct-ml
         run: python3 -m pip install aqueduct-ml
 
-      - name: Install local SDK dependencies
-        working-directory: sdk
-        run: pip3 install .
-      
-      - name: Install local executor dependencies
-        working-directory: src/python
-        run: pip3 install .
+      - name: Install compatible SQLAlchemy
+        run: pip3 install SQLAlchemy==1.4.46
 
       - name: Start the server
         run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,9 +3,6 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
-  push:
-    branches:
-      - fix_integration_test_with_hack
 
 jobs:
   run-tests:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previous fix #927 has problem with schema updates since it uses 'current' upload script with production binaries. Therefore we have to revert the change.

This PR adds additional fix for the SQLAlchemy dependency issue by pin the version in github action. We need to rethink how to streamline these version updates in future.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


