### PR TITLE
[2/2] [GH Actions] Update Pre-merge Integration Tests to use credential and config files

### DIFF
--- a/.github/actions/setup-server/action.yml
+++ b/.github/actions/setup-server/action.yml
@@ -1,0 +1,69 @@
+name: Setup Server
+description: "Sets up a server and installs the appropriate environment."
+
+runs:
+  using: composite
+  steps:
+    - name: Create the logs directory
+      shell: bash
+      run: mkdir -p logs
+
+    - name: Set filename for the server's output logs
+      shell: bash
+      run: echo "SERVER_LOGS_FILE=logs/server_logs_${{ matrix.python-version }}" >> $GITHUB_ENV
+
+    # Uniformly select from python versions 3.7 to 3.10.
+    # Write the selection to `.python-version` to be consumed by the setup-python action.
+    - name: Select random python version
+      shell: bash
+      run: echo 3.$(($RANDOM % 4 + 7)) >> .python-version
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+
+    - name: Set up GOPATH variable
+      shell: bash
+      run: echo "GOPATH=$(echo $HOME)" >> $GITHUB_ENV
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19.1
+
+    - name: Install aqueduct-ml
+      shell: bash
+      run: python3 -m pip install aqueduct-ml
+
+    - name: Install compatible SQLAlchemy
+      shell: bash
+      run: pip3 install SQLAlchemy==1.4.46
+
+    - name: Start the server
+      shell: bash
+      run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
+
+    - name: Wait for server
+      shell: bash
+      run: while ! echo exit | nc localhost 8080; do sleep 1; done
+
+    # Grabs the pid of the process bound to port 8080 and kills it.
+    - name: Kill the server
+      shell: bash
+      run: kill -9 $(lsof -nP -iTCP -sTCP:LISTEN | grep 8080 | awk '{print $2}')
+
+    # install_local.py requires ~/.aqueduct to exist.
+    - name: Update aqueduct with latest code
+      shell: bash
+      run: python3 scripts/install_local.py -g -s -e
+
+    - name: Start the server again
+      shell: bash
+      run: (aqueduct start --disable-usage-stats --verbose > $SERVER_LOGS_FILE 2>&1 &)
+
+    - name: Install packages needed for testing
+      shell: bash
+      run: python3 -m pip install nltk pytest-xdist
+
+    - name: Wait for server again
+      shell: bash
+      run: while ! echo exit | nc localhost 8080; do sleep 1; done

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -1,0 +1,24 @@
+name: Upload Artifact
+description: "Uploads an artifact with the supplied prefix."
+
+inputs:
+  prefix:
+    description: "A prefix used to deduplicate artifact names when multiple jobs the upload artifacts are run in the same workflow."
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.prefix }} - Test Config File
+        path: integration_tests/sdk/test-config.yml
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.prefix }} - Server Logs
+        path: logs/
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.prefix }} - Executor Logs
+        path: ~/.aqueduct/server/logs/*

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,81 +5,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    strategy:
-      matrix:
-        # These are all the Python versions that we support.
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-    
-    name: Run Fast Integration Tests with Python Version ${{ matrix.python-version }}
+  run-tests-aqueduct-engine-and-db:
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 20
+
+    name: Run all Integration Tests with Aqueduct Engine and DB
     steps:
       - uses: actions/checkout@v2
 
-      - name: Create the logs directory
-        run: mkdir -p logs
-
-      - name: Set filename for the server's output logs
-        run: echo "SERVER_LOGS_FILE=logs/server_logs_${{ matrix.python-version }}" >> $GITHUB_ENV
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set up GOPATH variable
-        run: echo "GOPATH=$(echo $HOME)" >> $GITHUB_ENV
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19.1
-      
-      - name: Install aqueduct-ml
-        run: python3 -m pip install aqueduct-ml
-
-      - name: Install compatible SQLAlchemy
-        run: pip3 install SQLAlchemy==1.4.46
-
-      - name: Start the server
-        run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
-
-      - name: Wait for server
-        timeout-minutes: 2
-        run: while ! echo exit | nc localhost 8080; do sleep 1; done
-
-      # Grabs the pid of the process bound to port 8080 and kills it.
-      - name: Kill the server
-        run: kill -9 $(lsof -nP -iTCP -sTCP:LISTEN | grep 8080 | awk '{print $2}')
-
-      # install_local.py requires ~/.aqueduct to exist.
-      - name: Update aqueduct with latest code
-        run: python3 scripts/install_local.py -g -s -e
-
-      - name: Start the server again
-        run: (aqueduct start --disable-usage-stats --verbose > $SERVER_LOGS_FILE 2>&1 &)
-
-      - name: Install packages needed for testing
-        run: python3 -m pip install nltk matplotlib pytest-xdist
-
-      - name: Wait for server again
+      - uses: ./.github/actions/setup-server
         timeout-minutes: 5
-        run: while ! echo exit | nc localhost 8080; do sleep 1; done
-
-      - name: Fetch the API key
-        run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
       - name: Set up the SDK Integration Tests
         working-directory: integration_tests/sdk
         run: |
-          echo "apikey: $(aqueduct apikey)" >> test-config.yml
-          echo "address: localhost:8080" >> test-config.yml
+          echo "apikey: $(aqueduct apikey)" >> test-credentials.yml
+          printf "address: localhost:8080" >> test-config.yml
+          printf "\ndata:\n  aqueduct_demo:" >> test-config.yml
+          printf "\ncompute:\n  aqueduct_engine:" >> test-config.yml
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 40
+        timeout-minutes: 10
         working-directory: integration_tests/sdk
-        run: python3 run_tests.py -n 5
+        run: python3 run_tests.py -n 8
+
+      - name: Set the API key as an env variable.
+        run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
       - name: Run the No-Concurrency Integration Tests
         timeout-minutes: 10
@@ -97,14 +48,7 @@ jobs:
           INTEGRATION: aqueduct_demo
         run: pytest . -rP -n 1
 
-      - uses: actions/upload-artifact@v3
+      - uses: ./.github/actions/upload-artifacts
         if: always()
         with:
-          name: Server Logs
-          path: logs/
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Executor Logs
-          path: ~/.aqueduct/server/logs/*
+          prefix: Aqueduct Engine and DB

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-tests-aqueduct-engine-and-db:
+  run-tests-basic:
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 20
 
-    name: Run all Integration Tests with Aqueduct Engine and DB
+    name: All Integration Tests with Basic Config
     steps:
       - uses: actions/checkout@v2
 
@@ -51,4 +51,4 @@ jobs:
       - uses: ./.github/actions/upload-artifacts
         if: always()
         with:
-          prefix: Aqueduct Engine and DB
+          prefix: Basic

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -11,63 +11,14 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        # These are all the Python versions that we support.
-        python-version: ['3.7', '3.8', '3.9', '3.10']
         concurrency: [ 2, 5 ]
 
     name: Run Integration Tests with Python Version ${{ matrix.python-version }} Concurrency ${{ matrix.concurrency }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Create the logs directory
-        run: mkdir -p logs
-
-      - name: Set filename for the server's output logs
-        run: echo "SERVER_LOGS_FILE=logs/server_logs_${{ matrix.python-version }}" >> $GITHUB_ENV
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Set up GOPATH variable
-        run: echo "GOPATH=$(echo $HOME)" >> $GITHUB_ENV
-
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19.1
-      
-      - name: Install aqueduct-ml
-        run: python3 -m pip install aqueduct-ml
-
-      - name: Start the server
-        run: (aqueduct start --verbose > $SERVER_LOGS_FILE 2>&1 &)
-
-      - name: Wait for server
-        timeout-minutes: 1
-        run: while ! echo exit | nc localhost 8080; do sleep 1; done
-
-      # Grabs the pid of the process bound to port 8080 and kills it.
-      - name: Kill the server
-        run: kill -9 $(lsof -nP -iTCP -sTCP:LISTEN | grep 8080 | awk '{print $2}')
-
-      # install_local.py requires ~/.aqueduct/server scaffolding to exist.
-      - name: Update aqueduct with latest code
-        run: python3 scripts/install_local.py --gobinary --sdk --executor
-
-      - name: Start the server again
-        run: (aqueduct start --disable-usage-stats --verbose > $SERVER_LOGS_FILE 2>&1 &)
-
-      - name: Install packages needed for testing
-        run: python3 -m pip install nltk matplotlib pytest-xdist
-
-      - name: Wait for server again
-        timeout-minutes: 1
-        run: while ! echo exit | nc localhost 8080; do sleep 1; done
-
-      - name: Fetch the API key
-        run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
+      - uses: ./.github/actions/setup-server
+        timeout-minutes: 5
 
       - name: Set up the SDK Integration Tests
         working-directory: integration_tests/sdk
@@ -76,22 +27,16 @@ jobs:
           echo "address: localhost:8080" >> test-config.yml
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 40
+        timeout-minutes: 30
         working-directory: integration_tests/sdk
         run: python3 run_tests.py -n 5
 
-      - uses: actions/upload-artifact@v3
+      - uses: ./.github/actions/upload-artifacts
         if: always()
         with:
-          name: Server Logs
-          path: logs/
+          prefix: Aqueduct Engine and DB
 
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: Executor Logs
-          path: ~/.aqueduct/server/logs/*
-
+      # Notifies Kenny, Suresh.
       - name: Report to Slack on Failure
         if: always()
         uses: ravsamhq/notify-slack-action@v1
@@ -101,6 +46,6 @@ jobs:
           message_format: '{emoji} *{workflow}* has {status_message}'
           footer: '{run_url}'
           notify_when: 'failure,warnings'
-          mention_users: 'U025MDH5KS6'
+          mention_users: 'U025MDH5KS6,U04CRDACQMQ'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -103,6 +103,8 @@ def use_deprecated(pytestconfig):
 
 
 def _type_from_engine_name(client, engine: str) -> ServiceType:
+    assert engine != "aqueduct_engine"
+
     integration_info_by_name = client.list_integrations()
     if engine not in integration_info_by_name.keys():
         raise Exception("Server is not connected to integration `%s`." % engine)

--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -5,10 +5,9 @@ address: <SERVER_ADDRESS>
 # OPTIONAL: If set, this can alter the metadata store of the server, so use
 # with care.
 metadata:
-  # If set, we will error if unless the server is in local metadata mode.
-  # This ensures that a metadata migration is performed. Otherwise, we allow
-  # the server to already be using the appropriate metadata store without any
-  # explicit migration action.
+  # If `must_migrate` is set, we will error unless the server is in local metadata mode.
+  # This ensures that a metadata migration is performed. Otherwise, the server
+  # is allowed to be using the appropriate metadata store already.
   must_migrate: true
   test_s3:
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR does the following:
- Updates our pre-merge integration tests to pick a python version at random, instead of iterating over them all. This mechanism will be useful in the future for our other tests.
- Refactors common server setup and upload artifact functionality into their appropriate composite actions, which makes the main yml file much cleaner.
- For the upload artifact composite action, you must specify a prefix, which allows for deduplication so that the same artifact (eg. server logs) can be uploaded at the end of a github workflow that has multiple parallel jobs.
- Also requests a beefier machine - with 8 cores we can finish these tests in 10 minutes.

## Related issue number (if any)
ENG-2350

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


