### PR TITLE
Allows use of flow name instead of id in SDK

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -604,3 +604,49 @@ def test_get_flow_with_name(client, flow_name, engine):
     # Failure case: flow id and name do not match
     with pytest.raises(InvalidUserArgumentException):
         client.flow(flow_id=flow.id(), flow_name="not a real flow")
+
+
+def test_refresh_flow_with_name(client, flow_name, engine):
+    """Tests triggering new run using the flow name."""
+
+    @op
+    def noop():
+        return 123
+
+    output = noop()
+
+    flow = publish_flow_test(
+        client,
+        artifacts=[output],
+        name=flow_name(),
+        engine=engine,
+    )
+
+    # Failure case: flow id and name do not match
+    with pytest.raises(InvalidUserArgumentException):
+        client.trigger(flow_id=flow.id(), flow_name="not a real flow")
+
+    client.trigger(flow_name=flow.name())
+
+
+def test_delete_flow_with_name(client, flow_name, engine):
+    """Tests deleting flow using name."""
+
+    @op
+    def noop():
+        return 123
+
+    output = noop()
+
+    flow = publish_flow_test(
+        client,
+        artifacts=[output],
+        name=flow_name(),
+        engine=engine,
+    )
+
+    # Failure case: flow id and name do not match
+    with pytest.raises(InvalidUserArgumentException):
+        client.delete_flow(flow_id=flow.id(), flow_name="not a real flow")
+
+    client.delete_flow(flow_name=flow.name())

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -580,6 +580,7 @@ def test_operators_with_custom_output_names(client, flow_name, engine):
 
 def test_get_flow_with_name(client, flow_name, engine):
     """Tests performing flow read operations using the flow name."""
+
     @op
     def noop():
         return 123

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -576,3 +576,29 @@ def test_operators_with_custom_output_names(client, flow_name, engine):
         @op(num_outputs=2, outputs=["output"])
         def bar():
             return 222
+
+
+def test_get_flow_with_name(client, flow_name):
+    """Tests performing flow read operations using the flow name."""
+    @op
+    def noop():
+        return 123
+
+    output = noop()
+
+    flow = publish_flow_test(
+        client,
+        artifacts=[output],
+        name=flow_name(),
+    )
+
+    fetched_with_id = client.flow(flow.id())
+    fetched_with_name = client.flow(flow.name())
+    fetched_with_id_and_name = client.flow(flow_id=flow.id(), flow_name=flow.name())
+
+    assert fetched_with_id == fetched_with_name
+    assert fetched_with_id == fetched_with_id_and_name
+
+    # Failure case: flow id and name do not match
+    with pytest.raises(InvalidUserArgumentException):
+        client.flow(flow_id=flow.id(), flow_name="not a real flow")

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -578,7 +578,7 @@ def test_operators_with_custom_output_names(client, flow_name, engine):
             return 222
 
 
-def test_get_flow_with_name(client, flow_name):
+def test_get_flow_with_name(client, flow_name, engine):
     """Tests performing flow read operations using the flow name."""
     @op
     def noop():
@@ -590,14 +590,15 @@ def test_get_flow_with_name(client, flow_name):
         client,
         artifacts=[output],
         name=flow_name(),
+        engine=engine,
     )
 
     fetched_with_id = client.flow(flow.id())
-    fetched_with_name = client.flow(flow.name())
+    fetched_with_name = client.flow(flow_name=flow.name())
     fetched_with_id_and_name = client.flow(flow_id=flow.id(), flow_name=flow.name())
 
-    assert fetched_with_id == fetched_with_name
-    assert fetched_with_id == fetched_with_id_and_name
+    assert fetched_with_id.id() == fetched_with_name.id()
+    assert fetched_with_id.id() == fetched_with_id_and_name.id()
 
     # Failure case: flow id and name do not match
     with pytest.raises(InvalidUserArgumentException):

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -185,17 +185,17 @@ def flow_name(client, request, pytestconfig):
     def cleanup_flows():
         if not pytestconfig.getoption("keep_flows"):
             for flow_name in flow_names:
-                flow_id = test_globals.flow_name_to_id[flow_name]
-
                 try:
                     client.delete_flow(
-                        str(flow_id),
-                        saved_objects_to_delete=client.flow(flow_id).list_saved_objects(),
+                        flow_name=flow_name,
+                        saved_objects_to_delete=client.flow(
+                            flow_name=flow_name
+                        ).list_saved_objects(),
                     )
                 except Exception as e:
-                    print("Error deleting workflow %s with exception: %s" % (flow_id, e))
+                    print("Error deleting workflow %s with exception: %s" % (flow_name, e))
                 else:
-                    print("Successfully deleted workflow %s" % flow_id)
+                    print("Successfully deleted workflow %s" % flow_name)
 
     request.addfinalizer(cleanup_flows)
     return get_new_flow_name

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -7,7 +7,6 @@ from aqueduct.constants.enums import ExecutionStatus
 
 import aqueduct
 from aqueduct import Flow
-from sdk.shared.globals import flow_name_to_id
 
 
 def publish_flow_test(
@@ -80,9 +79,6 @@ def publish_flow_test(
         source_flow=source_flow,
     )
     print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
-
-    # Necessary so that the flow is cleaned up at the end of the test.
-    flow_name_to_id[name] = flow.id()
 
     if should_block:
         wait_for_flow_runs(

--- a/integration_tests/sdk/shared/globals.py
+++ b/integration_tests/sdk/shared/globals.py
@@ -1,12 +1,6 @@
 import uuid
 from typing import Dict
 
-# TODO(ENG-1738): this global dictionary is only maintained because we don't have a way
-#  of deleting flows by name yet. The teardown code has the flow name, but not the flow id,
-#  since that is generated in the test by `publish_flow()`. Therefore, we must register every
-#  flow we publish in `publish_flow_test` in this dictionary.
-flow_name_to_id: Dict[str, uuid.UUID] = {}
-
 # Toggles whether we should test deprecated code paths. The is useful for ensuring both the new and
 # old code paths continue to work when the API changes, but we want to continue to ensure backwards
 # compatibility for a while.

--- a/integration_tests/sdk/shared/utils.py
+++ b/integration_tests/sdk/shared/utils.py
@@ -11,7 +11,6 @@ import aqueduct
 from aqueduct import Flow
 
 from .data_objects import DataObject
-from .globals import flow_name_to_id
 
 
 def generate_new_flow_name() -> str:
@@ -92,9 +91,6 @@ def publish_flow_test(
         source_flow=source_flow,
     )
     print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
-
-    # Necessary so that the flow is cleaned up at the end of the test.
-    flow_name_to_id[name] = flow.id()
 
     if should_block:
         wait_for_flow_runs(

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -36,7 +36,7 @@ from aqueduct.integrations.s3_integration import S3Integration
 from aqueduct.integrations.salesforce_integration import SalesforceIntegration
 from aqueduct.integrations.sql_integration import RelationalDBIntegration
 from aqueduct.logger import logger
-from aqueduct.models.config import EngineConfig, FlowConfig
+from aqueduct.models.config import FlowConfig
 from aqueduct.models.dag import Metadata, RetentionPolicy
 from aqueduct.models.integration import Integration, IntegrationInfo
 from aqueduct.models.operators import ParamSpec
@@ -53,7 +53,6 @@ from aqueduct.utils.utils import (
     generate_engine_config,
     generate_flow_schedule,
     generate_ui_url,
-    parse_user_supplied_id,
 )
 
 from aqueduct import globals
@@ -359,8 +358,9 @@ class Client:
             InvalidUserArgumentException:
                 If the provided flow id or name does not correspond to a flow the client knows about.
         """
+        flows = [(flow.id, flow.name) for flow in globals.__GLOBAL_API_CLIENT__.list_workflows()]
         flow_id = find_flow_with_user_supplied_id_and_name(
-            globals.__GLOBAL_API_CLIENT__.list_workflows(),
+            flows,
             flow_id,
             flow_name,
         )
@@ -657,8 +657,9 @@ class Client:
                 artifact_type = infer_artifact_type(new_val)
                 param_specs[name] = construct_param_spec(new_val, artifact_type)
 
+        flows = [(flow.id, flow.name) for flow in globals.__GLOBAL_API_CLIENT__.list_workflows()]
         flow_id = find_flow_with_user_supplied_id_and_name(
-            globals.__GLOBAL_API_CLIENT__.list_workflows(),
+            flows,
             flow_id,
             flow_name,
         )
@@ -697,8 +698,9 @@ class Client:
         if saved_objects_to_delete is None:
             saved_objects_to_delete = defaultdict()
 
+        flows = [(flow.id, flow.name) for flow in globals.__GLOBAL_API_CLIENT__.list_workflows()]
         flow_id = find_flow_with_user_supplied_id_and_name(
-            globals.__GLOBAL_API_CLIENT__.list_workflows(),
+            flows,
             flow_id,
             flow_name,
         )

--- a/sdk/aqueduct/tests/flow_test.py
+++ b/sdk/aqueduct/tests/flow_test.py
@@ -1,0 +1,32 @@
+import uuid
+from typing import Tuple
+
+import pytest
+from aqueduct.error import InvalidUserArgumentException
+from aqueduct.utils.utils import find_flow_with_user_supplied_id_and_name
+
+
+def test_find_flow_with_user_supplied_id_and_name():
+    flow_1_id = "9740eb10-d77d-4393-a9bc-42862d7008e0"
+    flow_2_id = "6d9d7b93-028f-48b1-b723-ebd9e66ac867"
+    flow_3_id = "431841d6-aac5-450f-b395-66e110ba547b"
+
+    flows = [
+        (uuid.UUID(flow_1_id), "flow_1"),
+        (uuid.UUID(flow_2_id), "flow_2"),
+        (uuid.UUID(flow_3_id), "flow_3"),
+    ]
+
+    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_id=flow_1_id)
+    assert flow_id == flow_1_id
+
+    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_name="flow_1")
+    assert flow_id == flow_1_id
+
+    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_id=flow_1_id, flow_name="flow_1")
+    assert flow_id == flow_1_id
+
+    with pytest.raises(InvalidUserArgumentException):
+        flow_id = find_flow_with_user_supplied_id_and_name(
+            flows, flow_id=flow_1_id, flow_name="flow_2"
+        )

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -1,8 +1,7 @@
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
-from aqueduct.backend.response_models import ListWorkflowResponseEntry
 from aqueduct.constants.enums import ArtifactType, RuntimeType, ServiceType, TriggerType
 from aqueduct.error import *
 from aqueduct.models.config import (
@@ -180,7 +179,7 @@ def generate_engine_config(
 
 
 def find_flow_with_user_supplied_id_and_name(
-    flows: List[ListWorkflowResponseEntry],
+    flows: List[Tuple[uuid.UUID, str]],
     flow_id: Optional[Union[str, uuid.UUID]] = None,
     flow_name: Optional[str] = None,
 ) -> str:
@@ -196,14 +195,14 @@ def find_flow_with_user_supplied_id_and_name(
 
     if flow_id:
         flow_id_str = parse_user_supplied_id(flow_id)
-        if all(uuid.UUID(flow_id_str) != flow.id for flow in flows):
+        if all(uuid.UUID(flow_id_str) != flow[0] for flow in flows):
             raise InvalidUserArgumentException("Unable to find a flow with id %s" % flow_id)
 
     if flow_name:
         flow_id_str_from_name = None
         for flow in flows:
-            if flow.name == flow_name:
-                flow_id_str_from_name = str(flow.id)
+            if flow[1] == flow_name:
+                flow_id_str_from_name = str(flow[0])
                 break
 
         if not flow_id_str_from_name:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR allows users to identify flows using the name instead of just an ID.

## Related issue number (if any)
ENG 1738

## Loom demo (if any)

## TESTS
- Added unit tests and integration test cases

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


