### PR TITLE
Fixes bug for listing big query tables

### DIFF
--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -54,7 +54,7 @@ class APIClient:
     REGISTER_WORKFLOW_ROUTE = "/api/workflow/register"
     REGISTER_AIRFLOW_WORKFLOW_ROUTE = "/api/workflow/register/airflow"
     LIST_INTEGRATIONS_ROUTE = "/api/integrations"
-    LIST_TABLES_ROUTE = "/api/%s/tables"
+    LIST_INTEGRATION_OBJECTS_ROUTE = "/api/integration/%s/objects"
     GET_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s"
     LIST_WORKFLOW_SAVED_OBJECTS_ROUTE = "/api/workflow/%s/objects"
     GET_ARTIFACT_RESULT_TEMPLATE = "/api/artifact/%s/%s/result"
@@ -241,16 +241,12 @@ class APIClient:
         """Returns a list of the tables in the specified integration.
         If the integration is not a relational database, it will throw an error.
         """
-        url = self.construct_full_url(self.LIST_TABLES_ROUTE % integration_id)
+        url = self.construct_full_url(self.LIST_INTEGRATION_OBJECTS_ROUTE % integration_id)
         headers = self._generate_auth_headers()
         resp = requests.get(url, headers=headers)
         self.raise_errors(resp)
 
-        print(resp)
-        print(str(resp._content))
-        print(resp.json())
-
-        return resp.json()["table_names"]
+        return resp.json()["object_names"]
 
     def connect_integration(
         self, name: str, service: ServiceType, config: IntegrationConfig

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -54,7 +54,7 @@ class APIClient:
     REGISTER_WORKFLOW_ROUTE = "/api/workflow/register"
     REGISTER_AIRFLOW_WORKFLOW_ROUTE = "/api/workflow/register/airflow"
     LIST_INTEGRATIONS_ROUTE = "/api/integrations"
-    LIST_INTEGRATION_OBJECTS_ROUTE = "/api/integration/%s/objects"
+    LIST_INTEGRATION_OBJECTS_ROUTE_TEMPLATE = "/api/integration/%s/objects"
     GET_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s"
     LIST_WORKFLOW_SAVED_OBJECTS_ROUTE = "/api/workflow/%s/objects"
     GET_ARTIFACT_RESULT_TEMPLATE = "/api/artifact/%s/%s/result"
@@ -241,7 +241,7 @@ class APIClient:
         """Returns a list of the tables in the specified integration.
         If the integration is not a relational database, it will throw an error.
         """
-        url = self.construct_full_url(self.LIST_INTEGRATION_OBJECTS_ROUTE % integration_id)
+        url = self.construct_full_url(self.LIST_INTEGRATION_OBJECTS_ROUTE_TEMPLATE % integration_id)
         headers = self._generate_auth_headers()
         resp = requests.get(url, headers=headers)
         self.raise_errors(resp)

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -246,7 +246,7 @@ class APIClient:
         resp = requests.get(url, headers=headers)
         self.raise_errors(resp)
 
-        return resp.json()["object_names"]
+        return [x for x in resp.json()["object_names"]]
 
     def connect_integration(
         self, name: str, service: ServiceType, config: IntegrationConfig

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -54,7 +54,7 @@ class APIClient:
     REGISTER_WORKFLOW_ROUTE = "/api/workflow/register"
     REGISTER_AIRFLOW_WORKFLOW_ROUTE = "/api/workflow/register/airflow"
     LIST_INTEGRATIONS_ROUTE = "/api/integrations"
-    LIST_TABLES_ROUTE = "/api/tables"
+    LIST_TABLES_ROUTE = "/api/%s/tables"
     GET_WORKFLOW_ROUTE_TEMPLATE = "/api/workflow/%s"
     LIST_WORKFLOW_SAVED_OBJECTS_ROUTE = "/api/workflow/%s/objects"
     GET_ARTIFACT_RESULT_TEMPLATE = "/api/artifact/%s/%s/result"
@@ -237,14 +237,20 @@ class APIClient:
         resp = requests.get(url, headers=headers)
         return [x for x in resp.json()["branches"]]
 
-    def list_tables(self, limit: int) -> List[Tuple[str, str]]:
-        url = self.construct_full_url(self.LIST_TABLES_ROUTE)
+    def list_tables(self, integration_id: str) -> List[str]:
+        """Returns a list of the tables in the specified integration.
+        If the integration is not a relational database, it will throw an error.
+        """
+        url = self.construct_full_url(self.LIST_TABLES_ROUTE % integration_id)
         headers = self._generate_auth_headers()
-        headers["limit"] = str(limit)
         resp = requests.get(url, headers=headers)
         self.raise_errors(resp)
 
-        return [(table["name"], table["owner"]) for table in resp.json()["tables"]]
+        print(resp)
+        print(str(resp._content))
+        print(resp.json())
+
+        return resp.json()["table_names"]
 
     def connect_integration(
         self, name: str, service: ServiceType, config: IntegrationConfig

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -104,7 +104,8 @@ class RelationalDBIntegration(Integration):
             pd.DataFrame of available tables.
         """
         if self.type() in [ServiceType.BIGQUERY]:
-            # Use the `list_tables` endpoint instead of a hardcoded SQL query
+            # Use the list integration objects endpoint instead of 
+            # providing a hardcoded SQL query to execute
             tables = globals.__GLOBAL_API_CLIENT__.list_tables(str(self.id()))
             return pd.DataFrame(tables, columns=['tablename'])
 

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -103,6 +103,11 @@ class RelationalDBIntegration(Integration):
         Returns:
             pd.DataFrame of available tables.
         """
+        if self.type() in [ServiceType.BIGQUERY]:
+            # Use the `list_tables` endpoint instead of a hardcoded SQL query
+            tables = globals.__GLOBAL_API_CLIENT__.list_tables(str(self.id()))
+            return pd.DataFrame(tables, columns=['tablename'])
+
         if self.type() in [
             ServiceType.POSTGRES,
             ServiceType.AQUEDUCTDEMO,
@@ -115,8 +120,6 @@ class RelationalDBIntegration(Integration):
             list_tables_query = LIST_TABLES_QUERY_MYSQL
         elif self.type() == ServiceType.SQLSERVER:
             list_tables_query = LIST_TABLES_QUERY_SQLSERVER
-        elif self.type() == ServiceType.BIGQUERY:
-            list_tables_query = LIST_TABLES_QUERY_BIGQUERY
         elif self.type() == ServiceType.SQLITE:
             list_tables_query = LIST_TABLES_QUERY_SQLITE
         elif self.type() == ServiceType.ATHENA:

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -32,7 +32,6 @@ LIST_TABLES_QUERY_MYSQL = "SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHER
 LIST_TABLES_QUERY_SQLSERVER = (
     "SELECT table_name FROM INFORMATION_SCHEMA.TABLES WHERE table_type = 'BASE TABLE';"
 )
-LIST_TABLES_QUERY_BIGQUERY = "SELECT schema_name FROM information_schema.schemata;"
 GET_TABLE_QUERY = "select * from %s"
 LIST_TABLES_QUERY_SQLITE = "SELECT name AS tablename FROM sqlite_master WHERE type='table';"
 LIST_TABLES_QUERY_ATHENA = "AQUEDUCT_ATHENA_LIST_TABLE"
@@ -104,10 +103,10 @@ class RelationalDBIntegration(Integration):
             pd.DataFrame of available tables.
         """
         if self.type() in [ServiceType.BIGQUERY]:
-            # Use the list integration objects endpoint instead of 
+            # Use the list integration objects endpoint instead of
             # providing a hardcoded SQL query to execute
             tables = globals.__GLOBAL_API_CLIENT__.list_tables(str(self.id()))
-            return pd.DataFrame(tables, columns=['tablename'])
+            return pd.DataFrame(tables, columns=["tablename"])
 
         if self.type() in [
             ServiceType.POSTGRES,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug in the SDK when listing tables in big query. We were previously using an explicit SQL query to look up tables in Big Query, but this query does not work without providing additional information about the Google Cloud project ID. Instead of surfacing this information to the SDK client and having to construct a query, it is better to use our `integration/[]/objects` endpoint, since this achieves the same functionality without having to maintain hardcoded SQL queries. 

We should do the same for the other integrations as well. This task is documented [here](https://linear.app/aqueducthq/issue/ENG-2358/refactor-sdk-list-tables-implementation-to-use-the).

## Related issue number (if any)
ENG 2340

## Testing
I verified that the `list_tables` API works for a Big Query integration via a test notebook. Full testing of big query will be added as part of the ongoing testing work.

<img width="387" alt="Screen Shot 2023-01-30 at 12 04 36 AM" src="https://user-images.githubusercontent.com/10413474/215421055-354f15c4-e435-454f-82a7-a30c0c4ab302.png">



## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


