### PR TITLE
Make sure deletion of cloud integration is working

### DIFF
--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -184,16 +184,23 @@ class DynamicK8sConfig(BaseConnectionConfig):
 
 
 class AWSConfig(BaseConnectionConfig):
-    access_key_id: str
-    secret_access_key: str
-    region: str
+    # Either 1) all of access_key_id, secret_access_key, region, or 2) both config_file_path and
+    # config_file_profile need to be specified. Any other cases will be rejected by the server's
+    # config validation process.
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    region: str = ""
+    config_file_path: str = ""
+    config_file_profile: str = ""
     k8s: Optional[DynamicK8sConfig]
 
 
 class _AWSConfigWithSerializedConfig(BaseConnectionConfig):
-    access_key_id: str
-    secret_access_key: str
-    region: str
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    region: str = ""
+    config_file_path: str = ""
+    config_file_profile: str = ""
     k8s_serialized: Optional[
         str
     ]  # this is a json-serialized string of AWSConfig.k8s, which is of type DynamicK8sConfig
@@ -335,6 +342,8 @@ def _prepare_aws_config(config: AWSConfig) -> _AWSConfigWithSerializedConfig:
         access_key_id=config.access_key_id,
         secret_access_key=config.secret_access_key,
         region=config.region,
+        config_file_path=config.config_file_path,
+        config_file_profile=config.config_file_profile,
         k8s_serialized=(None if config.k8s is None else config.k8s.json(exclude_none=True)),
     )
 

--- a/src/golang/cmd/server/handler/cloud_integration_utils.go
+++ b/src/golang/cmd/server/handler/cloud_integration_utils.go
@@ -137,7 +137,7 @@ func setupTerraformDirectory(dst string) error {
 // 1. Verifies that there is no workflow using the dynamic k8s integration.
 // 2. Deletes the EKS cluster if it's running.
 // 3. Deletes the cloud integration directory.
-// 4. Deletes the implicitly created dynamic k8s integration.
+// 4. Deletes the Aqueduct-generated dynamic k8s integration.
 func deleteCloudIntegrationHelper(
 	ctx context.Context,
 	args *deleteIntegrationArgs,
@@ -151,20 +151,7 @@ func deleteCloudIntegrationHelper(
 		h.Database,
 	)
 	if err != nil {
-		return http.StatusInternalServerError, errors.Wrap(err, "Failed to retrieve the implicitly created k8s integration.")
-	}
-
-	// If there are active workflows using the dynamic k8s integration, we need to reject the
-	// deletion request immediately, without deleting the cluster and Terraform directories.
-	if statusCode, err := validateNoActiveWorkflowOnIntegration(
-		ctx,
-		k8sIntegration.ID,
-		h.OperatorRepo,
-		h.DAGRepo,
-		h.IntegrationRepo,
-		h.Database,
-	); err != nil {
-		return statusCode, err
+		return http.StatusInternalServerError, errors.Wrap(err, "Failed to retrieve the Aqueduct-generated k8s integration.")
 	}
 
 	// Delete the EKS cluster
@@ -206,7 +193,7 @@ func deleteCloudIntegrationHelper(
 
 	_, statusCode, err = h.Perform(ctx, deleteK8sIntegrationArgs)
 	if err != nil {
-		return statusCode, errors.Wrap(err, "Failed to delete the implicitly created k8s integration.")
+		return statusCode, errors.Wrap(err, "Failed to delete the Aqueduct-generated k8s integration.")
 	}
 
 	return http.StatusOK, nil

--- a/src/golang/cmd/server/handler/cloud_integration_utils.go
+++ b/src/golang/cmd/server/handler/cloud_integration_utils.go
@@ -145,7 +145,7 @@ func deleteCloudIntegrationHelper(
 ) (int, error) {
 	k8sIntegration, err := h.IntegrationRepo.GetByNameAndUser(
 		ctx,
-		fmt.Sprintf("%s:%s", args.integrationObject.Name, dynamic.K8sClusterNameSuffix),
+		fmt.Sprintf("%s:%s", args.integrationObject.Name, dynamic.K8sIntegrationNameSuffix),
 		uuid.Nil,
 		args.OrgID,
 		h.Database,

--- a/src/golang/cmd/server/handler/cloud_integration_utils.go
+++ b/src/golang/cmd/server/handler/cloud_integration_utils.go
@@ -133,6 +133,11 @@ func setupTerraformDirectory(dst string) error {
 	return nil
 }
 
+// deleteCloudIntegrationHelper does the following:
+// 1. Verifies that there is no workflow using the dynamic k8s integration.
+// 2. Deletes the EKS cluster if it's running.
+// 3. Deletes the cloud integration directory.
+// 4. Deletes the implicitly created dynamic k8s integration.
 func deleteCloudIntegrationHelper(
 	ctx context.Context,
 	args *deleteIntegrationArgs,

--- a/src/golang/cmd/server/handler/cloud_integration_utils.go
+++ b/src/golang/cmd/server/handler/cloud_integration_utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 
@@ -130,4 +131,78 @@ func setupTerraformDirectory(dst string) error {
 	}
 
 	return nil
+}
+
+func deleteCloudIntegrationHelper(
+	ctx context.Context,
+	args *deleteIntegrationArgs,
+	h *DeleteIntegrationHandler,
+) (int, error) {
+	k8sIntegration, err := h.IntegrationRepo.GetByNameAndUser(
+		ctx,
+		fmt.Sprintf("%s:%s", args.integrationObject.Name, dynamic.K8sClusterNameSuffix),
+		uuid.Nil,
+		args.OrgID,
+		h.Database,
+	)
+	if err != nil {
+		return http.StatusInternalServerError, errors.Wrap(err, "Failed to retrieve the implicitly created k8s integration.")
+	}
+
+	// If there are active workflows using the dynamic k8s integration, we need to reject the
+	// deletion request immediately, without deleting the cluster and Terraform directories.
+	if statusCode, err := validateNoActiveWorkflowOnIntegration(
+		ctx,
+		k8sIntegration.ID,
+		h.OperatorRepo,
+		h.DAGRepo,
+		h.IntegrationRepo,
+		h.Database,
+	); err != nil {
+		return statusCode, err
+	}
+
+	// Delete the EKS cluster
+	editDynamicEngineArgs := &editDynamicEngineArgs{
+		AqContext:     args.AqContext,
+		action:        forceDeleteAction,
+		integrationId: k8sIntegration.ID,
+		configDelta:   &shared.DynamicK8sConfig{},
+	}
+	_, statusCode, err := (&EditDynamicEngineHandler{
+		Database:        h.Database,
+		IntegrationRepo: h.IntegrationRepo,
+	}).Perform(ctx, editDynamicEngineArgs)
+	if err != nil {
+		return statusCode, errors.Wrap(err, "Failed to delete the dynamic k8s cluster.")
+	}
+
+	// Clean up the cloud integration directory
+	_, stdErr, err := lib_utils.RunCmd("rm", []string{
+		"-rf",
+		path.Dir(k8sIntegration.Config[shared.K8sTerraformPathKey]),
+	}, // get the parent dir of Terraform path
+		"",
+		false,
+	)
+	if err != nil {
+		return http.StatusInternalServerError, errors.New(stdErr)
+	}
+
+	deleteK8sIntegrationArgs := &deleteIntegrationArgs{
+		AqContext:         args.AqContext,
+		integrationObject: k8sIntegration,
+		// We already validated this above, so we skip the validation during the deletion of the
+		// dynamic k8s integration. There may be race conditions where new workflows are deployed
+		// while we clean up the EKS cluster, but in these rare cases we just let the user delete
+		// the broken workflows themselves afterwards.
+		skipActiveWorkflowValidation: true,
+	}
+
+	_, statusCode, err = h.Perform(ctx, deleteK8sIntegrationArgs)
+	if err != nil {
+		return statusCode, errors.Wrap(err, "Failed to delete the implicitly created k8s integration.")
+	}
+
+	return http.StatusOK, nil
 }

--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -101,6 +101,8 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 	emptyResp := deleteIntegrationResponse{}
 
 	if args.integrationObject.Service == shared.AWS {
+		// Note that this will make a call to DeleteIntegrationHandler.Perform() to delete the
+		// Aqueduct-generated dynamic k8s integration.
 		if statusCode, err := deleteCloudIntegrationHelper(ctx, args, h); err != nil {
 			return emptyResp, statusCode, err
 		}

--- a/src/golang/cmd/server/handler/delete_integration.go
+++ b/src/golang/cmd/server/handler/delete_integration.go
@@ -29,7 +29,8 @@ import (
 // The `DeleteIntegrationHandler` does a best effort at deleting an integration.
 type deleteIntegrationArgs struct {
 	*aq_context.AqContext
-	integrationID uuid.UUID
+	integrationObject            *models.Integration
+	skipActiveWorkflowValidation bool
 }
 
 type deleteIntegrationResponse struct{}
@@ -62,6 +63,17 @@ func (h *DeleteIntegrationHandler) Prepare(r *http.Request) (interface{}, int, e
 		return nil, http.StatusBadRequest, errors.Wrap(err, "Malformed integration ID.")
 	}
 
+	integrationObject, err := h.IntegrationRepo.Get(r.Context(), integrationID, h.Database)
+	if err != nil {
+		return nil, http.StatusBadRequest, errors.Wrap(err, "Failed to retrieve integration object.")
+	}
+
+	if integrationObject.Service == shared.Kubernetes {
+		if _, ok := integrationObject.Config[shared.K8sCloudIntegrationIdKey]; ok {
+			return nil, http.StatusUnprocessableEntity, errors.Wrap(err, "Cannot delete implicitly created k8s integration.")
+		}
+	}
+
 	ok, err := h.IntegrationRepo.ValidateOwnership(
 		r.Context(),
 		integrationID,
@@ -78,8 +90,9 @@ func (h *DeleteIntegrationHandler) Prepare(r *http.Request) (interface{}, int, e
 	}
 
 	return &deleteIntegrationArgs{
-		AqContext:     aqContext,
-		integrationID: integrationID,
+		AqContext:                    aqContext,
+		integrationObject:            integrationObject,
+		skipActiveWorkflowValidation: false,
 	}, http.StatusOK, nil
 }
 
@@ -87,21 +100,23 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 	args := interfaceArgs.(*deleteIntegrationArgs)
 	emptyResp := deleteIntegrationResponse{}
 
-	code, err := validateNoActiveWorkflowOnIntegration(
-		ctx,
-		args.integrationID,
-		h.OperatorRepo,
-		h.DAGRepo,
-		h.IntegrationRepo,
-		h.Database,
-	)
-	if err != nil {
-		return emptyResp, code, err
+	if args.integrationObject.Service == shared.AWS {
+		if statusCode, err := deleteCloudIntegrationHelper(ctx, args, h); err != nil {
+			return emptyResp, statusCode, err
+		}
 	}
 
-	integrationObject, err := h.IntegrationRepo.Get(ctx, args.integrationID, h.Database)
-	if err != nil {
-		return emptyResp, http.StatusBadRequest, errors.Wrap(err, "failed to retrieve the given integration.")
+	if !args.skipActiveWorkflowValidation {
+		if statusCode, err := validateNoActiveWorkflowOnIntegration(
+			ctx,
+			args.integrationObject.ID,
+			h.OperatorRepo,
+			h.DAGRepo,
+			h.IntegrationRepo,
+			h.Database,
+		); err != nil {
+			return emptyResp, statusCode, err
+		}
 	}
 
 	txn, err := h.Database.BeginTx(ctx)
@@ -110,7 +125,7 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 	}
 	defer database.TxnRollbackIgnoreErr(ctx, txn)
 
-	err = h.IntegrationRepo.Delete(ctx, args.integrationID, txn)
+	err = h.IntegrationRepo.Delete(ctx, args.integrationObject.ID, txn)
 	if err != nil {
 		return emptyResp, http.StatusInternalServerError, errors.Wrap(err, "Unexpected error occurred while deleting integration.")
 	}
@@ -123,7 +138,7 @@ func (h *DeleteIntegrationHandler) Perform(ctx context.Context, interfaceArgs in
 
 	if err := cleanUpIntegration(
 		ctx,
-		integrationObject,
+		args.integrationObject,
 		h.OperatorRepo,
 		h.WorkflowRepo,
 		vaultObject,

--- a/src/golang/lib/dynamic/engine.go
+++ b/src/golang/lib/dynamic/engine.go
@@ -483,6 +483,8 @@ func generateTerraformVariables(
 	accessKeyVar := fmt.Sprintf("-var=access_key=%s", awsConfig.AccessKeyId)
 	secretAccessKeyVar := fmt.Sprintf("-var=secret_key=%s", awsConfig.SecretAccessKey)
 	regionVar := fmt.Sprintf("-var=region=%s", awsConfig.Region)
+	credentialPathVar := fmt.Sprintf("-var=credentials_file=%s", awsConfig.ConfigFilePath)
+	profileVar := fmt.Sprintf("-var=profile=%s", awsConfig.ConfigFileProfile)
 
 	cpuNodeTypeVar := fmt.Sprintf("-var=cpu_node_type=%s", engineConfig[shared.K8sCpuNodeTypeKey])
 	gpuNodeTypeVar := fmt.Sprintf("-var=gpu_node_type=%s", engineConfig[shared.K8sGpuNodeTypeKey])
@@ -497,6 +499,8 @@ func generateTerraformVariables(
 		accessKeyVar,
 		secretAccessKeyVar,
 		regionVar,
+		credentialPathVar,
+		profileVar,
 		cpuNodeTypeVar,
 		gpuNodeTypeVar,
 		minCpuNodeVar,

--- a/src/golang/lib/engine/authenticate.go
+++ b/src/golang/lib/engine/authenticate.go
@@ -79,8 +79,16 @@ func AuthenticateAWSConfig(authConf auth.Config) error {
 		return errors.Wrap(err, "Unable to parse configuration.")
 	}
 
-	if conf.AccessKeyId == "" || conf.SecretAccessKey == "" || conf.Region == "" {
-		return errors.New("AWS access key ID, secret access key, and region must be provided.")
+	if conf.AccessKeyId != "" && conf.SecretAccessKey != "" && conf.Region != "" {
+		if conf.ConfigFilePath != "" || conf.ConfigFileProfile != "" {
+			return errors.New("When authenticating via access keys, credential file path and profile must be empty.")
+		}
+	} else if conf.ConfigFilePath != "" && conf.ConfigFileProfile != "" {
+		if conf.AccessKeyId != "" || conf.SecretAccessKey != "" || conf.Region != "" {
+			return errors.New("When authenticating via credential file, access key fields must be empty.")
+		}
+	} else {
+		return errors.New("Either 1) AWS access key ID, secret access key, region, or 2) credential file path, profile must be provided.")
 	}
 
 	return nil

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -84,21 +84,37 @@ func RunCmd(command string, args []string, dir string, stream bool) (string, str
 		stdoutScanner := bufio.NewScanner(stdout)
 		stderrScanner := bufio.NewScanner(stderr)
 
+		var stderrMsg string
+		// Create a channel to communicate between the main process and the goroutine to exchange
+		// the stderr message.
+		ch := make(chan string)
+
 		// start separate goroutines to stream the output from each scanner
 		go func() {
+			// When the cmd exits, the scanner will break out of the loop.
 			for stdoutScanner.Scan() {
 				log.Infof("stdout: %s", stdoutScanner.Text())
 			}
 		}()
 		go func() {
+			var sb strings.Builder
+			// When the cmd exits, the scanner will break out of the loop.
 			for stderrScanner.Scan() {
 				log.Errorf("stderr: %s", stderrScanner.Text())
+				sb.WriteString(stderrScanner.Text())
+				sb.WriteString("\n")
 			}
+			ch <- sb.String()
 		}()
 
-		// wait for the command to complete
+		// Wait for the stderr goroutine to finish and receive the stderr from the channel.
+		// Even if there is no stderr message and we send an empty string to the channel,
+		// we will still be unblocked.
+		stderrMsg = <-ch
+
+		// Wait for the command to complete.
 		if err := cmd.Wait(); err != nil {
-			return "", "", errors.Wrap(err, "Error waiting for command to complete")
+			return "", stderrMsg, errors.New(stderrMsg)
 		}
 
 		return "", "", nil
@@ -246,10 +262,12 @@ func ParseAWSConfig(conf auth.Config) (*shared.AWSConfig, error) {
 	}
 
 	var c struct {
-		AccessKeyId     string `json:"access_key_id"`
-		SecretAccessKey string `json:"secret_access_key"`
-		Region          string `json:"region"`
-		K8sSerialized   string `json:"k8s_serialized"`
+		AccessKeyId       string `json:"access_key_id"`
+		SecretAccessKey   string `json:"secret_access_key"`
+		Region            string `json:"region"`
+		ConfigFilePath    string `json:"config_file_path"`
+		ConfigFileProfile string `json:"config_file_profile"`
+		K8sSerialized     string `json:"k8s_serialized"`
 	}
 	if err := json.Unmarshal(data, &c); err != nil {
 		return nil, err
@@ -263,10 +281,12 @@ func ParseAWSConfig(conf auth.Config) (*shared.AWSConfig, error) {
 	}
 
 	return &shared.AWSConfig{
-		AccessKeyId:     c.AccessKeyId,
-		SecretAccessKey: c.SecretAccessKey,
-		Region:          c.Region,
-		K8s:             &dynamicK8sConfig,
+		AccessKeyId:       c.AccessKeyId,
+		SecretAccessKey:   c.SecretAccessKey,
+		Region:            c.Region,
+		ConfigFilePath:    c.ConfigFilePath,
+		ConfigFileProfile: c.ConfigFileProfile,
+		K8s:               &dynamicK8sConfig,
 	}, nil
 }
 

--- a/src/golang/lib/models/shared/integration_config.go
+++ b/src/golang/lib/models/shared/integration_config.go
@@ -192,10 +192,12 @@ func (config *DynamicK8sConfig) Update(newConfig *DynamicK8sConfig) {
 }
 
 type AWSConfig struct {
-	AccessKeyId     string            `json:"access_key_id"`
-	SecretAccessKey string            `json:"secret_access_key"`
-	Region          string            `json:"region"`
-	K8s             *DynamicK8sConfig `json:"k8s"`
+	AccessKeyId       string            `json:"access_key_id"`
+	SecretAccessKey   string            `json:"secret_access_key"`
+	Region            string            `json:"region"`
+	ConfigFilePath    string            `json:"config_file_path"`
+	ConfigFileProfile string            `json:"config_file_profile"`
+	K8s               *DynamicK8sConfig `json:"k8s"`
 }
 
 type SparkIntegrationConfig struct {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR does the following:
1. Disallow users to delete the implicitly created k8s integration.
2. Allow deleting the cloud integration only when there is no workflow using the dynamic k8s integration.
3. GC the EKS cluster if it's running, and delete the cloud integration directory that contains Terraform files.
4. Also delete the implicitly created dynamic k8s integration when deleting the cloud integration.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


