### PR TITLE
Adds backend support for changing storage layer back to local

### DIFF
--- a/src/golang/cmd/server/handler/configure_storage.go
+++ b/src/golang/cmd/server/handler/configure_storage.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	aq_context "github.com/aqueducthq/aqueduct/lib/context"
+	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/engine"
+	"github.com/aqueducthq/aqueduct/lib/repos"
+)
+
+// Route: /config/storage
+// Method: POST
+// Request:
+//
+//	Headers:
+//		`api-key`: user's API Key
+//
+// Response: none
+type ConfigureStorageHandler struct {
+	PostHandler
+
+	Database database.Database
+	Engine   engine.Engine
+
+	ArtifactRepo repos.Artifact
+	DAGRepo      repos.DAG
+	DAGEdgeRepo  repos.DAGEdge
+	OperatorRepo repos.Operator
+	WorkflowRepo repos.Workflow
+}
+
+type configureStorageArgs struct {
+	*aq_context.AqContext
+}
+
+func (*ConfigureStorageHandler) Name() string {
+	return "ConfigureStorage"
+}
+
+func (h *ConfigureStorageHandler) Prepare(r *http.Request) (interface{}, int, error) {
+	return nil, -1, nil
+}
+
+func (h *ConfigureStorageHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
+	return nil, -1, nil
+}

--- a/src/golang/cmd/server/handler/configure_storage.go
+++ b/src/golang/cmd/server/handler/configure_storage.go
@@ -96,13 +96,16 @@ func (h *ConfigureStorageHandler) Perform(ctx context.Context, interfaceArgs int
 
 	log.Info("Starting storage migration process...")
 
+	log.Info("Waiting to pause the server")
 	// Wait until the server is paused
 	h.PauseServerFn()
 	// Makes sure that the server is restarted
 	defer h.RestartServerFn()
+	log.Info("Server has been paused")
 
 	// Wait until there are no more workflow runs in progress
 	lock := utils.NewExecutionLock()
+	log.Info("Waiting for execution lock")
 	if err := lock.Lock(); err != nil {
 		log.Errorf("Unexpected error when acquiring workflow execution lock: %v. Aborting storage migration!", err)
 		return nil, http.StatusInternalServerError, errors.Wrap(err, "Unable to migrate to the new storage layer")
@@ -112,6 +115,7 @@ func (h *ConfigureStorageHandler) Perform(ctx context.Context, interfaceArgs int
 			log.Errorf("Unexpected error when unlocking workflow execution lock: %v", err)
 		}
 	}()
+	log.Info("Execution lock has been acquired")
 
 	// Migrate all storage content to the new storage config
 	if err := utils.MigrateStorageAndVault(

--- a/src/golang/cmd/server/handler/configure_storage.go
+++ b/src/golang/cmd/server/handler/configure_storage.go
@@ -37,8 +37,8 @@ type ConfigureStorageHandler struct {
 	IntegrationRepo    repos.Integration
 	OperatorRepo       repos.Operator
 
-	PauseServer   func()
-	RestartServer func()
+	PauseServerFn   func()
+	RestartServerFn func()
 }
 
 type configureStorageArgs struct {
@@ -97,9 +97,9 @@ func (h *ConfigureStorageHandler) Perform(ctx context.Context, interfaceArgs int
 	log.Info("Starting storage migration process...")
 
 	// Wait until the server is paused
-	h.PauseServer()
+	h.PauseServerFn()
 	// Makes sure that the server is restarted
-	defer h.RestartServer()
+	defer h.RestartServerFn()
 
 	// Wait until there are no more workflow runs in progress
 	lock := utils.NewExecutionLock()

--- a/src/golang/cmd/server/handler/configure_storage.go
+++ b/src/golang/cmd/server/handler/configure_storage.go
@@ -3,14 +3,22 @@ package handler
 import (
 	"context"
 	"net/http"
+	"path"
 
+	"github.com/aqueducthq/aqueduct/cmd/server/routes"
+	"github.com/aqueducthq/aqueduct/config"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/engine"
+	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/repos"
+	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
+	"github.com/dropbox/godropbox/errors"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 )
 
-// Route: /config/storage
+// Route: /config/storage/{integrationID}
 // Method: POST
 // Request:
 //
@@ -33,6 +41,10 @@ type ConfigureStorageHandler struct {
 
 type configureStorageArgs struct {
 	*aq_context.AqContext
+	// This is the ID of the integration to use as the new storage layer.
+	// It should only be set if configureLocalStorage is false.
+	storageIntegrationID  uuid.UUID
+	configureLocalStorage bool
 }
 
 func (*ConfigureStorageHandler) Name() string {
@@ -40,9 +52,45 @@ func (*ConfigureStorageHandler) Name() string {
 }
 
 func (h *ConfigureStorageHandler) Prepare(r *http.Request) (interface{}, int, error) {
-	return nil, -1, nil
+	aqContext, statusCode, err := aq_context.ParseAqContext(r.Context())
+	if err != nil {
+		return nil, statusCode, errors.Wrap(err, "Unable to configure storage layer.")
+	}
+
+	integrationIDStr := chi.URLParam(r, routes.IntegrationIdUrlParam)
+
+	if integrationIDStr != "local" {
+		return nil, http.StatusBadRequest, errors.Wrap(err, "We currently only support changing the storage layer to the local filesystem from this route.")
+	}
+
+	return &configureStorageArgs{
+		AqContext: aqContext,
+		// TODO: Add support for switching to non-local storage
+		configureLocalStorage: true,
+	}, http.StatusOK, nil
 }
 
 func (h *ConfigureStorageHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
+	args := interfaceArgs.(*configureStorageArgs)
+
+	// TODO: Remove this assumption
+	if !args.configureLocalStorage {
+		return nil, http.StatusBadRequest, errors.New("We currently only support changing the storage layer to the local filesystem from this route.")
+	}
+
+	storageConfig := shared.StorageConfig{
+		Type: shared.FileStorageType,
+		FileConfig: &shared.FileConfig{
+			Directory: path.Join(config.AqueductPath(), "storage"),
+		},
+	}
+
+	currentStorageConfig := config.Storage()
+
+	utils.MigrateStorageAndVault(
+		ctx,
+		&currentStorageConfig,
+	)
+
 	return nil, -1, nil
 }

--- a/src/golang/cmd/server/handler/configure_storage.go
+++ b/src/golang/cmd/server/handler/configure_storage.go
@@ -83,14 +83,18 @@ func (h *ConfigureStorageHandler) Perform(ctx context.Context, interfaceArgs int
 		return nil, http.StatusBadRequest, errors.New("We currently only support changing the storage layer to the local filesystem from this route.")
 	}
 
+	currentStorageConfig := config.Storage()
+
+	if currentStorageConfig.Type == shared.FileStorageType {
+		return nil, http.StatusBadRequest, errors.New("The storage layer is already set to the local filesystem.")
+	}
+
 	newStorageConfig := shared.StorageConfig{
 		Type: shared.FileStorageType,
 		FileConfig: &shared.FileConfig{
 			Directory: path.Join(config.AqueductPath(), "storage"),
 		},
 	}
-
-	currentStorageConfig := config.Storage()
 
 	log.Info("Starting storage migration process...")
 

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -6,7 +6,7 @@ const (
 	GetArtifactResultRoute   = "/api/artifact/{workflowDagResultId}/{artifactId}/result"
 
 	GetConfigRoute        = "/api/config"
-	ConfigureStorageRoute = "/api/config/storage"
+	ConfigureStorageRoute = "/api/config/storage/{integrationId}"
 
 	GetFunctionRoute    = "/api/function/{functionId}"
 	ExportFunctionRoute = "/api/function/{operatorId}/export"

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -5,7 +5,8 @@ const (
 	GetArtifactVersionsRoute = "/api/artifact/versions"
 	GetArtifactResultRoute   = "/api/artifact/{workflowDagResultId}/{artifactId}/result"
 
-	GetConfigRoute = "/api/config"
+	GetConfigRoute        = "/api/config"
+	ConfigureStorageRoute = "/api/config/storage"
 
 	GetFunctionRoute    = "/api/function/{functionId}"
 	ExportFunctionRoute = "/api/function/{operatorId}/export"

--- a/src/golang/cmd/server/server/execute_handler.go
+++ b/src/golang/cmd/server/server/execute_handler.go
@@ -50,8 +50,12 @@ func HandleSuccess(
 
 func ExecuteHandler(server *AqServer, handlerObj handler.Handler) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		server.RequestMutex.RLock()
-		defer server.RequestMutex.RUnlock()
+		if handlerObj.Name() != new(handler.ConfigureStorageHandler).Name() {
+			// ConfigureStorageHandler requests an exclusive Lock on RequestMutex,
+			// so there would be dead-lock if this request first acquired a shared lock
+			server.RequestMutex.RLock()
+			defer server.RequestMutex.RUnlock()
+		}
 
 		args, statusCode, err := handlerObj.Prepare(r)
 		ctx := r.Context()

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -94,8 +94,8 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			IntegrationRepo:    s.IntegrationRepo,
 			OperatorRepo:       s.OperatorRepo,
 
-			PauseServer:   s.Pause,
-			RestartServer: s.Restart,
+			PauseServerFn:   s.Pause,
+			RestartServerFn: s.Restart,
 		},
 		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
 		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -84,8 +84,19 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			OperatorRepo:       s.OperatorRepo,
 			OperatorResultRepo: s.OperatorResultRepo,
 		},
-		routes.GetConfigRoute:        &handler.GetConfigHandler{},
-		routes.ConfigureStorageRoute: &handler.ConfigureStorageHandler{},
+		routes.GetConfigRoute: &handler.GetConfigHandler{},
+		routes.ConfigureStorageRoute: &handler.ConfigureStorageHandler{
+			Database: s.Database,
+
+			ArtifactRepo:       s.ArtifactRepo,
+			ArtifactResultRepo: s.ArtifactResultRepo,
+			DAGRepo:            s.DAGRepo,
+			IntegrationRepo:    s.IntegrationRepo,
+			OperatorRepo:       s.OperatorRepo,
+
+			PauseServer:   s.Pause,
+			RestartServer: s.Restart,
+		},
 		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
 		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{
 			Database: s.Database,

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -85,6 +85,7 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			OperatorResultRepo: s.OperatorResultRepo,
 		},
 		routes.GetConfigRoute:        &handler.GetConfigHandler{},
+		routes.ConfigureStorageRoute: &handler.ConfigureStorageHandler{},
 		routes.GetNodePositionsRoute: &handler.GetNodePositionsHandler{},
 		routes.GetOperatorResultRoute: &handler.GetOperatorResultHandler{
 			Database: s.Database,

--- a/src/golang/lib/workflow/utils/migrate.go
+++ b/src/golang/lib/workflow/utils/migrate.go
@@ -93,8 +93,6 @@ func MigrateStorageAndVault(
 			for _, artifactResult := range artifactResults {
 				log.Infof("Starting migration for artifact result %v of artifact %v", artifactResult.ID, artifact.ID)
 
-				log.Infof("The content path is: %v", artifactResult.ContentPath)
-
 				val, err := oldStore.Get(ctx, artifactResult.ContentPath)
 				if err != nil &&
 					!artifactResult.ExecState.IsNull &&

--- a/src/golang/lib/workflow/utils/migrate.go
+++ b/src/golang/lib/workflow/utils/migrate.go
@@ -93,6 +93,8 @@ func MigrateStorageAndVault(
 			for _, artifactResult := range artifactResults {
 				log.Infof("Starting migration for artifact result %v of artifact %v", artifactResult.ID, artifact.ID)
 
+				log.Infof("The content path is: %v", artifactResult.ContentPath)
+
 				val, err := oldStore.Get(ctx, artifactResult.ContentPath)
 				if err != nil &&
 					!artifactResult.ExecState.IsNull &&
@@ -103,7 +105,7 @@ func MigrateStorageAndVault(
 					return err
 				}
 
-				if err != nil {
+				if err == nil {
 					// Only try to migrate artifact result if there was no issue reading
 					// it from the `oldStore`
 					if err := newStore.Put(ctx, artifactResult.ContentPath, val); err != nil {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR implements a new route `api/config/storage/{integrationID}` which can be used to change the storage layer to an existing integration. Right now there is only support for changing back to the local storage layer using this route.

There is future work to add support for specifying any existing integration (that is compatible for storage, such as S3 or GCS) and setting that as the new storage layer. This is tracked by: https://linear.app/aqueducthq/issue/ENG-2574/add-backend-support-for-changing-the-storage-layer-to-an-existing

## Related issue number (if any)
ENG 2175

## Test
Tested via a Postman route

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


