### PR TITLE
Fix bug where error occurred during job manager launch is not caught as operator error

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/integration_test.py
+++ b/integration_tests/sdk/aqueduct_tests/integration_test.py
@@ -1,10 +1,14 @@
 import pytest
+from aqueduct.constants.enums import ServiceType
 from aqueduct.error import (
+    AqueductError,
     InvalidIntegrationException,
     InvalidUserActionException,
     InvalidUserArgumentException,
 )
 from pydantic import ValidationError
+
+from aqueduct import global_config
 
 from ..shared.data_objects import DataObject
 from .extract import extract
@@ -17,7 +21,7 @@ def test_invalid_source_integration(client):
         client.integration(name="wrong integration name")
 
 
-def test_invalid_destination_integration(client, data_integration):
+def test_invalid_destination_integration(data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
     output_artifact = dummy_sentiment_model(table_artifact)
 
@@ -46,3 +50,11 @@ def test_invalid_connect_integration(client):
     # Invalid config raises a pydantic error.
     with pytest.raises(ValidationError):
         client.connect_integration("New Integration", "SQLite", {})
+
+
+@pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
+def test_sqlite_with_k8s(data_integration, engine):
+    """Tests that running an extract operator that reads data from a SQLite database using k8s should fail."""
+    global_config({"engine": engine})
+    with pytest.raises(AqueductError):
+        extract(data_integration, DataObject.SENTIMENT)

--- a/integration_tests/sdk/aqueduct_tests/integration_test.py
+++ b/integration_tests/sdk/aqueduct_tests/integration_test.py
@@ -56,5 +56,5 @@ def test_invalid_connect_integration(client):
 def test_sqlite_with_k8s(data_integration, engine):
     """Tests that running an extract operator that reads data from a SQLite database using k8s should fail."""
     global_config({"engine": engine})
-    with pytest.raises(AqueductError):
+    with pytest.raises(AqueductError, match="Unknown integration service provided SQLite"):
         extract(data_integration, DataObject.SENTIMENT)

--- a/integration_tests/sdk/aqueduct_tests/integration_test.py
+++ b/integration_tests/sdk/aqueduct_tests/integration_test.py
@@ -61,7 +61,7 @@ def test_sqlite_with_k8s(data_integration, engine):
     with pytest.raises(AqueductError, match="Unknown integration service provided SQLite"):
         extract(data_integration, DataObject.SENTIMENT)
 
-        
+
 @pytest.mark.enable_only_for_local_storage()
 def test_compute_integration_without_cloud_storage(client):
     with pytest.raises(

--- a/sdk/aqueduct/backend/response_helpers.py
+++ b/sdk/aqueduct/backend/response_helpers.py
@@ -153,7 +153,7 @@ def _handle_preview_resp(preview_resp: PreviewResponse, dag: DAG) -> None:
         raise InternalAqueductError("Preview route should not be returning PENDING status.")
 
     if preview_resp.status == ExecutionStatus.FAILED:
-        # If non of the operators failed, this must be an issue with our
+        # If none of the operators failed, this must be an issue with our server.
         if len(op_err_msgs) == 0:
             raise InternalAqueductError(
                 f"Unexpected Server Error! If this issue persists, please file a bug report in github: "

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -100,6 +100,7 @@ class RelationalDBServices(str, Enum, metaclass=MetaEnum):
 class ExecutionStatus(str, Enum, metaclass=MetaEnum):
     UNKNOWN = "unknown"
     SUCCEEDED = "succeeded"
+    RUNNING = "running"
     FAILED = "failed"
     PENDING = "pending"
     REGISTERED = "registered"

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -26,8 +26,8 @@ func waitForInProgressOperators(
 		for opID, op := range inProgressOps {
 			execState, err := op.Poll(ctx)
 
-			// Resolve any jobs that aren't actively running or failed. We don't are if they succeeded or failed,
-			// since this is called after engestration exits.
+			// Resolve any jobs that aren't actively running or failed. We don't care if they succeeded or failed,
+			// since this is called after orchestration exits.
 			if err != nil || execState.Status != shared.RunningExecutionStatus {
 				delete(inProgressOps, opID)
 			}

--- a/src/golang/lib/job/errors.go
+++ b/src/golang/lib/job/errors.go
@@ -25,7 +25,7 @@ const (
 	// For example, polling a Lambda JobManager will return this error because there is no concept of
 	// fetching a specific job's information from Lambda. The caller must figure out the job status
 	// through other means.
-	Noop = 2
+	Noop = 3
 )
 
 type JobError interface {

--- a/src/golang/lib/job/errors.go
+++ b/src/golang/lib/job/errors.go
@@ -14,10 +14,10 @@ const (
 
 	// User error code indicates that the issue was the user's fault, and to surface that message
 	// to the user.
-	User = iota
+	User
 
 	// JobMissing indicates that the job manager could not find the specified job.
-	JobMissing = iota
+	JobMissing
 
 	// Noop indicates that the job manager does not have the context to make a definitive claim
 	// as to whether the job has succeeded or not. This is equivalent to saying "Do not ask me, I don't know.".
@@ -25,7 +25,7 @@ const (
 	// For example, polling a Lambda JobManager will return this error because there is no concept of
 	// fetching a specific job's information from Lambda. The caller must figure out the job status
 	// through other means.
-	Noop = iota
+	Noop
 )
 
 type JobError interface {

--- a/src/golang/lib/job/errors.go
+++ b/src/golang/lib/job/errors.go
@@ -10,14 +10,14 @@ type JobErrorCode int
 
 const (
 	// System indicates an unexpected system issue that we cannot recover from.
-	System JobErrorCode = 0
+	System JobErrorCode = iota
 
 	// User error code indicates that the issue was the user's fault, and to surface that message
 	// to the user.
-	User = 1
+	User = iota
 
 	// JobMissing indicates that the job manager could not find the specified job.
-	JobMissing = 2
+	JobMissing = iota
 
 	// Noop indicates that the job manager does not have the context to make a definitive claim
 	// as to whether the job has succeeded or not. This is equivalent to saying "Do not ask me, I don't know.".
@@ -25,7 +25,7 @@ const (
 	// For example, polling a Lambda JobManager will return this error because there is no concept of
 	// fetching a specific job's information from Lambda. The caller must figure out the job status
 	// through other means.
-	Noop = 3
+	Noop = iota
 )
 
 type JobError interface {

--- a/src/golang/lib/job/k8s.go
+++ b/src/golang/lib/job/k8s.go
@@ -140,7 +140,7 @@ func (j *k8sJobManager) Launch(ctx context.Context, name string, spec Spec) JobE
 
 	containerRepo, err := mapJobTypeToDockerImage(spec, launchGpu)
 	if err != nil {
-		return systemError(err)
+		return userError(err)
 	}
 	containerImage := fmt.Sprintf("%s:%s", containerRepo, lib.ServerVersionNumber)
 

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -319,7 +319,7 @@ func (j *ProcessJobManager) Launch(
 ) JobError {
 	log.Infof("Running %s job %s.", spec.Type(), name)
 	if _, ok := j.getCmd(name); ok {
-		return systemError(errors.Newf("Reached timeout waiting for the job %s to finish.", name))
+		return systemError(errors.Newf("A job with the same name %s already exists.", name))
 	}
 
 	cmd, err := j.mapJobTypeToCmd(name, spec)

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -165,6 +165,23 @@ func (bo *baseOperator) launch(ctx context.Context, spec job.Spec) error {
 		}
 	}
 
+	if err := bo.jobManager.Launch(ctx, spec.JobName(), spec); err != nil {
+		if err.Code() == job.User {
+			bo.UpdateExecState(
+				jobManagerUserFailureExecState(err, "Job manager Launch failed due to user error"),
+			)
+		} else if err.Code() == job.System {
+			bo.UpdateExecState(
+				unknownSystemFailureExecState(err, "Job manager Launch failed due to system error"),
+			)
+		} else {
+			log.Errorf("Unexpected job error code %d", err.Code())
+			bo.UpdateExecState(
+				unknownSystemFailureExecState(err, "Job manager Launch failed due to system error"),
+			)
+		}
+	}
+
 	return bo.jobManager.Launch(ctx, spec.JobName(), spec)
 }
 

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -165,7 +165,8 @@ func (bo *baseOperator) launch(ctx context.Context, spec job.Spec) error {
 		}
 	}
 
-	if err := bo.jobManager.Launch(ctx, spec.JobName(), spec); err != nil {
+	err := bo.jobManager.Launch(ctx, spec.JobName(), spec)
+	if err != nil {
 		if err.Code() == job.User {
 			bo.UpdateExecState(
 				jobManagerUserFailureExecState(err, "Job manager Launch failed due to user error"),
@@ -182,7 +183,7 @@ func (bo *baseOperator) launch(ctx context.Context, spec job.Spec) error {
 		}
 	}
 
-	return bo.jobManager.Launch(ctx, spec.JobName(), spec)
+	return err
 }
 
 // FetchExecState assumes that the operator has been computed already.

--- a/src/golang/lib/workflow/operator/base.go
+++ b/src/golang/lib/workflow/operator/base.go
@@ -169,16 +169,16 @@ func (bo *baseOperator) launch(ctx context.Context, spec job.Spec) error {
 	if err != nil {
 		if err.Code() == job.User {
 			bo.UpdateExecState(
-				jobManagerUserFailureExecState(err, "Job manager Launch failed due to user error"),
+				jobManagerUserFailureExecState(err, "Job manager's Launch API failed due to user error"),
 			)
 		} else if err.Code() == job.System {
 			bo.UpdateExecState(
-				unknownSystemFailureExecState(err, "Job manager Launch failed due to system error"),
+				unknownSystemFailureExecState(err, "Job manager's Launch API failed due to system error"),
 			)
 		} else {
 			log.Errorf("Unexpected job error code %d", err.Code())
 			bo.UpdateExecState(
-				unknownSystemFailureExecState(err, "Job manager Launch failed due to system error"),
+				unknownSystemFailureExecState(err, "Job manager's Launch API failed due to system error"),
 			)
 		}
 	}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The original bug was when running with k8s, an extract operator that attempts to read from the local sqlite database will silently fail. The root cause is when error occurs in operator.Launch(), we weren't setting the operator's exec state accordingly.

This PR also fixes a few other smaller issues and comment typos.

@kenxu95 let's sync up tmr on writing a k8s integration test for this.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


