### PR TITLE
ENG-2508: Safari Bug Fixes

### DIFF
--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -68,6 +68,7 @@
         "@mui/material": "^5.11.6",
         "@mui/x-data-grid": "5.17.8",
         "@reduxjs/toolkit": "^1.9.1",
+        "@ungap/structured-clone": "^1.0.2",
         "@zip.js/zip.js": "^2.6.62",
         "autosuggest-highlight": "^3.3.4",
         "core-js": "^3.22.8",
@@ -13871,6 +13872,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.2.tgz",
+      "integrity": "sha512-06PHwE0K24Wi8FBmC8MuMi/+nQ3DTpcXYL3y/IaZz2ScY2GOJXOe8fyMykVXyLOKxpL2Y0frAnJZmm65OxzMLQ==",
+      "peer": true
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "3.0.1",
@@ -44798,6 +44805,12 @@
         "@typescript-eslint/types": "5.49.0",
         "eslint-visitor-keys": "^3.3.0"
       }
+    },
+    "@ungap/structured-clone": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.0.2.tgz",
+      "integrity": "sha512-06PHwE0K24Wi8FBmC8MuMi/+nQ3DTpcXYL3y/IaZz2ScY2GOJXOe8fyMykVXyLOKxpL2Y0frAnJZmm65OxzMLQ==",
+      "peer": true
     },
     "@vitejs/plugin-react": {
       "version": "3.0.1",

--- a/src/ui/common/package.json
+++ b/src/ui/common/package.json
@@ -49,6 +49,7 @@
     "core-js": "^3.22.8",
     "cron-parser": "^4.0.0",
     "elkjs": "0.8.2",
+    "@ungap/structured-clone": "^1.0.2",
     "mui-image": "1.0.7",
     "plotly.js": "2.14.0",
     "query-string": "^7.1.1",

--- a/src/ui/common/src/components/pages/AccountPage.tsx
+++ b/src/ui/common/src/components/pages/AccountPage.tsx
@@ -191,12 +191,15 @@ const MetadataStorageInfo: React.FC<MetadataStorageInfoProps> = ({
   switch (serverConfig.storageConfig.type) {
     case 'file': {
       storageInfo = fileMetadataStorageInfo;
+      break;
     }
     case 'gcs': {
       storageInfo = gcsMetadataStorageInfo;
+      break;
     }
     case 's3': {
       storageInfo = s3MetadataStorageInfo;
+      break;
     }
   }
 

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -9,6 +9,7 @@ import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
+import _ from 'lodash';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
@@ -27,6 +28,7 @@ import CheckHistory from '../../../workflows/artifact/check/history';
 import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
+import structuredClone from '@ungap/structured-clone';
 
 type CheckDetailsPageProps = {
   user: UserProfile;

--- a/src/ui/common/src/components/pages/check/id/index.tsx
+++ b/src/ui/common/src/components/pages/check/id/index.tsx
@@ -9,7 +9,7 @@ import AlertTitle from '@mui/material/AlertTitle';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import _ from 'lodash';
+import structuredClone from '@ungap/structured-clone';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
@@ -28,7 +28,6 @@ import CheckHistory from '../../../workflows/artifact/check/history';
 import ArtifactSummaryList from '../../../workflows/artifact/summaryList';
 import DetailsPageHeader from '../../components/DetailsPageHeader';
 import { LayoutProps } from '../../types';
-import structuredClone from '@ungap/structured-clone';
 
 type CheckDetailsPageProps = {
   user: UserProfile;

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -51,7 +51,7 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
       <Box sx={{ fontSize: '24px' }}>
         <FontAwesomeIcon icon={icon} />
       </Box>
-      <Typography variant="body1" sx={{ pl: 1 }}>
+      <Typography variant="body1" sx={{ marginLeft: '8px' }}>
         {result === 'true' ? 'passed' : 'failed'}
       </Typography>
     </Box>

--- a/src/ui/common/src/components/workflows/storageSelector.tsx
+++ b/src/ui/common/src/components/workflows/storageSelector.tsx
@@ -16,7 +16,6 @@ export const StorageSelector: React.FC = () => {
   let selected = 'file';
   let selectedLocation = null;
   if (dag) {
-    console.log('dag: ', dag);
     selected = dag.storage_config.type;
     switch (selected) {
       case 's3': {

--- a/src/ui/common/src/components/workflows/storageSelector.tsx
+++ b/src/ui/common/src/components/workflows/storageSelector.tsx
@@ -16,8 +16,23 @@ export const StorageSelector: React.FC = () => {
   let selected = 'file';
   let selectedLocation = null;
   if (dag) {
+    console.log('dag: ', dag);
     selected = dag.storage_config.type;
-    selectedLocation = dag.storage_config.file_config.directory;
+    switch (selected) {
+      case 's3': {
+        selectedLocation = dag.storage_config.s3_config.bucket;
+        break;
+      }
+      case 'gcs': {
+        selectedLocation = dag.storage_config.gcs_config.bucket;
+        break;
+      }
+      case 'file':
+      default: {
+        selectedLocation = dag.storage_config.file_config.directory;
+        break;
+      }
+    }
   }
 
   const getMenuItems = () => {
@@ -44,10 +59,12 @@ export const StorageSelector: React.FC = () => {
 
   return (
     <Box>
-      <Typography style={{ fontWeight: 'bold' }}>
-        {' '}
-        Metadata Storage Locationasdf {selectedLocation}
-      </Typography>
+      <Box sx={{ display: 'flex' }}>
+        <Typography style={{ fontWeight: 'bold' }}>
+          Metadata Storage Location:
+        </Typography>
+        <Typography sx={{ marginLeft: '8px' }}>{selectedLocation}</Typography>
+      </Box>
       <Typography variant="body2">
         For more details on modifying the Aqueduct metadata store, please see{' '}
         <Link href="https://docs.aqueducthq.com/guides/changing-metadata-store">

--- a/src/ui/common/src/components/workflows/storageSelector.tsx
+++ b/src/ui/common/src/components/workflows/storageSelector.tsx
@@ -14,24 +14,8 @@ export const StorageSelector: React.FC = () => {
   const workflow = useSelector((state: RootState) => state.workflowReducer);
   const dag = workflow.selectedDag;
   let selected = 'file';
-  let selectedLocation = null;
   if (dag) {
     selected = dag.storage_config.type;
-    switch (selected) {
-      case 's3': {
-        selectedLocation = dag.storage_config.s3_config.bucket;
-        break;
-      }
-      case 'gcs': {
-        selectedLocation = dag.storage_config.gcs_config.bucket;
-        break;
-      }
-      case 'file':
-      default: {
-        selectedLocation = dag.storage_config.file_config.directory;
-        break;
-      }
-    }
   }
 
   const getMenuItems = () => {
@@ -59,10 +43,7 @@ export const StorageSelector: React.FC = () => {
   return (
     <Box>
       <Box sx={{ display: 'flex' }}>
-        <Typography style={{ fontWeight: 'bold' }}>
-          Metadata Storage Location:
-        </Typography>
-        <Typography sx={{ marginLeft: '8px' }}>{selectedLocation}</Typography>
+        <Typography style={{ fontWeight: 'bold' }}>Metadata Storage</Typography>
       </Box>
       <Typography variant="body2">
         For more details on modifying the Aqueduct metadata store, please see{' '}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Bugfix: UI blanks when clicking on a check node in older versions of Safari. UI crashes when viewing workflow settings when user chooses Storage Metadata other than file storage.

The cause of this bug was that the structuredClone function is not supported by older browsers.

## Related issue number (if any)
ENG-2508

## Loom demo (if any)

Latest Demo: https://www.loom.com/share/d940355f303d458481b5e01b9557f0a7

https://www.loom.com/share/35d87bc69d8148b1b8f6e2df4ba31020

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


