### PR TITLE
Fix mypy failure in GH actions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          python3 -m pip install mypy pydantic pymongo
+          python3 -m pip install mypy==1.0.0 pydantic pymongo
 
       - name: Install Type Stub Libraries
         run : |


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes mypy version issue in gh actions that's blocking all PR merges

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


