### PR TITLE
Fix bug when serializing a list of tables to S3

### DIFF
--- a/integration_tests/sdk/data_integration_tests/s3_data_validator.py
+++ b/integration_tests/sdk/data_integration_tests/s3_data_validator.py
@@ -46,6 +46,10 @@ class S3DataValidator:
 
         if isinstance(saved_data, pd.DataFrame):
             is_equal = saved_data.equals(expected_data)
+        elif isinstance(saved_data, list) and all(
+            isinstance(elem, pd.DataFrame) for elem in saved_data
+        ):
+            is_equal = all(elem.equals(expected_data[i]) for i, elem in enumerate(saved_data))
         else:
             is_equal = saved_data == expected_data
 

--- a/src/python/aqueduct_executor/operators/connectors/data/s3_serialization.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/s3_serialization.py
@@ -131,6 +131,7 @@ def serialize_val_for_s3(
                 artifact_type_to_s3_serialization_type(
                     elem_artifact_type,
                     format,
+                    ignore_format_requirement=True,
                 )
             )
 
@@ -162,10 +163,15 @@ class S3UnknownFileFormatException(Exception):
 def artifact_type_to_s3_serialization_type(
     artifact_type: ArtifactType,
     format: Optional[S3TableFormat],
+    ignore_format_requirement: bool = False,
 ) -> S3SerializationType:
     if artifact_type == ArtifactType.TABLE:
         if format is None:
-            raise Exception("You must specify a file format for table data.")
+            if not ignore_format_requirement:
+                raise Exception("You must specify a file format for table data.")
+
+            # Default format is Parquet.
+            format = S3TableFormat.PARQUET
 
         if format == S3TableFormat.CSV:
             return S3SerializationType.CSV_TABLE


### PR DESCRIPTION
## Describe your changes and why you are making these changes
For the inner serialization of a custom pickled dictionary, we use a default format value.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


