### PR TITLE
Have our GH actions slack integration always tag the appropriate oncall

### DIFF
--- a/.github/actions/fetch-test-config/action.yml
+++ b/.github/actions/fetch-test-config/action.yml
@@ -35,8 +35,8 @@ runs:
       shell: bash
       run: aws s3 cp s3://aqueduct-assets/test-credentials.yml ./test-credentials.yml
 
-#    - name: Update the apikey in credentials
-#      working-directory: integration_tests/sdk
-#      shell: bash
-#      run: |
-#        sed -i "1s/.*/apikey: $(aqueduct apikey)/" ./test-credentials.yml
+    - name: Update the apikey in credentials
+      working-directory: integration_tests/sdk
+      shell: bash
+      run: |
+        sed -i "1s/.*/apikey: $(aqueduct apikey)/" ./test-credentials.yml

--- a/.github/actions/fetch-test-config/action.yml
+++ b/.github/actions/fetch-test-config/action.yml
@@ -35,8 +35,8 @@ runs:
       shell: bash
       run: aws s3 cp s3://aqueduct-assets/test-credentials.yml ./test-credentials.yml
 
-    - name: Update the apikey in credentials
-      working-directory: integration_tests/sdk
-      shell: bash
-      run: |
-        sed -i "1s/.*/apikey: $(aqueduct apikey)/" ./test-credentials.yml
+#    - name: Update the apikey in credentials
+#      working-directory: integration_tests/sdk
+#      shell: bash
+#      run: |
+#        sed -i "1s/.*/apikey: $(aqueduct apikey)/" ./test-credentials.yml

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest # TODO: redo
     timeout-minutes: 180
     name: SDK Integration Tests against K8s Compute
     steps:
@@ -76,7 +76,7 @@ jobs:
         if: always()
         run: |
           aws s3 cp s3://aqueduct-assets/oncall.yml ./oncall.yml
-#          echo "ONCALL_SLACK_MEMBER_ID=$(python3 scripts/get_current_oncall.py --file ./oncall.yml) >> $GITHUB_ENV
+          echo "ONCALL_SLACK_MEMBER_ID=$(python3 scripts/get_current_oncall.py --file ./oncall.yml)" >> $GITHUB_ENV
 
       - name: Report to Slack on Failure
         if: always()

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest # TODO: redo
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 180
     name: SDK Integration Tests against K8s Compute
     steps:

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -76,7 +76,7 @@ jobs:
         if: always()
         run: |
           aws s3 cp s3://aqueduct-assets/oncall.yml ./oncall.yml
-          echo "ONCALL_SLACK_MEMBER_ID=$(python3 scripts/get_current_oncall.py --file ./oncall.yml) >> $GITHUB_ENV
+#          echo "ONCALL_SLACK_MEMBER_ID=$(python3 scripts/get_current_oncall.py --file ./oncall.yml) >> $GITHUB_ENV
 
       - name: Report to Slack on Failure
         if: always()

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -12,64 +12,62 @@ jobs:
     name: SDK Integration Tests against K8s Compute
     steps:
       - uses: actions/checkout@v2
-#
-#      - uses: ./.github/actions/setup-server
-#        timeout-minutes: 5
-#
+
+      - uses: ./.github/actions/setup-server
+        timeout-minutes: 5
+
       # TODO(ENG-2537): Use our separate GH actions credentials.
       - uses: ./.github/actions/fetch-test-config
         with:
           aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
           s3_test_config_path: periodic-compute-test-config.yml
-#
-#      - name: Install Terraform
-#        run: |
-#          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
-#          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-#          sudo apt update && sudo apt install terraform
-#
-#      - name: Create K8s Cluster
-#        working-directory: integration_tests/sdk/compute/k8s
-#        run: |
-#          terraform init
-#          terraform apply --auto-approve
-#
-#      - name: Update the Kubeconfig file
-#        working-directory: integration_tests/sdk/compute/k8s
-#        run: aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
-#
-#      - name: Update the test-config file with the appropriate cluster name
-#        working-directory: integration_tests/sdk
-#        run: sed -i "s/\(cluster_name:\s*\).*/\1 "$(terraform -chdir=compute/k8s/ output -raw cluster_name)"/" test-credentials.yml
-#
-#      - name: Install any data connector packages
-#        run: |
-#          aqueduct install s3
-#          aqueduct install snowflake
-#
-#      - name: Run the SDK Integration Tests
-#        working-directory: integration_tests/sdk
-#        run: pytest aqueduct_tests/ -rP -vv -n 4
-#
-#      - uses: actions/upload-artifact@v3
-#        if: always()
-#        with:
-#          name: Terraform State
-#          path: integration_tests/sdk/compute/k8s/*.tf
-#
-#      - uses: ./.github/actions/upload-artifacts
-#        if: always()
-#        with:
-#          prefix: K8s Compute
-#
-#      - name: Teardown K8s Cluster
-#        if: always()
-#        working-directory: integration_tests/sdk/compute/k8s
-#        run: terraform destroy --auto-approve
 
-      - name: Error
-        run: exit 1
+      - name: Install Terraform
+        run: |
+          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt install terraform
+
+      - name: Create K8s Cluster
+        working-directory: integration_tests/sdk/compute/k8s
+        run: |
+          terraform init
+          terraform apply --auto-approve
+
+      - name: Update the Kubeconfig file
+        working-directory: integration_tests/sdk/compute/k8s
+        run: aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
+
+      - name: Update the test-config file with the appropriate cluster name
+        working-directory: integration_tests/sdk
+        run: sed -i "s/\(cluster_name:\s*\).*/\1 "$(terraform -chdir=compute/k8s/ output -raw cluster_name)"/" test-credentials.yml
+
+      - name: Install any data connector packages
+        run: |
+          aqueduct install s3
+          aqueduct install snowflake
+
+      - name: Run the SDK Integration Tests
+        working-directory: integration_tests/sdk
+        run: pytest aqueduct_tests/ -rP -vv -n 4
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Terraform State
+          path: integration_tests/sdk/compute/k8s/*.tf
+
+      - uses: ./.github/actions/upload-artifacts
+        if: always()
+        with:
+          prefix: K8s Compute
+
+      - name: Teardown K8s Cluster
+        if: always()
+        working-directory: integration_tests/sdk/compute/k8s
+        run: terraform destroy --auto-approve
+
 
       # Sets it as an environmental variable.
       - name: Get the Slack ID for the current oncall

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -12,63 +12,72 @@ jobs:
     name: SDK Integration Tests against K8s Compute
     steps:
       - uses: actions/checkout@v2
+#
+#      - uses: ./.github/actions/setup-server
+#        timeout-minutes: 5
+#
+#      # TODO(ENG-2537): Use our separate GH actions credentials.
+#      - uses: ./.github/actions/fetch-test-config
+#        with:
+#          aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
+#          aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
+#          s3_test_config_path: periodic-compute-test-config.yml
+#
+#      - name: Install Terraform
+#        run: |
+#          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+#          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+#          sudo apt update && sudo apt install terraform
+#
+#      - name: Create K8s Cluster
+#        working-directory: integration_tests/sdk/compute/k8s
+#        run: |
+#          terraform init
+#          terraform apply --auto-approve
+#
+#      - name: Update the Kubeconfig file
+#        working-directory: integration_tests/sdk/compute/k8s
+#        run: aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
+#
+#      - name: Update the test-config file with the appropriate cluster name
+#        working-directory: integration_tests/sdk
+#        run: sed -i "s/\(cluster_name:\s*\).*/\1 "$(terraform -chdir=compute/k8s/ output -raw cluster_name)"/" test-credentials.yml
+#
+#      - name: Install any data connector packages
+#        run: |
+#          aqueduct install s3
+#          aqueduct install snowflake
+#
+#      - name: Run the SDK Integration Tests
+#        working-directory: integration_tests/sdk
+#        run: pytest aqueduct_tests/ -rP -vv -n 4
+#
+#      - uses: actions/upload-artifact@v3
+#        if: always()
+#        with:
+#          name: Terraform State
+#          path: integration_tests/sdk/compute/k8s/*.tf
+#
+#      - uses: ./.github/actions/upload-artifacts
+#        if: always()
+#        with:
+#          prefix: K8s Compute
+#
+#      - name: Teardown K8s Cluster
+#        if: always()
+#        working-directory: integration_tests/sdk/compute/k8s
+#        run: terraform destroy --auto-approve
 
-      - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+      - name: Error
+        run: exit 1
 
-      # TODO(ENG-2537): Use our separate GH actions credentials.
-      - uses: ./.github/actions/fetch-test-config
-        with:
-          aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
-          s3_test_config_path: periodic-compute-test-config.yml
-
-      - name: Install Terraform
-        run: |
-          wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          sudo apt update && sudo apt install terraform
-
-      - name: Create K8s Cluster
-        working-directory: integration_tests/sdk/compute/k8s
-        run: |
-          terraform init
-          terraform apply --auto-approve
-
-      - name: Update the Kubeconfig file
-        working-directory: integration_tests/sdk/compute/k8s
-        run: aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)
-
-      - name: Update the test-config file with the appropriate cluster name
-        working-directory: integration_tests/sdk
-        run: sed -i "s/\(cluster_name:\s*\).*/\1 "$(terraform -chdir=compute/k8s/ output -raw cluster_name)"/" test-credentials.yml
-
-      - name: Install any data connector packages
-        run: |
-          aqueduct install s3
-          aqueduct install snowflake
-
-      - name: Run the SDK Integration Tests
-        working-directory: integration_tests/sdk
-        run: pytest aqueduct_tests/ -rP -vv -n 4
-
-      - uses: actions/upload-artifact@v3
+      # Sets it as an environmental variable.
+      - name: Get the Slack ID for the current oncall
         if: always()
-        with:
-          name: Terraform State
-          path: integration_tests/sdk/compute/k8s/*.tf
+        run: |
+          aws s3 cp s3://aqueduct-assets/oncall.yml ./oncall.yml
+          echo "ONCALL_SLACK_MEMBER_ID=$(python3 scripts/get_current_oncall.py --file ./oncall.yml) >> $GITHUB_ENV
 
-      - uses: ./.github/actions/upload-artifacts
-        if: always()
-        with:
-          prefix: K8s Compute
-
-      - name: Teardown K8s Cluster
-        if: always()
-        working-directory: integration_tests/sdk/compute/k8s
-        run: terraform destroy --auto-approve
-
-      # TODO(ENG-2553): Notify the oncall, not just Kenny.
       - name: Report to Slack on Failure
         if: always()
         uses: ravsamhq/notify-slack-action@v1
@@ -78,6 +87,6 @@ jobs:
           message_format: '{emoji} *{workflow}* has {status_message}'
           footer: '{run_url}'
           notify_when: 'failure,warnings'
-          mention_users: 'U025MDH5KS6'
+          mention_users: ${{ env.ONCALL_SLACK_MEMBER_ID }}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -16,12 +16,12 @@ jobs:
 #      - uses: ./.github/actions/setup-server
 #        timeout-minutes: 5
 #
-#      # TODO(ENG-2537): Use our separate GH actions credentials.
-#      - uses: ./.github/actions/fetch-test-config
-#        with:
-#          aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
-#          aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
-#          s3_test_config_path: periodic-compute-test-config.yml
+      # TODO(ENG-2537): Use our separate GH actions credentials.
+      - uses: ./.github/actions/fetch-test-config
+        with:
+          aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
+          s3_test_config_path: periodic-compute-test-config.yml
 #
 #      - name: Install Terraform
 #        run: |

--- a/scripts/convert_nb_to_md.py
+++ b/scripts/convert_nb_to_md.py
@@ -3,9 +3,11 @@ def load_notepbook(notebook_path):
     Read the jupyter notebook as json.
     """
     import json
+
     with open(notebook_path, "r") as f:
         notebook = json.load(f)
     return notebook
+
 
 def write_markdown(notebook, output_path):
     """
@@ -13,8 +15,9 @@ def write_markdown(notebook, output_path):
     write them as markdown.
     """
     with open(output_path, "w") as f:
-        for cell in notebook['cells']:
-            write_cell(cell,f)
+        for cell in notebook["cells"]:
+            write_cell(cell, f)
+
 
 def write_cell(cell, f):
     """
@@ -22,12 +25,12 @@ def write_cell(cell, f):
     This currently only supports "mardown" and "code" cells.
     """
     f.write("\n\n\n<!-- ------------- New Cell ------------ -->\n\n\n")
-    if cell['cell_type'] == 'markdown':
+    if cell["cell_type"] == "markdown":
         write_markdown_cell(cell, f)
-    elif cell['cell_type'] == 'code':
+    elif cell["cell_type"] == "code":
         write_code_cell(cell, f)
     else:
-        print("Unknown cell type:", cell['cell_type'])
+        print("Unknown cell type:", cell["cell_type"])
     f.write("\n\n")
 
 
@@ -35,7 +38,8 @@ def write_markdown_cell(cell, f):
     """
     Write markdown cell as is.
     """
-    f.writelines(cell['source'])
+    f.writelines(cell["source"])
+
 
 def write_code_cell(cell, f):
     """
@@ -43,12 +47,13 @@ def write_code_cell(cell, f):
     nothing is written.  If code is found it is assumed to be python.
     If the code has output that is written here as well.
     """
-    if "".join(cell['source']).strip(): # drop empty source cells
+    if "".join(cell["source"]).strip():  # drop empty source cells
         f.write("```python\n")
-        f.writelines(cell['source'])
+        f.writelines(cell["source"])
         f.write("\n```")
-        if 'outputs' in cell:
-            write_outputs(cell['outputs'], f)
+        if "outputs" in cell:
+            write_outputs(cell["outputs"], f)
+
 
 def write_outputs(outputs, f):
     """
@@ -56,11 +61,12 @@ def write_outputs(outputs, f):
     "text/html" and "text/plain" output types.
     """
     for output in outputs:
-        if output['output_type'] == "execute_result":
-            if 'text/html' in output['data']:
+        if output["output_type"] == "execute_result":
+            if "text/html" in output["data"]:
                 f.write("\n**Output**\n")
-                html_lines = "".join(output['data']['text/html'])
+                html_lines = "".join(output["data"]["text/html"])
                 import re
+
                 html_lines_without_style = re.sub(r"<style(.|\n)*</style>", "", html_lines)
 
                 # This line is needed because scikit-learn has started
@@ -68,26 +74,29 @@ def write_outputs(outputs, f):
                 # and prints out some silly HTML box for its models when the
                 # user is in Jupyter. This renders some spammy message on our
                 # docs, so we hardcode a rule to get rid of it.
-                html_lines_without_skl_warn = re.sub(r"<b>In a Jupyter environment(.|\n)*</b>", "", html_lines_without_style)
+                html_lines_without_skl_warn = re.sub(
+                    r"<b>In a Jupyter environment(.|\n)*</b>", "", html_lines_without_style
+                )
 
                 f.writelines(html_lines_without_skl_warn)
-            elif 'text/plain' in output['data']:
+            elif "text/plain" in output["data"]:
                 f.write("\n**Output:**\n")
                 f.write("\n\n```\n")
-                f.writelines(output['data']['text/plain'])
+                f.writelines(output["data"]["text/plain"])
                 f.write("\n```\n\n")
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     import argparse
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("--input", required=True, help="The relative path to the notebook to render.")
-    parser.add_argument("--output", required=True, help="The relative path to the desired markdown location.")
+    parser.add_argument(
+        "--input", required=True, help="The relative path to the notebook to render."
+    )
+    parser.add_argument(
+        "--output", required=True, help="The relative path to the desired markdown location."
+    )
     args = parser.parse_args()
     notebook = load_notepbook(args.input)
     write_markdown(notebook, args.output)
     print("Notebook rendered to markdown successfully!")
-
-

--- a/scripts/get_current_oncall.py
+++ b/scripts/get_current_oncall.py
@@ -14,7 +14,7 @@ Slack Member ID:
     ...
 ```
 
-Print out Slack Member ID of the current oncall.
+Prints out Slack Member ID of the current oncall.
 """
 import argparse
 from datetime import datetime, timedelta

--- a/scripts/get_current_oncall.py
+++ b/scripts/get_current_oncall.py
@@ -2,6 +2,8 @@
 This script prints out the Slack Member ID of the current oncall, to be consumed by our GH actions so that we tag
 the current oncall on any Slack notifications (to #eng-monitoring, for example).
 
+This script expects, as input, a filepath to a yaml in the following format.
+
 ```
 Rotation:
     <oncall name>: <start date> # the date is in the format MM/DD
@@ -14,7 +16,7 @@ Slack Member ID:
     ...
 ```
 
-Prints out Slack Member ID of the current oncall.
+It will then print out the Slack Member ID of the current oncall.
 """
 import argparse
 from datetime import datetime, timedelta

--- a/scripts/get_current_oncall.py
+++ b/scripts/get_current_oncall.py
@@ -1,0 +1,76 @@
+"""
+This script prints out the Slack Member ID of the current oncall, to be consumed by our GH actions so that we tag
+the current oncall on any Slack notifications (to #eng-monitoring, for example).
+
+```
+Rotation:
+    <oncall name>: <start date> # the date is in the format MM/DD
+    <oncall name>: <start date>
+    ...
+
+Slack Member ID:
+    <oncall name>: <slack id>
+    <oncall name>: <slack id>
+    ...
+```
+
+Print out Slack Member ID of the current oncall.
+"""
+import argparse
+from datetime import datetime, timedelta
+from typing import Optional
+
+import yaml
+
+SLACK_MEMBER_ID_KEY = "Slack Member ID"
+ROTATION_KEY = "Rotation"
+
+
+def _most_recently_passed_monday():
+    """Calculate the date of the most recently passed Monday. Return it in MM/DD string format."""
+    today = datetime.today()
+    last_monday = today - timedelta(days=today.weekday())  # Since Monday's weekday() value is 0.
+    return last_monday.strftime("%m/%d")
+
+
+def print_current_oncall_slack_member_id(config_filepath: str):
+    with open(config_filepath, "r") as f:
+        config_dict = yaml.safe_load(f)
+
+        assert SLACK_MEMBER_ID_KEY in config_dict.keys()
+        assert ROTATION_KEY in config_dict.keys()
+
+        curr_oncall_start_date_str = _most_recently_passed_monday()
+        if curr_oncall_start_date_str not in config_dict[ROTATION_KEY].values():
+            raise Exception(
+                "Expected an entry in %s for the week of %s, but found none."
+                % (config_filepath, curr_oncall_start_date_str)
+            )
+
+        oncall_name: Optional[str] = None
+        for name, start_date_str in config_dict[ROTATION_KEY].items():
+            if start_date_str == curr_oncall_start_date_str:
+                oncall_name = name
+        assert oncall_name is not None
+
+        # Look up the oncall's slack member id.
+        assert (
+            oncall_name in config_dict[SLACK_MEMBER_ID_KEY].keys()
+        ), "%s does not have a slack entry in %s" % (oncall_name, config_filepath)
+
+        print(config_dict[SLACK_MEMBER_ID_KEY][oncall_name])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--filepath",
+        dest="filepath",
+        required=True,
+        action="store",
+        help="The yml file containing the appropriate format described at the top of this script.",
+    )
+    args = parser.parse_args()
+
+    print_current_oncall_slack_member_id(args.filepath)

--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -119,17 +119,21 @@ if __name__ == "__main__":
         execute_command(["pip", "install", "."], cwd=join(cwd, "src", "python"))
         os.environ["PWD"] = prev_pwd
 
-        execute_command([
-            "cp",
-            "./src/python/aqueduct_executor/start-function-executor.sh",
-            join(server_directory, "bin")
-        ])
+        execute_command(
+            [
+                "cp",
+                "./src/python/aqueduct_executor/start-function-executor.sh",
+                join(server_directory, "bin"),
+            ]
+        )
 
-        execute_command([
-            "cp",
-            "./src/python/aqueduct_executor/operators/airflow/dag.template",
-            join(server_directory, "bin")
-        ])
+        execute_command(
+            [
+                "cp",
+                "./src/python/aqueduct_executor/operators/airflow/dag.template",
+                join(server_directory, "bin"),
+            ]
+        )
 
     # Build and replace backend binaries.
     if args.update_go_binary:
@@ -183,7 +187,9 @@ if __name__ == "__main__":
         # To prevent unnecessary files from getting into our releases
         # Will replace the react-code-block component soon (next week) to avoid this concern completely
         files = [f for f in listdir(ui_directory) if isfile(join(ui_directory, f))]
-        fileNameRegex = re.compile(r'^(python|core|markup|clike|javascript|css|index|favicon)\..*(html|js|css|map|ico)$')
+        fileNameRegex = re.compile(
+            r"^(python|core|markup|clike|javascript|css|index|favicon)\..*(html|js|css|map|ico)$"
+        )
         for f in files:
             if not fileNameRegex.search(f) and not f == "__version__":
                 execute_command(["rm", f], cwd=ui_directory)

--- a/scripts/run_linters.py
+++ b/scripts/run_linters.py
@@ -30,6 +30,7 @@ def lint_python(cwd):
     execute_command(["black", join(cwd, "sdk"), "--line-length=100"])
     execute_command(["black", join(cwd, "integration_tests"), "--line-length=100"])
     execute_command(["black", join(cwd, "manual_qa_tests"), "--line-length=100"])
+    execute_command(["black", join(cwd, "scripts/"), "--line-length=100"])
     execute_command(["isort", ".", "-l", "100", "--profile", "black"])
     execute_command(
         [


### PR DESCRIPTION
## Describe your changes and why you are making these changes
In `aqueduct-assets`, we now expect an `oncall.yml` file that designates our future oncall rotation. When tests in GH actions fail, the appropriate oncall will then be notified. This is done by interpreting this `oncall.yml` file using the new `get_current_oncall.py` script.

This PR also adds the `scripts/` directory to the linter, so there's a bit more spam. 

For reviewers, you only need to look at the new `get_current_oncall.py` and `periodic-integration-tests.yml`

## Related issue number (if any)
ENG-2564

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


