### PR TITLE
Refactors lib/database to follow new errors convention

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/dynamic"
 	"github.com/aqueducthq/aqueduct/lib/engine"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	exec_env "github.com/aqueducthq/aqueduct/lib/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	lambda_utils "github.com/aqueducthq/aqueduct/lib/lambda"
@@ -30,7 +31,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
 	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -763,7 +763,7 @@ func ValidatePrerequisites(
 	if err == nil {
 		return http.StatusBadRequest, errors.Newf("Cannot connect to an integration %s, since it already exists.", name)
 	}
-	if err != database.ErrNoRows {
+	if !errors.Is(err, database.ErrNoRows()) {
 		return http.StatusInternalServerError, errors.Wrap(err, "Unable to query for existing integrations.")
 	}
 

--- a/src/golang/cmd/server/handler/edit_integration.go
+++ b/src/golang/cmd/server/handler/edit_integration.go
@@ -9,13 +9,13 @@ import (
 	"github.com/aqueducthq/aqueduct/config"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -193,7 +193,7 @@ func (h *EditIntegrationHandler) Perform(ctx context.Context, interfaceArgs inte
 	emptyResp := EditIntegrationResponse{}
 
 	integrationObject, err := h.IntegrationRepo.Get(ctx, ID, h.Database)
-	if err == database.ErrNoRows {
+	if errors.Is(err, database.ErrNoRows()) {
 		return emptyResp, http.StatusBadRequest, err
 	}
 

--- a/src/golang/cmd/server/handler/get_artifact_result.go
+++ b/src/golang/cmd/server/handler/get_artifact_result.go
@@ -213,7 +213,7 @@ func (h *GetArtifactResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
-		if err != database.ErrNoRows {
+		if !errors.Is(err, database.ErrNoRows()) {
 			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving artifact result.")
 		}
 		// ArtifactResult was never created, so we use the WorkflowDagResult's status as this ArtifactResult's status

--- a/src/golang/cmd/server/handler/get_operator_result.go
+++ b/src/golang/cmd/server/handler/get_operator_result.go
@@ -7,9 +7,9 @@ import (
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/repos"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -119,7 +119,7 @@ func (h *GetOperatorResultHandler) Perform(ctx context.Context, interfaceArgs in
 		h.Database,
 	)
 	if err != nil {
-		if err != database.ErrNoRows {
+		if !errors.Is(err, database.ErrNoRows()) {
 			return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when retrieving operator result.")
 		}
 		// OperatorResult was never created, so we use the WorkflowDagResult's status as this OperatorResult's status

--- a/src/golang/cmd/server/handler/register_workflow.go
+++ b/src/golang/cmd/server/handler/register_workflow.go
@@ -8,6 +8,7 @@ import (
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
 	"github.com/aqueducthq/aqueduct/lib/engine"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	exec_env "github.com/aqueducthq/aqueduct/lib/execution_environment"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	shared_utils "github.com/aqueducthq/aqueduct/lib/lib_utils"
@@ -19,7 +20,6 @@ import (
 	operator_utils "github.com/aqueducthq/aqueduct/lib/workflow/operator"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/github"
 	"github.com/aqueducthq/aqueduct/lib/workflow/utils"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -112,7 +112,7 @@ func (h *RegisterWorkflowHandler) Prepare(r *http.Request) (interface{}, int, er
 		h.Database,
 	)
 	if err != nil {
-		if err != database.ErrNoRows {
+		if !errors.Is(err, database.ErrNoRows()) {
 			return nil, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred when checking for existing workflows.")
 		}
 		// A colliding workflow does not exist, so this is not an update

--- a/src/golang/cmd/server/handler/test_integration.go
+++ b/src/golang/cmd/server/handler/test_integration.go
@@ -8,11 +8,11 @@ import (
 	"github.com/aqueducthq/aqueduct/config"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/job"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/vault"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/auth"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
@@ -86,7 +86,7 @@ func (h *TestIntegrationHandler) Perform(ctx context.Context, interfaceArgs inte
 	emptyResp := TestIntegrationResponse{}
 
 	integrationObject, err := h.IntegrationRepo.Get(ctx, ID, h.Database)
-	if err == database.ErrNoRows {
+	if errors.Is(err, database.ErrNoRows()) {
 		return emptyResp, http.StatusBadRequest, err
 	}
 

--- a/src/golang/cmd/server/middleware/authentication/authentication.go
+++ b/src/golang/cmd/server/middleware/authentication/authentication.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aqueducthq/aqueduct/cmd/server/routes"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 )
 
@@ -21,7 +22,7 @@ func RequireApiKey(userRepo repos.User, db database.Database) func(http.Handler)
 			apiKey := r.Header.Get(routes.ApiKeyHeader)
 
 			user, err := userRepo.GetByAPIKey(r.Context(), apiKey, db)
-			if err == database.ErrNoRows {
+			if errors.Is(err, database.ErrNoRows()) {
 				response.SendErrorResponse(w, "Invalid API key credentials.", http.StatusForbidden)
 			} else if err != nil {
 				// Something went wrong with accessing the database

--- a/src/golang/cmd/server/server/test_account.go
+++ b/src/golang/cmd/server/server/test_account.go
@@ -6,11 +6,11 @@ import (
 	"github.com/aqueducthq/aqueduct/cmd/server/handler"
 	aq_context "github.com/aqueducthq/aqueduct/lib/context"
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/repos"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator/connector/demo"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 )
 
@@ -22,11 +22,11 @@ func CreateTestAccount(
 ) (*models.User, error) {
 	// Check if test user already exists
 	testUser, err := s.UserRepo.GetByAPIKey(ctx, apiKey, s.Database)
-	if err != nil && err != database.ErrNoRows {
+	if err != nil && !errors.Is(err, database.ErrNoRows()) {
 		return nil, errors.Newf("Unable to check if test account exists: %v", err)
 	}
 
-	if err == database.ErrNoRows {
+	if errors.Is(err, database.ErrNoRows()) {
 		// Create a test user to perform actions from SDK.
 		testUser, err = s.UserRepo.Create(
 			ctx,

--- a/src/golang/lib/database/database.go
+++ b/src/golang/lib/database/database.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	stmt "github.com/aqueducthq/aqueduct/lib/database/stmt_preparers"
-	"github.com/dropbox/godropbox/errors"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 )
 
 const (
@@ -12,10 +12,13 @@ const (
 	ErrCodeTableDoesNotExist = "SQLSTATE 42P01"
 )
 
-var (
-	ErrNoRows            = errors.New("Query returned no rows.")
-	ErrUnsupportedDbType = errors.New("DB Type is not supported")
-)
+func ErrNoRows() error {
+	return errors.New("Query returned no rows.")
+}
+
+func ErrUnsupportedDbType() error {
+	return errors.New("DB Type is not supported")
+}
 
 // Database is the interface that must be implemented by any database driver.
 type Database interface {
@@ -83,5 +86,5 @@ func NewDatabase(conf *DatabaseConfig) (Database, error) {
 		return NewSqliteDatabase(sqliteConf)
 	}
 
-	return nil, ErrUnsupportedDbType
+	return nil, ErrUnsupportedDbType()
 }

--- a/src/golang/lib/database/scanner.go
+++ b/src/golang/lib/database/scanner.go
@@ -39,7 +39,7 @@ func scanRows(rows *sql.Rows, dest interface{}) error {
 			}
 
 			// No rows to scan
-			return ErrNoRows
+			return ErrNoRows()
 		}
 		return scanRow(rows, dest)
 	case reflect.Slice:

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -8,11 +8,11 @@ import (
 	"sort"
 
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/lib_utils"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/repos"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -175,7 +175,7 @@ func CreateMissingAndSyncExistingEnvs(
 		)
 
 		// Env is missing
-		if err == database.ErrNoRows {
+		if errors.Is(err, database.ErrNoRows()) {
 			err = env.CreateDBRecord(ctx, execEnvRepo, txn)
 			if err != nil {
 				return nil, err

--- a/src/golang/lib/repos/sqlite/artifact.go
+++ b/src/golang/lib/repos/sqlite/artifact.go
@@ -236,7 +236,7 @@ func getArtifact(ctx context.Context, DB database.Database, query string, args .
 	}
 
 	if len(artifacts) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(artifacts) != 1 {

--- a/src/golang/lib/repos/sqlite/artifact_result.go
+++ b/src/golang/lib/repos/sqlite/artifact_result.go
@@ -317,7 +317,7 @@ func getArtifactResult(ctx context.Context, DB database.Database, query string, 
 	}
 
 	if len(artifactResults) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(artifactResults) != 1 {

--- a/src/golang/lib/repos/sqlite/dag.go
+++ b/src/golang/lib/repos/sqlite/dag.go
@@ -348,7 +348,7 @@ func getDAG(ctx context.Context, DB database.Database, query string, args ...int
 	}
 
 	if len(dags) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(dags) != 1 {

--- a/src/golang/lib/repos/sqlite/dag_edge.go
+++ b/src/golang/lib/repos/sqlite/dag_edge.go
@@ -141,7 +141,7 @@ func getDAGEdge(ctx context.Context, DB database.Database, query string, args ..
 	}
 
 	if len(edges) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(edges) != 1 {

--- a/src/golang/lib/repos/sqlite/dag_result.go
+++ b/src/golang/lib/repos/sqlite/dag_result.go
@@ -185,7 +185,7 @@ func getDAGResult(ctx context.Context, DB database.Database, query string, args 
 	}
 
 	if len(dagResults) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(dagResults) != 1 {

--- a/src/golang/lib/repos/sqlite/execution_environment.go
+++ b/src/golang/lib/repos/sqlite/execution_environment.go
@@ -160,7 +160,7 @@ func getExecutionEnvironment(ctx context.Context, DB database.Database, query st
 	}
 
 	if len(executionEnvironments) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(executionEnvironments) != 1 {

--- a/src/golang/lib/repos/sqlite/integration.go
+++ b/src/golang/lib/repos/sqlite/integration.go
@@ -242,7 +242,7 @@ func getIntegration(ctx context.Context, DB database.Database, query string, arg
 	}
 
 	if len(integrations) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(integrations) != 1 {

--- a/src/golang/lib/repos/sqlite/notification.go
+++ b/src/golang/lib/repos/sqlite/notification.go
@@ -113,7 +113,7 @@ func getNotification(ctx context.Context, DB database.Database, query string, ar
 	}
 
 	if len(notifications) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(notifications) != 1 {

--- a/src/golang/lib/repos/sqlite/operator.go
+++ b/src/golang/lib/repos/sqlite/operator.go
@@ -508,7 +508,7 @@ func getOperator(ctx context.Context, DB database.Database, query string, args .
 	}
 
 	if len(operators) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(operators) != 1 {

--- a/src/golang/lib/repos/sqlite/operator_result.go
+++ b/src/golang/lib/repos/sqlite/operator_result.go
@@ -256,7 +256,7 @@ func getOperatorResult(ctx context.Context, DB database.Database, query string, 
 	}
 
 	if len(operatorResults) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(operatorResults) != 1 {

--- a/src/golang/lib/repos/sqlite/schema_version.go
+++ b/src/golang/lib/repos/sqlite/schema_version.go
@@ -101,7 +101,7 @@ func getSchemaVersion(ctx context.Context, DB database.Database, query string, a
 	}
 
 	if len(schemaVersions) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(schemaVersions) != 1 {

--- a/src/golang/lib/repos/sqlite/user.go
+++ b/src/golang/lib/repos/sqlite/user.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/aqueducthq/aqueduct/lib/database"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models"
 	"github.com/aqueducthq/aqueduct/lib/repos"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 )
 
@@ -114,7 +114,7 @@ func getUser(ctx context.Context, DB database.Database, query string, args ...in
 	}
 
 	if len(users) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(users) != 1 {
@@ -136,7 +136,7 @@ func generateAPIKey(ctx context.Context, DB database.Database) (string, error) {
 
 		r := &userReader{}
 		_, err = r.GetByAPIKey(ctx, apiKey, DB)
-		if err != nil && errors.IsError(err, database.ErrNoRows) {
+		if err != nil && errors.Is(err, database.ErrNoRows()) {
 			// No row with this API key was found
 			return apiKey, nil
 		}

--- a/src/golang/lib/repos/sqlite/workflow.go
+++ b/src/golang/lib/repos/sqlite/workflow.go
@@ -334,7 +334,7 @@ func getWorkflow(ctx context.Context, DB database.Database, query string, args .
 	}
 
 	if len(workflows) == 0 {
-		return nil, database.ErrNoRows
+		return nil, database.ErrNoRows()
 	}
 
 	if len(workflows) != 1 {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There was another `var error = ...` code pattern that is very high priority to refactor, because it was an error seen frequently. So this PR refactors errors defined in `lib/database` so that we capture the stack trace correctly. This builds on the work done by #1076 

## Related issue number (if any)
ENG 2600

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


