### PR TITLE
Fix performance issue when using S3 as metadata storage

### DIFF
--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -56,6 +56,8 @@ func (f *fileStorage) Delete(ctx context.Context, key string) error {
 func (f *fileStorage) Exists(ctx context.Context, key string) bool {
 	path := f.getFullPath(key)
 	_, err := os.Stat(path)
+	// TODO: ENG-2428 we should explicitly surface other error types to the caller
+	// instead of just returning `false` for non os.ErrNotExist errors.
 	return !errors.Is(err, os.ErrNotExist)
 }
 

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -53,6 +53,12 @@ func (f *fileStorage) Delete(ctx context.Context, key string) error {
 	return os.Remove(f.getFullPath(key))
 }
 
+func (f *fileStorage) Exists(ctx context.Context, key string) bool {
+	path := f.getFullPath(key)
+	_, err := os.Stat(path)
+	return !errors.Is(err, os.ErrNotExist)
+}
+
 func (f *fileStorage) getFullPath(key string) string {
 	return fmt.Sprintf("%s/%s", f.fileConfig.Directory, key)
 }

--- a/src/golang/lib/storage/gcs.go
+++ b/src/golang/lib/storage/gcs.go
@@ -115,6 +115,8 @@ func (g *gcsStorage) Exists(ctx context.Context, key string) bool {
 
 	// Check if object exists
 	_, err = client.Bucket(bucket).Object(key).Attrs(ctx)
+	// TODO: ENG-2428 we should explicitly surface other error types to the caller
+	// instead of just returning `false` for non storage.ErrObjectNotExist errors.
 	return err != storage.ErrObjectNotExist
 }
 

--- a/src/golang/lib/storage/gcs.go
+++ b/src/golang/lib/storage/gcs.go
@@ -104,6 +104,20 @@ func (g *gcsStorage) Delete(ctx context.Context, key string) error {
 	return client.Bucket(bucket).Object(key).Delete(ctx)
 }
 
+func (g *gcsStorage) Exists(ctx context.Context, key string) bool {
+	client, err := g.newClient(ctx)
+	if err != nil {
+		return false
+	}
+	defer client.Close()
+
+	bucket, key := g.parseBucketAndKey(key)
+
+	// Check if object exists
+	_, err = client.Bucket(bucket).Object(key).Attrs(ctx)
+	return err != storage.ErrObjectNotExist
+}
+
 // newClient returns a GCS client for this storage object.
 // The caller must call `defer client.Close()` on the returned storage client.
 func (g *gcsStorage) newClient(ctx context.Context) (*storage.Client, error) {

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -132,6 +132,8 @@ func (s *s3Storage) Exists(ctx context.Context, key string) bool {
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
 	})
+	// TODO: ENG-2428 we should explicitly surface other error types to the caller
+	// instead of just returning `false` for non s3.ErrCodeNoSuchKey errors.
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"path"
 	"strings"
@@ -64,7 +64,7 @@ func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
 	}
 	defer result.Body.Close()
 
-	content, err := ioutil.ReadAll(result.Body)
+	content, err := io.ReadAll(result.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
 	"net/url"
 	"path"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
 type s3Storage struct {
@@ -48,32 +48,28 @@ func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
 		return nil, err
 	}
 
-	buff := &aws.WriteAtBuffer{}
-	downloader := s3manager.NewDownloader(sess)
-
 	bucket, key, err := s.parseBucketAndKey(key)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = downloader.DownloadWithContext(
-		ctx,
-		buff,
-		&s3.GetObjectInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-		})
+	svc := s3.New(sess)
+	// Get the object
+	result, err := svc.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
 	if err != nil {
-		// Cast `err` to an AWS error to check code
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == s3.ErrCodeNoSuchKey {
-				return nil, ErrObjectDoesNotExist
-			}
-		}
-
 		return nil, err
 	}
-	return buff.Bytes(), nil
+	defer result.Body.Close()
+
+	content, err := ioutil.ReadAll(result.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return content, err
 }
 
 func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
@@ -82,26 +78,18 @@ func (s *s3Storage) Put(ctx context.Context, key string, value []byte) error {
 		return err
 	}
 
-	file := bytes.NewReader(value)
-
-	uploader := s3manager.NewUploader(sess)
-
 	bucket, key, err := s.parseBucketAndKey(key)
 	if err != nil {
 		return err
 	}
 
-	_, err = uploader.UploadWithContext(
-		ctx,
-		&s3manager.UploadInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-			Body:   file,
-		})
-	if err != nil {
-		return err
-	}
-	return nil
+	svc := s3.New(sess)
+	_, err = svc.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(value),
+	})
+	return err
 }
 
 func (s *s3Storage) Delete(ctx context.Context, key string) error {
@@ -125,6 +113,37 @@ func (s *s3Storage) Delete(ctx context.Context, key string) error {
 		},
 	)
 	return err
+}
+
+func (s *s3Storage) Exists(ctx context.Context, key string) bool {
+	sess, err := CreateS3Session(s.s3Config)
+	if err != nil {
+		return false
+	}
+
+	s3Client := s3.New(sess)
+
+	bucket, key, err := s.parseBucketAndKey(key)
+	if err != nil {
+		return false
+	}
+
+	_, err = s3Client.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchKey:
+				return false
+			default:
+				return false
+			}
+		}
+		return false
+	}
+	return true
 }
 
 func CreateS3Session(s3Config *shared.S3Config) (*session.Session, error) {

--- a/src/golang/lib/storage/storage.go
+++ b/src/golang/lib/storage/storage.go
@@ -15,6 +15,7 @@ type Storage interface {
 	Get(ctx context.Context, key string) ([]byte, error)
 	Put(ctx context.Context, key string, value []byte) error
 	Delete(ctx context.Context, key string) error
+	Exists(ctx context.Context, key string) bool
 }
 
 func NewStorage(config *shared.StorageConfig) Storage {

--- a/src/golang/lib/workflow/utils/storage.go
+++ b/src/golang/lib/workflow/utils/storage.go
@@ -24,8 +24,7 @@ func CleanupStorageFiles(ctx context.Context, storageConfig *shared.StorageConfi
 }
 
 func ObjectExistsInStorage(ctx context.Context, storageConfig *shared.StorageConfig, path string) bool {
-	_, err := storage.NewStorage(storageConfig).Get(ctx, path)
-	return err != storage.ErrObjectDoesNotExist
+	return storage.NewStorage(storageConfig).Exists(ctx, path)
 }
 
 func ReadFromStorage(ctx context.Context, storageConfig *shared.StorageConfig, path string, container interface{}) error {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There're two reasons for the slowdown:
1. The APIs we were using to read and write from S3 on the Golang side were inefficient, and I replaced both with a much more efficient version.
2. When checking if a key exists, we were invoking GET on the key of the artifact's payload, which is both unnecessary and has high overhead because the payload can be big. So I added another API called `Exists` to the storage interface that just checks if the key is there or not, which is much faster.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


