### PR TITLE
ENG 2405 Fix bug where log and stack traces divs don't have backgrounds

### DIFF
--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import React, { useState } from 'react';
+import { theme } from '../../styles/theme/theme';
 
 import { Error, Logs } from '../../utils/shared';
 import { Tab, Tabs } from '../primitives/Tabs.styles';
@@ -15,7 +16,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
 
   const [selectedTab, setSelectedTab] = useState(0);
   const emptyElement = (
-    <Box sx={{ p: 2, backgroundColor: 'gray.100' }}>Nothing to see here!</Box>
+    <Box sx={{ p: 2, backgroundColor: theme.palette.gray[100] }}>Nothing to see here!</Box>
   );
 
   return (
@@ -37,8 +38,8 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
         {err !== undefined && hasOutput(err?.tip) ? (
           <Box
             sx={{
-              backgroundColor: 'red.100',
-              color: 'red.600',
+              backgroundColor: theme.palette.red[100],
+              color: theme.palette.red[600],
               p: 2,
               height: 'fit-content',
             }}
@@ -53,7 +54,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={1} role="tabpanel" hidden={selectedTab !== 1}>
         {hasOutput(logs?.stdout) ? (
           <Box
-            sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
+            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
           >
             <pre style={{ margin: '0px' }}>{logs.stdout}</pre>
           </Box>
@@ -65,7 +66,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={2} role="tabpanel" hidden={selectedTab !== 2}>
         {hasOutput(logs?.stderr) ? (
           <Box
-            sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
+            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
           >
             <pre style={{ margin: '0px' }}>{logs.stderr}</pre>
           </Box>

--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import React, { useState } from 'react';
-import { theme } from '../../styles/theme/theme';
 
+import { theme } from '../../styles/theme/theme';
 import { Error, Logs } from '../../utils/shared';
 import { Tab, Tabs } from '../primitives/Tabs.styles';
 
@@ -16,7 +16,9 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
 
   const [selectedTab, setSelectedTab] = useState(0);
   const emptyElement = (
-    <Box sx={{ p: 2, backgroundColor: theme.palette.gray[100] }}>Nothing to see here!</Box>
+    <Box sx={{ p: 2, backgroundColor: theme.palette.gray[100] }}>
+      Nothing to see here!
+    </Box>
   );
 
   return (
@@ -54,7 +56,11 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={1} role="tabpanel" hidden={selectedTab !== 1}>
         {hasOutput(logs?.stdout) ? (
           <Box
-            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
+            sx={{
+              backgroundColor: theme.palette.gray[100],
+              p: 2,
+              height: 'fit-content',
+            }}
           >
             <pre style={{ margin: '0px' }}>{logs.stdout}</pre>
           </Box>
@@ -66,7 +72,11 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={2} role="tabpanel" hidden={selectedTab !== 2}>
         {hasOutput(logs?.stderr) ? (
           <Box
-            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
+            sx={{
+              backgroundColor: theme.palette.gray[100],
+              p: 2,
+              height: 'fit-content',
+            }}
           >
             <pre style={{ margin: '0px' }}>{logs.stderr}</pre>
           </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Add the colors back to the logs :)

## Related issue number (if any)
ENG 2405

## Demo
<img width="1440" alt="Error Log" src="https://user-images.githubusercontent.com/30596854/217633671-3d2e48b8-18ad-4177-ab17-14bb1bedae33.png">
<img width="1440" alt="Empty Log" src="https://user-images.githubusercontent.com/30596854/217633679-2e8463d9-6418-42dc-a2f1-994d9c3603c3.png">
<img width="1440" alt="StdErr Log" src="https://user-images.githubusercontent.com/30596854/217633681-b67bf7e3-bb99-459f-9f81-92f82c91c11f.png">
<img width="1440" alt="StdOut Log" src="https://user-images.githubusercontent.com/30596854/217633684-385e811a-ef06-4ee9-b84f-b2c2d1554339.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


