### PR TITLE
ENG 2332 Differentiate warning between pending and upstream failure

### DIFF
--- a/src/ui/common/src/components/pages/artifact/id/components/Preview.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/components/Preview.tsx
@@ -1,0 +1,72 @@
+import { Alert, Box, Divider, Typography } from '@mui/material';
+import React from 'react';
+
+import ArtifactContent from '../../../../../components/workflows/artifact/content';
+import { ArtifactResultResponse } from '../../../../../handlers/responses/artifact';
+import { ContentWithLoadingStatus } from '../../../../../reducers/artifactResultContents';
+
+type PreviewProps = {
+  upstreamPending: boolean;
+  previewAvailable: boolean;
+  artifact: ArtifactResultResponse;
+  contentWithLoadingStatus: ContentWithLoadingStatus;
+};
+
+export const Preview: React.FC<PreviewProps> = ({
+  upstreamPending,
+  previewAvailable,
+  artifact,
+  contentWithLoadingStatus,
+}) => {
+  let preview = (
+    <>
+      <Divider sx={{ marginY: '32px' }} />
+
+      <Box marginBottom="32px">
+        <Alert severity="warning">
+          An upstream operator failed, causing this artifact to not be created.
+        </Alert>
+      </Box>
+    </>
+  );
+
+  if (upstreamPending) {
+    preview = (
+      <>
+        <Divider sx={{ marginY: '32px' }} />
+
+        <Box marginBottom="32px">
+          <Alert severity="warning">
+            An upstream operator is in progress so this artifact is not yet
+            created.
+          </Alert>
+        </Box>
+      </>
+    );
+  } else if (previewAvailable) {
+    preview = (
+      <>
+        <Divider sx={{ marginY: '32px' }} />
+        <Box width="100%" marginTop="12px">
+          <Typography
+            variant="h6"
+            component="div"
+            marginBottom="8px"
+            fontWeight="normal"
+          >
+            Preview
+          </Typography>
+          <ArtifactContent
+            artifact={artifact}
+            contentWithLoadingStatus={contentWithLoadingStatus}
+          />
+        </Box>
+
+        <Divider sx={{ marginY: '32px' }} />
+      </>
+    );
+  }
+  return preview;
+};
+
+export default Preview;

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -204,10 +204,11 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const inputs = mapOperators([artifact.from]);
   const outputs = mapOperators(artifact.to ? artifact.to : []);
-  
+
   let upstream_pending = false;
   inputs.some((operator) => {
-    let operator_pending = operator.result.exec_state.status === ExecutionStatus.Pending;
+    const operator_pending =
+      operator.result.exec_state.status === ExecutionStatus.Pending;
     if (operator_pending) {
       upstream_pending = operator_pending;
     }
@@ -224,8 +225,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
       <Box marginBottom="32px">
         <Alert severity="warning">
-          An upstream operator failed, causing this artifact to not be
-          created.
+          An upstream operator failed, causing this artifact to not be created.
         </Alert>
       </Box>
     </>
@@ -235,7 +235,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
     preview = (
       <>
         <Divider sx={{ marginY: '32px' }} />
-  
+
         <Box marginBottom="32px">
           <Alert severity="warning">
             An upstream operator is in progress so this artifact is not yet

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -204,10 +204,69 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
 
   const inputs = mapOperators([artifact.from]);
   const outputs = mapOperators(artifact.to ? artifact.to : []);
+  
+  let upstream_pending = false;
+  inputs.some((operator) => {
+    let operator_pending = operator.result.exec_state.status === ExecutionStatus.Pending;
+    if (operator_pending) {
+      upstream_pending = operator_pending;
+    }
+    return operator_pending;
+  });
 
   const artifactStatus = artifact?.result?.exec_state?.status;
   const previewAvailable =
     artifactStatus && artifactStatus !== ExecutionStatus.Canceled;
+
+  let preview = (
+    <>
+      <Divider sx={{ marginY: '32px' }} />
+
+      <Box marginBottom="32px">
+        <Alert severity="warning">
+          An upstream operator failed, causing this artifact to not be
+          created.
+        </Alert>
+      </Box>
+    </>
+  );
+
+  if (upstream_pending) {
+    preview = (
+      <>
+        <Divider sx={{ marginY: '32px' }} />
+  
+        <Box marginBottom="32px">
+          <Alert severity="warning">
+            An upstream operator is in progress so this artifact is not yet
+            created.
+          </Alert>
+        </Box>
+      </>
+    );
+  } else if (previewAvailable) {
+    preview = (
+      <>
+        <Divider sx={{ marginY: '32px' }} />
+        <Box width="100%" marginTop="12px">
+          <Typography
+            variant="h6"
+            component="div"
+            marginBottom="8px"
+            fontWeight="normal"
+          >
+            Preview
+          </Typography>
+          <ArtifactContent
+            artifact={artifact}
+            contentWithLoadingStatus={contentWithLoadingStatus}
+          />
+        </Box>
+
+        <Divider sx={{ marginY: '32px' }} />
+      </>
+    );
+  }
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
@@ -250,38 +309,7 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             )}
           </Box>
 
-          {previewAvailable ? (
-            <>
-              <Divider sx={{ marginY: '32px' }} />
-              <Box width="100%" marginTop="12px">
-                <Typography
-                  variant="h6"
-                  component="div"
-                  marginBottom="8px"
-                  fontWeight="normal"
-                >
-                  Preview
-                </Typography>
-                <ArtifactContent
-                  artifact={artifact}
-                  contentWithLoadingStatus={contentWithLoadingStatus}
-                />
-              </Box>
-
-              <Divider sx={{ marginY: '32px' }} />
-            </>
-          ) : (
-            <>
-              <Divider sx={{ marginY: '32px' }} />
-
-              <Box marginBottom="32px">
-                <Alert severity="warning">
-                  An upstream operator failed, causing this artifact to not be
-                  created.
-                </Alert>
-              </Box>
-            </>
-          )}
+          {preview}
 
           <Box display="flex" width="100%">
             <MetricsOverview metrics={metrics} />

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -1,8 +1,7 @@
-import { CircularProgress, Divider } from '@mui/material';
+import { CircularProgress } from '@mui/material';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
@@ -22,7 +21,6 @@ import ExecutionStatus, {
   isSucceeded,
 } from '../../../../utils/shared';
 import DefaultLayout, { SidesheetContentWidth } from '../../../layouts/default';
-import ArtifactContent from '../../../workflows/artifact/content';
 import CsvExporter from '../../../workflows/artifact/csvExporter';
 import {
   ChecksOverview,
@@ -31,6 +29,7 @@ import {
 import OperatorSummaryList from '../../../workflows/operator/summaryList';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
+import Preview from './components/Preview';
 
 type ArtifactDetailsPageProps = {
   user: UserProfile;
@@ -205,12 +204,12 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const inputs = mapOperators([artifact.from]);
   const outputs = mapOperators(artifact.to ? artifact.to : []);
 
-  let upstream_pending = false;
+  let upstreamPending = false;
   inputs.some((operator) => {
     const operator_pending =
       operator.result.exec_state.status === ExecutionStatus.Pending;
     if (operator_pending) {
-      upstream_pending = operator_pending;
+      upstreamPending = operator_pending;
     }
     return operator_pending;
   });
@@ -218,55 +217,6 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
   const artifactStatus = artifact?.result?.exec_state?.status;
   const previewAvailable =
     artifactStatus && artifactStatus !== ExecutionStatus.Canceled;
-
-  let preview = (
-    <>
-      <Divider sx={{ marginY: '32px' }} />
-
-      <Box marginBottom="32px">
-        <Alert severity="warning">
-          An upstream operator failed, causing this artifact to not be created.
-        </Alert>
-      </Box>
-    </>
-  );
-
-  if (upstream_pending) {
-    preview = (
-      <>
-        <Divider sx={{ marginY: '32px' }} />
-
-        <Box marginBottom="32px">
-          <Alert severity="warning">
-            An upstream operator is in progress so this artifact is not yet
-            created.
-          </Alert>
-        </Box>
-      </>
-    );
-  } else if (previewAvailable) {
-    preview = (
-      <>
-        <Divider sx={{ marginY: '32px' }} />
-        <Box width="100%" marginTop="12px">
-          <Typography
-            variant="h6"
-            component="div"
-            marginBottom="8px"
-            fontWeight="normal"
-          >
-            Preview
-          </Typography>
-          <ArtifactContent
-            artifact={artifact}
-            contentWithLoadingStatus={contentWithLoadingStatus}
-          />
-        </Box>
-
-        <Divider sx={{ marginY: '32px' }} />
-      </>
-    );
-  }
 
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
@@ -309,7 +259,12 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             )}
           </Box>
 
-          {preview}
+          <Preview
+            upstreamPending={upstreamPending}
+            previewAvailable={previewAvailable}
+            artifact={artifact}
+            contentWithLoadingStatus={contentWithLoadingStatus}
+          />
 
           <Box display="flex" width="100%">
             <MetricsOverview metrics={metrics} />


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Correct artifact messaging.
Unable to reproduce other observations: https://linear.app/aqueducthq/issue/ENG-2332#comment-a9e27957

## Related issue number (if any)
ENG 2332 

## Demo (if any)
Update messaging if input is pending for metric & operator artifacts:
<img width="1437" alt="Screen Shot 2023-02-10 at 8 13 17 PM" src="https://user-images.githubusercontent.com/30596854/218239877-0f399e79-0b7c-4323-9ee9-6e8b3c3f89e2.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/30596854/218240110-5f6a8b2f-9419-4b67-93e9-c9b2e6675b9b.png">

Messaging remains correct in failure case: 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/30596854/218240176-9c01342b-6c76-4ef2-aa3f-8237d533d303.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


