### PR TITLE
Fix a test case that's expected to run only when using sqlite as data integration

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/integration_test.py
+++ b/integration_tests/sdk/aqueduct_tests/integration_test.py
@@ -55,6 +55,7 @@ def test_invalid_connect_integration(client):
 
 
 @pytest.mark.enable_only_for_engine_type(ServiceType.K8S)
+@pytest.mark.enable_only_for_data_integration_type(ServiceType.SQLITE)
 def test_sqlite_with_k8s(data_integration, engine):
     """Tests that running an extract operator that reads data from a SQLite database using k8s should fail."""
     global_config({"engine": engine})

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -180,7 +180,7 @@ def enable_only_for_engine_type(request, client, engine):
 
 @pytest.fixture(autouse=True)
 def enable_only_for_local_storage(request, client, engine):
-    """xxx"""
+    """When a test is marked with this, we run it only when the local file system is used as storage."""
     if not request.node.get_closest_marker("enable_only_for_local_storage"):
         return
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


