### PR TITLE
Add K8s integration tests to our periodic integration tests

### DIFF
--- a/.github/actions/setup-server/action.yml
+++ b/.github/actions/setup-server/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: Set filename for the server's output logs
       shell: bash
-      run: echo "SERVER_LOGS_FILE=logs/server_logs_${{ matrix.python-version }}" >> $GITHUB_ENV
+      run: echo "SERVER_LOGS_FILE=logs/server_logs" >> $GITHUB_ENV
 
     # Uniformly select from python versions 3.7 to 3.10.
     # Write the selection to `.python-version` to be consumed by the setup-python action.

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -20,5 +20,5 @@ runs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.prefix }} - Executor Logs
+        name: ${{ inputs.prefix }} - Server Directory Logs
         path: ~/.aqueduct/server/logs/*

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -2,43 +2,73 @@ name: Periodic Integration Tests
 
 on:
   schedule:
-     - cron: '0 15 * * 1-5' # Run at 7AM PST on every weekday
+     - cron: '0 12 * * 1-5' # Run at 4AM PST on every weekday
   workflow_dispatch:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        concurrency: [ 2, 5 ]
-
-    name: Run Integration Tests with Python Version ${{ matrix.python-version }} Concurrency ${{ matrix.concurrency }}
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 180
+    name: SDK Integration Tests against K8s Compute
     steps:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
         timeout-minutes: 5
 
-      - name: Set up the SDK Integration Tests
-        working-directory: integration_tests/sdk
+      # TODO(ENG-2537): Use our separate GH actions credentials.
+      - uses: ./.github/actions/fetch-test-config
+        with:
+          aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
+          s3_test_config_path: periodic-compute-test-config.yml
+
+      - name: Install Terraform
         run: |
-          echo "apikey: $(aqueduct apikey)" >> test-credentials.yml
-          printf "address: localhost:8080" >> test-config.yml
-          printf "\ndata:\n  aqueduct_demo:" >> test-config.yml
-          printf "\ncompute:\n  aqueduct_engine:" >> test-config.yml
+          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt install terraform
+
+      - name: Create K8s Cluster
+        working-directory: integration_tests/sdk/compute/k8s
+        run: |
+          terraform init
+          terraform apply --auto-approve
+
+      - name: Update the Kubeconfig file
+        working-directory: integration_tests/sdk/compute/k8s
+        run: aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
+
+      - name: Update the test-config file with the appropriate cluster name
+        working-directory: integration_tests/sdk
+        run: sed -i "s/\(cluster_name:\s*\).*/\1 "$(terraform -chdir=compute/k8s/ output -raw cluster_name)"/" test-credentials.yml
+
+      - name: Install any data connector packages
+        run: |
+          aqueduct install s3
+          aqueduct install snowflake
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 30
         working-directory: integration_tests/sdk
-        run: python3 run_tests.py -n 5
+        run: pytest aqueduct_tests/ -rP -vv -n 4
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Terraform State
+          path: integration_tests/sdk/compute/k8s/*.tf
 
       - uses: ./.github/actions/upload-artifacts
         if: always()
         with:
-          prefix: Aqueduct Engine and DB
+          prefix: K8s Compute
 
-      # Notifies Kenny, Suresh.
+      - name: Teardown K8s Cluster
+        if: always()
+        working-directory: integration_tests/sdk/compute/k8s
+        run: terraform destroy --auto-approve
+
+      # TODO(ENG-2553): Notify the oncall, not just Kenny.
       - name: Report to Slack on Failure
         if: always()
         uses: ravsamhq/notify-slack-action@v1
@@ -48,6 +78,6 @@ jobs:
           message_format: '{emoji} *{workflow}* has {status_message}'
           footer: '{run_url}'
           notify_when: 'failure,warnings'
-          mention_users: 'U025MDH5KS6,U04CRDACQMQ'
+          mention_users: 'U025MDH5KS6'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/integration_tests/sdk/aqueduct_tests/resources_test.py
+++ b/integration_tests/sdk/aqueduct_tests/resources_test.py
@@ -67,24 +67,6 @@ def test_custom_num_cpus(client, flow_name, engine):
     )
 
 
-@pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_too_many_cpus_requested(client, flow_name, engine):
-    """Assumption: nodes in the k8s cluster have less then 20 CPUs."""
-    global_config({"engine": engine})
-
-    @op(requirements=[], resources={"num_cpus": 20})
-    def too_many_cpus():
-        return 123
-
-    with pytest.raises(AqueductError):
-        too_many_cpus()
-    output = too_many_cpus.lazy()
-
-    publish_flow_test(
-        client, output, name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED
-    )
-
-
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S, ServiceType.LAMBDA)
 def test_custom_memory(client, flow_name, engine):
     """Assumption: nodes in the K8s cluster have more than 200MB of capacity.
@@ -123,24 +105,6 @@ def test_custom_memory(client, flow_name, engine):
         artifacts=failure_output,
         engine=engine,
         expected_statuses=ExecutionStatus.FAILED,
-    )
-
-
-@pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
-def test_too_much_memory_requested_K8s(client, flow_name, engine):
-    """Assumption: nodes in the k8s cluster have less then 100GB of memory."""
-    global_config({"engine": engine})
-
-    @op(requirements=[], resources={"memory": "100GB"})
-    def too_much_memory():
-        return 123
-
-    with pytest.raises(AqueductError):
-        _ = too_much_memory()
-    output = too_much_memory.lazy()
-
-    publish_flow_test(
-        client, [output], name=flow_name(), engine=engine, expected_statuses=ExecutionStatus.FAILED
     )
 
 

--- a/integration_tests/sdk/compute/k8s/main.tf
+++ b/integration_tests/sdk/compute/k8s/main.tf
@@ -1,0 +1,73 @@
+provider "aws" {
+  shared_config_files      = ["~/.aws/config"]
+  shared_credentials_files = ["~/.aws/credentials"]
+  profile                  = "default"
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  cluster_name = "automated-testing-${random_string.suffix.result}"
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.19.0"
+
+  name = "education-vpc"
+
+  cidr = "10.0.0.0/16"
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = 1
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.5.1"
+
+  cluster_name    = local.cluster_name
+  cluster_version = "1.24"
+
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = module.vpc.private_subnets
+  cluster_endpoint_public_access = true
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2_x86_64"
+
+  }
+
+  eks_managed_node_groups = {
+    one = {
+      name = "cpu"
+
+      instance_types = ["t3.2xlarge"]
+
+      min_size     = 1
+      max_size     = 5
+      desired_size = 5
+      disk_size = 32
+    }
+  }
+}

--- a/integration_tests/sdk/compute/k8s/outputs.tf
+++ b/integration_tests/sdk/compute/k8s/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  description = "Security group ids attached to the cluster control plane"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "cluster_name" {
+  description = "Kubernetes Cluster Name"
+  value       = module.eks.cluster_name
+}

--- a/integration_tests/sdk/compute/k8s/terraform.tf
+++ b/integration_tests/sdk/compute/k8s/terraform.tf
@@ -1,0 +1,27 @@
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.47.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.4"
+    }
+
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.2.0"
+    }
+  }
+
+  required_version = "~> 1.3"
+}
+

--- a/integration_tests/sdk/compute/k8s/variables.tf
+++ b/integration_tests/sdk/compute/k8s/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-2"
+}

--- a/integration_tests/sdk/run_tests.py
+++ b/integration_tests/sdk/run_tests.py
@@ -12,7 +12,9 @@ def _execute_command(args, cwd=None) -> None:
 
 
 def _run_tests(
-    dir_name: str, test_case: str, concurrency: int, rerun_failed: bool, skip_data_setup: bool
+    dir_name: str,
+    test_case: str,
+    concurrency: int, rerun_failed: bool, skip_data_setup: bool, skip_engine_setup: bool,
 ) -> None:
     """Either test_case or rerun_failed can be set, but not both."""
     if rerun_failed:
@@ -25,6 +27,8 @@ def _run_tests(
 
     if skip_data_setup:
         cmd.append("--skip-data-setup")
+    if skip_engine_setup:
+        cmd.append("--skip-engine-setup")
 
     _execute_command(cmd)
 
@@ -73,6 +77,14 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
+        "--skip-engine-setup",
+        dest="skip_engine_setup",
+        default=False,
+        action="store_true",
+        help="If set, skips any engine integration setup to speed up testing.",
+    )
+
+    parser.add_argument(
         "-n",
         dest="concurrency",
         default=8,
@@ -103,6 +115,7 @@ if __name__ == "__main__":
             args.concurrency,
             args.rerun_failed,
             args.skip_data_setup,
+            args.skip_engine_setup,
         )
 
     if args.data_integration_tests:
@@ -113,4 +126,5 @@ if __name__ == "__main__":
             args.concurrency,
             args.rerun_failed,
             args.skip_data_setup,
+            args.skip_engine_setup,
         )

--- a/integration_tests/sdk/run_tests.py
+++ b/integration_tests/sdk/run_tests.py
@@ -14,7 +14,10 @@ def _execute_command(args, cwd=None) -> None:
 def _run_tests(
     dir_name: str,
     test_case: str,
-    concurrency: int, rerun_failed: bool, skip_data_setup: bool, skip_engine_setup: bool,
+    concurrency: int,
+    rerun_failed: bool,
+    skip_data_setup: bool,
+    skip_engine_setup: bool,
 ) -> None:
     """Either test_case or rerun_failed can be set, but not both."""
     if rerun_failed:

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -7,6 +7,7 @@ from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.artifacts.table_artifact import TableArtifact
 from aqueduct.constants.enums import ArtifactType, ServiceType
 from aqueduct.error import AqueductError
+from aqueduct.integrations.connect_config import AWSCredentialType
 from aqueduct.integrations.mongodb_integration import MongoDBIntegration
 from aqueduct.integrations.s3_integration import S3Integration
 from aqueduct.integrations.sql_integration import RelationalDBIntegration
@@ -163,11 +164,11 @@ def _setup_s3_data(client: Client, s3: S3Integration):
 
 
 def setup_data_integrations(client: Client, filter_to: Optional[str] = None) -> None:
-    """Connects to the given integration name if the server hasn't yet. It also ensures
+    """Connects to the given data integration(s) if the server hasn't yet. It also ensures
     that the appropriate data is populated.
 
     If `filter_to` is set, we only connect to that given integration name. Otherwise,
-    we attempt to connect to every integration listed in the config file.
+    we attempt to connect to every integration listed in the test config file.
     """
     if filter_to is not None:
         data_integrations = [filter_to]
@@ -185,7 +186,7 @@ def setup_data_integrations(client: Client, filter_to: Optional[str] = None) -> 
     for integration_name in data_integrations:
         # Only connect to integrations that don't already exist.
         if integration_name not in connected_integrations.keys():
-            integration_config = _fetch_data_integration_credentials(integration_name)
+            integration_config = _fetch_integration_credentials("data", integration_name)
 
             client.connect_integration(
                 integration_name,
@@ -208,6 +209,38 @@ def setup_data_integrations(client: Client, filter_to: Optional[str] = None) -> 
             raise Exception("Test suite does not yet support %s." % integration.type())
 
 
+def setup_compute_integrations(client: Client, filter_to: Optional[str] = None) -> None:
+    """Connects to the given compute integration(s) if the server hasn't yet. It *does not*
+    ensure that the compute resources are set up appropriately.
+
+    If `filter_to` is set, we only connect to that given integration name. Otherwise,
+    we attempt to connect to every integration listed in the test config file.
+    """
+    if filter_to is not None:
+        compute_integrations = [filter_to]
+    else:
+        compute_integrations = list_compute_integrations()
+
+    # No need to do any setup for the demo db.
+    if "aqueduct_engine" in compute_integrations:
+        compute_integrations.remove("aqueduct_engine")
+
+    if len(compute_integrations) == 0:
+        return
+
+    connected_integrations = client.list_integrations()
+    for integration_name in compute_integrations:
+        # Only connect to integrations that don't already exist.
+        if integration_name not in connected_integrations.keys():
+            integration_config = _fetch_integration_credentials("compute", integration_name)
+
+            client.connect_integration(
+                integration_name,
+                integration_config["type"],
+                _sanitize_integration_config_for_connect(integration_config),
+            )
+
+
 def setup_storage_layer(client: Client) -> None:
     """If a storage data integration is specified, perform a migration if we aren't already connected to it."""
     test_config = _parse_config_file()
@@ -221,13 +254,18 @@ def setup_storage_layer(client: Client) -> None:
 
     connected_integrations = client.list_integrations()
     if name not in connected_integrations.keys():
-        integration_config = _fetch_data_integration_credentials(name)
+        integration_config = _fetch_integration_credentials("data", name)
         integration_config["use_as_storage"] = "true"
+
+        # There is a naming collision between the "type" field in `test-credentials.yml`
+        # and the "type" field on the S3Config.
+        service_type = integration_config["type"]
+        integration_config["type"] = AWSCredentialType.CONFIG_FILE_PATH
 
         client.connect_integration(
             name,
-            integration_config["type"],
-            _sanitize_integration_config_for_connect(integration_config),
+            service_type,
+            integration_config,
         )
 
         # Poll on the server until the integration is ready.
@@ -249,14 +287,17 @@ def _sanitize_integration_config_for_connect(config: Dict[str, Any]) -> Dict[str
     return config
 
 
-def _fetch_data_integration_credentials(name: str) -> Dict[str, Any]:
+def _fetch_integration_credentials(section: str, name: str) -> Dict[str, Any]:
+    """
+    `section` can be "data" or "compute".
+    """
     test_credentials = _parse_credentials_file()
-    assert "data" in test_credentials
+    assert section in test_credentials, "%s section expected in test-credentials.yml" % section
 
-    assert name in test_credentials["data"], (
-        "Data integration `%s` needs to have credentials in test-credentials.yml." % name
-    )
-    return test_credentials["data"][name]
+    assert (
+        name in test_credentials[section]
+    ), "%s Integration `%s` must have its credentials in test-credentials.yml." % (section, name)
+    return test_credentials[section][name]
 
 
 def list_data_integrations() -> List[str]:

--- a/integration_tests/sdk/test-credentials-example.yml
+++ b/integration_tests/sdk/test-credentials-example.yml
@@ -73,4 +73,10 @@ data:
     warehouse:
   test_sqlite:
     type: SQLite
-    
+
+compute:
+  test_k8s:
+    type: Kubernetes
+    kubeconfig_path:
+    # This key name should be globally unique since we do a find-and-replace.
+    cluster_name: <CLUSTER_NAME>

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -266,7 +266,10 @@ class APIClient:
             {
                 "integration-name": name,
                 "integration-service": integration_service,
-                "integration-config": config.json(),
+
+                # `by_alias` is necessary to get this to use `schema` as a key for SnowflakeConfig.
+                # `exclude_none` is necessary to exclude `role` when None as SnowflakeConfig.
+                "integration-config": config.json(exclude_none=True, by_alias=True),
             }
         )
         url = self.construct_full_url(

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -266,7 +266,6 @@ class APIClient:
             {
                 "integration-name": name,
                 "integration-service": integration_service,
-
                 # `by_alias` is necessary to get this to use `schema` as a key for SnowflakeConfig.
                 # `exclude_none` is necessary to exclude `role` when None as SnowflakeConfig.
                 "integration-config": config.json(exclude_none=True, by_alias=True),

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -114,17 +114,19 @@ class AthenaConfig(BaseConnectionConfig):
 
 
 class SnowflakeConfig(BaseConnectionConfig):
+    """Must be dumped to JSON with the `exclude_none` and `by_alias` flags."""
     username: str
     password: str
     account_identifier: str
     database: str
     warehouse: str
     db_schema: Optional[str] = Field("public", alias="schema")  # schema is a Pydantic keyword
-    role: Optional[str] = None
+    role: Optional[str] = None  # we must exclude this field if None when dumping to json.
 
     class Config:
         # Ensures that Pydantic parses JSON keys named "schema" or "db_schema" to
-        # the `db_schema` field
+        # the `db_schema` field. This is only for converting dict -> pydantic object.
+        # When dumping this config to a dictionary, be sure to use `SnowflakeConfig.json(by_alias=True)`.
         allow_population_by_field_name = True
 
 
@@ -183,6 +185,14 @@ class SparkConfig(BaseConnectionConfig):
     livy_server_url: str
 
 
+class K8sConfig(BaseConnectionConfig):
+    kubeconfig_path: str
+    cluster_name: str
+    use_same_cluster: str = "false"
+    dynamic: str = "false"
+    cloud_integration_id: str = ""
+
+
 IntegrationConfig = Union[
     BigQueryConfig,
     EmailConfig,
@@ -199,6 +209,7 @@ IntegrationConfig = Union[
     AWSConfig,
     _SlackConfigWithStringField,
     SparkConfig,
+    K8sConfig,
 ]
 
 
@@ -233,6 +244,8 @@ def convert_dict_to_integration_connect_config(
         return SparkConfig(**config_dict)
     elif service == ServiceType.AWS:
         return AWSConfig(**config_dict)
+    elif service == ServiceType.K8S:
+        return K8sConfig(**config_dict)
     raise InternalAqueductError("Unexpected Service Type: %s" % service)
 
 

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -115,6 +115,7 @@ class AthenaConfig(BaseConnectionConfig):
 
 class SnowflakeConfig(BaseConnectionConfig):
     """Must be dumped to JSON with the `exclude_none` and `by_alias` flags."""
+
     username: str
     password: str
     account_identifier: str

--- a/src/golang/lib/job/config.go
+++ b/src/golang/lib/job/config.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"encoding/gob"
 	"path"
-	"regexp"
-	"strings"
 
 	"github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
 	"github.com/dropbox/godropbox/errors"
-	log "github.com/sirupsen/logrus"
 )
 
 type ManagerType string

--- a/src/golang/lib/job/config.go
+++ b/src/golang/lib/job/config.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/gob"
 	"path"
+	"regexp"
+	"strings"
 
 	"github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
 	"github.com/dropbox/godropbox/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 type ManagerType string
@@ -186,6 +189,7 @@ func GenerateJobManagerConfig(
 		if err != nil {
 			return nil, errors.Wrap(err, "Unable to parse k8s config.")
 		}
+
 		return &K8sJobManagerConfig{
 			KubeconfigPath:     k8sConfig.KubeconfigPath,
 			ClusterName:        k8sConfig.ClusterName,

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
+	"strings"
 
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
@@ -267,13 +269,28 @@ func ExtractAwsCredentials(config *shared.S3Config) (string, string, error) {
 
 	for fileScanner.Scan() {
 		if profileString == fileScanner.Text() {
+			// Parse `aws_access_key_id`.
 			if fileScanner.Scan() {
-				fmt.Sscanf(fileScanner.Text(), "aws_access_key_id=%v", &awsAccessKeyId)
+				accessKeyIdRegex := regexp.MustCompile(`aws_access_key_id\s*=\s*([^\n]+)`)
+				match := accessKeyIdRegex.FindStringSubmatch(fileScanner.Text())
+				if len(match) < 2 {
+					log.Errorf("Unable to scan access key id from credentials file. The file may be malformed.")
+					return "", "", errors.New("Unable to extract AWS credentials.")
+				}
+				awsAccessKeyId = strings.TrimSpace(match[1])
 			} else {
 				return "", "", errors.New("Unable to extract AWS credentials.")
 			}
+
+			// Parse `aws_secret_access_key`.
 			if fileScanner.Scan() {
-				fmt.Sscanf(fileScanner.Text(), "aws_secret_access_key=%v", &awsSecretAccessKey)
+				secretAccessKeyRegex := regexp.MustCompile(`aws_secret_access_key\s*=\s*([^\n]+)`)
+				match := secretAccessKeyRegex.FindStringSubmatch(fileScanner.Text())
+				if len(match) < 2 {
+					log.Errorf("Unable to scan access key id from credentials file. The file may be malformed.")
+					return "", "", errors.New("Unable to extract AWS credentials.")
+				}
+				awsSecretAccessKey = strings.TrimSpace(match[1])
 			} else {
 				return "", "", errors.New("Unable to extract AWS credentials.")
 			}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
You can now add a K8s integration to the "compute" section of `test-config.yml`.

Testing: I was able to run flow_test.py against K8s in about 30 minutes (including spinnup and teardown). I need to verify that this works against the full suite. I think I also saw some transient errors that need to be sorted out. 

[UPDATE] Got a full run working: https://github.com/aqueducthq/aqueduct/actions/runs/4326011758/jobs/7552902876


## Related issue number (if any)
ENG-2346

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


