### PR TITLE
Removes deprecated save API from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ demo_db = client.integration("aqueduct_demo")
 reviews_table = demo_db.sql("select * from hotel_reviews;")
 
 strlen_table = transform_data(reviews_table)
-strlen_table.save(demo_db.config(table="strlen_table", update_mode="replace")) 
+demo_db.save(strlen_table, "strlen_table", "replace)
 
 client.publish_flow(name="review_strlen", artifacts=[strlen_table])
 ```


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Removes the old save API on the README that's since been deprecated.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [N/A] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


