### PR TITLE
[5/5] Properly migrate data for conda refactor

### DIFF
--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -26,7 +26,7 @@ server_directory = join(os.environ["HOME"], ".aqueduct", "server")
 ui_directory = join(os.environ["HOME"], ".aqueduct", "ui")
 
 # Make sure to update this if there is any schema change we want to include in the upgrade.
-SCHEMA_VERSION = "23"
+SCHEMA_VERSION = "24"
 
 
 def execute_command(args, cwd=None):

--- a/src/golang/cmd/migrator/migrator/register.go
+++ b/src/golang/cmd/migrator/migrator/register.go
@@ -26,6 +26,7 @@ import (
 	_000021 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000021_add_gc_column_to_env_table"
 	_000022 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000022_backfill_python_type"
 	_000023 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000023_add_notification_settings_column"
+	_000024 "github.com/aqueducthq/aqueduct/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine"
 	"github.com/aqueducthq/aqueduct/lib/database"
 )
 
@@ -170,5 +171,11 @@ func init() {
 		upPostgres: _000023.UpPostgres, upSqlite: _000023.UpSqlite,
 		downPostgres: _000023.DownPostgres,
 		name:         "add notification_settings column to workflow table",
+	}
+
+	registeredMigrations[24] = &migration{
+		upPostgres: _000024.UpPostgres, upSqlite: _000024.UpSqlite,
+		downPostgres: _000024.DownPostgres,
+		name:         "migrate exec env to conda engine",
 	}
 }

--- a/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/down_postgres.go
+++ b/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/down_postgres.go
@@ -1,0 +1,10 @@
+package _000024_migrate_exec_env_to_conda_engine
+
+const downPostgresScript = `
+UPDATE operator SET execution_environment_id = NULL
+WHERE jsonb_extract_path_text(spec, '{engine_config, type}') != 'aqueduct_conda';
+
+UPDATE operator SET spec = jsonb_set(spec, '{engine_config}', jsonb_build_object(
+	'type', 'aqueduct'
+)) WHERE jsonb_extract_path_text(spec, '{engine_config, type}') = 'aqueduct_conda';
+`

--- a/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/main.go
+++ b/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/main.go
@@ -1,0 +1,19 @@
+package _000024_migrate_exec_env_to_conda_engine
+
+import (
+	"context"
+
+	"github.com/aqueducthq/aqueduct/lib/database"
+)
+
+func UpPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upPostgresScript)
+}
+
+func UpSqlite(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, upSqliteScript)
+}
+
+func DownPostgres(ctx context.Context, db database.Database) error {
+	return db.Execute(ctx, downPostgresScript)
+}

--- a/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/up_postgres.go
+++ b/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/up_postgres.go
@@ -1,0 +1,9 @@
+package _000024_migrate_exec_env_to_conda_engine
+
+const upPostgresScript = `
+UPDATE operator SET spec = jsonb_set(spec, '{engine_config}', jsonb_build_object(
+	'type', 'aqueduct_conda', 'aqueduct_conda_config', jsonb_build_object(
+		'env', 'aqueduct_' || execution_environment_id
+	)
+)) WHERE execution_environment_id IS NOT NULL;
+`

--- a/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/up_sqlite.go
+++ b/src/golang/cmd/migrator/versions/000024_migrate_exec_env_to_conda_engine/up_sqlite.go
@@ -1,0 +1,11 @@
+package _000024_migrate_exec_env_to_conda_engine
+
+const upSqliteScript = `
+UPDATE operator SET spec = CAST(
+	json_set(spec, '$.engine_config', json_object(
+		'type', 'aqueduct_conda', 'aqueduct_conda_config', json_object(
+			'env', 'aqueduct_' || execution_environment_id
+		)
+	)) AS BLOB
+) WHERE execution_environment_id IS NOT NULL;
+`

--- a/src/golang/lib/models/schema_version.go
+++ b/src/golang/lib/models/schema_version.go
@@ -9,7 +9,7 @@ const (
 	// This is the source of truth for the required schema version
 	// for both the server and executor. This value MUST be updated
 	// when a new schema change is added.
-	CurrentSchemaVersion = 23
+	CurrentSchemaVersion = 24
 
 	SchemaVersionTable = "schema_version"
 

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -20,7 +20,7 @@ import yaml
 from packaging.version import parse as parse_version
 from tqdm import tqdm
 
-SCHEMA_VERSION = "23"
+SCHEMA_VERSION = "24"
 CHUNK_SIZE = 4096
 
 # Connector Package Version Bounds


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds proper data migration for conda refactor. We added conda engine config for all operators with exec_env_id in older version, since in older version, having this ID implies the op is / was running using conda engine.

## Related issue number (if any)
ENG-2467

## Loom demo (if any)
Performed regression test:
* Create wf using older version
* update binary and perform migration
* Run wf using new version
* Verified UI, etc. works properly.

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


