### PR TITLE
Fixes bug in handling user error with mismatch in output count

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/error_handling_test.py
+++ b/integration_tests/sdk/aqueduct_tests/error_handling_test.py
@@ -14,6 +14,11 @@ def bad_op(df):
     return df
 
 
+@aqueduct.op(num_outputs=2)
+def bad_op_multiple_outputs(df):
+    return bad_op(df)
+
+
 # These tips should match executor code so that we can verify the correct error is generated.
 TIP_OP_EXECUTION = "Error executing operator. Please refer to the stack trace for fix."
 
@@ -23,6 +28,15 @@ def test_handle_bad_op_error(client, data_integration):
 
     try:
         bad_op(table_artifact)
+    except AqueductError as e:
+        assert TIP_OP_EXECUTION in e.message
+
+
+def test_handle_bad_op_with_multiple_outputs(client, data_integration):
+    table_artifact = extract(data_integration, DataObject.SENTIMENT)
+
+    try:
+        bad_op_multiple_outputs(table_artifact)
     except AqueductError as e:
         assert TIP_OP_EXECUTION in e.message
 

--- a/integration_tests/sdk/aqueduct_tests/error_handling_test.py
+++ b/integration_tests/sdk/aqueduct_tests/error_handling_test.py
@@ -35,10 +35,8 @@ def test_handle_bad_op_error(client, data_integration):
 def test_handle_bad_op_with_multiple_outputs(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    try:
+    with pytest.raises(AqueductError, match=TIP_OP_EXECUTION):
         bad_op_multiple_outputs(table_artifact)
-    except AqueductError as e:
-        assert TIP_OP_EXECUTION in e.message
 
 
 def test_file_dependencies_invalid(client):

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -155,8 +155,6 @@ def _validate_result_count_and_infer_type(
     Raises:
         ExecFailureException: If the expected number of results were not returned
     """
-    # We only validate the number of results if multiple outputs are expected.
-    # Otherwise, we treat the results as a single object.
     if len(spec.output_content_paths) != len(results):
         raise ExecFailureException(
             failure_type=FailureType.USER_FATAL,

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -123,7 +123,7 @@ def _execute_function(
         return invoke(*inputs)
 
     results = _invoke()
-    if not isinstance(results, list):
+    if len(spec.output_content_paths) == 1:
         results = [results]
 
     elapsedTime = timer.stop()
@@ -155,7 +155,7 @@ def _validate_result_count_and_infer_type(
     Raises:
         ExecFailureException: If the expected number of results were not returned
     """
-    if len(spec.output_content_paths) != len(results):
+    if len(spec.output_content_paths) > 1 and len(spec.output_content_paths) != len(results):
         raise ExecFailureException(
             failure_type=FailureType.USER_FATAL,
             tip="Expected function to have %s outputs, but instead it had %s."

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -123,20 +123,8 @@ def _execute_function(
         return invoke(*inputs)
 
     results = _invoke()
-
-    # We only validate the number of results if multiple outputs are expected.
-    # Otherwise, we treat the results as a single object.
-    if len(spec.output_content_paths) > 1 and len(spec.output_content_paths) != len(results):
-        raise ExecFailureException(
-            failure_type=FailureType.USER_FATAL,
-            tip="Expected function to have %s outputs, but instead it had %s."
-            % (len(spec.output_content_paths), len(results)),
-        )
-
-    if len(spec.output_content_paths) == 1:
+    if not isinstance(results, list):
         results = [results]
-
-    inferred_result_types = [infer_artifact_type(res) for res in results]
 
     elapsedTime = timer.stop()
     _, peak = tracemalloc.get_traced_memory()
@@ -146,7 +134,37 @@ def _execute_function(
     }
 
     sys.path.pop(0)
-    return results, inferred_result_types, system_metadata
+    return results, system_metadata
+
+
+def _validate_result_count_and_infer_type(
+    spec: FunctionSpec,
+    results: List[Any],
+) -> List[ArtifactType]:
+    """
+    Validates that the expected number of results were returned by the Function
+    and infers the ArtifactType of each result.
+
+    Args:
+        spec: The FunctionSpec for the Function
+        results: The results returned by the Function
+
+    Returns:
+        The ArtifactType of each result
+
+    Raises:
+        ExecFailureException: If the expected number of results were not returned
+    """
+    # We only validate the number of results if multiple outputs are expected.
+    # Otherwise, we treat the results as a single object.
+    if len(spec.output_content_paths) != len(results):
+        raise ExecFailureException(
+            failure_type=FailureType.USER_FATAL,
+            tip="Expected function to have %s outputs, but instead it had %s."
+            % (len(spec.output_content_paths), len(results)),
+        )
+
+    return [infer_artifact_type(res) for res in results]
 
 
 def validate_spec(spec: FunctionSpec) -> None:
@@ -214,13 +232,15 @@ def run(spec: FunctionSpec) -> None:
 
         derived_from_bson = SerializationType.BSON_TABLE in serialization_types
         print("Invoking the function...")
-        results, result_types, system_metadata = _execute_function(spec, inputs, exec_state)
+        results, system_metadata = _execute_function(spec, inputs, exec_state)
         if exec_state.status == ExecutionStatus.FAILED:
             # user failure
             utils.write_exec_state(storage, spec.metadata_path, exec_state)
             sys.exit(1)
 
         print("Function invoked successfully!")
+
+        result_types = _validate_result_count_and_infer_type(spec, results)
 
         # Perform type checking on the function output.
         if spec.operator_type == OperatorType.METRIC:
@@ -290,14 +310,6 @@ def run(spec: FunctionSpec) -> None:
             result_types[0] = ArtifactType.BOOL
             results[0] = True
         else:
-            # Error if the number of expected outputs is not what was returned by the user's function.
-            if len(results) != len(spec.expected_output_artifact_types):
-                raise ExecFailureException(
-                    failure_type=FailureType.USER_FATAL,
-                    tip="Expected function to return %d outputs, but instead got %d."
-                    % (len(spec.expected_output_artifact_types), len(results)),
-                )
-
             for i, expected_output_type in enumerate(spec.expected_output_artifact_types):
                 if (
                     expected_output_type != ArtifactType.UNTYPED

--- a/src/python/aqueduct_executor/operators/function_executor/execute.py
+++ b/src/python/aqueduct_executor/operators/function_executor/execute.py
@@ -104,7 +104,7 @@ def _execute_function(
     spec: FunctionSpec,
     inputs: List[Any],
     exec_state: ExecutionState,
-) -> Tuple[List[Any], List[ArtifactType], Dict[str, str]]:
+) -> Tuple[List[Any], Dict[str, str]]:
     """
     Invokes the given function on the input data. Does not raise an exception on any
     user function errors, but instead annotates the given exec state with the error.

--- a/src/python/aqueduct_executor/operators/spark/execute_function.py
+++ b/src/python/aqueduct_executor/operators/spark/execute_function.py
@@ -75,7 +75,7 @@ def _execute_function(
         return invoke(*inputs)
 
     results = _invoke()
-    if not isinstance(results, list):
+    if len(spec.output_content_paths) == 1:
         results = [results]
 
     elapsedTime = timer.stop()
@@ -107,7 +107,7 @@ def _validate_result_count_and_infer_type(
     Raises:
         ExecFailureException: If the expected number of results were not returned
     """
-    if len(spec.output_content_paths) != len(results):
+    if len(spec.output_content_paths) > 1 and len(spec.output_content_paths) != len(results):
         raise ExecFailureException(
             failure_type=FailureType.USER_FATAL,
             tip="Expected function to have %s outputs, but instead it had %s."

--- a/src/python/aqueduct_executor/operators/spark/execute_function.py
+++ b/src/python/aqueduct_executor/operators/spark/execute_function.py
@@ -56,7 +56,7 @@ def _execute_function(
     spec: FunctionSpec,
     inputs: List[Any],
     exec_state: ExecutionState,
-) -> Tuple[List[Any], List[ArtifactType], Dict[str, str]]:
+) -> Tuple[List[Any], Dict[str, str]]:
     """
     Invokes the given function on the input data. Does not raise an exception on any
     user function errors, but instead annotates the given exec state with the error.
@@ -75,20 +75,8 @@ def _execute_function(
         return invoke(*inputs)
 
     results = _invoke()
-
-    # We only validate the number of results if multiple outputs are expected.
-    # Otherwise, we treat the results as a single object.
-    if len(spec.output_content_paths) > 1 and len(spec.output_content_paths) != len(results):
-        raise ExecFailureException(
-            failure_type=FailureType.USER_FATAL,
-            tip="Expected function to have %s outputs, but instead it had %s."
-            % (len(spec.output_content_paths), len(results)),
-        )
-
-    if len(spec.output_content_paths) == 1:
+    if not isinstance(results, list):
         results = [results]
-
-    inferred_result_types = [_infer_artifact_type_spark(res) for res in results]
 
     elapsedTime = timer.stop()
     _, peak = tracemalloc.get_traced_memory()
@@ -98,7 +86,35 @@ def _execute_function(
     }
 
     sys.path.pop(0)
-    return results, inferred_result_types, system_metadata
+    return results, system_metadata
+
+
+def _validate_result_count_and_infer_type(
+    spec: FunctionSpec,
+    results: List[Any],
+) -> List[ArtifactType]:
+    """
+    Validates that the expected number of results were returned by the Function
+    and infers the ArtifactType of each result.
+
+    Args:
+        spec: The FunctionSpec for the Function
+        results: The results returned by the Function
+
+    Returns:
+        The ArtifactType of each result
+
+    Raises:
+        ExecFailureException: If the expected number of results were not returned
+    """
+    if len(spec.output_content_paths) != len(results):
+        raise ExecFailureException(
+            failure_type=FailureType.USER_FATAL,
+            tip="Expected function to have %s outputs, but instead it had %s."
+            % (len(spec.output_content_paths), len(results)),
+        )
+
+    return [_infer_artifact_type_spark(res) for res in results]
 
 
 def run(spec: FunctionSpec, spark_session_obj: SparkSession) -> None:
@@ -122,13 +138,15 @@ def run(spec: FunctionSpec, spark_session_obj: SparkSession) -> None:
 
         derived_from_bson = SerializationType.BSON_TABLE in serialization_types
         print("Invoking the function...")
-        results, result_types, system_metadata = _execute_function(spec, inputs, exec_state)
+        results, system_metadata = _execute_function(spec, inputs, exec_state)
         if exec_state.status == ExecutionStatus.FAILED:
             # user failure
             utils.write_exec_state(storage, spec.metadata_path, exec_state)
             sys.exit(1)
 
         print("Function invoked successfully!")
+
+        result_types = _validate_result_count_and_infer_type(spec, results)
 
         # Perform type checking on the function output.
         if spec.operator_type == OperatorType.METRIC:
@@ -199,14 +217,6 @@ def run(spec: FunctionSpec, spark_session_obj: SparkSession) -> None:
             result_types[0] = ArtifactType.BOOL
             results[0] = True
         else:
-            # Error if the number of expected outputs is not what was returned by the user's function.
-            if len(results) != len(spec.expected_output_artifact_types):
-                raise ExecFailureException(
-                    failure_type=FailureType.USER_FATAL,
-                    tip="Expected function to return %d outputs, but instead got %d."
-                    % (len(spec.expected_output_artifact_types), len(results)),
-                )
-
             for i, expected_output_type in enumerate(spec.expected_output_artifact_types):
                 if (
                     expected_output_type != ArtifactType.UNTYPED


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug in how we handle the following types of errors:
1. There is an error in the user code, i.e. an exception is thrown.
2. The number of outputs do not match what was expected.

Previously, we were prioritizing Error #2 over #1 and escalating that to the user. The correct use case is to catch Error #1 first and if so provide the user with the appropriate stack trace.

This PR also adds a new integration test case for this specific behavior.

## Related issue number (if any)
ENG 2333

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


