### PR TITLE
[2/2] Improve parameter management from Aqueduct client

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -528,26 +528,30 @@ def test_param_management(client):
 
     bar_output = bar(foo_output)
 
-    # Create a global parameter with no attachements.
+    # Create a global parameter with no attachments.
     client.create_param("param3", default="content")
 
     assert client.list_params() == {
-        "param1": 1000,
-        "param2": "string val",
+        "foo:param1": 1000,
+        "foo:param2": "string val",
         "param3": "content",
     }
 
     # Delete the unattached parameter.
     client.delete_param("param3")
     assert client.list_params() == {
-        "param1": 1000,
-        "param2": "string val",
+        "foo:param1": 1000,
+        "foo:param2": "string val",
     }
 
     # Delete one of the attached parameters.
     with pytest.raises(InvalidUserActionException, match="Cannot delete parameter"):
-        client.delete_param("param1")
+        client.delete_param("foo:param1")
 
-    client.delete_param("param1", force=True)
-    client.delete_param("param2", force=True)
+    client.delete_param("foo:param1", force=True)
+    client.delete_param("foo:param2", force=True)
     assert client.list_params() == {}
+
+    # Check that bar_output is now invalid
+    with pytest.raises(Exception):
+        bar_output.get()

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -12,7 +12,14 @@ from aqueduct.artifacts.bool_artifact import BoolArtifact
 from aqueduct.artifacts.create import create_param_artifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.backend.response_models import SavedObjectUpdate
-from aqueduct.constants.enums import ExecutionStatus, RelationalDBServices, RuntimeType, ServiceType
+from aqueduct.constants.enums import (
+    ArtifactType,
+    ExecutionStatus,
+    OperatorType,
+    RelationalDBServices,
+    RuntimeType,
+    ServiceType,
+)
 from aqueduct.error import (
     InvalidIntegrationException,
     InvalidUserActionException,
@@ -41,12 +48,14 @@ from aqueduct.models.dag import Metadata, RetentionPolicy
 from aqueduct.models.integration import Integration, IntegrationInfo
 from aqueduct.models.operators import ParamSpec
 from aqueduct.utils.dag_deltas import (
+    RemoveOperatorDelta,
     SubgraphDAGDelta,
     apply_deltas_to_dag,
     validate_overwriting_parameters,
 )
 from aqueduct.utils.function_packaging import infer_requirements_from_env
-from aqueduct.utils.type_inference import infer_artifact_type
+from aqueduct.utils.serialization import deserialize
+from aqueduct.utils.type_inference import _base64_string_to_bytes, infer_artifact_type
 from aqueduct.utils.utils import (
     construct_param_spec,
     find_flow_with_user_supplied_id_and_name,
@@ -194,6 +203,53 @@ class Client:
             A parameter artifact.
         """
         return create_param_artifact(self._dag, name, default, description)
+
+    def list_params(self) -> Dict[str, Any]:
+        """Lists all the currently tracked parameters.
+
+        Returns:
+            A dict where the keys are the existing parameter names and the values
+            are the default values.
+        """
+        param_ops = globals.__GLOBAL_DAG__.list_operators(filter_to=[OperatorType.PARAM])
+
+        param_dict = {}
+        for op in param_ops:
+            assert op.spec.param is not None
+            param_dict[op.name] = deserialize(
+                op.spec.param.serialization_type,
+                ArtifactType.UNTYPED,  # This argument is irrelevant, as long as it's not TUPLE.
+                _base64_string_to_bytes(op.spec.param.val),
+            )
+
+        return param_dict
+
+    def delete_param(self, name: str, force: bool = False) -> None:
+        """Deletes the given parameter from client's context.
+
+        Args:
+            name:
+                The name of the parameter to delete.
+            force:
+                If set, we will delete the parameter and any operators that it is dependency of.
+                Otherwise, we will error if it is a dependency of any operator.
+        """
+        param_op = self._dag.get_operator(with_name=name)
+        if param_op is None:
+            raise InvalidUserArgumentException(
+                "Unable to delete parameter %s. Not such parameter exists." % name
+            )
+
+        if not force:
+            assert len(param_op.outputs) == 1, "Parameter operators only have one output."
+            downstream_ops = self._dag.list_operators(on_artifact_id=param_op.outputs[0])
+            if len(downstream_ops) > 0:
+                raise InvalidUserActionException(
+                    "Cannot delete parameter %s because operator %s uses it. If you would like to "
+                    "delete the parameter and it's dependents anyways, set `force=True`."
+                )
+
+        apply_deltas_to_dag(self._dag, [RemoveOperatorDelta(param_op.id)])
 
     def connect_integration(
         self, name: str, service: ServiceType, config: Union[Dict[str, str], IntegrationConfig]

--- a/sdk/aqueduct/utils/type_inference.py
+++ b/sdk/aqueduct/utils/type_inference.py
@@ -61,3 +61,8 @@ def _bytes_to_base64_string(content: bytes) -> str:
     such bytes to string, we must use this function.
     """
     return base64.b64encode(content).decode(DEFAULT_ENCODING)
+
+
+def _base64_string_to_bytes(content: str) -> bytes:
+    """Helpers to convert base64-string back to bytes."""
+    return base64.b64decode(content)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds the ability to list and delete parameters in the current working context. See the `test_param_management` test case to see how this would be used.

## Related issue number (if any)
ENG-2343

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


