### PR TITLE
ENG-2406 Fix for metrics not showing properly on the data page.

### DIFF
--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -137,7 +137,8 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
             metricId: metric.id,
             name: metric.name,
             value: metric.result.content_serialized,
-            status: metric.status,
+            status:
+              metric.result?.exec_state?.status ?? ExecutionStatus.Unknown,
           };
         });
       }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where metrics rendered as a status indicator instead of a value when shown on the data page.

## Related issue number (if any)
ENG-2406

## Loom demo (if any)
<img width="1874" alt="image" src="https://user-images.githubusercontent.com/1031759/217400431-150bba00-4dae-4688-8246-4a3a27c83386.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


