### PR TITLE
Allows users to reuse operator in a workflow

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/naming_test.py
+++ b/integration_tests/sdk/aqueduct_tests/naming_test.py
@@ -117,13 +117,3 @@ def test_naming_collision_with_different_types(client, data_integration):
     _ = dummy_sentiment_model(table_artifact)
     with pytest.raises(InvalidUserActionException):
         _ = extract(data_integration, DataObject.SENTIMENT, op_name="dummy_sentiment_model")
-
-
-def test_naming_collision_with_dependency(client, data_integration):
-    # Overwrite is invalid when the operator being replaced is an upstream dependency.
-    table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sentiment_model")
-    dummy_model_output = dummy_model(table_artifact)
-    dummy_model_2_output = dummy_model_2(dummy_model_output)
-
-    with pytest.raises(InvalidUserActionException):
-        _ = dummy_model(dummy_model_2_output)

--- a/integration_tests/sdk/aqueduct_tests/naming_test.py
+++ b/integration_tests/sdk/aqueduct_tests/naming_test.py
@@ -113,11 +113,6 @@ def test_naming_collision_with_different_types(client, data_integration):
     # An overwrite is invalid because the operators are of different types.
     table_artifact = extract(data_integration, DataObject.SENTIMENT, op_name="sql query")
 
-    # Function collides with existing sql artifact
-    _ = extract(data_integration, DataObject.SENTIMENT, op_name="dummy_model")
-    with pytest.raises(InvalidUserActionException):
-        dummy_model(table_artifact)
-
     # SQL collides with existing function
     _ = dummy_sentiment_model(table_artifact)
     with pytest.raises(InvalidUserActionException):

--- a/integration_tests/sdk/aqueduct_tests/operator_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_test.py
@@ -1,4 +1,6 @@
+import pytest
 from aqueduct.decorator import to_operator
+from aqueduct.error import ArtifactNotFoundException
 
 from aqueduct import op
 from sdk.aqueduct_tests.test_function import dummy_sentiment_model_function
@@ -25,6 +27,82 @@ def test_to_operator_local_function(client, data_integration):
     df_func = output_artifact_from_to_operator.get()
 
     assert df_normal["positivity"].equals(df_func["positivity"])
+
+
+def test_operator_reuse(data_integration):
+    """Tests reusing the same operator multiple times in a workflow with different
+    input artifacts.
+    """
+    sentiment_artifact = extract(data_integration, DataObject.SENTIMENT)
+    wine_artifact = extract(data_integration, DataObject.WINE)
+
+    @op
+    def noop(df):
+        return df
+
+    _ = noop(sentiment_artifact).get()
+    _ = noop(wine_artifact).get()
+
+    @op
+    def noop_multiple(df1, df2):
+        return df1
+
+    # Tests to check that 2 operators are created because the order of
+    # the input artifacts are different
+    _ = noop_multiple(sentiment_artifact, wine_artifact).get()
+    _ = noop_multiple(wine_artifact, sentiment_artifact).get()
+
+
+def test_operator_overwrite(data_integration):
+    """Tests the cases when an operator should be overwritten instead of being
+    reused. This happens if an operator with the same name and input artifacts
+    is created.
+    """
+
+    @op
+    def no_args():
+        return 456
+
+    no_args_old = no_args()
+    no_args_new = no_args()
+
+    # The operator should be overwritten, since the input artifacts (none)
+    # are the same.
+    with pytest.raises(ArtifactNotFoundException):
+        no_args_old.get()
+
+    _ = no_args_new.get()
+
+    sentiment_artifact = extract(data_integration, DataObject.SENTIMENT)
+    wine_artifact = extract(data_integration, DataObject.WINE)
+
+    @op
+    def single_args(df):
+        return df
+
+    single_args_old = single_args(sentiment_artifact)
+    single_args_new = single_args(sentiment_artifact)
+
+    # The operator should be overwritten, since the input artifact
+    # is the same.
+    with pytest.raises(ArtifactNotFoundException):
+        single_args_old.get()
+
+    _ = single_args_new.get()
+
+    @op
+    def double_args(df1, df2):
+        return df1
+
+    double_args_old = double_args(sentiment_artifact, wine_artifact)
+    double_args_new = double_args(sentiment_artifact, wine_artifact)
+
+    # The operator should be overwritten, since the input artifacts
+    # are the same.
+    with pytest.raises(ArtifactNotFoundException):
+        double_args_old.get()
+
+    _ = double_args_new.get()
 
 
 # TODO(ENG-1470): This doesn't work in pytest, but is fine in a jupyter notebook.

--- a/integration_tests/sdk/aqueduct_tests/operator_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_test.py
@@ -42,7 +42,7 @@ def test_operator_reuse(data_integration):
 
     noop_artifact_1 = noop(sentiment_artifact).get()
     noop_artifact_2 = noop(wine_artifact).get()
-    
+
     assert noop_artifact_1.name() == "noop artifact"
     assert noop_artifact_2.name() == "noop (1) artifact"
 
@@ -110,6 +110,31 @@ def test_operator_overwrite(data_integration):
     _ = double_args_new.get()
 
     assert double_args_new.name() == "double_args artifact"
+
+
+def test_operator_reuse_chain(data_integration):
+    """Tests reusing the same operator when it is chained together by a dependency."""
+    wine_artifact = extract(data_integration, DataObject.WINE)
+
+    @op
+    def noop_1(df):
+        return df
+
+    @op
+    def noop_2(df):
+        return df
+
+    a = noop_1(wine_artifact)
+    b = noop_2(a)
+    c = noop_1(b)
+
+    _ = a.get()
+    _ = b.get()
+    _ = c.get()
+
+    assert a.name() == "noop_1 artifact"
+    assert b.name() == "noop_2 artifact"
+    assert c.name() == "noop_1 (1) artifact"
 
 
 # TODO(ENG-1470): This doesn't work in pytest, but is fine in a jupyter notebook.

--- a/integration_tests/sdk/aqueduct_tests/operator_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_test.py
@@ -40,11 +40,14 @@ def test_operator_reuse(data_integration):
     def noop(df):
         return df
 
-    noop_artifact_1 = noop(sentiment_artifact).get()
-    noop_artifact_2 = noop(wine_artifact).get()
+    noop_artifact_1 = noop(sentiment_artifact)
+    noop_artifact_2 = noop(wine_artifact)
 
     assert noop_artifact_1.name() == "noop artifact"
     assert noop_artifact_2.name() == "noop (1) artifact"
+
+    _ = noop_artifact_1.get()
+    _ = noop_artifact_2.get()
 
     @op
     def noop_multiple(df1, df2):

--- a/integration_tests/sdk/aqueduct_tests/operator_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_test.py
@@ -40,8 +40,11 @@ def test_operator_reuse(data_integration):
     def noop(df):
         return df
 
-    _ = noop(sentiment_artifact).get()
-    _ = noop(wine_artifact).get()
+    noop_artifact_1 = noop(sentiment_artifact).get()
+    noop_artifact_2 = noop(wine_artifact).get()
+    
+    assert noop_artifact_1.name() == "noop artifact"
+    assert noop_artifact_2.name() == "noop (1) artifact"
 
     @op
     def noop_multiple(df1, df2):
@@ -90,6 +93,8 @@ def test_operator_overwrite(data_integration):
 
     _ = single_args_new.get()
 
+    assert single_args_new.name() == "single_args artifact"
+
     @op
     def double_args(df1, df2):
         return df1
@@ -103,6 +108,8 @@ def test_operator_overwrite(data_integration):
         double_args_old.get()
 
     _ = double_args_new.get()
+
+    assert double_args_new.name() == "double_args artifact"
 
 
 # TODO(ENG-1470): This doesn't work in pytest, but is fine in a jupyter notebook.

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -111,9 +111,9 @@ def wrap_spec(
     operator_id = generate_uuid()
     output_artifact_ids = [generate_uuid() for _ in output_artifact_type_hints]
 
-    print('Adding Operator: ', op_name)
-    print('Got inputs: ', input_artifacts)
-    print('Input IDs: ', [x.id() for x in input_artifacts])
+    print("Adding Operator: ", op_name)
+    print("Got inputs: ", input_artifacts)
+    print("Input IDs: ", [x.id() for x in input_artifacts])
 
     # Cases for should de-duplicate
     # 1. Clashing op does not exist --> FALSE
@@ -122,17 +122,17 @@ def wrap_spec(
     overwrite_existing_op = True
     colliding_op = dag.get_operator(with_name=op_name)
     if colliding_op is not None:
-        print('There is a clashing operator that we need to resolve')
-        print('It has inputs: ', colliding_op.inputs)
+        print("There is a clashing operator that we need to resolve")
+        print("It has inputs: ", colliding_op.inputs)
         # There is already an operator with the same name.
         # If the input artifacts are different for this new operator
         # and the existing operator, then a new operator should be added.
         # Otherwise, the existing operator should be overwritten.
         input_artifact_ids = [input_artf.id() for input_artf in input_artifacts]
         if input_artifact_ids != colliding_op.inputs:
-            print('The inputs are NOT the same, so we do not overwrite')
+            print("The inputs are NOT the same, so we do not overwrite")
             overwrite_existing_op = False
-    
+
     op_name, artifact_names = resolve_op_and_artifact_names(
         dag,
         op_name,

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -122,6 +122,7 @@ def wrap_spec(
         if input_artifact_ids != colliding_op.inputs:
             overwrite_existing_op = False
 
+    original_op_name = op_name
     op_name, artifact_names = resolve_op_and_artifact_names(
         dag,
         op_name,
@@ -129,6 +130,12 @@ def wrap_spec(
         candidate_artifact_names=output_artifact_names,
         num_outputs=len(output_artifact_ids),
     )
+
+    if colliding_op is not None and op_name != original_op_name:
+        print(
+            "Warning: There is already an operator named %s so this operator is being renamed to %s"
+            % (original_op_name, op_name)
+        )
 
     apply_deltas_to_dag(
         dag,

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -111,10 +111,32 @@ def wrap_spec(
     operator_id = generate_uuid()
     output_artifact_ids = [generate_uuid() for _ in output_artifact_type_hints]
 
+    print('Adding Operator: ', op_name)
+    print('Got inputs: ', input_artifacts)
+    print('Input IDs: ', [x.id() for x in input_artifacts])
+
+    # Cases for should de-duplicate
+    # 1. Clashing op does not exist --> FALSE
+    # 2. Clashing op exists with same input artifacts --> FALSE
+    # 3. Clashing op exists with different input artifacts --> TRUE
+    overwrite_existing_op = True
+    colliding_op = dag.get_operator(with_name=op_name)
+    if colliding_op is not None:
+        print('There is a clashing operator that we need to resolve')
+        print('It has inputs: ', colliding_op.inputs)
+        # There is already an operator with the same name.
+        # If the input artifacts are different for this new operator
+        # and the existing operator, then a new operator should be added.
+        # Otherwise, the existing operator should be overwritten.
+        input_artifact_ids = [input_artf.id() for input_artf in input_artifacts]
+        if input_artifact_ids != colliding_op.inputs:
+            print('The inputs are NOT the same, so we do not overwrite')
+            overwrite_existing_op = False
+    
     op_name, artifact_names = resolve_op_and_artifact_names(
         dag,
         op_name,
-        overwrite_existing_op_name=True,
+        overwrite_existing_op_name=overwrite_existing_op,
         candidate_artifact_names=output_artifact_names,
         num_outputs=len(output_artifact_ids),
     )

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -111,26 +111,15 @@ def wrap_spec(
     operator_id = generate_uuid()
     output_artifact_ids = [generate_uuid() for _ in output_artifact_type_hints]
 
-    print("Adding Operator: ", op_name)
-    print("Got inputs: ", input_artifacts)
-    print("Input IDs: ", [x.id() for x in input_artifacts])
-
-    # Cases for should de-duplicate
-    # 1. Clashing op does not exist --> FALSE
-    # 2. Clashing op exists with same input artifacts --> FALSE
-    # 3. Clashing op exists with different input artifacts --> TRUE
     overwrite_existing_op = True
     colliding_op = dag.get_operator(with_name=op_name)
     if colliding_op is not None:
-        print("There is a clashing operator that we need to resolve")
-        print("It has inputs: ", colliding_op.inputs)
         # There is already an operator with the same name.
         # If the input artifacts are different for this new operator
         # and the existing operator, then a new operator should be added.
         # Otherwise, the existing operator should be overwritten.
         input_artifact_ids = [input_artf.id() for input_artf in input_artifacts]
         if input_artifact_ids != colliding_op.inputs:
-            print("The inputs are NOT the same, so we do not overwrite")
             overwrite_existing_op = False
 
     op_name, artifact_names = resolve_op_and_artifact_names(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR allows users to reuse an operator in a workflow, as long as the input artifacts provided to the operator are different from previous instances of the operator. If a user attempts to add a new operator that collides with an existing operator and it has the exact same input artifacts in the same order, we simply overwrite the original operator.

## Related issue number (if any)
ENG 2462

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


