### PR TITLE
ENG 2271 GC  workflow notification settings when deleting an notification

### DIFF
--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -32,6 +32,7 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			ExecutionEnvironmentRepo: s.ExecutionEnvironmentRepo,
 			IntegrationRepo:          s.IntegrationRepo,
 			OperatorRepo:             s.OperatorRepo,
+			WorkflowRepo:             s.WorkflowRepo,
 		},
 		routes.DeleteWorkflowRoute: &handler.DeleteWorkflowHandler{
 			Database:   s.Database,

--- a/src/golang/lib/repos/sqlite/workflow.go
+++ b/src/golang/lib/repos/sqlite/workflow.go
@@ -304,6 +304,26 @@ func (*workflowWriter) Update(
 	return &workflow, err
 }
 
+func (*workflowWriter) RemoveNotificationFromSettings(ctx context.Context, NotificationIntegrationID uuid.UUID, DB database.Database) error {
+	query := `
+	UPDATE workflow
+	SET
+		notification_settings=CAST(
+			json_remove(
+				notification_settings,
+				$1
+			) AS BLOB
+		)
+	WHERE
+		notification_settings IS NOT NULL
+		AND json_extract(
+			notification_settings,
+			$1
+		) IS NOT NULL;`
+	json_path := fmt.Sprintf("$.settings.%s", NotificationIntegrationID)
+	return DB.Execute(ctx, query, json_path)
+}
+
 func getWorkflows(ctx context.Context, DB database.Database, query string, args ...interface{}) ([]models.Workflow, error) {
 	var workflows []models.Workflow
 	err := DB.Query(ctx, &workflows, query, args...)

--- a/src/golang/lib/repos/workflow.go
+++ b/src/golang/lib/repos/workflow.go
@@ -73,4 +73,10 @@ type workflowWriter interface {
 
 	// Update applies changes to the Workflow with ID. It returns the updated Workflow.
 	Update(ctx context.Context, ID uuid.UUID, changes map[string]interface{}, DB database.Database) (*models.Workflow, error)
+
+	// RemoveNotificationFromSettings removes `NotificationIntegrationID` from notification_settings
+	// field when possible.
+	// If the ID does not appear in any notification_settings field,
+	// the API simply return without error.
+	RemoveNotificationFromSettings(ctx context.Context, NotificationIntegrationID uuid.UUID, DB database.Database) error
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds supports that, when an notification integration is deleted, the server also deletes any notification ID that appears in an workflow-specific settings. This is done by removing the json field appears in the `notification_settings` field of workflow table.

## Related issue number (if any)
ENG 2271

## Tests
* Unit tests
* Confirmed in UI that the notification is automatically deleted in a workflow:
Before:
<img width="623" alt="Screenshot 2023-02-06 at 10 59 12 PM" src="https://user-images.githubusercontent.com/10411887/217172819-d0c1eb78-c2d3-45c5-ac47-822b04fec54e.png">
After (deleting the email):
<img width="644" alt="Screenshot 2023-02-06 at 10 59 49 PM" src="https://user-images.githubusercontent.com/10411887/217172858-5c1eff8c-cb52-415a-9fc4-0ee7487cfa16.png">


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


