### PR TITLE
Get our credentials paths working with ~

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/athenaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/athenaDialog.tsx
@@ -124,7 +124,7 @@ export const AthenaDialog: React.FC<Props> = ({
         spellCheck={false}
         required={true}
         label="AWS Credentials File Path*"
-        description={'The absolute path to the credentials file'}
+        description={'The path to the credentials file'}
         placeholder={Placeholders.config_file_path}
         onChange={(event) =>
           onUpdateField('config_file_path', event.target.value)

--- a/src/ui/common/src/components/integrations/dialogs/awsDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/awsDialog.tsx
@@ -99,7 +99,7 @@ export const AWSDialog: React.FC<Props> = ({
         spellCheck={false}
         required={true}
         label="AWS Credentials File Path*"
-        description={'The absolute path to the credentials file'}
+        description={'The path to the credentials file'}
         placeholder={Placeholders.config_file_path}
         onChange={(event) =>
           onUpdateField('config_file_path', event.target.value)

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -121,7 +121,7 @@ export const S3Dialog: React.FC<Props> = ({
         spellCheck={false}
         required={true}
         label="AWS Credentials File Path*"
-        description={'The absolute path to the credentials file'}
+        description={'The path to the credentials file'}
         placeholder={Placeholders.config_file_path}
         onChange={(event) =>
           onUpdateField('config_file_path', event.target.value)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Hard to write test because the we don't know the path to the credential file on the GitHub action environment, but I tested manually and it works.

Maybe we can still write a test that's only to be run during manual testing? Is there a way to skip this test for all GitHub action runs? @kenxu95 

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


