### PR TITLE
Adds cascading updates support for workflows running on Airflow

### DIFF
--- a/src/golang/cmd/server/handler/refresh_workflow.go
+++ b/src/golang/cmd/server/handler/refresh_workflow.go
@@ -6,16 +6,13 @@ import (
 
 	"github.com/aqueducthq/aqueduct/cmd/server/request"
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
-	"github.com/aqueducthq/aqueduct/lib/airflow"
 	"github.com/aqueducthq/aqueduct/lib/collections/operator/param"
-	"github.com/aqueducthq/aqueduct/lib/collections/shared"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/engine"
 	shared_utils "github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/vault"
-	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
 	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -45,10 +42,6 @@ type RefreshWorkflowHandler struct {
 	Engine   engine.Engine
 	Vault    vault.Vault
 
-	ArtifactRepo repos.Artifact
-	DAGRepo      repos.DAG
-	DAGEdgeRepo  repos.DAGEdge
-	OperatorRepo repos.Operator
 	WorkflowRepo repos.Workflow
 }
 
@@ -101,35 +94,13 @@ func (h *RefreshWorkflowHandler) Perform(ctx context.Context, interfaceArgs inte
 
 	emptyResp := struct{}{}
 
-	dag, err := utils.ReadLatestDAGFromDatabase(
-		ctx,
-		args.WorkflowId,
-		h.WorkflowRepo,
-		h.DAGRepo,
-		h.OperatorRepo,
-		h.ArtifactRepo,
-		h.DAGEdgeRepo,
-		h.Database,
-	)
-	if err != nil {
-		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to trigger workflow.")
-	}
-
-	if dag.EngineConfig.Type == shared.AirflowEngineType {
-		// This is an Airflow workflow
-		if err := airflow.TriggerWorkflow(ctx, dag, h.Vault); err != nil {
-			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unable to trigger workflow on Airflow.")
-		}
-		return emptyResp, http.StatusOK, nil
-	}
-
 	timeConfig := &engine.AqueductTimeConfig{
 		OperatorPollInterval: engine.DefaultPollIntervalMillisec,
 		ExecTimeout:          engine.DefaultExecutionTimeout,
 		CleanupTimeout:       engine.DefaultCleanupTimeout,
 	}
 
-	_, err = h.Engine.TriggerWorkflow(
+	_, err := h.Engine.TriggerWorkflow(
 		ctx,
 		args.WorkflowId,
 		shared_utils.AppendPrefix(args.WorkflowId.String()),

--- a/src/golang/cmd/server/server/cron.go
+++ b/src/golang/cmd/server/server/cron.go
@@ -32,10 +32,6 @@ func (s *AqServer) triggerMissedCronJobs(
 			Engine:   s.AqEngine,
 			Vault:    s.Vault,
 
-			ArtifactRepo: s.ArtifactRepo,
-			DAGRepo:      s.DAGRepo,
-			DAGEdgeRepo:  s.DAGEdgeRepo,
-			OperatorRepo: s.OperatorRepo,
 			WorkflowRepo: s.WorkflowRepo,
 		}).Perform(
 			ctx,

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -207,10 +207,6 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			Engine:   s.AqEngine,
 			Vault:    s.Vault,
 
-			ArtifactRepo: s.ArtifactRepo,
-			DAGRepo:      s.DAGRepo,
-			DAGEdgeRepo:  s.DAGEdgeRepo,
-			OperatorRepo: s.OperatorRepo,
 			WorkflowRepo: s.WorkflowRepo,
 		},
 		routes.RegisterWorkflowRoute: &handler.RegisterWorkflowHandler{


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds support for cascading update-based schedules for workflows that run on Airflow. We still do not support using an Airflow workflow as the source workflow. It can only be a target workflow.

## Related issue number (if any)
ENG 2202

## Loom demo (if any)

## Testing
TODO: Need to manually verify this on an Airflow cluster

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


