### PR TITLE
Copies migrator binary instead of moving it

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ server:
 migrator-release:
 	cd golang/cmd/migrator && go install -ldflags="-s -w" -trimpath
 	mkdir -p build # Make the build directory if it doesn't exist
-	mv $$GOPATH/bin/migrator build/migrator
+	cp $$GOPATH/bin/migrator build/migrator
 
 executor-release:
 	cd golang/cmd/executor && go install -ldflags="-s -w" -trimpath


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This is necessary for the release process to copy the migrator binary just as we do for server and executor instead of moving it.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


