### PR TITLE
Eng 2511 deprecate flowconfig in sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,4 +98,4 @@ integration_tests/sdk/test-credentials.yml
 integration_tests/sdk/test-config.yml
 integration_tests/sdk/test-config-run.yml
 
-
+**/.devcontainer/

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -10,7 +10,6 @@ from aqueduct.error import (
     InvalidUserArgumentException,
 )
 from aqueduct.integrations.airflow_integration import AirflowIntegration
-from aqueduct.models.config import FlowConfig
 from aqueduct.models.integration import IntegrationInfo
 
 import aqueduct
@@ -486,41 +485,6 @@ def test_flow_with_args(client):
     # Implicit parameter creation is disallowed for variable-length parameters.
     with pytest.raises(InvalidUserArgumentException):
         foo_with_args(*[str_val, num_val])
-
-
-def test_publish_with_redundant_config_fields(client):
-    """Once the user-facing `FlowConfig` struct is deprecated, we can get rid of this test."""
-
-    @op
-    def noop():
-        return 123
-
-    output = noop()
-
-    # Test redundant engine field.
-    dummy_integration_info = IntegrationInfo(
-        id=uuid.uuid4(),
-        name="dummy",
-        service=ServiceType.LAMBDA,
-        createdAt=123,
-        validated=True,
-    )
-    with pytest.raises(InvalidUserArgumentException):
-        client.publish_flow(
-            generate_new_flow_name(),
-            artifacts=[output],
-            engine="something",
-            config=FlowConfig(engine=AirflowIntegration(dummy_integration_info)),
-        )
-
-    # Test redundant `k_latest_runs` field.
-    with pytest.raises(InvalidUserArgumentException):
-        client.publish_flow(
-            generate_new_flow_name(),
-            artifacts=[output],
-            k_latest_runs=10,
-            config=FlowConfig(k_latest_runs=123),
-        )
 
 
 def test_flow_list_saved_objects_none(client, flow_name, engine):

--- a/scripts/install_local.py
+++ b/scripts/install_local.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         print("Updating the Python SDK...")
         prev_pwd = os.environ["PWD"]
         os.environ["PWD"] = join(os.environ["PWD"], "sdk")
-        execute_command(["pip", "install", "."], cwd=join(cwd, "sdk"))
+        execute_command(["python3", "-m", "pip", "install", "."], cwd=join(cwd, "sdk"))
         os.environ["PWD"] = prev_pwd
 
     # Install the local python operators.
@@ -116,7 +116,7 @@ if __name__ == "__main__":
         print("Updating the Python executor...")
         prev_pwd = os.environ["PWD"]
         os.environ["PWD"] = join(os.environ["PWD"], "src/python")
-        execute_command(["pip", "install", "."], cwd=join(cwd, "src", "python"))
+        execute_command(["python3", "-m", "pip", "install", "."], cwd=join(cwd, "src", "python"))
         os.environ["PWD"] = prev_pwd
 
         execute_command(

--- a/sdk/aqueduct/integrations/__init__.py
+++ b/sdk/aqueduct/integrations/__init__.py
@@ -11,4 +11,5 @@ from aqueduct.integrations.connect_config import (
     SparkConfig,
     SQLiteConfig,
     SqlServerConfig,
+    K8sConfig,
 )

--- a/sdk/aqueduct/models/config.py
+++ b/sdk/aqueduct/models/config.py
@@ -58,21 +58,3 @@ class EngineConfig(BaseModel):
         fields = {
             "name": {"exclude": ...},
         }
-
-
-# TODO(ENG-2511): this is deprecated.
-class FlowConfig(BaseModel):
-    engine: Optional[
-        Union[
-            AirflowIntegration,
-            K8sIntegration,
-            LambdaIntegration,
-            DatabricksIntegration,
-            SparkIntegration,
-        ]
-    ]
-    k_latest_runs: int = -1
-
-    class Config:
-        # Necessary to allow an engine field
-        arbitrary_types_allowed = True

--- a/src/ui/common/src/components/pages/integration/id/index.tsx
+++ b/src/ui/common/src/components/pages/integration/id/index.tsx
@@ -169,6 +169,8 @@ const IntegrationDetailsPage: React.FC<IntegrationDetailsPageProps> = ({
             user={user}
             integrationId={selectedIntegration.id}
             integrationName={selectedIntegration.name}
+            integrationType={selectedIntegration.service}
+            config={selectedIntegration.config}
             onCloseDialog={() => setShowDeleteTableDialog(false)}
           />
         )}

--- a/src/ui/common/src/utils/storage.ts
+++ b/src/ui/common/src/utils/storage.ts
@@ -1,3 +1,5 @@
+import { IntegrationConfig, Service } from './integrations';
+
 export enum StorageType {
   S3 = 's3',
   File = 'file',
@@ -13,10 +15,10 @@ export const StorageTypeNames = {
 export type S3Config = {
   region: string;
   bucket: string;
-  credentials_path: string;
-  credentials_profile: string;
-  aws_access_key_id: string;
-  aws_secret_access_key: string;
+  credentials_path?: string;
+  credentials_profile?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
 };
 
 export type FileConfig = {
@@ -25,7 +27,7 @@ export type FileConfig = {
 
 export type GCSConfig = {
   bucket: string;
-  service_account_credentials: string;
+  service_account_credentials?: string;
 };
 
 export type StorageConfig = {
@@ -34,3 +36,68 @@ export type StorageConfig = {
   file_config?: FileConfig;
   gcs_config?: GCSConfig;
 };
+
+export type MetadataStorageConfig = {
+  type: StorageType;
+  s3Config?: S3Config;
+  fileConfig?: FileConfig;
+  gcsConfig?: GCSConfig;
+};
+
+export type ServerConfig = {
+  aqPath: string;
+  retentionJobPeriod: string;
+  apiKey: string;
+  storageConfig: MetadataStorageConfig;
+};
+
+function convertS3IntegrationtoMetadataStorageConfig(
+  storage: S3Config
+): MetadataStorageConfig {
+  return {
+    type: StorageType.S3,
+    s3Config: {
+      region: storage.region,
+      bucket: 's3://' + storage.bucket,
+    },
+  };
+}
+
+function convertGCSIntegrationtoMetadataStorageConfig(
+  storage: GCSConfig
+): MetadataStorageConfig {
+  return {
+    type: StorageType.GCS,
+    gcsConfig: {
+      bucket: storage.bucket,
+    },
+  };
+}
+
+export function convertIntegrationConfigToServerConfig(
+  storage: IntegrationConfig,
+  metadataStorage: ServerConfig,
+  service: Service
+): ServerConfig {
+  let storageConfig;
+  switch (service) {
+    case 'S3':
+      storageConfig = convertS3IntegrationtoMetadataStorageConfig(
+        storage as S3Config
+      );
+      break;
+    case 'GCS':
+      storageConfig = convertGCSIntegrationtoMetadataStorageConfig(
+        storage as GCSConfig
+      );
+      break;
+    default:
+      return null;
+  }
+  return {
+    aqPath: metadataStorage.aqPath,
+    retentionJobPeriod: metadataStorage.retentionJobPeriod,
+    apiKey: metadataStorage.apiKey,
+    storageConfig: storageConfig,
+  };
+}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Remove the deprecated FlowConfig configuration parameter from publish_flow method
Add the missing K8sConfig for integrations config

## Related issue number (if any)
ENG 2511

## Loom demo (if any)

## Checklist before requesting a review
- [ x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


