### PR TITLE
Allows user to specify optional Snowflake schema in UI

### DIFF
--- a/src/ui/common/src/components/integrations/cards/snowflakeCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/snowflakeCard.tsx
@@ -28,6 +28,10 @@ export const SnowflakeCard: React.FC<Props> = ({ integration }) => {
         <strong>Database: </strong>
         {config.database}
       </Typography>
+      <Typography variant="body2">
+        <strong>Schema: </strong>
+        {config.schema ? config.schema : 'public'}
+      </Typography>
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { SnowflakeConfig } from '../../../utils/integrations';
 import { readOnlyFieldDisableReason, readOnlyFieldWarning } from './constants';
@@ -9,6 +9,7 @@ const Placeholders: SnowflakeConfig = {
   account_identifier: '123456',
   warehouse: 'aqueduct-warehouse',
   database: 'aqueduct-db',
+  schema: 'public',
   username: 'aqueduct',
   password: '********',
 };
@@ -24,6 +25,18 @@ export const SnowflakeDialog: React.FC<Props> = ({
   value,
   editMode,
 }) => {
+  const [schema, setSchema] = useState<string>(
+    value?.schema ?? Placeholders.schema
+  );
+
+  useEffect(() => {
+    if (schema) {
+      onUpdateField('schema', schema);
+    } else {
+      onUpdateField('schema', Placeholders.schema);
+    }
+  }, [schema]);
+
   return (
     <Box sx={{ mt: 2 }}>
       <IntegrationTextInputField
@@ -62,6 +75,19 @@ export const SnowflakeDialog: React.FC<Props> = ({
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
         value={value?.database ?? null}
+        warning={editMode ? undefined : readOnlyFieldWarning}
+        disabled={editMode}
+        disableReason={editMode ? readOnlyFieldDisableReason : undefined}
+      />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={false}
+        label="Schema"
+        description="The name of the schema to connect to. The public schema will be used if none is provided."
+        placeholder={Placeholders.schema}
+        onChange={(event) => setSchema(event.target.value)}
+        value={schema !== Placeholders.schema ? schema : null}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disabled={editMode}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -33,6 +33,7 @@ export type SnowflakeConfig = {
   account_identifier: string;
   warehouse: string;
   database: string;
+  schema: string;
   username: string;
   password?: string;
 };


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the UI did not allow users to specify a non-default schema. We already have backend support for custom schemas. This change is also backwards compatible, as previous integrations added from the UI will continue to use the default (`public`) schema.

## Related issue number (if any)
ENG 2419

## Loom demo (if any)
https://www.loom.com/share/29d975604d9248b2bde216c6b068abe9

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


