### PR TITLE
Fix notifications doc link in UI

### DIFF
--- a/src/ui/common/src/utils/docs.ts
+++ b/src/ui/common/src/utils/docs.ts
@@ -1,1 +1,1 @@
-export const AqueductDocsLink = 'https://docs.aqueducthq.com/';
+export const AqueductDocsLink = 'https://docs.aqueducthq.com';

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -421,13 +421,13 @@ export const SupportedIntegrations: ServiceInfoMap = {
     logo: ServiceLogos['Email'],
     activated: true,
     category: IntegrationCategories.NOTIFICATION,
-    docs: `${addingIntegrationLink}/connecting-to-email`,
+    docs: `${AqueductDocsLink}/notifications/connecting-to-email`,
   },
   ['Slack']: {
     logo: ServiceLogos['Slack'],
     activated: true,
     category: IntegrationCategories.NOTIFICATION,
-    docs: `${addingIntegrationLink}/connecting-to-slack`,
+    docs: `${AqueductDocsLink}/notifications/connecting-to-slack`,
   },
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR updates notification doc link in UI as we decided to put docs in a different place than original plan.

## Related issue number (if any)
ENG-2504

## Loom demo (if any)
Verified the link actually jump to real content

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


