### PR TITLE
Eng 2362 Fix IP address display for common cloud providers

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -363,10 +363,22 @@ def generate_welcome_message(expose, port):
             ec2_ip = requests.get(
                 "http://169.254.169.254/latest/meta-data/public-ipv4", timeout=0.25
             )
-            if ec2_ip.status_code != 404: # User is in EC2 isntance.
+            if ec2_ip.status_code != 404: # User is in EC2 instance.
                 expose_ip = ec2_ip.content.decode("utf-8")
             else:  
-                expose_ip = "<IP_ADDRESS>"
+                # Assume is Google Cloud
+                metadata_flavor = {'Metadata-Flavor': 'Google'}
+                gcp_ip = requests.get('http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip', headers = metadata_flavor)
+                if gcp_ip.status_code != 404:
+                    expose_ip = gcp_ip.text
+                else:
+                    # Assume is Azure
+                    azure_ip = requests.get('http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text', headers = {'Metadata': 'true'})
+                    if azure_ip.status_code != 404:
+                        expose_ip = azure_ip.text
+                    else:
+                        # Default
+                        expose_ip = "<IP_ADDRESS>"
         except:  # If you're not running on EC2, this will return an error.
             expose_ip = "<IP_ADDRESS>"
 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -360,9 +360,13 @@ def generate_welcome_message(expose, port):
         expose_ip = "localhost"
     else:
         try:
-            expose_ip = requests.get(
+            ec2_ip = requests.get(
                 "http://169.254.169.254/latest/meta-data/public-ipv4", timeout=0.25
-            ).content.decode("utf-8")
+            )
+            if ec2_ip.status_code != 404: # User is in EC2 isntance.
+                expose_ip = ec2_ip.content.decode("utf-8")
+            else:  
+                expose_ip = "<IP_ADDRESS>"
         except:  # If you're not running on EC2, this will return an error.
             expose_ip = "<IP_ADDRESS>"
 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -368,12 +368,12 @@ def generate_welcome_message(expose, port):
             else:  
                 # Assume is Google Cloud
                 metadata_flavor = {'Metadata-Flavor': 'Google'}
-                gcp_ip = requests.get('http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip', headers = metadata_flavor)
+                gcp_ip = requests.get('http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip', headers = metadata_flavor, timeout=0.25)
                 if gcp_ip.status_code != 404:
                     expose_ip = gcp_ip.text
                 else:
                     # Assume is Azure
-                    azure_ip = requests.get('http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text', headers = {'Metadata': 'true'})
+                    azure_ip = requests.get('http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text', headers = {'Metadata': 'true'}, timeout=0.25)
                     if azure_ip.status_code != 404:
                         expose_ip = azure_ip.text
                     else:

--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import React, { useState } from 'react';
+import { theme } from '../../styles/theme/theme';
 
 import { Error, Logs } from '../../utils/shared';
 import { Tab, Tabs } from '../primitives/Tabs.styles';
@@ -15,7 +16,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
 
   const [selectedTab, setSelectedTab] = useState(0);
   const emptyElement = (
-    <Box sx={{ p: 2, backgroundColor: 'gray.100' }}>Nothing to see here!</Box>
+    <Box sx={{ p: 2, backgroundColor: theme.palette.gray[100] }}>Nothing to see here!</Box>
   );
 
   return (
@@ -37,8 +38,8 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
         {err !== undefined && hasOutput(err?.tip) ? (
           <Box
             sx={{
-              backgroundColor: 'red.100',
-              color: 'red.600',
+              backgroundColor: theme.palette.red[100],
+              color: theme.palette.red[600],
               p: 2,
               height: 'fit-content',
             }}
@@ -53,7 +54,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={1} role="tabpanel" hidden={selectedTab !== 1}>
         {hasOutput(logs?.stdout) ? (
           <Box
-            sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
+            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
           >
             <pre style={{ margin: '0px' }}>{logs.stdout}</pre>
           </Box>
@@ -65,7 +66,7 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={2} role="tabpanel" hidden={selectedTab !== 2}>
         {hasOutput(logs?.stderr) ? (
           <Box
-            sx={{ backgroundColor: 'gray.100', p: 2, height: 'fit-content' }}
+            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
           >
             <pre style={{ margin: '0px' }}>{logs.stderr}</pre>
           </Box>

--- a/src/ui/common/src/components/LogViewer/index.tsx
+++ b/src/ui/common/src/components/LogViewer/index.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box';
 import React, { useState } from 'react';
-import { theme } from '../../styles/theme/theme';
 
+import { theme } from '../../styles/theme/theme';
 import { Error, Logs } from '../../utils/shared';
 import { Tab, Tabs } from '../primitives/Tabs.styles';
 
@@ -16,7 +16,9 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
 
   const [selectedTab, setSelectedTab] = useState(0);
   const emptyElement = (
-    <Box sx={{ p: 2, backgroundColor: theme.palette.gray[100] }}>Nothing to see here!</Box>
+    <Box sx={{ p: 2, backgroundColor: theme.palette.gray[100] }}>
+      Nothing to see here!
+    </Box>
   );
 
   return (
@@ -54,7 +56,11 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={1} role="tabpanel" hidden={selectedTab !== 1}>
         {hasOutput(logs?.stdout) ? (
           <Box
-            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
+            sx={{
+              backgroundColor: theme.palette.gray[100],
+              p: 2,
+              height: 'fit-content',
+            }}
           >
             <pre style={{ margin: '0px' }}>{logs.stdout}</pre>
           </Box>
@@ -66,7 +72,11 @@ const LogViewer: React.FC<Props> = ({ logs, err }) => {
       <Box key={2} role="tabpanel" hidden={selectedTab !== 2}>
         {hasOutput(logs?.stderr) ? (
           <Box
-            sx={{ backgroundColor: theme.palette.gray[100], p: 2, height: 'fit-content' }}
+            sx={{
+              backgroundColor: theme.palette.gray[100],
+              p: 2,
+              height: 'fit-content',
+            }}
           >
             <pre style={{ margin: '0px' }}>{logs.stderr}</pre>
           </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Based on: https://stackoverflow.com/questions/23362887/can-you-get-external-ip-address-from-within-a-google-compute-vm-instance

Keeping machine on until PR merged.

## Related issue number (if any)
Eng 2362

## Demo (if any)
Ran the relevant code for GCP here and could get the IP address.
<img width="1437" alt="Screen Shot 2023-02-10 at 9 40 14 AM" src="https://user-images.githubusercontent.com/30596854/218160333-b6c185a1-4b3d-436c-b328-0044aff4c4a2.png">

Before:
<img width="1440" alt="Screen Shot 2023-02-09 at 10 30 46 AM" src="https://user-images.githubusercontent.com/30596854/218162226-caaff6d2-5cca-4d23-b24b-d1bcf0a4b6ed.png">

After:
<img width="1439" alt="Screen Shot 2023-02-10 at 9 55 35 AM" src="https://user-images.githubusercontent.com/30596854/218162212-91a47449-15b4-4aac-a0af-10f0371f21d7.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


