### PR TITLE
ENG-2285 MySQL Integration Testing Setup

### DIFF
--- a/integration_tests/sdk/test-config-example.yml
+++ b/integration_tests/sdk/test-config-example.yml
@@ -20,6 +20,7 @@ data:
   test_s3:
   test_mongo_db:
   test_athena:
+  test_mysql:
 
 # REQUIRED: All the compute integrations to run the test suite against.
 # All entries here must be present in `test-credentials.yml`, except

--- a/integration_tests/sdk/test-credentials-example.yml
+++ b/integration_tests/sdk/test-credentials-example.yml
@@ -40,7 +40,7 @@ data:
     warehouse:
   test_sqlite:
     type: SQLite
-    database: 
+    database:
   test_athena:
     type: Athena
     database: test
@@ -55,3 +55,10 @@ data:
     # config_file_path:
     # config_file_profile:
     # config_file_content:
+  test_mysql:
+    type: MySQL
+    username:
+    password:
+    database:
+    host:
+    port:

--- a/scripts/mysql_test_setup.sh
+++ b/scripts/mysql_test_setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Create the Docker container
+docker run --name aqueduct-mysql -e MYSQL_ROOT_PASSWORD='secret' -d -p 3306:3306 mysql
+
+# Wait for the database to be ready
+echo "Waiting for MySQL database container to be ready ..."
+until docker exec aqueduct-mysql mysql -uroot -psecret -e 'show databases;' &> /dev/null; do
+  sleep 1
+done
+
+# Create the 'aqueducttest' database
+echo "Creating aqueducttest database ..."
+docker exec -it aqueduct-mysql mysql -uroot -psecret -e "CREATE DATABASE aqueducttest;"
+
+echo "MySQL container with the 'aqueducttest' database created successfully."

--- a/scripts/mysql_test_teardown.sh
+++ b/scripts/mysql_test_teardown.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker stop aqueduct-mysql
+docker rm aqueduct-mysql


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds MySQL to our data integration testing suite.

Currently unable to run this on my M1 Macbook, but I suspect that this has something to do with arm specific binaries. Going to try out on ec2 instance and see if this works

## Related issue number (if any)
ENG-2285

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


