### PR TITLE
Adds a storage.exists() check to replace extra storage.get()

### DIFF
--- a/src/python/aqueduct_executor/operators/utils/storage/file.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/file.py
@@ -1,3 +1,5 @@
+import os
+
 from aqueduct_executor.operators.utils.storage.config import FileStorageConfig
 from aqueduct_executor.operators.utils.storage.storage import Storage
 
@@ -19,6 +21,11 @@ class FileStorage(Storage):
         print(f"reading from file: {path}")
         with open(path, "rb") as f:
             return f.read()
+
+    def exists(self, key: str) -> bool:
+        path = self.get_full_path(key)
+        print(f"checking if file exists: {path}")
+        return os.path.isfile(path)
 
     def get_full_path(self, key: str) -> str:
         return self._config.directory + "/" + key

--- a/src/python/aqueduct_executor/operators/utils/storage/gcs.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/gcs.py
@@ -32,3 +32,10 @@ class GCSStorage(Storage):
 
         print(f"reading from gcs: {key}")
         return bytes(blob.download_as_bytes())
+
+    def exists(self, key: str) -> bool:
+        bucket = self._client.bucket(self._config.bucket)
+        blob = bucket.blob(key)
+
+        print(f"checking if exists in gcs: {key}")
+        return bool(blob.exists())

--- a/src/python/aqueduct_executor/operators/utils/storage/storage.py
+++ b/src/python/aqueduct_executor/operators/utils/storage/storage.py
@@ -9,3 +9,7 @@ class Storage(ABC):
     @abstractmethod
     def get(self, key: str) -> bytes:
         pass
+
+    @abstractmethod
+    def exists(self, key: str) -> bool:
+        pass

--- a/src/python/aqueduct_executor/operators/utils/utils.py
+++ b/src/python/aqueduct_executor/operators/utils/utils.py
@@ -69,8 +69,8 @@ def read_artifacts(
     for input_path, input_metadata_path in zip(input_paths, input_metadata_paths):
         # Make sure that the input paths exist.
         try:
-            _ = storage.get(input_path)
-            _ = storage.get(input_metadata_path)
+            _ = storage.exists(input_path)
+            _ = storage.exists(input_metadata_path)
         except Exception as e:
             # TODO(ENG-1627): think about retrying the parent operator in such instances.
             raise MissingInputPathsException(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We had a defensive storage.get() call to see if the key exists in storage. Replaced these checks with storage.exists() that takes advantage of faster APIs
## Related issue number (if any)
Eng-2429
## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


