### PR TITLE
Fix bug where rerunning a function with multiple implicit parameters fails

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -150,7 +150,7 @@ def test_implicitly_created_param_overwrites(client, flow_name, engine):
     assert flow_run.artifact("different_fn:param").get() == "different value"
 
 
-def test_multiple_implicitly_created_param_multiple(client):
+def test_multiple_implicitly_created_param(client):
     @op
     def foo(param1, param2):
         return param1 + param2

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -150,7 +150,16 @@ def test_implicitly_created_param_overwrites(client, flow_name, engine):
     assert flow_run.artifact("different_fn:param").get() == "different value"
 
 
-def test_implicit_created_param_failures(client):
+def test_multiple_implicitly_created_param_multiple(client):
+    @op
+    def foo(param1, param2):
+        return param1 + param2
+
+    assert foo(100, 50).get() == 150
+    assert foo(500, 500).get() == 1000
+
+
+def test_implicitly_created_param_failures(client):
     # Test that an implicit parameter colliding with a globally created parameter will error.
     @op
     def bar(param):

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -9,7 +9,7 @@ import __main__ as main
 import yaml
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.bool_artifact import BoolArtifact
-from aqueduct.artifacts.create import create_param_artifact
+from aqueduct.artifacts.create import check_explicit_param_name, create_param_artifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.backend.response_models import SavedObjectUpdate
 from aqueduct.constants.enums import (
@@ -217,6 +217,7 @@ class Client:
         Returns:
             A parameter artifact.
         """
+        check_explicit_param_name(self._dag, name)
         return create_param_artifact(self._dag, name, default, description)
 
     def list_params(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This bug came about because we processed each implicit parameter one at a time, performing validation and then creating the parameter. However, the act of creating the parameter would alter the validation step for the remaining implicit parameters, causing the assertion error described in the task.

The solution is to perform the validation for all implicit parameters at once, and only afterwards to alter the state of the dag.

## Related issue number (if any)
ENG-2481
https://github.com/aqueducthq/aqueduct/issues/1003

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


