### PR TITLE
Set restriction on sdk for using Databricks Integration

### DIFF
--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -96,14 +96,20 @@ class DAG(BaseModel):
                         "All operators must run on Airflow. Operator %s is designated to run on custom engine `%s`."
                         % (op.name, op.spec.engine_config.name),
                     )
-                # DAG's expected to run on Databricks cannot have different Operator specs. 
-                if dag_engine_config.type == RuntimeType.DATABRICKS and op.spec.engine_config.type != RuntimeType.DATABRICKS:
+                # DAG's expected to run on Databricks cannot have different Operator specs.
+                if (
+                    dag_engine_config.type == RuntimeType.DATABRICKS
+                    and op.spec.engine_config.type != RuntimeType.DATABRICKS
+                ):
                     raise InvalidUserActionException(
                         "All operators must run on Databricks. Operator %s is designated to run on custom engine `%s`."
                         % (op.name, op.spec.engine_config.name),
                     )
                 # We don't allow individual operators to set Databricks as an engine spec without setting it globally.
-                if dag_engine_config.type != RuntimeType.DATABRICKS and op.spec.engine_config.type == RuntimeType.DATABRICKS:
+                if (
+                    dag_engine_config.type != RuntimeType.DATABRICKS
+                    and op.spec.engine_config.type == RuntimeType.DATABRICKS
+                ):
                     raise InvalidUserActionException(
                         """In order to use 
                         Databricks while previewing operators, please set 

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -96,11 +96,18 @@ class DAG(BaseModel):
                         "All operators must run on Airflow. Operator %s is designated to run on custom engine `%s`."
                         % (op.name, op.spec.engine_config.name),
                     )
-                elif dag_engine_config.type == RuntimeType.DATABRICKS:
+                # DAG's expected to run on Databricks cannot have different Operator specs. 
+                if dag_engine_config.type == RuntimeType.DATABRICKS and op.spec.engine_config.type != RuntimeType.DATABRICKS:
                     raise InvalidUserActionException(
-                        """All operators must run on Databricks. In order to use 
+                        "All operators must run on Databricks. Operator %s is designated to run on custom engine `%s`."
+                        % (op.name, op.spec.engine_config.name),
+                    )
+                # We don't allow individual operators to set Databricks as an engine spec without setting it globally.
+                if dag_engine_config.type != RuntimeType.DATABRICKS and op.spec.engine_config.type == RuntimeType.DATABRICKS:
+                    raise InvalidUserActionException(
+                        """In order to use 
                         Databricks while previewing operators, please set 
-                        aqueduct.global_config(/{'engine': '<databricks_integration>'/})""",
+                        aqueduct.global_config({'engine': '<databricks_integration>'})""",
                     )
 
                 op_engine_config = op.spec.engine_config

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -96,6 +96,12 @@ class DAG(BaseModel):
                         "All operators must run on Airflow. Operator %s is designated to run on custom engine `%s`."
                         % (op.name, op.spec.engine_config.name),
                     )
+                elif dag_engine_config.type == RuntimeType.DATABRICKS:
+                    raise InvalidUserActionException(
+                        """All operators must run on Databricks. In order to use 
+                        Databricks while previewing operators, please set 
+                        aqueduct.global_config(/{'engine': '<databricks_integration>'/})""",
+                    )
 
                 op_engine_config = op.spec.engine_config
 

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -145,6 +145,7 @@ def generate_engine_config(
     if integration.service == ServiceType.AIRFLOW:
         return EngineConfig(
             type=RuntimeType.AIRFLOW,
+            name=integration_name,
             airflow_config=AirflowEngineConfig(
                 integration_id=integration.id,
             ),
@@ -152,6 +153,7 @@ def generate_engine_config(
     elif integration.service == ServiceType.K8S:
         return EngineConfig(
             type=RuntimeType.K8S,
+            name=integration_name,
             k8s_config=K8sEngineConfig(
                 integration_id=integration.id,
             ),
@@ -159,6 +161,7 @@ def generate_engine_config(
     elif integration.service == ServiceType.LAMBDA:
         return EngineConfig(
             type=RuntimeType.LAMBDA,
+            name=integration_name,
             lambda_config=LambdaEngineConfig(
                 integration_id=integration.id,
             ),
@@ -166,6 +169,7 @@ def generate_engine_config(
     elif integration.service == ServiceType.DATABRICKS:
         return EngineConfig(
             type=RuntimeType.DATABRICKS,
+            name=integration_name,
             databricks_config=DatabricksEngineConfig(
                 integration_id=integration.id,
             ),


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Set restriction on usage of Databricks integration.
1. Can only be used to preview by setting aq.global_config({'engine':<databricks_integration>})
2. Can't be mixed with other compute integrations.
## Related issue number (if any)

## Loom demo (if any)
Running 
```
#With no global default set
@op(engine='d4')
def bad_op(df):
    5 / 0
    return df

output = bad_op()
```
results in 
```
InvalidUserActionException: In order to use 
                        Databricks while previewing operators, please set 
                        aqueduct.global_config({'engine': '<databricks_integration>'})
```

as expected.
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


