### PR TITLE
ENG 2400 Fix aqueduct install mariadb for Mac M1

### DIFF
--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -482,7 +482,11 @@ def install_mysql():
         else:
             print("Unsupported distribution:", distro.id())
     elif system == "Darwin":
-        execute_command(["brew", "install", "mysql"])
+        cmd = ["brew", "install", "mysql"]
+        architecture = subprocess.Popen(["which", "-a", "brew"], stdout=subprocess.PIPE ).communicate()[0]
+        if architecture.startswith(b"/opt/homebrew"): # Using arm verison of brew
+            cmd = ["arch", "-arm64", *cmd]
+        execute_command(cmd)
     else:
         print("Unsupported operating system:", system)
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixed `aqueduct install mariadb` for Mac M1. Should also work for M2.

## Related issue number (if any)
ENG 2400

## Demo (if any)
Installation works correctly now.

Before:
Runs: `brew install mysql` (Confirmed by printing the cmd variable)
```
>> aqueduct install mariadb
Error: Cannot install under Rosetta 2 in ARM default prefix (/opt/homebrew)!
To rerun under ARM use:
arch -arm64 brew install ...
To install under x86_64, install Homebrew into /usr/local.
Traceback (most recent call last):
File "/opt/anaconda3/envs/aqdev/bin/aqueduct", line 759, in <module>
install(args.system[0])  # argparse makes this an array so only pass in value [0].
File "/opt/anaconda3/envs/aqdev/bin/aqueduct", line 545, in install
install_mysql()
File "/opt/anaconda3/envs/aqdev/bin/aqueduct", line 491, in install_mysql
execute_command(cmd)
File "/opt/anaconda3/envs/aqdev/bin/aqueduct", line 351, in execute_command
raise Exception("Error executing command: %s" % args)
Exception: Error executing command: ['brew', 'install', 'mysql']
```

After:
Runs: `arch -arm64 brew install mysql` (Confirmed by printing the cmd variable)
```
>> aqueduct install mariadb
==> Fetching mysql
==> Downloading https://ghcr.io/v2/homebrew/core/mysql/manifests/8.0.32
Already downloaded: /Users/eunicechan/Library/Caches/Homebrew/downloads/86baf5da15e3e54f1fb5a1ecba7990f44cf642194348bba25fa21ff4a95f205b--mysql-8.0.32.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/mysql/blobs/sha256:6bcaa04f58dceb28478a81ff49dd2fc9886523270e5aae26ed7b6a433c6ba549
Already downloaded: /Users/eunicechan/Library/Caches/Homebrew/downloads/9b501a9249ecee799c37cbffd10d23e53ca505d055eae0cee2f1f4c5ae322ba6--mysql--8.0.32.arm64_monterey.bottle.tar.gz
==> Pouring mysql--8.0.32.arm64_monterey.bottle.tar.gz
==> Caveats
We've installed your MySQL database without a root password. To secure it run:
    mysql_secure_installation

MySQL is configured to only allow connections from localhost by default

To connect run:
    mysql -u root

To restart mysql after an upgrade:
  brew services restart mysql
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/mysql/bin/mysqld_safe --datadir=/opt/homebrew/var/mysql
==> Summary
🍺  /opt/homebrew/Cellar/mysql/8.0.32: 317 files, 298.2MB
==> Running `brew cleanup mysql`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Requirement already satisfied: mysqlclient<=2.1.1 in /opt/anaconda3/envs/aqdev/lib/python3.9/site-packages (2.1.1)
```

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


