### PR TITLE
ENG-2475: Bug: Better align operator and artifact 'outputs' and 'generated by' headers

### DIFF
--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -138,7 +138,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-          artifactId
+            artifactId
           ]
       )
       .filter((artf) => !!artf);

--- a/src/ui/common/src/components/pages/operator/id/index.tsx
+++ b/src/ui/common/src/components/pages/operator/id/index.tsx
@@ -138,7 +138,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
       .map(
         (artifactId) =>
           (workflowDagResultWithLoadingStatus.result?.artifacts ?? {})[
-            artifactId
+          artifactId
           ]
       )
       .filter((artf) => !!artf);
@@ -160,7 +160,7 @@ const OperatorDetailsPage: React.FC<OperatorDetailsPageProps> = ({
               )}
             </Box>
           )}
-          <Box display="flex" width="100%" pt={sideSheetMode ? '16px' : '40px'}>
+          <Box display="flex" width="100%" pt={sideSheetMode ? '16px' : '64px'}>
             {inputs.length > 0 && (
               <Box width="100%" mr="32px">
                 <ArtifactSummaryList


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Use same padding top on operator page as artifact page for secondary headers.

## Related issue number (if any)
ENG-2475

## Loom demo (if any)
https://www.loom.com/share/8edba2152b654e02aabee7ee5f5a6b16

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


