### PR TITLE
Error when AWS integration dependencies aren't installed

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -775,7 +775,7 @@ func ValidatePrerequisites(
 		if err = exec_env.ValidateCondaDevelop(); err != nil {
 			return http.StatusBadRequest, errors.Wrap(
 				err,
-				"You don't seem to have `conda develop` available. We use this to help set up conda environments. Please install the dependency before connecting Aqueduct to Conda. Typically, this can be done by running `conda install conda-build`.",
+				"Failed to run `conda develop`. We use this to help set up conda environments. Please install the dependency before connecting Aqueduct to Conda. Typically, this can be done by running `conda install conda-build`.",
 			)
 		}
 
@@ -798,6 +798,17 @@ func ValidatePrerequisites(
 		}
 
 		return http.StatusOK, nil
+	}
+
+	// For AWS integration, we require the user to have AWS CLI and Terraform installed.
+	if svc == shared.AWS {
+		if _, _, err := lib_utils.RunCmd("terraform", []string{"--version"}, "", false); err != nil {
+			return http.StatusBadRequest, errors.Wrap(err, "terraform executable not found. Please go to https://developer.hashicorp.com/terraform/downloads to install terraform")
+		}
+
+		if _, _, err := lib_utils.RunCmd("aws", []string{"--version"}, "", false); err != nil {
+			return http.StatusBadRequest, errors.Wrap(err, "aws CLI executable not found. Please go to https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html to install aws CLI")
+		}
 	}
 
 	return http.StatusOK, nil

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -807,7 +807,7 @@ func ValidatePrerequisites(
 		}
 
 		if _, _, err := lib_utils.RunCmd("aws", []string{"--version"}, "", false); err != nil {
-			return http.StatusBadRequest, errors.Wrap(err, "aws CLI executable not found. Please go to https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html to install aws CLI")
+			return http.StatusBadRequest, errors.Wrap(err, "AWS CLI executable not found. Please go to https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html to install AWS CLI")
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The error message points the user to the installation documentation.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


