### PR TITLE
Fix bug where calling an operator fixes it's execution mode

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/lazy_execution_test.py
+++ b/integration_tests/sdk/aqueduct_tests/lazy_execution_test.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 from aqueduct.artifacts.bool_artifact import BoolArtifact
 from aqueduct.artifacts.generic_artifact import GenericArtifact
+from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.constants.enums import ArtifactType
 from aqueduct.error import InvalidUserArgumentException
 
@@ -238,3 +239,21 @@ def test_lazy_artifact_with_save(client, flow_name, data_integration, engine, da
     data_validator.check_saved_artifact_data(
         flow, review_copied.id(), expected_data=copy_field.local(reviews)
     )
+
+
+def test_eager_then_lazy(client):
+    """For an operator, checks that we can switch its execution mode from eager to lazy."""
+
+    @op
+    def number():
+        return 1
+
+    result = number()
+    assert isinstance(result, NumericArtifact)
+    assert result.get() == 1
+
+    global_config({"lazy": True})
+
+    result = number()
+    assert isinstance(result, GenericArtifact)
+    assert result.get() == 1

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -88,6 +88,8 @@ def test_basic_file_dependencies(client, data_integration):
 
 
 def test_invalid_file_dependencies(client, data_integration):
+    global_config({"lazy": False})
+    
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(AqueductError):

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -88,8 +88,6 @@ def test_basic_file_dependencies(client, data_integration):
 
 
 def test_invalid_file_dependencies(client, data_integration):
-    global_config({"lazy": False})
-
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(AqueductError):

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -89,7 +89,7 @@ def test_basic_file_dependencies(client, data_integration):
 
 def test_invalid_file_dependencies(client, data_integration):
     global_config({"lazy": False})
-    
+
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(AqueductError):

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -4,6 +4,7 @@ import time
 import pandas as pd
 
 from aqueduct import op
+from aqueduct import global_config
 
 from ..shared.data_objects import DataObject
 from .extract import extract
@@ -56,6 +57,8 @@ def test_system_runtime_metric(client, data_integration):
 
 
 def test_system_max_memory_metric(client, data_integration):
+    global_config({"lazy": False})
+
     table = extract(data_integration, DataObject.SENTIMENT)
     timed_table = mem_intensive_function(table)
 

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -3,8 +3,7 @@ import time
 
 import pandas as pd
 
-from aqueduct import op
-from aqueduct import global_config
+from aqueduct import global_config, op
 
 from ..shared.data_objects import DataObject
 from .extract import extract

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -56,8 +56,6 @@ def test_system_runtime_metric(client, data_integration):
 
 
 def test_system_max_memory_metric(client, data_integration):
-    global_config({"lazy": False})
-
     table = extract(data_integration, DataObject.SENTIMENT)
     timed_table = mem_intensive_function(table)
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from aqueduct.constants.enums import ServiceType
 from aqueduct.models.dag import DAG, Metadata
 
-from aqueduct import Client, globals
+from aqueduct import Client, global_config, globals
 from sdk.setup_integration import (
     get_aqueduct_config,
     has_storage_config,
@@ -254,3 +254,11 @@ def flow_name(client, request, pytestconfig):
 @pytest.fixture(scope="function")
 def validator(client, data_integration):
     return Validator(client, data_integration)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def post_process():
+    # Pre-processing code
+    yield
+    # Post-processing code
+    global_config({"lazy": False})

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -257,7 +257,7 @@ def validator(client, data_integration):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def post_process():
+def post_process_reset_execution_mode_to_eager():
     # Pre-processing code
     yield
     # Post-processing code

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -550,7 +550,7 @@ def op(
             assert isinstance(description, str)
 
             if execution_mode == None:
-                execution_mode = _get_execution_mode()
+                execution_mode = _get_global_execution_mode()
 
             assert isinstance(execution_mode, ExecutionMode)
 
@@ -714,7 +714,7 @@ def metric(
             assert isinstance(description, str)
 
             if execution_mode == None:
-                execution_mode = _get_execution_mode()
+                execution_mode = _get_global_execution_mode()
 
             assert isinstance(execution_mode, ExecutionMode)
 
@@ -901,7 +901,7 @@ def check(
             assert isinstance(description, str)
 
             if execution_mode == None:
-                execution_mode = _get_execution_mode()
+                execution_mode = _get_global_execution_mode()
 
             assert isinstance(execution_mode, ExecutionMode)
 
@@ -1026,7 +1026,7 @@ def to_operator(
     return func_op(func)
 
 
-def _get_execution_mode() -> ExecutionMode:
+def _get_global_execution_mode() -> ExecutionMode:
     if globals.__GLOBAL_CONFIG__.lazy:
         return ExecutionMode.LAZY
     else:

--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -536,7 +536,7 @@ def op(
             description = func.__doc__ or ""
 
         def _wrapped_util(
-            *input_artifacts: BaseArtifact, execution_mode: ExecutionMode
+            *input_artifacts: BaseArtifact, execution_mode: Optional[ExecutionMode] = None
         ) -> Union[BaseArtifact, List[BaseArtifact]]:
             """
             Creates the following files in the zipped folder structure:
@@ -548,6 +548,11 @@ def op(
             """
             assert isinstance(name, str)
             assert isinstance(description, str)
+
+            if execution_mode == None:
+                execution_mode = _get_execution_mode()
+
+            assert isinstance(execution_mode, ExecutionMode)
 
             artifacts = _convert_input_arguments_to_parameters(
                 *input_artifacts,
@@ -583,7 +588,7 @@ def op(
             )
 
         def wrapped(*input_artifacts: BaseArtifact) -> Union[BaseArtifact, List[BaseArtifact]]:
-            return _wrapped_util(*input_artifacts, execution_mode=ExecutionMode.EAGER)
+            return _wrapped_util(*input_artifacts)
 
         # Enable the .local(*args) attribute, which calls the original function with the raw inputs.
         def local_func(*inputs: Any) -> Any:
@@ -596,9 +601,6 @@ def op(
             return _wrapped_util(*input_artifacts, execution_mode=ExecutionMode.LAZY)
 
         setattr(wrapped, "lazy", lazy_mode)
-
-        if globals.__GLOBAL_CONFIG__.lazy:
-            return lazy_mode
 
         return wrapped
 
@@ -698,7 +700,7 @@ def metric(
             description = func.__doc__ or ""
 
         def _wrapped_util(
-            *input_artifacts: BaseArtifact, execution_mode: ExecutionMode
+            *input_artifacts: BaseArtifact, execution_mode: Optional[ExecutionMode] = None
         ) -> NumericArtifact:
             """
             Creates the following files in the zipped folder structure:
@@ -710,6 +712,11 @@ def metric(
             """
             assert isinstance(name, str)
             assert isinstance(description, str)
+
+            if execution_mode == None:
+                execution_mode = _get_execution_mode()
+
+            assert isinstance(execution_mode, ExecutionMode)
 
             if len(input_artifacts) == 0:
                 raise InvalidUserArgumentException(
@@ -762,7 +769,7 @@ def metric(
         def wrapped(
             *input_artifacts: BaseArtifact,
         ) -> NumericArtifact:
-            return _wrapped_util(*input_artifacts, execution_mode=ExecutionMode.EAGER)
+            return _wrapped_util(*input_artifacts)
 
         # Enable the .local(*args) attribute, which calls the original function with the raw inputs.
         def local_func(*inputs: Any) -> Number:
@@ -775,9 +782,6 @@ def metric(
             return _wrapped_util(*input_artifacts, execution_mode=ExecutionMode.LAZY)
 
         setattr(wrapped, "lazy", lazy_mode)
-
-        if globals.__GLOBAL_CONFIG__.lazy:
-            return lazy_mode
 
         return wrapped
 
@@ -883,7 +887,7 @@ def check(
             description = func.__doc__ or ""
 
         def _wrapped_util(
-            *input_artifacts: BaseArtifact, execution_mode: ExecutionMode
+            *input_artifacts: BaseArtifact, execution_mode: Optional[ExecutionMode] = None
         ) -> BoolArtifact:
             """
             Creates the following files in the zipped folder structure:
@@ -895,6 +899,11 @@ def check(
             """
             assert isinstance(name, str)
             assert isinstance(description, str)
+
+            if execution_mode == None:
+                execution_mode = _get_execution_mode()
+
+            assert isinstance(execution_mode, ExecutionMode)
 
             if len(input_artifacts) == 0:
                 raise InvalidUserArgumentException(
@@ -945,7 +954,7 @@ def check(
         def wrapped(
             *input_artifacts: BaseArtifact,
         ) -> BoolArtifact:
-            return _wrapped_util(*input_artifacts, execution_mode=ExecutionMode.EAGER)
+            return _wrapped_util(*input_artifacts)
 
         # Enable the .local(*args) attribute, which calls the original function with the raw inputs.
         def local_func(*inputs: Any) -> Union[bool, np.bool_]:
@@ -959,8 +968,6 @@ def check(
 
         setattr(wrapped, "lazy", lazy_mode)
 
-        if globals.__GLOBAL_CONFIG__.lazy:
-            return lazy_mode
         return wrapped
 
     if callable(name):
@@ -1017,3 +1024,10 @@ def to_operator(
         ),
     )
     return func_op(func)
+
+
+def _get_execution_mode() -> ExecutionMode:
+    if globals.__GLOBAL_CONFIG__.lazy:
+        return ExecutionMode.LAZY
+    else:
+        return ExecutionMode.EAGER


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixed by moving the global_config check into the execution path, instead of the decorator instantiation path.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


