### PR TITLE
Do not require an explicit apikey field in test-credentials.yml

### DIFF
--- a/.github/actions/fetch-test-config/action.yml
+++ b/.github/actions/fetch-test-config/action.yml
@@ -34,9 +34,3 @@ runs:
       working-directory: integration_tests/sdk
       shell: bash
       run: aws s3 cp s3://aqueduct-assets/test-credentials.yml ./test-credentials.yml
-
-    - name: Update the apikey in credentials
-      working-directory: integration_tests/sdk
-      shell: bash
-      run: |
-        sed -i "1s/.*/apikey: $(aqueduct apikey)/" ./test-credentials.yml

--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -26,6 +26,7 @@ Both these test suites share a collection of command line flags:
 * `--keep-flows`: If set, we will not delete any flows created by the test run. This is useful for debugging.
 * `--deprecated`: Runs against any deprecated API that still exists in the SDK. Such code paths should be eventually deleted after some time, but this ensures backwards compatibility.
 * `--skip-data-setup`: Skips the checking and setup of external data integrations. Instead, assumes that all data integrations have been set up correctly with the appropriate data.
+* `--skip-engine-setup`: Skips the checking and setup of external compute integrations.
 
 For additional markers/fixtures/flags, please inspect `conftest.py` in this directory. For test-specific configurations,
 see `aqueduct_tests/conftest.py` and  `data_integration_tests/conftest.py`.
@@ -36,8 +37,8 @@ To run all SDK Integration Tests, from the `integration_tests/sdk` directory, ru
 `python3 run_tests.py [-lf] [-n CONCURRENCY]`
 
 To run just one of the test suites:
-- `python3 run_tests.py --aqueduct [-lf] [-n CONCURRENCY]`
-- `python3 run_tests.py --data-integration [-lf] [-n CONCURRENCY]`
+- `python3 run_tests.py --aqueduct [-lf] [-n CONCURRENCY] [-k TEST_CASE]`
+- `python3 run_tests.py --data-integration [-lf] [-n CONCURRENCY] [-k TEST_CASE]`
 
 To run tests with concurrency > 1, `pytest-xdist` must be installed.
 

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -13,7 +13,7 @@ from aqueduct.integrations.s3_integration import S3Integration
 from aqueduct.integrations.sql_integration import RelationalDBIntegration
 from aqueduct.models.integration import Integration
 
-from aqueduct import Client
+from aqueduct import Client, get_apikey
 from sdk.aqueduct_tests.save import save
 from sdk.shared.demo_db import demo_db_tables
 from sdk.shared.flow_helpers import delete_flow, publish_flow_test
@@ -317,10 +317,16 @@ def list_compute_integrations() -> List[str]:
 
 
 def get_aqueduct_config() -> Tuple[str, str]:
-    # Returns the apikey and server address.
+    """
+    Returns the apikey and server address. If "apikey" does not exist in test-credentials, we will
+    assume the server is on the same machine, and will use "aqueduct apikey".
+    """
     test_config = _parse_config_file()
+
     test_credentials = _parse_credentials_file()
-    assert (
-        "apikey" in test_credentials and "address" in test_config
-    ), "apikey and address must be set in test-credentials.yml and test-config.yml, respectively."
-    return test_credentials["apikey"], test_config["address"]
+    if "apikey" in test_credentials:
+        apikey = test_credentials["apikey"]
+    else:
+        apikey = get_apikey()
+
+    return apikey, test_config["address"]


### PR DESCRIPTION
## Describe your changes and why you are making these changes
It's pretty annoying to have to update the apikey in test-credentials.yml anytime you clear the server. We make this field optional. If it's there, we will respect it, but otherwise we will attempt to infer the apikey with `aqueduct apikey`.

## Related issue number (if any)
ENG-2565

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


