### PR TITLE
Use context.Background() for deferred functions

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -471,7 +471,7 @@ func ValidateConfig(
 
 	defer func() {
 		// Delete storage files created for authenticate job metadata
-		go utils.CleanupStorageFiles(ctx, storageConfig, []string{jobMetadataPath})
+		go utils.CleanupStorageFiles(context.Background(), storageConfig, []string{jobMetadataPath})
 	}()
 
 	jobSpec := job.NewAuthenticateSpec(

--- a/src/golang/cmd/server/handler/delete_workflow.go
+++ b/src/golang/cmd/server/handler/delete_workflow.go
@@ -283,7 +283,7 @@ func DeleteSavedObject(
 
 	defer func() {
 		// Delete storage files created for delete saved objects job metadata
-		go workflow_utils.CleanupStorageFiles(ctx, storageConfig, []string{jobMetadataPath, contentPath})
+		go workflow_utils.CleanupStorageFiles(context.Background(), storageConfig, []string{jobMetadataPath, contentPath})
 	}()
 
 	integrationConfigs := make(map[string]auth.Config, len(integrationNameToID))

--- a/src/golang/cmd/server/handler/discover.go
+++ b/src/golang/cmd/server/handler/discover.go
@@ -117,7 +117,7 @@ func (h *DiscoverHandler) Perform(
 
 	defer func() {
 		// Delete storage files created for list tables job metadata
-		go workflow_utils.CleanupStorageFiles(ctx, args.StorageConfig, []string{jobMetadataPath, jobResultPath})
+		go workflow_utils.CleanupStorageFiles(context.Background(), args.StorageConfig, []string{jobMetadataPath, jobResultPath})
 	}()
 
 	storageConfig := config.Storage()

--- a/src/golang/cmd/server/handler/list_integration_objects.go
+++ b/src/golang/cmd/server/handler/list_integration_objects.go
@@ -94,7 +94,7 @@ func (h *ListIntegrationObjectsHandler) Perform(ctx context.Context, interfaceAr
 
 	defer func() {
 		// Delete storage files created for list objects job metadata
-		go workflow_utils.CleanupStorageFiles(ctx, args.StorageConfig, []string{jobMetadataPath, jobResultPath})
+		go workflow_utils.CleanupStorageFiles(context.Background(), args.StorageConfig, []string{jobMetadataPath, jobResultPath})
 	}()
 
 	storageConfig := config.Storage()

--- a/src/golang/cmd/server/handler/preview_table.go
+++ b/src/golang/cmd/server/handler/preview_table.go
@@ -127,7 +127,7 @@ func (h *PreviewTableHandler) Perform(ctx context.Context, interfaceArgs interfa
 
 	defer func() {
 		// Delete storage files created for preview table data
-		go workflow_utils.CleanupStorageFiles(ctx, args.StorageConfig, []string{operatorMetadataPath, artifactMetadataPath, artifactContentPath})
+		go workflow_utils.CleanupStorageFiles(context.Background(), args.StorageConfig, []string{operatorMetadataPath, artifactMetadataPath, artifactContentPath})
 	}()
 
 	var queryParams connector.ExtractParams

--- a/src/golang/lib/airflow/schedule.go
+++ b/src/golang/lib/airflow/schedule.go
@@ -204,7 +204,7 @@ func ScheduleWorkflow(
 	operatorOutputPath := fmt.Sprintf("compile-airflow-output-%s", uuid.New().String())
 
 	defer func() {
-		go utils.CleanupStorageFiles(ctx, &dag.StorageConfig, []string{operatorMetadataPath, operatorOutputPath})
+		go utils.CleanupStorageFiles(context.Background(), &dag.StorageConfig, []string{operatorMetadataPath, operatorOutputPath})
 	}()
 
 	jobName := fmt.Sprintf("compile-airflow-operator-%s", uuid.New().String())


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previously, we had called :
```
defer func() {
		// Delete storage files created for list objects job metadata
		go workflow_utils.CleanupStorageFiles(ctx, args.StorageConfig, []string{jobMetadataPath, jobResultPath})
	}()
```

We shouldn't be using the passed in context (since it will get canceled). This PR switches to using context.Background().
## Related issue number (if any)
[Eng-2570
](https://linear.app/aqueducthq/issue/ENG-2570/fix-bug-where-the-server-errors-with-context-cancelled-when-previewing)## Loom demo (if any)
Fixed output after previewing a base table on the UI
```
INFO[0023]/home/ubuntu/aqueduct/src/golang/lib/job/process.go:382 github.com/aqueducthq/aqueduct/lib/job.(*ProcessJobManager).Poll() Job extract-operator-bdb37a05-9c88-4d8d-873c-27307b338d86 Stdout:
 Running Connector for extract job: extract-operator-bdb37a05-9c88-4d8d-873c-27307b338d86
Compiling queries ['SELECT * FROM customer_activity;'] .
Compiled query is SELECT * FROM customer_activity; .
Expanded query is `SELECT * FROM customer_activity;`.
User execution succeeded. Full log: {"user_logs": {"stdout": "", "stderr": ""}, "status": "pending", "failure_type": null, "error": null}
writing to s3: artifact-content-f54cee3c-c44a-11ed-b15a-0a956c5df36e
writing to s3: artifact-metadata-f54cee3c-c44a-11ed-b15a-0a956c5df36e
writing to s3: operator-metadata-f54cee3c-c44a-11ed-b15a-0a956c5df36e
{
    "job": "extract-operator-bdb37a05-9c88-4d8d-873c-27307b338d86",
    "type": "extract",
    "step": "Running Connector",
    "latency(s)": 4.430547475814819
}

 Stderr:
 /home/ubuntu/anaconda3/lib/python3.9/site-packages/snowflake/connector/options.py:96: UserWarning: You have an incompatible version of 'pyarrow' installed (7.0.0), please install a version that adheres to: 'pyarrow<8.1.0,>=8.0.0; extra == "pandas"'
  warn_incompatible_dep(
INFO[0023]/home/ubuntu/aqueduct/src/golang/lib/logging/response.go:76 github.com/aqueducthq/aqueduct/lib/logging.LogRoute()                                               Code=200 Component=Server Error= Headers=map[Cookie:[aqueduct-api-key=H2JTRVUSN1YME0Q3OBGZ9PC4L75KWAF8] Table-Name:[customer_activity]] Route=PreviewTable ServiceName= Status=SUCCEEDED URL=/api/integration/26a88d31-8ccc-4c8e-9e6b-73e10709e1e4/preview UserId=f7022127-05f0-4dc5-8fba-3f7fce997309 UserRequestId=f54cee3c-c44a-11ed-b15a-0a956c5df36e
2023/03/16 22:36:20 "GET http://3.130.165.53:8080/api/integration/26a88d31-8ccc-4c8e-9e6b-73e10709e1e4/preview HTTP/1.1" from 136.25.74.20:49317 - 200 972321B in 6.000788732s
```

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


