### PR TITLE
Support notifications in manual QA testing script

### DIFF
--- a/manual_qa_tests/README.md
+++ b/manual_qa_tests/README.md
@@ -15,7 +15,7 @@ To run with more flexibility, configure the following commandline flags:
 * `--example-notebooks`: also run all example notebooks
 * `--slack-token`: The Slack App bot token to integrate with slack notifications.
 * `--slack-channel`: The channel to send Slack notifications.
-* `--notification-level`: The notification threshold level. (e.g. 'Success' to recieve all notifications, 'Warning' to recieve for warning / failed workflows, and 'Error' for faile workflows only.)
+* `--notification-level`: The notification threshold level. (e.g. 'Success' to receive all notifications, 'Warning' to recieve for warning / failed workflows, and 'Error' for failed workflows only.)
 
 ## Checklist
 * **Workflows** Page: There should be **4** workflows. **3** Succeeded and **1** Failed.

--- a/manual_qa_tests/README.md
+++ b/manual_qa_tests/README.md
@@ -13,6 +13,9 @@ To run with more flexibility, configure the following commandline flags:
 * `--data-integration`: the data integration name. The data integration need to be pre-configured before running the script.
 * `--api-key`: the API key if different from `aqueduct.api_key()` by any reason.
 * `--example-notebooks`: also run all example notebooks
+* `--slack-token`: The Slack App bot token to integrate with slack notifications.
+* `--slack-channel`: The channel to send Slack notifications.
+* `--notification-level`: The notification threshold level. (e.g. 'Success' to recieve all notifications, 'Warning' to recieve for warning / failed workflows, and 'Error' for faile workflows only.)
 
 ## Checklist
 * **Workflows** Page: There should be **4** workflows. **3** Succeeded and **1** Failed.
@@ -26,6 +29,15 @@ To run with more flexibility, configure the following commandline flags:
     * There should be **4** workflows in **Workflows** section.
     * If you are using `aqueduct_demo`, there should be **8** tables in **Data** section.
 * **Data** Page: There should be **1** data available.
+* Slack channel:
+    * There should be **4** new notifications.
+    * Each notification should have the following aspects:
+        * A title including the workflow's name and status
+        * Workflow name
+        * ID
+        * Result ID
+        * If the workflow has check failures, it should list all failed checks with correct error or warning state.
+        * A link to the workflow result's UI page.
 
 ## Keep It Up to Date
 * The scripts and **Checklist** should be focused on features that:

--- a/manual_qa_tests/initialize.py
+++ b/manual_qa_tests/initialize.py
@@ -1,6 +1,8 @@
 import argparse
 
 import deploy_example
+from aqueduct.constants.enums import NotificationLevel
+from notification import connect_spark
 from workflows import fail_bad_check, succeed_complex, succeed_parameters, warning_bad_check
 
 import aqueduct as aq
@@ -33,10 +35,21 @@ if __name__ == "__main__":
     parser.add_argument("--api-key", default="")
     # parser.add_argument("-q", "--quiet", action="store_true")
     parser.add_argument("--example-notebooks", action="store_true")
+    parser.add_argument("--slack-token", default="")
+    parser.add_argument("--slack-channel", default="")
+    parser.add_argument("--notification-level", default="success")
     args = parser.parse_args()
 
     api_key = args.api_key if args.api_key else aq.get_apikey()
     client = aq.Client(api_key, args.addr)
+
+    if args.slack_token and args.slack_channel:
+        connect_spark(
+            client,
+            args.slack_token,
+            args.slack_channel,
+            NotificationLevel(args.notification_level),
+        )
 
     if args.example_notebooks:
         for example_path in EXAMPLE_NOTEBOOKS_PATHS:

--- a/manual_qa_tests/notification.py
+++ b/manual_qa_tests/notification.py
@@ -1,0 +1,17 @@
+from aqueduct.constants.enums import NotificationLevel
+from aqueduct.integrations.connect_config import ServiceType, SlackConfig
+
+import aqueduct as aq
+
+
+def connect_spark(
+    client: aq.Client,
+    token: str,
+    channel: str,
+    level: NotificationLevel,
+) -> None:
+    client.connect_integration(
+        "test_slack_notification",
+        "Slack",
+        SlackConfig(token=token, channels=[channel], level=level, enabled=True),
+    )

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -186,3 +186,9 @@ class RuntimeType(Enum, metaclass=MetaEnum):
     K8S = "k8s"
     LAMBDA = "lambda"
     DATABRICKS = "databricks"
+
+
+class NotificationLevel(Enum, metaclass=MetaEnum):
+    SUCCESS = "success"
+    WARNING = "warning"
+    ERROR = "error"


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds simple SDK supports to connect to notification integrations. We also add manual QA test over slack channel which can be future taken by release process.

## Related issue number (if any)
ENG-2272

## Loom demo (if any)
Confirmed with QA testing in my own slack channel:
```
python3 manual_qa_tests/initialize.py --slack-token <TOKEN> --slack-channel general
```

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


