### PR TITLE
ENG-2453 Dag Width and Height Fixes

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -329,7 +329,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -368,7 +369,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -387,7 +389,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -406,7 +409,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -512,7 +516,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
               display: 'flex',
               flexGrow: 1,
               height: '100%',
-              backgroundColor: theme.palette.gray[50]
+              backgroundColor: theme.palette.gray[50],
             }}
           >
             <ReactFlowProvider>

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -329,8 +329,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -369,8 +368,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -389,8 +387,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -409,8 +406,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -449,8 +445,14 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         id={`simple-tabpanel-${index}`}
         aria-labelledby={`simple-tab-${index}`}
         {...other}
+        style={{
+          height: '100%',
+          width: '100%',
+          margin: 0,
+          padding: '0 0 32px 0',
+        }}
       >
-        {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+        {value === index && children}
       </div>
     );
   }
@@ -506,24 +508,21 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         <TabPanel value={currentTab} index="Details">
           <Box
             sx={{
-              flex: 1,
-              mt: 2,
-              p: 3,
-              mb: contentBottomOffsetInPx,
-              width: '100%',
+              flexDirection: 'column',
+              display: 'flex',
+              flexGrow: 1,
               height: '100%',
-              boxSizing: 'border-box',
-              backgroundColor: theme.palette.gray['50'],
+              backgroundColor: theme.palette.gray[50]
             }}
           >
-            <Box style={{ height: '100%' }}>
-              <ReactFlowProvider>
+            <ReactFlowProvider>
+              <Box sx={{ flexGrow: 1 }}>
                 <ReactFlowCanvas
                   switchSideSheet={switchSideSheet}
                   onPaneClicked={onPaneClicked}
                 />
-              </ReactFlowProvider>
-            </Box>
+              </Box>
+            </ReactFlowProvider>
           </Box>
         </TabPanel>
 

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -1,9 +1,5 @@
-import Box from '@mui/material/Box';
-import React, { useEffect } from 'react';
-import ReactFlow, {
-  Node as ReactFlowNode,
-  useReactFlow,
-} from 'react-flow-renderer';
+import React from 'react';
+import ReactFlow, { Node as ReactFlowNode } from 'react-flow-renderer';
 import { useSelector } from 'react-redux';
 
 import { RootState } from '../../stores/store';
@@ -29,30 +25,22 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
     (state: RootState) => state.workflowReducer.selectedDagPosition
   );
 
-  const { fitView } = useReactFlow();
-
-  useEffect(() => {
-    fitView();
-  }, [dagPositionState, fitView]);
-
   const { edges, nodes } = dagPositionState.result ?? { edges: [], nodes: [] };
 
   return (
-    <Box sx={{ height: '50vh', width: '100%' }}>
-      <ReactFlow
-        onPaneClick={onPaneClicked}
-        nodes={nodes}
-        edges={edges}
-        onNodeClick={switchSideSheet}
-        nodeTypes={nodeTypes}
-        connectionLineStyle={connectionLineStyle}
-        snapToGrid={true}
-        snapGrid={snapGrid as [number, number]}
-        defaultZoom={1}
-        edgeTypes={EdgeTypes}
-        minZoom={0.25}
-      />
-    </Box>
+    <ReactFlow
+      onPaneClick={onPaneClicked}
+      nodes={nodes}
+      edges={edges}
+      onNodeClick={switchSideSheet}
+      nodeTypes={nodeTypes}
+      connectionLineStyle={connectionLineStyle}
+      snapToGrid={true}
+      snapGrid={snapGrid as [number, number]}
+      defaultZoom={1}
+      edgeTypes={EdgeTypes}
+      minZoom={0.25}
+    />
   );
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where the DAG did not take up the full width and height of the details tab on the workflow details page.

## Related issue number (if any)
ENG-24523

## Loom demo (if any)
https://www.loom.com/share/35efcf76eb604aad971e52c636d547f5

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


