### PR TITLE
Fixes bug in the storage migration process with migrating failed artifact results

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -182,14 +182,12 @@ func (h *ConnectIntegrationHandler) Perform(ctx context.Context, interfaceArgs i
 		// the connect integration request has succeeded and that the migration is now
 		// under way.
 		go func() {
-			log.Info("Starting storage migration process")
-			log.Info("Waiting for server to be paused...")
+			log.Info("Starting storage migration process...")
 			// Wait until the server is paused
 			h.PauseServer()
 			// Makes sure that the server is restarted
 			defer h.RestartServer()
 
-			log.Info("Waiting to acquire workflow execution lock...")
 			// Wait until there are no more workflow runs in progress
 			lock := utils.NewExecutionLock()
 			if err := lock.Lock(); err != nil {
@@ -201,7 +199,6 @@ func (h *ConnectIntegrationHandler) Perform(ctx context.Context, interfaceArgs i
 					log.Errorf("Unexpected error when unlocking workflow execution lock: %v", err)
 				}
 			}()
-			log.Info("Acquired workflow execution lock")
 
 			if err := setIntegrationAsStorage(
 				context.Background(),
@@ -217,6 +214,8 @@ func (h *ConnectIntegrationHandler) Perform(ctx context.Context, interfaceArgs i
 			); err != nil {
 				log.Errorf("Unexpected error when setting the new storage layer: %v", err)
 			}
+
+			log.Info("Successfully migrated the storage layer!")
 		}()
 	}
 

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -182,11 +182,14 @@ func (h *ConnectIntegrationHandler) Perform(ctx context.Context, interfaceArgs i
 		// the connect integration request has succeeded and that the migration is now
 		// under way.
 		go func() {
+			log.Info("Starting storage migration process")
+			log.Info("Waiting for server to be paused...")
 			// Wait until the server is paused
 			h.PauseServer()
 			// Makes sure that the server is restarted
 			defer h.RestartServer()
 
+			log.Info("Waiting to acquire workflow execution lock...")
 			// Wait until there are no more workflow runs in progress
 			lock := utils.NewExecutionLock()
 			if err := lock.Lock(); err != nil {
@@ -198,6 +201,7 @@ func (h *ConnectIntegrationHandler) Perform(ctx context.Context, interfaceArgs i
 					log.Errorf("Unexpected error when unlocking workflow execution lock: %v", err)
 				}
 			}()
+			log.Info("Acquired workflow execution lock")
 
 			if err := setIntegrationAsStorage(
 				context.Background(),

--- a/src/golang/lib/workflow/utils/migrate.go
+++ b/src/golang/lib/workflow/utils/migrate.go
@@ -59,7 +59,7 @@ func MigrateStorageAndVault(
 	toDelete := []string{}
 
 	for _, dag := range dags {
-		log.Infof("Migrating artifact and operator content for DAG and workflow %v: %v", dag.ID, dag.Metadata.Name)
+		log.Infof("Migrating artifact and operator content for DAG and workflow %v", dag.ID)
 		if dag.EngineConfig.Type == shared.AirflowEngineType {
 			// We cannot migrate content for Airflow workflows
 			continue


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where the migration logic was trying to look for artifact results that had failed and therefore did not exists in storage and then subsequently caused the entire process to be marked as failed. We now have a check to only throw an error during artifact result migration if the status was actually successful.

This PR also adds a bunch of useful debug logs that will be important when debugging in the future.

## Related issue number (if any)
ENG 2411

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


