### PR TITLE
ENG-2171 Add Tabs to Workflow Details Page

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -49,9 +49,9 @@ export const S3Dialog: React.FC<Props> = ({
   const fileData =
     fileName && !!value?.config_file_content
       ? {
-          name: fileName,
-          data: value.config_file_content,
-        }
+        name: fileName,
+        data: value.config_file_content,
+      }
       : null;
 
   useEffect(() => {

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -49,9 +49,9 @@ export const S3Dialog: React.FC<Props> = ({
   const fileData =
     fileName && !!value?.config_file_content
       ? {
-        name: fileName,
-        data: value.config_file_content,
-      }
+          name: fileName,
+          data: value.config_file_content,
+        }
       : null;
 
   useEffect(() => {

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -453,6 +453,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   }
 
   // TODO: Make this a component, probably can put this near the other tab component that we have
+  // Linear Task: https://linear.app/aqueducthq/issue/ENG-2409/tabpanel-component
   function TabPanel(props: TabPanelProps) {
     const { children, value, index, ...other } = props;
 

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -57,6 +57,8 @@ import WorkflowHeader, {
 } from '../../../workflows/workflowHeader';
 import { LayoutProps } from '../../types';
 
+import { Tab, Tabs } from '../../../primitives/Tabs.styles';
+
 type WorkflowPageProps = {
   user: UserProfile;
   Layout?: React.FC<LayoutProps>;
@@ -72,6 +74,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   const urlSearchParams = parse(window.location.search);
   const location = useLocation();
   const path = location.pathname;
+  const [currentTab, setCurrentTab] = React.useState<string>("Overview");
 
   const currentNode = useSelector(
     (state: RootState) => state.nodeSelectionReducer.selected
@@ -333,8 +336,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -381,8 +383,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -401,8 +402,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -421,8 +421,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -438,6 +437,38 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   };
 
   const drawerHeaderHeightInPx = 64;
+
+  const handleTabChange = (event: React.SyntheticEvent, newTab: string) => {
+    setCurrentTab(newTab);
+  };
+
+  interface TabPanelProps {
+    children?: React.ReactNode;
+    index: string;
+    value: string;
+  }
+
+  // TODO: Make this a component, probably can put this near the other tab component that we have
+  function TabPanel(props: TabPanelProps) {
+    const { children, value, index, ...other } = props;
+
+    return (
+      <div
+        role="tabpanel"
+        hidden={value !== index}
+        id={`simple-tabpanel-${index}`}
+        aria-labelledby={`simple-tab-${index}`}
+        {...other}
+      >
+        {value === index && (
+          <Box sx={{ p: 3 }}>
+            {children}
+          </Box>
+        )}
+      </div>
+    );
+  }
+
 
   return (
     <Layout
@@ -481,92 +512,111 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         )}
 
         <Divider />
+        {/* Start of tabs for Workflow details page */}
+        <Tabs value={currentTab} onChange={handleTabChange}>
+          <Tab value="Details" label="Details" />
+          <Tab value="Settings" label="Settings" />
+        </Tabs>
 
-        <Box
-          sx={{
-            flex: 1,
-            mt: 2,
-            p: 3,
-            mb: contentBottomOffsetInPx,
-            width: '100%',
-            boxSizing: 'border-box',
-            backgroundColor: theme.palette.gray['50'],
-          }}
-        >
-          <ReactFlowProvider>
-            <ReactFlowCanvas
-              switchSideSheet={switchSideSheet}
-              onPaneClicked={onPaneClicked}
-            />
-          </ReactFlowProvider>
-        </Box>
-      </Box>
-
-      {currentNode.type !== NodeType.None && (
-        <Drawer
-          anchor="right"
-          variant="persistent"
-          open={true}
-          PaperProps={{
-            sx: {
-              transition: 'width 200ms ease-in-out',
-              transitionDelay: '1000ms',
-            },
-          }}
-        >
+        <TabPanel value={currentTab} index="Details">
           <Box
-            width={SidesheetWidth}
-            maxWidth={SidesheetWidth}
-            minHeight="100vh"
-            display="flex"
-            flexDirection="column"
+            sx={{
+              flex: 1,
+              mt: 2,
+              p: 3,
+              mb: contentBottomOffsetInPx,
+              width: '100%',
+              height: '100%',
+              boxSizing: 'border-box',
+              backgroundColor: theme.palette.gray['50'],
+            }}
           >
-            <Box
-              width="100%"
-              sx={{ backgroundColor: theme.palette.gray['100'] }}
-              height={`${drawerHeaderHeightInPx}px`}
-            >
-              <Box display="flex">
-                <Box
-                  sx={{ cursor: 'pointer', m: 1, alignSelf: 'center' }}
-                  onClick={onPaneClicked}
-                >
-                  <FontAwesomeIcon icon={faChevronRight} />
-                </Box>
-                <Box maxWidth="400px">
-                  <Typography
-                    variant="h5"
-                    padding="16px"
-                    textOverflow="ellipsis"
-                    overflow="hidden"
-                    whiteSpace="nowrap"
-                  >
-                    {getNodeLabel()}
-                  </Typography>
-                </Box>
-                <Box sx={{ mx: 2, alignSelf: 'center' }}>
-                  {getNodeActionButton()}
-                </Box>
-              </Box>
-            </Box>
-            <Box
-              sx={{
-                overflow: 'auto',
-                flexGrow: 1,
-                marginBottom: DefaultLayoutMargin,
-              }}
-            >
-              {getDataSideSheetContent(
-                user,
-                currentNode,
-                workflowId,
-                workflow.selectedResult.id
-              )}
+            <Box style={{ height: '100%' }}>
+              <ReactFlowProvider>
+                <ReactFlowCanvas
+                  switchSideSheet={switchSideSheet}
+                  onPaneClicked={onPaneClicked}
+                />
+              </ReactFlowProvider>
             </Box>
           </Box>
-        </Drawer>
-      )}
-    </Layout>
+        </TabPanel>
+
+
+        <TabPanel value={currentTab} index="Settings">
+          Settings Tab
+        </TabPanel>
+
+        {/* End of tabs for workflow details page */}
+      </Box >
+
+      {
+        currentNode.type !== NodeType.None && (
+          <Drawer
+            anchor="right"
+            variant="persistent"
+            open={true}
+            PaperProps={{
+              sx: {
+                transition: 'width 200ms ease-in-out',
+                transitionDelay: '1000ms',
+              },
+            }}
+          >
+            <Box
+              width={SidesheetWidth}
+              maxWidth={SidesheetWidth}
+              minHeight="100vh"
+              display="flex"
+              flexDirection="column"
+            >
+              <Box
+                width="100%"
+                sx={{ backgroundColor: theme.palette.gray['100'] }}
+                height={`${drawerHeaderHeightInPx}px`}
+              >
+                <Box display="flex">
+                  <Box
+                    sx={{ cursor: 'pointer', m: 1, alignSelf: 'center' }}
+                    onClick={onPaneClicked}
+                  >
+                    <FontAwesomeIcon icon={faChevronRight} />
+                  </Box>
+                  <Box maxWidth="400px">
+                    <Typography
+                      variant="h5"
+                      padding="16px"
+                      textOverflow="ellipsis"
+                      overflow="hidden"
+                      whiteSpace="nowrap"
+                    >
+                      {getNodeLabel()}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ mx: 2, alignSelf: 'center' }}>
+                    {getNodeActionButton()}
+                  </Box>
+                </Box>
+              </Box>
+              <Box
+                sx={{
+                  overflow: 'auto',
+                  flexGrow: 1,
+                  marginBottom: DefaultLayoutMargin,
+                }}
+              >
+                {getDataSideSheetContent(
+                  user,
+                  currentNode,
+                  workflowId,
+                  workflow.selectedResult.id
+                )}
+              </Box>
+            </Box>
+          </Drawer>
+        )
+      }
+    </Layout >
   );
 };
 

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -511,7 +511,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         )}
 
         <Divider />
-        {/* Start of tabs for Workflow details page */}
+
         <Tabs value={currentTab} onChange={handleTabChange}>
           <Tab value="Details" label="Details" />
           <Tab value="Settings" label="Settings" />
@@ -551,8 +551,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             </Box>
           )}
         </TabPanel>
-
-        {/* End of tabs for workflow details page */}
       </Box>
 
       {currentNode.type !== NodeType.None && (

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -51,14 +51,13 @@ import DefaultLayout, {
   SidesheetWidth,
 } from '../../../layouts/default';
 import { Button } from '../../../primitives/Button.styles';
+import { Tab, Tabs } from '../../../primitives/Tabs.styles';
 import ReactFlowCanvas from '../../../workflows/ReactFlowCanvas';
 import WorkflowHeader, {
   WorkflowPageContentId,
 } from '../../../workflows/workflowHeader';
-import { LayoutProps } from '../../types';
-
-import { Tab, Tabs } from '../../../primitives/Tabs.styles';
 import WorkflowSettings from '../../../workflows/WorkflowSettings';
+import { LayoutProps } from '../../types';
 
 type WorkflowPageProps = {
   user: UserProfile;
@@ -75,7 +74,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   const urlSearchParams = parse(window.location.search);
   const location = useLocation();
   const path = location.pathname;
-  const [currentTab, setCurrentTab] = React.useState<string>("Details");
+  const [currentTab, setCurrentTab] = React.useState<string>('Details');
 
   const currentNode = useSelector(
     (state: RootState) => state.nodeSelectionReducer.selected
@@ -337,7 +336,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -384,7 +384,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -403,7 +404,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -422,7 +424,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -461,15 +464,10 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         aria-labelledby={`simple-tab-${index}`}
         {...other}
       >
-        {value === index && (
-          <Box sx={{ p: 3 }}>
-            {children}
-          </Box>
-        )}
+        {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
       </div>
     );
   }
-
 
   return (
     <Layout
@@ -543,7 +541,6 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           </Box>
         </TabPanel>
 
-
         <TabPanel value={currentTab} index="Settings">
           {workflow.selectedDag && (
             <Box marginBottom={1}>
@@ -556,75 +553,73 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         </TabPanel>
 
         {/* End of tabs for workflow details page */}
-      </Box >
+      </Box>
 
-      {
-        currentNode.type !== NodeType.None && (
-          <Drawer
-            anchor="right"
-            variant="persistent"
-            open={true}
-            PaperProps={{
-              sx: {
-                transition: 'width 200ms ease-in-out',
-                transitionDelay: '1000ms',
-              },
-            }}
+      {currentNode.type !== NodeType.None && (
+        <Drawer
+          anchor="right"
+          variant="persistent"
+          open={true}
+          PaperProps={{
+            sx: {
+              transition: 'width 200ms ease-in-out',
+              transitionDelay: '1000ms',
+            },
+          }}
+        >
+          <Box
+            width={SidesheetWidth}
+            maxWidth={SidesheetWidth}
+            minHeight="100vh"
+            display="flex"
+            flexDirection="column"
           >
             <Box
-              width={SidesheetWidth}
-              maxWidth={SidesheetWidth}
-              minHeight="100vh"
-              display="flex"
-              flexDirection="column"
+              width="100%"
+              sx={{ backgroundColor: theme.palette.gray['100'] }}
+              height={`${drawerHeaderHeightInPx}px`}
             >
-              <Box
-                width="100%"
-                sx={{ backgroundColor: theme.palette.gray['100'] }}
-                height={`${drawerHeaderHeightInPx}px`}
-              >
-                <Box display="flex">
-                  <Box
-                    sx={{ cursor: 'pointer', m: 1, alignSelf: 'center' }}
-                    onClick={onPaneClicked}
+              <Box display="flex">
+                <Box
+                  sx={{ cursor: 'pointer', m: 1, alignSelf: 'center' }}
+                  onClick={onPaneClicked}
+                >
+                  <FontAwesomeIcon icon={faChevronRight} />
+                </Box>
+                <Box maxWidth="400px">
+                  <Typography
+                    variant="h5"
+                    padding="16px"
+                    textOverflow="ellipsis"
+                    overflow="hidden"
+                    whiteSpace="nowrap"
                   >
-                    <FontAwesomeIcon icon={faChevronRight} />
-                  </Box>
-                  <Box maxWidth="400px">
-                    <Typography
-                      variant="h5"
-                      padding="16px"
-                      textOverflow="ellipsis"
-                      overflow="hidden"
-                      whiteSpace="nowrap"
-                    >
-                      {getNodeLabel()}
-                    </Typography>
-                  </Box>
-                  <Box sx={{ mx: 2, alignSelf: 'center' }}>
-                    {getNodeActionButton()}
-                  </Box>
+                    {getNodeLabel()}
+                  </Typography>
+                </Box>
+                <Box sx={{ mx: 2, alignSelf: 'center' }}>
+                  {getNodeActionButton()}
                 </Box>
               </Box>
-              <Box
-                sx={{
-                  overflow: 'auto',
-                  flexGrow: 1,
-                  marginBottom: DefaultLayoutMargin,
-                }}
-              >
-                {getDataSideSheetContent(
-                  user,
-                  currentNode,
-                  workflowId,
-                  workflow.selectedResult.id
-                )}
-              </Box>
             </Box>
-          </Drawer>
-        )
-      }
-    </Layout >
+            <Box
+              sx={{
+                overflow: 'auto',
+                flexGrow: 1,
+                marginBottom: DefaultLayoutMargin,
+              }}
+            >
+              {getDataSideSheetContent(
+                user,
+                currentNode,
+                workflowId,
+                workflow.selectedResult.id
+              )}
+            </Box>
+          </Box>
+        </Drawer>
+      )}
+    </Layout>
   );
 };
 

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -58,6 +58,7 @@ import WorkflowHeader, {
 import { LayoutProps } from '../../types';
 
 import { Tab, Tabs } from '../../../primitives/Tabs.styles';
+import WorkflowSettings from '../../../workflows/WorkflowSettings';
 
 type WorkflowPageProps = {
   user: UserProfile;
@@ -74,7 +75,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
   const urlSearchParams = parse(window.location.search);
   const location = useLocation();
   const path = location.pathname;
-  const [currentTab, setCurrentTab] = React.useState<string>("Overview");
+  const [currentTab, setCurrentTab] = React.useState<string>("Details");
 
   const currentNode = useSelector(
     (state: RootState) => state.nodeSelectionReducer.selected
@@ -544,7 +545,14 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
 
 
         <TabPanel value={currentTab} index="Settings">
-          Settings Tab
+          {workflow.selectedDag && (
+            <Box marginBottom={1}>
+              <WorkflowSettings
+                user={user}
+                workflowDag={workflow.selectedDag}
+              />
+            </Box>
+          )}
         </TabPanel>
 
         {/* End of tabs for workflow details page */}

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -38,7 +38,7 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
   const { edges, nodes } = dagPositionState.result ?? { edges: [], nodes: [] };
 
   return (
-    <Box sx={{ height: '55vh', width: '88vw' }}>
+    <Box sx={{ height: '50vh', width: '100%' }}>
       <ReactFlow
         onPaneClick={onPaneClicked}
         nodes={nodes}

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -1,3 +1,4 @@
+import Box from '@mui/material/Box';
 import React, { useEffect } from 'react';
 import ReactFlow, {
   Node as ReactFlowNode,
@@ -37,19 +38,21 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
   const { edges, nodes } = dagPositionState.result ?? { edges: [], nodes: [] };
 
   return (
-    <ReactFlow
-      onPaneClick={onPaneClicked}
-      nodes={nodes}
-      edges={edges}
-      onNodeClick={switchSideSheet}
-      nodeTypes={nodeTypes}
-      connectionLineStyle={connectionLineStyle}
-      snapToGrid={true}
-      snapGrid={snapGrid as [number, number]}
-      defaultZoom={1}
-      edgeTypes={EdgeTypes}
-      minZoom={0.25}
-    />
+    <Box sx={{ height: '55vh', width: '88vw' }}>
+      <ReactFlow
+        onPaneClick={onPaneClicked}
+        nodes={nodes}
+        edges={edges}
+        onNodeClick={switchSideSheet}
+        nodeTypes={nodeTypes}
+        connectionLineStyle={connectionLineStyle}
+        snapToGrid={true}
+        snapGrid={snapGrid as [number, number]}
+        defaultZoom={1}
+        edgeTypes={EdgeTypes}
+        minZoom={0.25}
+      />
+    </Box>
   );
 };
 

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -449,7 +449,6 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const [deleteValidation, setDeleteValidation] = useState('');
   const handleDeleteClicked = (event) => {
     event.preventDefault();
-    //onClose(); // Close the settings modal.
     setShowDeleteDialog(true);
   };
 
@@ -973,6 +972,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
         color="info"
         variant="outlined"
         sx={{ marginRight: 2 }}
+        disabled={!settingsChanged}
         onClick={() => {
           setName(initialSettings.name);
           setDescription(initialSettings.description);

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -32,7 +32,7 @@ import Snackbar from '@mui/material/Snackbar';
 import Switch from '@mui/material/Switch';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
@@ -228,8 +228,6 @@ const RetentionPolicySelector: React.FC<RetentionPolicyProps> = ({
 type WorkflowSettingsProps = {
   user: UserProfile;
   workflowDag: WorkflowDag;
-  open: boolean;
-  onClose: () => void;
 };
 
 // Returns whether `updated` is different from `existing`.
@@ -257,15 +255,13 @@ function IsNotificationSettingsMapUpdated(
 const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   user,
   workflowDag,
-  open,
-  onClose,
 }) => {
   const { apiAddress } = useAqueductConsts();
   const navigate = useNavigate();
 
   const dispatch: AppDispatch = useDispatch();
 
-  useEffect(() => {
+  useCallback(() => {
     dispatch(
       handleListWorkflowSavedObjects({
         apiKey: user.apiKey,
@@ -429,7 +425,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-      WorkflowUpdateTrigger.Periodic &&
+    WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(
@@ -453,7 +449,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
   const [deleteValidation, setDeleteValidation] = useState('');
   const handleDeleteClicked = (event) => {
     event.preventDefault();
-    onClose(); // Close the settings modal.
+    //onClose(); // Close the settings modal.
     setShowDeleteDialog(true);
   };
 
@@ -811,7 +807,7 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                   <ListItem key={`${integrationName}-${objectResult.name}`}>
                     <ListItemIcon style={{ minWidth: '30px' }}>
                       {objectResult.exec_state.status ===
-                      ExecutionStatus.Succeeded ? (
+                        ExecutionStatus.Succeeded ? (
                         <FontAwesomeIcon
                           icon={faCircleCheck}
                           style={{
@@ -837,13 +833,13 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
                   </ListItem>
                   {objectResult.exec_state.status ===
                     ExecutionStatus.Failed && (
-                    <Alert icon={false} severity="error">
-                      <AlertTitle>
-                        Failed to delete {objectResult.name}.
-                      </AlertTitle>
-                      <pre>{objectResult.exec_state.error.context}</pre>
-                    </Alert>
-                  )}
+                      <Alert icon={false} severity="error">
+                        <AlertTitle>
+                          Failed to delete {objectResult.name}.
+                        </AlertTitle>
+                        <pre>{objectResult.exec_state.error.context}</pre>
+                      </Alert>
+                    )}
                 </>
               ))
             )
@@ -868,160 +864,175 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
 
   return (
     <>
-      <Dialog open={open} onClose={onClose} maxWidth={false}>
-        <DialogTitle>
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-            <Box sx={{ flex: 1 }}>
-              <Typography variant="h5">
-                {' '}
-                {/* We don't use the `name` state here because it will update when the user is mid-changes, which is awkward. */}
-                <span style={{ fontFamily: 'Monospace' }}>
-                  {workflowDag.metadata?.name}
-                </span>{' '}
-                Settings{' '}
-              </Typography>
-            </Box>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="h5">
+            {' '}
+            {/* We don't use the `name` state here because it will update when the user is mid-changes, which is awkward. */}
+            <span style={{ fontFamily: 'Monospace' }}>
+              {workflowDag.metadata?.name}
+            </span>{' '}
+            Settings{' '}
+          </Typography>
+        </Box>
 
-            <FontAwesomeIcon
-              icon={faXmark}
-              onClick={() => {
-                setName(initialSettings.name);
-                setDescription(initialSettings.description);
-                setTriggerType(initialSettings.triggerType);
-                setSchedule(initialSettings.schedule);
-                setSourceId(initialSettings.sourceId);
-                setPaused(initialSettings.paused);
-                setRetentionPolicy(initialSettings.retentionPolicy);
+        {/* <FontAwesomeIcon
+          icon={faXmark}
+          onClick={() => {
+            // TODO: Add button to handle resetting the settings dialog.
+            setName(initialSettings.name);
+            setDescription(initialSettings.description);
+            setTriggerType(initialSettings.triggerType);
+            setSchedule(initialSettings.schedule);
+            setSourceId(initialSettings.sourceId);
+            setPaused(initialSettings.paused);
+            setRetentionPolicy(initialSettings.retentionPolicy);
 
-                // Finally close the dialog
-                if (onClose) {
-                  onClose();
-                }
-              }}
-              style={{ cursor: 'pointer' }}
-            />
-          </Box>
-        </DialogTitle>
+            // Finally close the dialog
+            // if (onClose) {
+            //   onClose();
+            // }
+          }}
+          style={{ cursor: 'pointer' }}
+        /> */}
+      </Box>
+      {/* </DialogTitle> */}
 
-        <DialogContent sx={{ width: '600px' }}>
-          <Box sx={{ mb: 2 }}>
-            <Box sx={{ mb: 2 }}>
-              <Typography sx={{ fontWeight: 'bold' }} component="span">
-                ID:
-              </Typography>
-              <Typography component="span">
-                {' '}
-                {workflowDag.workflow_id}
-              </Typography>
-            </Box>
-          </Box>
+      {/* <DialogContent sx={{ width: '600px' }}> */}
+      <Box sx={{ mb: 2 }}>
+        <Box sx={{ mb: 2 }}>
+          <Typography sx={{ fontWeight: 'bold' }} component="span">
+            ID:
+          </Typography>
+          <Typography component="span">
+            {' '}
+            {workflowDag.workflow_id}
+          </Typography>
+        </Box>
+      </Box>
 
-          <Box sx={{ my: 2 }}>
-            <Typography style={{ fontWeight: 'bold' }}> Name </Typography>
+      <Box sx={{ my: 2 }}>
+        <Typography style={{ fontWeight: 'bold' }}> Name </Typography>
 
-            <Box sx={{ my: 1 }}>
-              <TextField
-                fullWidth
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                size="small"
-              />
-            </Box>
-          </Box>
+        <Box sx={{ my: 1 }}>
+          <TextField
+            fullWidth
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            size="small"
+          />
+        </Box>
+      </Box>
 
-          <Box sx={{ my: 2 }}>
-            <Typography style={{ fontWeight: 'bold' }}>
-              {' '}
-              Description{' '}
-            </Typography>
+      <Box sx={{ my: 2 }}>
+        <Typography style={{ fontWeight: 'bold' }}>
+          {' '}
+          Description{' '}
+        </Typography>
 
-            <Box sx={{ my: 1 }}>
-              <TextField
-                fullWidth
-                placeholder="Your description goes here."
-                value={description}
-                multiline
-                rows={4}
-                size="small"
-                onChange={(e) => setDescription(e.target.value)}
-              />
-            </Box>
-          </Box>
+        <Box sx={{ my: 1 }}>
+          <TextField
+            fullWidth
+            placeholder="Your description goes here."
+            value={description}
+            multiline
+            rows={4}
+            size="small"
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </Box>
+      </Box>
 
-          {dagResults && dagResults.length > 0 && <StorageSelector />}
+      {dagResults && dagResults.length > 0 && <StorageSelector />}
 
-          <Box sx={{ my: 2 }}>
-            <Typography style={{ fontWeight: 'bold' }}> Schedule </Typography>
-            {scheduleSelector}
-            {nextUpdateComponent}
-          </Box>
+      <Box sx={{ my: 2 }}>
+        <Typography style={{ fontWeight: 'bold' }}> Schedule </Typography>
+        {scheduleSelector}
+        {nextUpdateComponent}
+      </Box>
 
-          <Box sx={{ my: 2 }}>
-            <Typography style={{ fontWeight: 'bold' }}>
-              Retention Policy
-            </Typography>
+      <Box sx={{ my: 2 }}>
+        <Typography style={{ fontWeight: 'bold' }}>
+          Retention Policy
+        </Typography>
 
-            <Box sx={{ my: 1 }}>
-              <RetentionPolicySelector
-                retentionPolicy={retentionPolicy}
-                setRetentionPolicy={setRetentionPolicy}
-              />
-            </Box>
-          </Box>
+        <Box sx={{ my: 1 }}>
+          <RetentionPolicySelector
+            retentionPolicy={retentionPolicy}
+            setRetentionPolicy={setRetentionPolicy}
+          />
+        </Box>
+      </Box>
 
-          {notificationIntegrations.length > 0 && (
-            <Box sx={{ my: 2 }}>
-              <Typography style={{ fontWeight: 'bold' }}>
-                Notifications
-              </Typography>
+      {notificationIntegrations.length > 0 && (
+        <Box sx={{ my: 2 }}>
+          <Typography style={{ fontWeight: 'bold' }}>
+            Notifications
+          </Typography>
 
-              <WorkflowNotificationSettings
-                notificationIntegrations={notificationIntegrations}
-                curSettingsMap={notificationSettingsMap}
-                onSelect={(id, level, replacingID) => {
-                  const newSettings = { ...notificationSettingsMap };
-                  newSettings[id] = level;
-                  if (replacingID) {
-                    delete newSettings[replacingID];
-                  }
+          <WorkflowNotificationSettings
+            notificationIntegrations={notificationIntegrations}
+            curSettingsMap={notificationSettingsMap}
+            onSelect={(id, level, replacingID) => {
+              const newSettings = { ...notificationSettingsMap };
+              newSettings[id] = level;
+              if (replacingID) {
+                delete newSettings[replacingID];
+              }
 
-                  setNotificationSettingsMap(newSettings);
-                }}
-                onRemove={(id) => {
-                  const newSettings = { ...notificationSettingsMap };
-                  delete newSettings[id];
-                  setNotificationSettingsMap(newSettings);
-                }}
-              />
-            </Box>
-          )}
+              setNotificationSettingsMap(newSettings);
+            }}
+            onRemove={(id) => {
+              const newSettings = { ...notificationSettingsMap };
+              delete newSettings[id];
+              setNotificationSettingsMap(newSettings);
+            }}
+          />
+        </Box>
+      )}
 
-          <LoadingButton
-            loading={isUpdating}
-            onClick={updateSettings}
-            sx={{ my: 1 }}
-            color="primary"
-            variant="contained"
-            disabled={!settingsChanged}
-          >
-            Save
-          </LoadingButton>
+      <Button
+        color="info"
+        variant="outlined"
+        sx={{ marginRight: 2 }}
+        onClick={() => {
+          setName(initialSettings.name);
+          setDescription(initialSettings.description);
+          setTriggerType(initialSettings.triggerType);
+          setSchedule(initialSettings.schedule);
+          setSourceId(initialSettings.sourceId);
+          setPaused(initialSettings.paused);
+          setRetentionPolicy(initialSettings.retentionPolicy);
+        }}
+      >
+        Discard Changes
+      </Button>
 
-          <Divider />
+      <LoadingButton
+        loading={isUpdating}
+        onClick={updateSettings}
+        sx={{ my: 1 }}
+        color="primary"
+        variant="contained"
+        disabled={!settingsChanged}
+      >
+        Save
+      </LoadingButton>
 
-          <Box sx={{ my: 2 }}>
-            <Typography variant="h6"> Danger Zone </Typography>
-          </Box>
+      <Divider />
 
-          <Button
-            color="error"
-            variant="outlined"
-            onClick={handleDeleteClicked}
-          >
-            Delete Workflow
-          </Button>
-        </DialogContent>
-      </Dialog>
+      <Box sx={{ my: 2 }}>
+        <Typography variant="h6"> Danger Zone </Typography>
+      </Box>
+
+      <Button
+        color="error"
+        variant="outlined"
+        onClick={handleDeleteClicked}
+      >
+        Delete Workflow
+      </Button>
+
       {deleteDialog}
       {savedObjectDeletionResultsDialog}
 

--- a/src/ui/common/src/components/workflows/WorkflowSettings.tsx
+++ b/src/ui/common/src/components/workflows/WorkflowSettings.tsx
@@ -885,30 +885,8 @@ const WorkflowSettings: React.FC<WorkflowSettingsProps> = ({
             Settings{' '}
           </Typography>
         </Box>
-
-        {/* <FontAwesomeIcon
-          icon={faXmark}
-          onClick={() => {
-            // TODO: Add button to handle resetting the settings dialog.
-            setName(initialSettings.name);
-            setDescription(initialSettings.description);
-            setTriggerType(initialSettings.triggerType);
-            setSchedule(initialSettings.schedule);
-            setSourceId(initialSettings.sourceId);
-            setPaused(initialSettings.paused);
-            setRetentionPolicy(initialSettings.retentionPolicy);
-
-            // Finally close the dialog
-            // if (onClose) {
-            //   onClose();
-            // }
-          }}
-          style={{ cursor: 'pointer' }}
-        /> */}
       </Box>
-      {/* </DialogTitle> */}
 
-      {/* <DialogContent sx={{ width: '600px' }}> */}
       <Box sx={{ mb: 2 }}>
         <Box sx={{ mb: 2 }}>
           <Typography sx={{ fontWeight: 'bold' }} component="span">

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -83,7 +83,6 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
 
   const [showErrorToast, setShowErrorToast] = useState(false);
   const [showSuccessToast, setShowSuccessToast] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
 
   const handleSuccessToastClose = async () => {
     setShowSuccessToast(false);
@@ -111,7 +110,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-      WorkflowUpdateTrigger.Periodic &&
+    WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(
@@ -343,23 +342,6 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
             <Typography sx={{ ml: 1 }}>Run Workflow</Typography>
           </Button>
 
-          <Button
-            variant="outlined"
-            color="primary"
-            onClick={() => setShowSettings(true)}
-            sx={{ py: 0 }}
-          >
-            <Box sx={{ fontSize: '20px' }}>
-              <FontAwesomeIcon icon={faGear} />
-            </Box>
-          </Button>
-
-          <WorkflowSettings
-            user={user}
-            open={showSettings}
-            onClose={() => setShowSettings(false)}
-            workflowDag={workflowDag}
-          />
         </Box>
       </Box>
 

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -1,4 +1,4 @@
-import { faGear, faPlay } from '@fortawesome/free-solid-svg-icons';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Alert, Snackbar, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -31,7 +31,6 @@ import { useAqueductConsts } from '../hooks/useAqueductConsts';
 import { Button } from '../primitives/Button.styles';
 import { WorkflowStatusBar } from './StatusBar';
 import VersionSelector from './version_selector';
-import WorkflowSettings from './WorkflowSettings';
 import StatusChip from './workflowStatus';
 
 export const WorkflowPageContentId = 'workflow-page-main';
@@ -110,7 +109,7 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
   let nextUpdateComponent;
   if (
     workflowDag.metadata?.schedule?.trigger ===
-    WorkflowUpdateTrigger.Periodic &&
+      WorkflowUpdateTrigger.Periodic &&
     !workflowDag.metadata?.schedule?.paused
   ) {
     const nextUpdateTime = getNextUpdateTime(
@@ -341,7 +340,6 @@ const WorkflowHeader: React.FC<Props> = ({ user, workflowDag, workflowId }) => {
             <FontAwesomeIcon icon={faPlay} />
             <Typography sx={{ ml: 1 }}>Run Workflow</Typography>
           </Button>
-
         </Box>
       </Box>
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds two tabs to the workflow details page: Details and Settings.

The details tab shows the same DAG contents as before and the settings tab shows the contents of the settings modal inside of a tab view.

## Related issue number (if any)
ENG-2171

## Loom demo (if any)
https://www.loom.com/share/40b94a61520a420896c28fc013a45032

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


