### PR TITLE
Allows users to optionally specify snowflake role

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,6 @@ jobs:
     name: All Integration Tests with Basic Config
     steps:
       - uses: actions/checkout@v2
-        ref: eng-2490-allow-users-to-optionally-specify-role-snowflake
 
       - uses: ./.github/actions/setup-server
         timeout-minutes: 5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,6 +17,7 @@ jobs:
     name: All Integration Tests with Basic Config
     steps:
       - uses: actions/checkout@v2
+        ref: eng-2490-allow-users-to-optionally-specify-role-snowflake
 
       - uses: ./.github/actions/setup-server
         timeout-minutes: 5

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -120,6 +120,7 @@ class SnowflakeConfig(BaseConnectionConfig):
     database: str
     warehouse: str
     db_schema: Optional[str] = Field("public", alias="schema")  # schema is a Pydantic keyword
+    role: Optional[str] = None
 
     class Config:
         # Ensures that Pydantic parses JSON keys named "schema" or "db_schema" to

--- a/sdk/aqueduct/integrations/sql_integration.py
+++ b/sdk/aqueduct/integrations/sql_integration.py
@@ -104,7 +104,7 @@ class RelationalDBIntegration(Integration):
         Returns:
             pd.DataFrame of available tables.
         """
-        if self.type() in [ServiceType.BIGQUERY]:
+        if self.type() in [ServiceType.BIGQUERY, ServiceType.SNOWFLAKE]:
             # Use the list integration objects endpoint instead of
             # providing a hardcoded SQL query to execute
             tables = globals.__GLOBAL_API_CLIENT__.list_tables(str(self.id()))
@@ -116,8 +116,6 @@ class RelationalDBIntegration(Integration):
             ServiceType.REDSHIFT,
         ]:
             list_tables_query = LIST_TABLES_QUERY_PG
-        elif self.type() == ServiceType.SNOWFLAKE:
-            list_tables_query = LIST_TABLES_QUERY_SNOWFLAKE
         elif self.type() == ServiceType.MYSQL:
             list_tables_query = LIST_TABLES_QUERY_MYSQL
         elif self.type() == ServiceType.MARIADB:

--- a/src/python/aqueduct_executor/operators/connectors/data/config.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/config.py
@@ -90,6 +90,7 @@ class SnowflakeConfig(models.BaseConfig):
     database: str
     warehouse: str
     db_schema: Optional[str] = Field("public", alias="schema")  # schema is a Pydantic keyword
+    role: Optional[str] = None
 
     class Config:
         # Ensures that Pydantic parses JSON keys named "schema" or "db_schema" to

--- a/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
@@ -26,6 +26,11 @@ def create_snowflake_engine(config: config.SnowflakeConfig) -> engine.Engine:
         schema=config.db_schema,
         warehouse=config.warehouse,
     )
+
+    if config.role:
+        url += "?role={role}"
+        url = url.format(role=config.role)
+
     return create_engine(url)
 
 

--- a/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
@@ -28,7 +28,8 @@ def create_snowflake_engine(config: config.SnowflakeConfig) -> engine.Engine:
     )
 
     if config.role:
-        url += "?role={role}"
+        # Assume a role explicitly, because one has been provided
+        url += "&role={role}"
         url = url.format(role=config.role)
 
     return create_engine(url)

--- a/src/python/aqueduct_executor/operators/connectors/data/spark/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/spark/snowflake.py
@@ -1,18 +1,15 @@
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any
 
 from aqueduct_executor.operators.connectors.data import (
     common,
     config,
-    connector,
     extract,
     load,
     relational,
     snowflake,
-    utils,
 )
 from aqueduct_executor.operators.utils.enums import ArtifactType
 from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql.functions import col
 from pyspark.sql.types import FloatType
 
 

--- a/src/python/aqueduct_executor/operators/connectors/data/spark/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/spark/snowflake.py
@@ -29,6 +29,10 @@ class SparkSnowflakeConnector(relational.RelationalConnector):
             "sfSchema": config.schema,
             "sfWarehouse": config.warehouse,
         }
+
+        if config.role:
+            self.snowflake_spark_options["sfRole"] = config.role
+
         super().__init__(conn_engine)
 
     def extract_spark(

--- a/src/ui/common/src/components/integrations/cards/snowflakeCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/snowflakeCard.tsx
@@ -32,6 +32,12 @@ export const SnowflakeCard: React.FC<Props> = ({ integration }) => {
         <strong>Schema: </strong>
         {config.schema ? config.schema : 'public'}
       </Typography>
+      {config.role && (
+        <Typography variant="body2">
+          <strong>Role: </strong>
+          {config.role}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -78,7 +78,7 @@ import {
   SlackDefaultsOnCreate,
   SlackDialog,
 } from './slackDialog';
-import { SnowflakeDialog } from './snowflakeDialog';
+import { isSnowflakeConfigComplete, SnowflakeDialog } from './snowflakeDialog';
 import { isSparkConfigComplete, SparkDialog } from './sparkDialog';
 import { SQLiteDialog } from './sqliteDialog';
 
@@ -493,25 +493,26 @@ export function isConfigComplete(
   service: Service
 ): boolean {
   switch (service) {
-    case 'S3':
-      return isS3ConfigComplete(config as S3Config);
     case 'Athena':
       return isAthenaConfigComplete(config as AthenaConfig);
-    case 'Kubernetes':
-      return isK8sConfigComplete(config as KubernetesConfig);
+    case 'AWS':
+      return isAWSConfigComplete(config as AWSConfig);
     case 'Conda':
       return true;
     case 'Databricks':
       return isDatabricksConfigComplete(config as DatabricksConfig);
     case 'Email':
       return isEmailConfigComplete(config as EmailConfig);
+    case 'Kubernetes':
+      return isK8sConfigComplete(config as KubernetesConfig);
+    case 'S3':
+      return isS3ConfigComplete(config as S3Config);
     case 'Slack':
       return isSlackConfigComplete(config as SlackConfig);
     case 'Spark':
       return isSparkConfigComplete(config as SparkConfig);
-    case 'AWS':
-      return isAWSConfigComplete(config as AWSConfig);
-
+    case 'Snowflake':
+      return isSnowflakeConfigComplete(config as SnowflakeConfig);
     default:
       // Make sure config is not empty and all fields are not empty as well.
       return (

--- a/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
@@ -129,11 +129,12 @@ export const SnowflakeDialog: React.FC<Props> = ({
 };
 
 export function isSnowflakeConfigComplete(config: SnowflakeConfig): boolean {
-  const optional = ['role'];
-  return (
-    Object.values(config).length > 0 &&
-    Object.keys(config)
-      .filter((key) => !optional.includes(key))
-      .every((key) => !!config[key])
-  );
+  const required = [
+    'account_identifier',
+    'username',
+    'password',
+    'warehouse',
+    'database',
+  ];
+  return required.every((key) => key in config && config[key].length > 0);
 }

--- a/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
@@ -12,6 +12,7 @@ const Placeholders: SnowflakeConfig = {
   schema: 'public',
   username: 'aqueduct',
   password: '********',
+  role: '',
 };
 
 type Props = {
@@ -113,6 +114,26 @@ export const SnowflakeDialog: React.FC<Props> = ({
         onChange={(event) => onUpdateField('password', event.target.value)}
         value={value?.password ?? null}
       />
+
+      <IntegrationTextInputField
+        spellCheck={false}
+        required={false}
+        label="Role"
+        description="The role to use when accessing the database above."
+        placeholder={Placeholders.role}
+        onChange={(event) => onUpdateField('role', event.target.value)}
+        value={value?.role ?? null}
+      />
     </Box>
   );
 };
+
+export function isSnowflakeConfigComplete(config: SnowflakeConfig): boolean {
+  const optional = ['role'];
+  return (
+    Object.values(config).length > 0 &&
+    Object.keys(config)
+      .filter((key) => !optional.includes(key))
+      .every((key) => !!config[key])
+  );
+}

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -37,6 +37,7 @@ export type SnowflakeConfig = {
   schema: string;
   username: string;
   password?: string;
+  role: string;
 };
 
 export type RedshiftConfig = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR allows users to specify a role when using a Snowflake role. Currently all operations for Snowflake would just assume the default role of the user.

## Related issue number (if any)
ENG 2490

## Loom demo (if any)
https://www.loom.com/share/49cdc9aefc9f4800b35b21ffec36d073

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video. **TODO**
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


