### PR TITLE
Fix bug in S3 GET error handling and k8s pod status handling

### DIFF
--- a/src/golang/lib/job/poll.go
+++ b/src/golang/lib/job/poll.go
@@ -33,6 +33,7 @@ func PollJob(
 				return status, nil
 			}
 		case <-timeout.C:
+			// TODO: ENG-2447 Surface more info on why a job timed out
 			return shared.UnknownExecutionStatus, errors.Newf("Reached timeout waiting for the job %s to finish.", name)
 		}
 	}

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -60,6 +60,14 @@ func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
 		Key:    aws.String(key),
 	})
 	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case s3.ErrCodeNoSuchKey:
+				return nil, ErrObjectDoesNotExist
+			default:
+				return nil, err
+			}
+		}
 		return nil, err
 	}
 	defer result.Body.Close()


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes 2 bugs:
1. S3's “file not exist”’s error wasn’t properly converted to our enum.
2. When scheduling pods, if there’s insufficient resource, we immediately fail. But we shouldn’t because this might be temporary. So we are removing this error checking, and instead returns a pending status. Once the job hits the poll timeout, we will error at that point.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


