### PR TITLE
Allows user to provide filepath to BigQuery credentials when connecting via SDK

### DIFF
--- a/integration_tests/no_concurrency/sdk/requirements_test.py
+++ b/integration_tests/no_concurrency/sdk/requirements_test.py
@@ -147,7 +147,6 @@ def test_default_requirements_installation(client):
 
 
 def test_requirements_invalid_arguments(client):
-
     with pytest.raises(InvalidUserArgumentException):
 
         @op(requirements=123)

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -120,7 +120,6 @@ def _setup_snowflake_data(client: Client, snowflake: RelationalDBIntegration) ->
 
 
 def _setup_s3_data(client: Client, s3: S3Integration):
-
     # Find all the objects that already exist.
     existing_names = set()
     for object_name in demo_db_tables():

--- a/manual_qa_tests/deploy_example.py
+++ b/manual_qa_tests/deploy_example.py
@@ -8,6 +8,8 @@ CELL_CODE_HEADER_TEMPLATE = 'print("Cell %d")\n'
 SERVER_ADDRESS_CODE_SNIPPET = "address = "
 API_KEY_SNIPPET = "aqueduct.get_apikey()"
 ABBR_API_KEY_SNIPPET = "aq.get_apikey()"
+
+
 # Pull out the client credential value in the notebook, formatted like "<credential_prefix> <value>\n".
 # Strips out any quotes.
 def extract_credential(code: str, credential_prefix: str) -> str:

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -255,7 +255,7 @@ class APIClient:
         headers.update(
             {
                 "integration-name": name,
-                "integration-service": service,
+                "integration-service": service.value,
                 "integration-config": config.json(),
             }
         )

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -251,11 +251,16 @@ class APIClient:
     def connect_integration(
         self, name: str, service: ServiceType, config: IntegrationConfig
     ) -> None:
+        integration_service = service
+        if not isinstance(integration_service, str):
+            # The enum value needs to be used
+            integration_service = integration_service.value
+
         headers = self._generate_auth_headers()
         headers.update(
             {
                 "integration-name": name,
-                "integration-service": service.value,
+                "integration-service": integration_service,
                 "integration-config": config.json(),
             }
         )

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -25,6 +25,7 @@ from aqueduct.integrations.connect_config import (
     BaseConnectionConfig,
     IntegrationConfig,
     convert_dict_to_integration_connect_config,
+    prepare_integration_config,
 )
 from aqueduct.integrations.databricks_integration import DatabricksIntegration
 from aqueduct.integrations.google_sheets_integration import GoogleSheetsIntegration
@@ -229,6 +230,8 @@ class Client:
         if isinstance(config, dict):
             config = convert_dict_to_integration_connect_config(service, config)
         assert isinstance(config, BaseConnectionConfig)
+
+        config = prepare_integration_config(service, config)
 
         globals.__GLOBAL_API_CLIENT__.connect_integration(name, service, config)
         logger().info("Successfully connected to new %s integration `%s`." % (service, name))

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, cast
 
 from aqueduct.constants.enums import MetaEnum, ServiceType
 from aqueduct.error import InternalAqueductError
@@ -19,8 +19,22 @@ class BaseConnectionConfig(BaseModel):
 
 
 class BigQueryConfig(BaseConnectionConfig):
+    """
+    BigQueryConfig defines the Pydantic Config for a BigQuery integration.
+    One of the following between `service_account_credentials` and
+    `service_account_credentials_path` must be specified. If `service_account_credentials_path`
+    is specified, it takes priority.
+    """
+
     project_id: str
-    service_account_credentials: str
+    service_account_credentials: Optional[str]
+    service_account_credentials_path: Optional[str]
+
+    def json(self, **kwargs: Any) -> Any:
+        """Overrides default JSON serialization to ensure that `service_account_credentials_path`
+        is not passed along to the backend.
+        """
+        return super().json(exclude={"service_account_credentials_path"}, **kwargs)
 
 
 class MySQLConfig(BaseConnectionConfig):
@@ -155,3 +169,28 @@ def convert_dict_to_integration_connect_config(
     elif service == ServiceType.REDSHIFT:
         return RedshiftConfig(**config_dict)
     raise InternalAqueductError("Unexpected Service Type: %s" % service)
+
+
+def prepare_integration_config(
+    service: ServiceType, config: IntegrationConfig
+) -> IntegrationConfig:
+    """Prepares the IntegrationConfig object to be sent to the backend
+    as part of a request to connect a new integration.
+    """
+    if service == ServiceType.BIGQUERY:
+        return _prepare_big_query_config(cast(BigQueryConfig, config))
+    return config
+
+
+def _prepare_big_query_config(config: BigQueryConfig) -> BigQueryConfig:
+    """Prepares the BigQueryConfig object by reading the service account
+    credentials into a string field if the filepath is specified.
+    """
+    if not config.service_account_credentials_path:
+        return config
+
+    with open(config.service_account_credentials_path, "r") as file:
+        credentials = file.read().replace("\n", "")
+        config.service_account_credentials = credentials
+
+    return config

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union, cast
 
 from aqueduct.constants.enums import MetaEnum, ServiceType
-from aqueduct.error import InternalAqueductError
+from aqueduct.error import InternalAqueductError, InvalidUserArgumentException
 from pydantic import BaseModel, Extra, Field
 
 """Copied mostly over from `aqueduct_executor/operators/connectors/data/config.py` for now, please keep them in sync."""
@@ -27,8 +27,8 @@ class BigQueryConfig(BaseConnectionConfig):
     """
 
     project_id: str
-    service_account_credentials: Optional[str]
-    service_account_credentials_path: Optional[str]
+    service_account_credentials: Optional[str] = None
+    service_account_credentials_path: Optional[str] = None
 
     def json(self, **kwargs: Any) -> Any:
         """Overrides default JSON serialization to ensure that `service_account_credentials_path`
@@ -186,6 +186,11 @@ def _prepare_big_query_config(config: BigQueryConfig) -> BigQueryConfig:
     """Prepares the BigQueryConfig object by reading the service account
     credentials into a string field if the filepath is specified.
     """
+    if not config.service_account_credentials and not config.service_account_credentials_path:
+        raise InvalidUserArgumentException(
+            "At least one of `service_account_credentials` or `service_account_credentials_path` must be set for a BigQueryConfig."
+        )
+
     if not config.service_account_credentials_path:
         return config
 

--- a/sdk/aqueduct/integrations/salesforce_integration.py
+++ b/sdk/aqueduct/integrations/salesforce_integration.py
@@ -103,7 +103,6 @@ class SalesforceIntegration(Integration):
         query: str,
         extract_type: SalesforceExtractType,
     ) -> uuid.UUID:
-
         integration_info = self._metadata
 
         op_name = _generate_extract_op_name(self._dag, integration_info.name, name)

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -42,6 +42,7 @@ TAG_PATTERN = r"{{\s*[\w-]+\s*}}"
 # The TAG for 'previous table' when the user specifies a chained query.
 PREV_TABLE_TAG = "$"
 
+
 # A dictionary of built-in tags to their replacement string functions.
 def replace_today() -> str:
     return "'" + date.today().strftime("%Y-%m-%d") + "'"

--- a/sdk/aqueduct/models/config.py
+++ b/sdk/aqueduct/models/config.py
@@ -51,7 +51,6 @@ class EngineConfig(BaseModel):
 
 # TODO(...): this is deprecated.
 class FlowConfig(BaseModel):
-
     engine: Optional[
         Union[AirflowIntegration, K8sIntegration, LambdaIntegration, DatabricksIntegration]
     ]

--- a/src/python/aqueduct_executor/operators/connectors/data/extract.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/extract.py
@@ -82,7 +82,7 @@ class RelationalParams(models.BaseParams):
         with_clause = "WITH\n"
         prev_table_name = ""
         normalized_query = ""
-        for (idx, query) in enumerate(queries):
+        for idx, query in enumerate(queries):
             # Remove spaces and trailing semicolumns if any.
             normalized_query = query.strip().rstrip(";")
 

--- a/src/python/aqueduct_executor/operators/connectors/data/spark/s3.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/spark/s3.py
@@ -23,7 +23,6 @@ s3_template = "s3a://%s/%s"
 
 class SparkS3Connector(s3.S3Connector):
     def __init__(self, config: S3Config):
-
         super().__init__(config)
 
     def _fetch_object_spark(

--- a/src/python/aqueduct_executor/operators/connectors/data/spark/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/spark/snowflake.py
@@ -54,7 +54,6 @@ class SparkSnowflakeConnector(relational.RelationalConnector):
     def load_spark(
         self, params: load.RelationalParams, df: DataFrame, artifact_type: ArtifactType
     ) -> None:
-
         snowflake_update_mode = _map_to_snowflake_mode(params)
 
         df.write.format("snowflake").options(**self.snowflake_spark_options).option(

--- a/src/python/aqueduct_executor/operators/function_executor/install_requirements.py
+++ b/src/python/aqueduct_executor/operators/function_executor/install_requirements.py
@@ -14,7 +14,6 @@ from aqueduct_executor.operators.utils.storage.parse import parse_storage
 def install_missing_packages(
     missing_path: str, spec: FunctionSpec, conda_env: Optional[str]
 ) -> None:
-
     if conda_env:
         install_output = subprocess.run(
             [

--- a/src/python/aqueduct_executor/operators/spark/utils.py
+++ b/src/python/aqueduct_executor/operators/spark/utils.py
@@ -56,8 +56,7 @@ def read_artifacts_spark(
     artifact_types: List[ArtifactType] = []
     serialization_types: List[SerializationType] = []
 
-    for (input_path, input_metadata_path) in zip(input_paths, input_metadata_paths):
-
+    for input_path, input_metadata_path in zip(input_paths, input_metadata_paths):
         artifact_metadata = json.loads(storage.get(input_metadata_path).decode(DEFAULT_ENCODING))
         artifact_type = artifact_metadata[_METADATA_ARTIFACT_TYPE_KEY]
         artifact_types.append(artifact_type)

--- a/src/python/aqueduct_executor/operators/utils/storage/s3.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/s3.py
@@ -12,7 +12,6 @@ class S3Storage(Storage):
     _config: S3StorageConfig
 
     def __init__(self, config: S3StorageConfig):
-
         if config.aws_access_key_id and config.aws_secret_access_key:
             # The AWS keys are passed in as part of the storage spec for AWS Lambda engines
             self._client = boto3.client(

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -66,7 +66,7 @@ def read_artifacts(
     artifact_types: List[ArtifactType] = []
     serialization_types: List[SerializationType] = []
 
-    for (input_path, input_metadata_path) in zip(input_paths, input_metadata_paths):
+    for input_path, input_metadata_path in zip(input_paths, input_metadata_paths):
         # Make sure that the input paths exist.
         try:
             _ = storage.get(input_path)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previously we only allowed users to connect to BigQuery from the SDK if they provided a string of the svc account credentials. This is not user-friendly so we should allow them the option of specifying a file, since typically these credentials are downloaded in a JSON file.

This was also a pre-req for our integration tests, since it is easier to specify a credentials file instead of copying a long JSON string in the test-credentials file.

## Related issue number (if any)
ENG 2386

## Test
See the following notebook commands:
![Screen Shot 2023-02-02 at 5 19 36 PM](https://user-images.githubusercontent.com/10413474/216488157-3b9be575-e1c0-4d8e-a693-1bdee4c763b2.png)


## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


