### PR TITLE
Refactors storage error to include stack trace

### DIFF
--- a/src/golang/cmd/migrator/versions/000016_add_artifact_type_column_to_artifact/utils.go
+++ b/src/golang/cmd/migrator/versions/000016_add_artifact_type_column_to_artifact/utils.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/aqueducthq/aqueduct/config"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/models/utils"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/storage"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -268,7 +268,7 @@ func migrateArtifact(ctx context.Context, db database.Database) error {
 			// and we need to revert the content change.
 			originalContent, err := storage.NewStorage(&storageConfig).Get(ctx, artifactResult.ContentPath)
 			if err != nil {
-				if artifactResult.Status != SucceededExecutionStatus && err == storage.ErrObjectDoesNotExist {
+				if artifactResult.Status != SucceededExecutionStatus && errors.Is(err, storage.ErrObjectDoesNotExist()) {
 					log.Infof("Skipping data migration for artifact result %s since its content wasn't generated.", artifactResult.Id)
 					continue
 				} else {

--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -10,10 +10,10 @@ import (
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/storage"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -252,7 +252,7 @@ func (h *GetArtifactResultHandler) Perform(ctx context.Context, interfaceArgs in
 	data, err := storage.NewStorage(&dag.StorageConfig).Get(ctx, dbArtifactResult.ContentPath)
 	if err == nil {
 		response.Data = data
-	} else if err != storage.ErrObjectDoesNotExist {
+	} else if !errors.Is(err, storage.ErrObjectDoesNotExist()) {
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Failed to retrieve data for the artifact result.")
 	}
 

--- a/src/golang/cmd/server/handler/get_artifact_versions.go
+++ b/src/golang/cmd/server/handler/get_artifact_versions.go
@@ -6,13 +6,13 @@ import (
 
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/models/shared/operator/connector"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/storage"
 	"github.com/aqueducthq/aqueduct/lib/workflow/artifact"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 )
 
@@ -347,7 +347,7 @@ func (h *GetArtifactVersionsHandler) updateVersionsWithChecksAndMetrics(
 						if err == nil {
 							content := string(contentBytes)
 							contentPtr = &content
-						} else if err != storage.ErrObjectDoesNotExist {
+						} else if !errors.Is(err, storage.ErrObjectDoesNotExist()) {
 							return errors.Wrap(err, "Unable to get artifact content from storage")
 						}
 					}

--- a/src/golang/cmd/server/handler/get_workflow_dag_result.go
+++ b/src/golang/cmd/server/handler/get_workflow_dag_result.go
@@ -7,12 +7,12 @@ import (
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/storage"
 	"github.com/aqueducthq/aqueduct/lib/workflow/dag"
 	workflow_utils "github.com/aqueducthq/aqueduct/lib/workflow/utils"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -175,7 +175,7 @@ func getArtifactContents(
 				path := artfResult.ContentPath
 				// Read data from storage and deserialize payload to `container`.
 				contentBytes, err := storageObj.Get(ctx, path)
-				if err == storage.ErrObjectDoesNotExist {
+				if errors.Is(err, storage.ErrObjectDoesNotExist()) {
 					// If the data does not exist, skip the fetch.
 					continue
 				}

--- a/src/golang/cmd/server/handler/list_workflows.go
+++ b/src/golang/cmd/server/handler/list_workflows.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/airflow"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/logging"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	db_operator "github.com/aqueducthq/aqueduct/lib/models/shared/operator"
@@ -17,7 +18,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/artifact"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 )
 
@@ -158,7 +158,7 @@ func (h *ListWorkflowsHandler) Perform(ctx context.Context, interfaceArgs interf
 					if err == nil {
 						content := string(contentBytes)
 						contentPtr = &content
-					} else if err != storage.ErrObjectDoesNotExist {
+					} else if !errors.Is(err, storage.ErrObjectDoesNotExist()) {
 						return nil, http.StatusInternalServerError, errors.Wrap(
 							err, "Unable to get metric content from storage",
 						)

--- a/src/golang/lib/errors/errors_test.go
+++ b/src/golang/lib/errors/errors_test.go
@@ -1,0 +1,42 @@
+package errors
+
+import (
+	stderrors "errors"
+	"io"
+	"testing"
+
+	"github.com/dropbox/godropbox/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIs(t *testing.T) {
+	type test struct {
+		err1     error
+		err2     error
+		areEqual bool
+	}
+
+	tests := []test{
+		// Dropbox Errors
+		{err1: errors.New("This is a sample error."), err2: errors.New("This is a sample error."), areEqual: true},
+		{err1: errors.New("This is a sample error."), err2: errors.New("This is NOT a sample error."), areEqual: false},
+
+		// Standard Errors
+		{err1: stderrors.New("This is a sample error."), err2: stderrors.New("This is a sample error."), areEqual: true},
+		{err1: stderrors.New("This is a sample error."), err2: stderrors.New("This is NOT a sample error."), areEqual: false},
+
+		// Mix Dropbox and Standard Errors
+		{err1: stderrors.New("This is a sample error."), err2: errors.New("This is a sample error."), areEqual: false},
+
+		// Wrapped Errors
+		{
+			err1:     Wrap(io.EOF, "This is a sample error."),
+			err2:     errors.New("This is a sample error."),
+			areEqual: true,
+		},
+	}
+
+	for _, tc := range tests {
+		require.Equal(t, tc.areEqual, Is(tc.err1, tc.err2))
+	}
+}

--- a/src/golang/lib/storage/file.go
+++ b/src/golang/lib/storage/file.go
@@ -28,7 +28,7 @@ func newFileStorage(fileConfig *shared.FileConfig) *fileStorage {
 func (f *fileStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	path := f.getFullPath(key)
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		return nil, ErrObjectDoesNotExist
+		return nil, ErrObjectDoesNotExist()
 	}
 	return os.ReadFile(path)
 }

--- a/src/golang/lib/storage/gcs.go
+++ b/src/golang/lib/storage/gcs.go
@@ -54,7 +54,7 @@ func (g *gcsStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	_, err = client.Bucket(bucket).Object(key).Attrs(ctx)
 	if err != nil {
 		if err == storage.ErrObjectNotExist {
-			return nil, ErrObjectDoesNotExist
+			return nil, ErrObjectDoesNotExist()
 		}
 		return nil, err
 	}

--- a/src/golang/lib/storage/s3.go
+++ b/src/golang/lib/storage/s3.go
@@ -63,7 +63,7 @@ func (s *s3Storage) Get(ctx context.Context, key string) ([]byte, error) {
 		if aerr, ok := err.(awserr.Error); ok {
 			switch aerr.Code() {
 			case s3.ErrCodeNoSuchKey:
-				return nil, ErrObjectDoesNotExist
+				return nil, ErrObjectDoesNotExist()
 			default:
 				return nil, err
 			}

--- a/src/golang/lib/storage/storage.go
+++ b/src/golang/lib/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-
 	"log"
 
 	"github.com/aqueducthq/aqueduct/lib/errors"

--- a/src/golang/lib/storage/storage.go
+++ b/src/golang/lib/storage/storage.go
@@ -2,13 +2,16 @@ package storage
 
 import (
 	"context"
+
 	"log"
 
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
-	"github.com/dropbox/godropbox/errors"
 )
 
-var ErrObjectDoesNotExist = errors.New("Object does not exist in storage.")
+func ErrObjectDoesNotExist() error {
+	return errors.New("Object does not exist in storage.")
+}
 
 type Storage interface {
 	// Throws `ErrObjectDoesNotExist` if the path does not exist.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR lays out the ground work for removing all of the `var Err... = errors.New(...)` code pattern in our codebase, as this was preventing us from capturing the right stack trace as part of the `DropboxError`.

This PR defines our own `errors` lib so that we don't need to import several different `errors` packages in the same file. >80% of this library is just calling the dropbox errors library. The only part that is custom is checking for error equality. This has to be custom because we will always have a mix of dropbox errors and standard errors in our codebase. Consider something like `io.ErrNoFile`, which is defined in the standard `io` package. If we want to perform equality correctly for all errors we need to deal with cases where we could be dealing with either a standard error or a dropbox error.

Checking for equality with dropbox errors requires us to ignore the stack trace, because the stack trace will be different, and instead just look at the outermost error message.

A follow on PR will address removing all of the other `var Err == ` patterns in our codebase and deal with changing the package import from the dropbox errors pkg to our internal one.

## Related issue number (if any)
ENG 2580

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


