### PR TITLE
ENG 2410 improve metadata migration notice looking

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -38,7 +38,7 @@ const AddIntegrations: React.FC<Props> = ({
             setShowMigrationDialog(false);
           }}
           severity="info"
-          sx={{ width: '100%' }}
+          sx={{ margin: 1 }}
         >
           {`Storage migration is in progress. The server will be temporarily unavailable. Please refresh the page to check if the server is ready.`}
         </Alert>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR improves the rendering of metadata migration alerts by properly assign width and margin to this component.

## Related issue number (if any)
ENG-2410

## Loom demo (if any)
Before:
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/10411887/224588338-d0a45981-7307-4869-bf23-73c4a0dc3e77.png">

After:
![Screenshot 2023-03-12 at 6 27 16 PM](https://user-images.githubusercontent.com/10411887/224588301-9b727f32-45bb-40e3-8c47-016495c8beaa.png)


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


