### PR TITLE
ENG-2457: Fixes DAG flashing on workflow details page

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -12,7 +12,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { BreadcrumbLink } from '../../../../components/layouts/NavBar';
-import { TabPanel } from '../../../../components/Tabs/TabPanel';
 import { handleLoadIntegrations } from '../../../../reducers/integrations';
 import {
   NodeType,
@@ -325,7 +324,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -364,7 +364,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -383,7 +384,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -402,7 +404,8 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${
+                  workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -451,7 +454,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           flexDirection: 'column',
           transition: WidthTransition,
           transitionDelay: '-150ms',
-          paddingBottom: '24px'
+          paddingBottom: '24px',
         }}
         id={WorkflowPageContentId}
       >
@@ -472,40 +475,32 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           <Tab value="Settings" label="Settings" />
         </Tabs>
 
-        {
-          currentTab === "Details" && (
-            <Box
-              sx={{
-                flexDirection: 'column',
-                display: 'flex',
-                flexGrow: 1,
-                height: '100%',
-                backgroundColor: theme.palette.gray[50],
-              }}
-            >
-              <ReactFlowProvider>
-                <Box sx={{ flexGrow: 1 }}>
-                  <ReactFlowCanvas
-                    switchSideSheet={switchSideSheet}
-                    onPaneClicked={onPaneClicked}
-                  />
-                </Box>
-              </ReactFlowProvider>
-            </Box>
-          )
-        }
+        {currentTab === 'Details' && (
+          <Box
+            sx={{
+              flexDirection: 'column',
+              display: 'flex',
+              flexGrow: 1,
+              height: '100%',
+              backgroundColor: theme.palette.gray[50],
+            }}
+          >
+            <ReactFlowProvider>
+              <Box sx={{ flexGrow: 1 }}>
+                <ReactFlowCanvas
+                  switchSideSheet={switchSideSheet}
+                  onPaneClicked={onPaneClicked}
+                />
+              </Box>
+            </ReactFlowProvider>
+          </Box>
+        )}
 
-        {
-          currentTab === "Settings" && workflow.selectedDag && (
-            <Box sx={{ paddingBottom: '24px' }}>
-              <WorkflowSettings
-                user={user}
-                workflowDag={workflow.selectedDag}
-              />
-            </Box>
-          )
-        }
-
+        {currentTab === 'Settings' && workflow.selectedDag && (
+          <Box sx={{ paddingBottom: '24px' }}>
+            <WorkflowSettings user={user} workflowDag={workflow.selectedDag} />
+          </Box>
+        )}
       </Box>
 
       {currentNode.type !== NodeType.None && (

--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -325,8 +325,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             onClick={() => {
               // All we're really doing here is adding the artifactId onto the end of the URL.
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/artifact/${currentNode.id}`
               );
             }}
@@ -365,8 +364,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/metric/${currentNode.id}`
               );
             }}
@@ -385,8 +383,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/operator/${currentNode.id}`
               );
             }}
@@ -405,8 +402,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
             style={buttonStyle}
             onClick={() => {
               navigate(
-                `${getPathPrefix()}/workflow/${workflowId}/result/${
-                  workflow.selectedResult.id
+                `${getPathPrefix()}/workflow/${workflowId}/result/${workflow.selectedResult.id
                 }/check/${currentNode.id}`
               );
             }}
@@ -455,6 +451,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           flexDirection: 'column',
           transition: WidthTransition,
           transitionDelay: '-150ms',
+          paddingBottom: '24px'
         }}
         id={WorkflowPageContentId}
       >
@@ -475,37 +472,40 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
           <Tab value="Settings" label="Settings" />
         </Tabs>
 
-        <TabPanel value={currentTab} index="Details">
-          <Box
-            sx={{
-              flexDirection: 'column',
-              display: 'flex',
-              flexGrow: 1,
-              height: '100%',
-              backgroundColor: theme.palette.gray[50],
-            }}
-          >
-            <ReactFlowProvider>
-              <Box sx={{ flexGrow: 1 }}>
-                <ReactFlowCanvas
-                  switchSideSheet={switchSideSheet}
-                  onPaneClicked={onPaneClicked}
-                />
-              </Box>
-            </ReactFlowProvider>
-          </Box>
-        </TabPanel>
+        {
+          currentTab === "Details" && (
+            <Box
+              sx={{
+                flexDirection: 'column',
+                display: 'flex',
+                flexGrow: 1,
+                height: '100%',
+                backgroundColor: theme.palette.gray[50],
+              }}
+            >
+              <ReactFlowProvider>
+                <Box sx={{ flexGrow: 1 }}>
+                  <ReactFlowCanvas
+                    switchSideSheet={switchSideSheet}
+                    onPaneClicked={onPaneClicked}
+                  />
+                </Box>
+              </ReactFlowProvider>
+            </Box>
+          )
+        }
 
-        <TabPanel value={currentTab} index="Settings">
-          {workflow.selectedDag && (
-            <Box marginBottom={1}>
+        {
+          currentTab === "Settings" && workflow.selectedDag && (
+            <Box sx={{ paddingBottom: '24px' }}>
               <WorkflowSettings
                 user={user}
                 workflowDag={workflow.selectedDag}
               />
             </Box>
-          )}
-        </TabPanel>
+          )
+        }
+
       </Box>
 
       {currentNode.type !== NodeType.None && (


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes the small flash that would happen when users refresh the workflow details page.

Apparently ReactFlow and our TabPanel component do not get along so well. Simply adding a conditional check on which tab is active to show Settings or Details did the trick here.

## Related issue number (if any)
ENG-2457

## Loom demo (if any)
https://www.loom.com/share/c556e48d888b4a879326f4eea3c15762

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


