### PR TITLE
Allows for Snowflake VARCHAR to be of the max size

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/connector.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/connector.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any, List
 
-import pandas as pd
 from aqueduct_executor.operators.utils.enums import ArtifactType
 from aqueduct_executor.operators.utils.saved_object_delete import SavedObjectDelete
 

--- a/src/python/aqueduct_executor/operators/connectors/data/connector.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/connector.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, List
 
+import pandas as pd
 from aqueduct_executor.operators.utils.enums import ArtifactType
 from aqueduct_executor.operators.utils.saved_object_delete import SavedObjectDelete
 

--- a/src/python/aqueduct_executor/operators/connectors/data/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/relational.py
@@ -43,12 +43,14 @@ class RelationalConnector(connector.DataConnector):
     def __init__(
         self,
         conn_engine: engine.Engine,
-        object_to_varchar_mapper: Optional[
-            Callable[[pd.DataFrame], Dict[str, VARCHAR]]
-        ] = default_map_object_dtype_to_varchar,
+        object_to_varchar_mapper: Optional[Callable[[pd.DataFrame], Dict[str, VARCHAR]]] = None,
     ):
         self.engine = conn_engine
-        self.map_object_dtype_to_varchar = object_to_varchar_mapper
+        self.map_object_dtype_to_varchar: Callable[
+            [pd.DataFrame], Dict[str, VARCHAR]
+        ] = default_map_object_dtype_to_varchar
+        if object_to_varchar_mapper is not None:
+            self.map_object_dtype_to_varchar = object_to_varchar_mapper
 
     def __del__(self) -> None:
         self.engine.dispose()

--- a/src/python/aqueduct_executor/operators/connectors/data/relational.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/relational.py
@@ -58,11 +58,6 @@ class RelationalConnector(connector.DataConnector):
         return results
 
     def _map_object_dtype_to_varchar(self, df: pd.DataFrame) -> Dict[str, VARCHAR]:
-        """Given a DataFrame, for each string column (i.e. object dtype), it
-        returns a mapping of column name to the appropriate SQL type VARCHAR(N),
-        where N is large enough for all values in the column. Non-string
-        columns will not be included in the returned map.
-        """
         col_to_type = {}
         for col in df.select_dtypes(include=["object"]):
             max_size = df[col].astype(str).str.len().max()
@@ -85,7 +80,7 @@ class RelationalConnector(connector.DataConnector):
                 col_to_type[col] = VARCHAR(65535)
             else:
                 raise Exception(
-                    "Cannot support saving string columns with length greater than 65535 bytes"
+                    "(saurav) Cannot support saving string columns with length greater than 65535 bytes"
                 )
         return col_to_type
 

--- a/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
@@ -1,8 +1,7 @@
 from typing import Dict
 
 import pandas as pd
-from aqueduct_executor.operators.connectors.data import config, relational, utils, load
-from aqueduct_executor.operators.utils.enums import ArtifactType
+from aqueduct_executor.operators.connectors.data import config, relational, utils
 from sqlalchemy import create_engine, engine
 from sqlalchemy.types import VARCHAR
 
@@ -10,7 +9,10 @@ from sqlalchemy.types import VARCHAR
 class SnowflakeConnector(relational.RelationalConnector):
     def __init__(self, config: config.SnowflakeConfig):
         conn_engine = create_snowflake_engine(config)
-        super().__init__(conn_engine)
+        super().__init__(
+            conn_engine=conn_engine,
+            object_to_varchar_mapper=map_object_dtype_to_varchar,
+        )
 
 
 def create_snowflake_engine(config: config.SnowflakeConfig) -> engine.Engine:
@@ -27,32 +29,8 @@ def create_snowflake_engine(config: config.SnowflakeConfig) -> engine.Engine:
     return create_engine(url)
 
 
-def _map_object_dtype_to_varchar(self, df: pd.DataFrame) -> Dict[str, VARCHAR]:
+def map_object_dtype_to_varchar(df: pd.DataFrame) -> Dict[str, VARCHAR]:
     col_to_type = {}
     for col in df.select_dtypes(include=["object"]):
         col_to_type[col] = VARCHAR()
     return col_to_type
-
-
-def load(
-        self, params: load.RelationalParams, df: pd.DataFrame, artifact_type: ArtifactType
-    ) -> None:
-        if artifact_type != ArtifactType.TABLE:
-            raise Exception("The data being loaded must be of type table, found %s" % artifact_type)
-
-        # Map of only string columns to their SQL type
-        # If a column is not in this map, we rely on Panda's default mapping
-        col_to_type = self._map_object_dtype_to_varchar(df)
-
-        # NOTE (saurav): df._to_sql has known performance issues. Using `method="multi"` helps incrementally,
-        # since pandas will pass multiple rows in a single INSERT. If this still remains an issue, we can pass in a
-        # callable function for `method` that does bulk loading.
-        # See: https://pandas.pydata.org/docs/user_guide/io.html#io-sql-method
-        df.to_sql(
-            params.table,
-            con=self.engine,
-            if_exists=params.update_mode.value,
-            index=False,
-            dtype=col_to_type,
-            method="multi",
-        )

--- a/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
@@ -1,5 +1,10 @@
-from aqueduct_executor.operators.connectors.data import config, relational, utils
+from typing import Dict
+
+import pandas as pd
+from aqueduct_executor.operators.connectors.data import config, relational, utils, load
+from aqueduct_executor.operators.utils.enums import ArtifactType
 from sqlalchemy import create_engine, engine
+from sqlalchemy.types import VARCHAR
 
 
 class SnowflakeConnector(relational.RelationalConnector):
@@ -20,3 +25,34 @@ def create_snowflake_engine(config: config.SnowflakeConfig) -> engine.Engine:
         warehouse=config.warehouse,
     )
     return create_engine(url)
+
+
+def _map_object_dtype_to_varchar(self, df: pd.DataFrame) -> Dict[str, VARCHAR]:
+    col_to_type = {}
+    for col in df.select_dtypes(include=["object"]):
+        col_to_type[col] = VARCHAR()
+    return col_to_type
+
+
+def load(
+        self, params: load.RelationalParams, df: pd.DataFrame, artifact_type: ArtifactType
+    ) -> None:
+        if artifact_type != ArtifactType.TABLE:
+            raise Exception("The data being loaded must be of type table, found %s" % artifact_type)
+
+        # Map of only string columns to their SQL type
+        # If a column is not in this map, we rely on Panda's default mapping
+        col_to_type = self._map_object_dtype_to_varchar(df)
+
+        # NOTE (saurav): df._to_sql has known performance issues. Using `method="multi"` helps incrementally,
+        # since pandas will pass multiple rows in a single INSERT. If this still remains an issue, we can pass in a
+        # callable function for `method` that does bulk loading.
+        # See: https://pandas.pydata.org/docs/user_guide/io.html#io-sql-method
+        df.to_sql(
+            params.table,
+            con=self.engine,
+            if_exists=params.update_mode.value,
+            index=False,
+            dtype=col_to_type,
+            method="multi",
+        )

--- a/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/snowflake.py
@@ -32,5 +32,10 @@ def create_snowflake_engine(config: config.SnowflakeConfig) -> engine.Engine:
 def map_object_dtype_to_varchar(df: pd.DataFrame) -> Dict[str, VARCHAR]:
     col_to_type = {}
     for col in df.select_dtypes(include=["object"]):
+        # We do not need to provide an explicit size, because Snowflake
+        # will default to allowing the maximum number of characters.
+        # There is no performance difference between using the full-length VARCHAR
+        # declaration VARCHAR(16777216) and a smaller length.
+        # See: https://docs.snowflake.com/en/sql-reference/data-types-text
         col_to_type[col] = VARCHAR()
     return col_to_type


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug that was restricting Snowflake VARCHAR columns to be no larger than 2^16 bytes. Since Snowflake supports columns of size 16MB, we have removed this.

## Related issue number (if any)
ENG 2538

## Testing
- Ran a sample workflow against Snowflake where the table had a column with values of size 16MB
- Ran data integration tests against Snowflake for regression testing

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


