### PR TITLE
ENG-2573: Updates node text size and the initial viewport of react flow canvas.

### DIFF
--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -1,9 +1,5 @@
 import React from 'react';
-import ReactFlow, {
-  Controls,
-  MiniMap,
-  Node as ReactFlowNode,
-} from 'react-flow-renderer';
+import ReactFlow, { Node as ReactFlowNode } from 'react-flow-renderer';
 import { useSelector } from 'react-redux';
 
 import { RootState } from '../../stores/store';
@@ -62,10 +58,7 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
         reactFlowInstance.setViewport({ x: 50, y: 50, zoom: 0.7 });
       }}
       minZoom={0.2}
-    >
-      <MiniMap />
-      <Controls />
-    </ReactFlow>
+    />
   );
 };
 

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
-import ReactFlow, { Node as ReactFlowNode } from 'react-flow-renderer';
+import ReactFlow, {
+  Controls,
+  MiniMap,
+  Node as ReactFlowNode,
+} from 'react-flow-renderer';
 import { useSelector } from 'react-redux';
 
 import { RootState } from '../../stores/store';
@@ -7,7 +11,6 @@ import { EdgeTypes, ReactFlowNodeData } from '../../utils/reactflow';
 import nodeTypes from './nodes/nodeTypes';
 
 const connectionLineStyle = { stroke: '#fff' };
-const snapGrid = [20, 20];
 
 type ReactFlowCanvasProps = {
   onPaneClicked: (event: React.MouseEvent) => void;
@@ -54,13 +57,22 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
       onNodeClick={switchSideSheet}
       nodeTypes={nodeTypes}
       connectionLineStyle={connectionLineStyle}
-      snapToGrid={true}
-      snapGrid={snapGrid as [number, number]}
-      defaultZoom={1}
       edgeTypes={EdgeTypes}
-      minZoom={0.25}
-      fitView={true}
-    />
+      onInit={(reactFlowInstance) => {
+        console.log('onInitCalled, ', reactFlowInstance);
+        //reactFlowInstance.fitBounds({ x: 0, y: 0, width: 0, height: 0 });
+        //reactFlowInstance.fitView();
+        reactFlowInstance.setViewport({ x: 50, y: 50, zoom: 0.4 });
+      }}
+      onMove={(event, viewport) => {
+        console.log('onMove viewport: ', viewport);
+      }}
+      defaultZoom={2}
+      minZoom={0.2}
+    >
+      <MiniMap />
+      <Controls />
+    </ReactFlow>
   );
 };
 

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -59,15 +59,8 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
       connectionLineStyle={connectionLineStyle}
       edgeTypes={EdgeTypes}
       onInit={(reactFlowInstance) => {
-        console.log('onInitCalled, ', reactFlowInstance);
-        //reactFlowInstance.fitBounds({ x: 0, y: 0, width: 0, height: 0 });
-        //reactFlowInstance.fitView();
         reactFlowInstance.setViewport({ x: 50, y: 50, zoom: 0.4 });
       }}
-      onMove={(event, viewport) => {
-        console.log('onMove viewport: ', viewport);
-      }}
-      defaultZoom={2}
       minZoom={0.2}
     >
       <MiniMap />

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -59,7 +59,7 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
       connectionLineStyle={connectionLineStyle}
       edgeTypes={EdgeTypes}
       onInit={(reactFlowInstance) => {
-        reactFlowInstance.setViewport({ x: 50, y: 50, zoom: 0.4 });
+        reactFlowInstance.setViewport({ x: 50, y: 50, zoom: 0.7 });
       }}
       minZoom={0.2}
     >

--- a/src/ui/common/src/components/workflows/nodes/BaseNode.styles.tsx
+++ b/src/ui/common/src/components/workflows/nodes/BaseNode.styles.tsx
@@ -10,9 +10,9 @@ const BaseNode = styled(Box)({
   borderStyle: 'solid',
   borderWidth: '2px',
   width: '310px',
-  height: '160px',
+  height: '120px',
   maxWidth: '310px',
-  maxHeight: '160px',
+  maxHeight: '120px',
 });
 
 export { BaseNode };

--- a/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/CheckOperatorNode.tsx
@@ -51,7 +51,7 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
       <Box sx={{ fontSize: '24px' }}>
         <FontAwesomeIcon icon={icon} />
       </Box>
-      <Typography variant="body1" sx={{ marginLeft: '8px' }}>
+      <Typography variant="body1" sx={{ marginLeft: '8px', fontSize: '24px' }}>
         {result === 'true' ? 'passed' : 'failed'}
       </Typography>
     </Box>
@@ -96,7 +96,7 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     >
       <Box
         sx={{
-          height: '32px',
+          height: '36px',
           width: '100%',
           borderBottom: `1px solid ${borderColor}`,
         }}
@@ -111,7 +111,17 @@ const CheckOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
           <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
             <FontAwesomeIcon icon={faCircleCheck} />
           </Box>
-          <Typography variant="body1">{label}</Typography>
+          <Typography
+            sx={{
+              fontSize: '24px',
+              maxWidth: '80%',
+              width: '80%',
+              overflow: 'clip',
+            }}
+            variant="body1"
+          >
+            {label}
+          </Typography>
         </Box>
       </Box>
 

--- a/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
+++ b/src/ui/common/src/components/workflows/nodes/MetricOperatorNode.tsx
@@ -97,7 +97,7 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
     >
       <Box
         sx={{
-          height: '32px',
+          height: '36px',
           width: '100%',
           borderBottom: `1px solid ${borderColor}`,
         }}
@@ -112,7 +112,17 @@ const MetricOperatorNode: React.FC<Props> = ({ data, isConnectable }) => {
           <Box sx={{ fontSize: '24px', marginRight: '8px' }}>
             <FontAwesomeIcon icon={faHashtag} />
           </Box>
-          <Typography variant="body1">{label}</Typography>
+          <Typography
+            sx={{
+              fontSize: '24px',
+              maxWidth: '80%',
+              width: '80%',
+              overflow: 'clip',
+            }}
+            variant="body1"
+          >
+            {label}
+          </Typography>
         </Box>
       </Box>
 

--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -98,12 +98,13 @@ export const Node: React.FC<Props> = ({
 
         <Typography
           sx={{
-            fontSize: '18px',
+            fontSize: '24px',
             maxWidth: '80%',
             width: '80%',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
+            //whiteSpace: 'nowrap',
+            //overflow: 'hidden',
+            overflow: 'clip',
+            //textOverflow: 'ellipsis',
           }}
         >
           {label}

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -485,9 +485,9 @@ export const handleGetSelectDagPosition = createAsyncThunk<
         return {
           id: node.id,
           // width of the node in px.
-          width: 300,
+          width: 310,
           // height of the node in px.
-          height: 150,
+          height: 120,
         };
       });
 
@@ -496,8 +496,8 @@ export const handleGetSelectDagPosition = createAsyncThunk<
         layoutOptions: {
           'elk.algorithm': 'layered',
           'elk.direction': 'RIGHT',
-          'elk.spacing.nodeNode': '300',
-          'elk.layered.spacing.nodeNodeBetweenLayers': '300',
+          'elk.spacing.nodeNode': '200',
+          'elk.layered.spacing.nodeNodeBetweenLayers': '200',
           'elk.layered.nodePlacement.strategy': 'INTERACTIVE',
         },
         children: mappedNodes,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR updates the viewport starting x,y,zoom of ReactFlow canvas as well as makes the text size of DAG nodes larger.

## Related issue number (if any)
N/A (will create soon)

## Loom demo (if any)
https://www.loom.com/share/dff9a948609441aebeb1bea6443a2876

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


