### PR TITLE
Disable AWS integration registration from UI and SDK

### DIFF
--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -288,7 +288,7 @@ class Client:
             raise InvalidUserArgumentException(
                 "Support for service type AWS is not ready yet. Please stay tuned!"
             )
-        
+
         if service not in ServiceType:
             raise InvalidUserArgumentException(
                 "Service argument must match exactly one of the enum values in ServiceType (case-sensitive)."

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -284,6 +284,11 @@ class Client:
                 Either a dictionary or an IntegrationConnectConfig object that contains the
                 configuration credentials needed to connect.
         """
+        if service == ServiceType.AWS:
+            raise InvalidUserArgumentException(
+                "Support for service type AWS is not ready yet. Please stay tuned!"
+            )
+        
         if service not in ServiceType:
             raise InvalidUserArgumentException(
                 "Service argument must match exactly one of the enum values in ServiceType (case-sensitive)."

--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -131,7 +131,14 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
           size="large"
         />
       </Box>
-      <Typography variant={'body1'} align={'center'} sx={{ marginTop: '16px', color: integration.activated ? 'inherit' : 'grey' }}>
+      <Typography
+        variant={'body1'}
+        align={'center'}
+        sx={{
+          marginTop: '16px',
+          color: integration.activated ? 'inherit' : 'grey',
+        }}
+      >
         {service}
       </Typography>
     </Box>

--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -131,7 +131,7 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
           size="large"
         />
       </Box>
-      <Typography variant={'body1'} align={'center'} sx={{ marginTop: '16px' }}>
+      <Typography variant={'body1'} align={'center'} sx={{ marginTop: '16px', color: integration.activated ? 'inherit' : 'grey' }}>
         {service}
       </Typography>
     </Box>

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -68,14 +68,6 @@ const IntegrationsPage: React.FC<Props> = ({
             Add an Integration
           </Typography>
           <Typography variant="h6" marginY={2}>
-            Cloud
-          </Typography>
-          <AddIntegrations
-            user={user}
-            category={IntegrationCategories.CLOUD}
-            supportedIntegrations={SupportedIntegrations}
-          />
-          <Typography variant="h6" marginY={2}>
             Compute
           </Typography>
           <AddIntegrations
@@ -89,6 +81,14 @@ const IntegrationsPage: React.FC<Props> = ({
           <AddIntegrations
             user={user}
             category={IntegrationCategories.DATA}
+            supportedIntegrations={SupportedIntegrations}
+          />
+          <Typography variant="h6" marginY={2}>
+            Cloud
+          </Typography>
+          <AddIntegrations
+            user={user}
+            category={IntegrationCategories.CLOUD}
             supportedIntegrations={SupportedIntegrations}
           />
           <Typography variant="h6" marginY={2}>

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -458,7 +458,7 @@ export const SupportedIntegrations: ServiceInfoMap = {
   },
   ['AWS']: {
     logo: ServiceLogos['AWS'],
-    activated: true,
+    activated: false,
     category: IntegrationCategories.CLOUD,
     docs: addingIntegrationLink,
   },


### PR DESCRIPTION
## Describe your changes and why you are making these changes
We will re-enable when the project ships. The PR also greys out the disabled service's text field.

@vsreekanti let me know if the integration page looks fine.
![Screen Shot 2023-03-06 at 10 29 45 AM](https://user-images.githubusercontent.com/6820919/223199319-759c833a-c4c1-4885-80b0-8b031e02d67b.png)

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


