### PR TITLE
[ENG-2631] Fixes bug that caused navigation buttons to be misaligned

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -551,7 +551,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
                 <Tooltip title="Previous Run" arrow>
                   <Box sx={{ px: 0, flex: 1 }}>
                     <Button
-                      sx={{ fontSize: '28px' }}
+                      sx={{ fontSize: '28px', width: '100%' }}
                       variant="text"
                       onClick={() => {
                         // This might be confusing, but index 0 is the most recent run, so incrementing the index goes
@@ -575,7 +575,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
                 <Tooltip title="Next Run" arrow>
                   <Box sx={{ px: 0, flex: 1 }}>
                     <Button
-                      sx={{ fontSize: '28px' }}
+                      sx={{ fontSize: '28px', width: '100%' }}
                       variant="text"
                       onClick={() => {
                         // This might be confusing, but index 0 is the most recent run, so decrementing the index goes

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -216,7 +216,7 @@ const WorkflowHeader: React.FC<Props> = ({ workflowDag }) => {
               ),
             }}
           >
-            {description ?? '*No description.*'}
+            {description === '' ? '*No description.*' : description}
           </Markdown>
         </Box>
       </Collapse>


### PR DESCRIPTION
## Describe your changes and why you are making these changes

In the latest release, we regressed the alignment of this button. This PR fixes that.

## Related issue number (if any)

ENG-2631

## Loom demo (if any)

*Current version (v0.2.6)*
<img width="132" alt="image" src="https://user-images.githubusercontent.com/867892/225515566-5c826491-cb3b-4ef2-9601-b078cdf101c2.png">

*Fixed, as of this PR*:
<img width="142" alt="image" src="https://user-images.githubusercontent.com/867892/225515586-faaae023-b6b2-4538-a37a-c03c224ff756.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


