### PR TITLE
ENG-2308 Metric Preview Fixes

### DIFF
--- a/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/MetricItem.tsx
@@ -78,11 +78,11 @@ const MetricItem: React.FC<MetricItemProps> = ({ metrics }) => {
             {metrics[i].name}
           </Typography>
           {metrics[i].status === ExecutionStatus.Succeeded ? (
-            <StatusIndicator status={metrics[i].status} />
-          ) : (
             <Typography variant="body1" sx={{ fontWeight: 300 }}>
               {parseMetricResult(metrics[i].value, 3)}
             </Typography>
+          ) : (
+            <StatusIndicator status={metrics[i].status} />
           )}
         </Box>
       );


### PR DESCRIPTION
## Describe your changes and why you are making these changes
-This PR fixes a bug where failing metrics show as NaN in metric preview list.
-Also fixes another issue where the metric previews were showing as status indicators.

## Related issue number (if any)
ENG-2308

## Loom demo (if any)
Here we see a failed metric that is being rendered as it's actual status, which is 'canceled'
<img width="548" alt="image" src="https://user-images.githubusercontent.com/1031759/215583294-05534295-0047-4a0c-851f-c914278a3a12.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


