### PR TITLE
Surface error message to the user when setting the `stream` flag to true

### DIFF
--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -184,16 +184,23 @@ class DynamicK8sConfig(BaseConnectionConfig):
 
 
 class AWSConfig(BaseConnectionConfig):
-    access_key_id: str
-    secret_access_key: str
-    region: str
+    # Either 1) all of access_key_id, secret_access_key, region, or 2) both config_file_path and
+    # config_file_profile need to be specified. Any other cases will be rejected by the server's
+    # config validation process.
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    region: str = ""
+    config_file_path: str = ""
+    config_file_profile: str = ""
     k8s: Optional[DynamicK8sConfig]
 
 
 class _AWSConfigWithSerializedConfig(BaseConnectionConfig):
-    access_key_id: str
-    secret_access_key: str
-    region: str
+    access_key_id: str = ""
+    secret_access_key: str = ""
+    region: str = ""
+    config_file_path: str = ""
+    config_file_profile: str = ""
     k8s_serialized: Optional[
         str
     ]  # this is a json-serialized string of AWSConfig.k8s, which is of type DynamicK8sConfig
@@ -335,6 +342,8 @@ def _prepare_aws_config(config: AWSConfig) -> _AWSConfigWithSerializedConfig:
         access_key_id=config.access_key_id,
         secret_access_key=config.secret_access_key,
         region=config.region,
+        config_file_path=config.config_file_path,
+        config_file_profile=config.config_file_profile,
         k8s_serialized=(None if config.k8s is None else config.k8s.json(exclude_none=True)),
     )
 

--- a/src/golang/lib/dynamic/engine.go
+++ b/src/golang/lib/dynamic/engine.go
@@ -483,6 +483,8 @@ func generateTerraformVariables(
 	accessKeyVar := fmt.Sprintf("-var=access_key=%s", awsConfig.AccessKeyId)
 	secretAccessKeyVar := fmt.Sprintf("-var=secret_key=%s", awsConfig.SecretAccessKey)
 	regionVar := fmt.Sprintf("-var=region=%s", awsConfig.Region)
+	credentialPathVar := fmt.Sprintf("-var=credentials_file=%s", awsConfig.ConfigFilePath)
+	profileVar := fmt.Sprintf("-var=profile=%s", awsConfig.ConfigFileProfile)
 
 	cpuNodeTypeVar := fmt.Sprintf("-var=cpu_node_type=%s", engineConfig[shared.K8sCpuNodeTypeKey])
 	gpuNodeTypeVar := fmt.Sprintf("-var=gpu_node_type=%s", engineConfig[shared.K8sGpuNodeTypeKey])
@@ -497,6 +499,8 @@ func generateTerraformVariables(
 		accessKeyVar,
 		secretAccessKeyVar,
 		regionVar,
+		credentialPathVar,
+		profileVar,
 		cpuNodeTypeVar,
 		gpuNodeTypeVar,
 		minCpuNodeVar,

--- a/src/golang/lib/engine/authenticate.go
+++ b/src/golang/lib/engine/authenticate.go
@@ -79,8 +79,16 @@ func AuthenticateAWSConfig(authConf auth.Config) error {
 		return errors.Wrap(err, "Unable to parse configuration.")
 	}
 
-	if conf.AccessKeyId == "" || conf.SecretAccessKey == "" || conf.Region == "" {
-		return errors.New("AWS access key ID, secret access key, and region must be provided.")
+	if conf.AccessKeyId != "" && conf.SecretAccessKey != "" && conf.Region != "" {
+		if conf.ConfigFilePath != "" || conf.ConfigFileProfile != "" {
+			return errors.New("When authenticating via access keys, credential file path and profile must be empty.")
+		}
+	} else if conf.ConfigFilePath != "" && conf.ConfigFileProfile != "" {
+		if conf.AccessKeyId != "" || conf.SecretAccessKey != "" || conf.Region != "" {
+			return errors.New("When authenticating via credential file, access key fields must be empty.")
+		}
+	} else {
+		return errors.New("Either 1) AWS access key ID, secret access key, region, or 2) credential file path, profile must be provided.")
 	}
 
 	return nil

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -98,6 +98,7 @@ func RunCmd(command string, args []string, dir string, stream bool) (string, str
 		go func() {
 			var sb strings.Builder
 			for stderrScanner.Scan() {
+				log.Errorf("stderr: %s", stderrScanner.Text())
 				sb.WriteString(stderrScanner.Text())
 				sb.WriteString("\n")
 			}

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -262,10 +262,12 @@ func ParseAWSConfig(conf auth.Config) (*shared.AWSConfig, error) {
 	}
 
 	var c struct {
-		AccessKeyId     string `json:"access_key_id"`
-		SecretAccessKey string `json:"secret_access_key"`
-		Region          string `json:"region"`
-		K8sSerialized   string `json:"k8s_serialized"`
+		AccessKeyId       string `json:"access_key_id"`
+		SecretAccessKey   string `json:"secret_access_key"`
+		Region            string `json:"region"`
+		ConfigFilePath    string `json:"config_file_path"`
+		ConfigFileProfile string `json:"config_file_profile"`
+		K8sSerialized     string `json:"k8s_serialized"`
 	}
 	if err := json.Unmarshal(data, &c); err != nil {
 		return nil, err
@@ -279,10 +281,12 @@ func ParseAWSConfig(conf auth.Config) (*shared.AWSConfig, error) {
 	}
 
 	return &shared.AWSConfig{
-		AccessKeyId:     c.AccessKeyId,
-		SecretAccessKey: c.SecretAccessKey,
-		Region:          c.Region,
-		K8s:             &dynamicK8sConfig,
+		AccessKeyId:       c.AccessKeyId,
+		SecretAccessKey:   c.SecretAccessKey,
+		Region:            c.Region,
+		ConfigFilePath:    c.ConfigFilePath,
+		ConfigFileProfile: c.ConfigFileProfile,
+		K8s:               &dynamicK8sConfig,
 	}, nil
 }
 

--- a/src/golang/lib/lib_utils/utils.go
+++ b/src/golang/lib/lib_utils/utils.go
@@ -91,12 +91,14 @@ func RunCmd(command string, args []string, dir string, stream bool) (string, str
 
 		// start separate goroutines to stream the output from each scanner
 		go func() {
+			// When the cmd exits, the scanner will break out of the loop.
 			for stdoutScanner.Scan() {
 				log.Infof("stdout: %s", stdoutScanner.Text())
 			}
 		}()
 		go func() {
 			var sb strings.Builder
+			// When the cmd exits, the scanner will break out of the loop.
 			for stderrScanner.Scan() {
 				log.Errorf("stderr: %s", stderrScanner.Text())
 				sb.WriteString(stderrScanner.Text())
@@ -106,6 +108,8 @@ func RunCmd(command string, args []string, dir string, stream bool) (string, str
 		}()
 
 		// Wait for the stderr goroutine to finish and receive the stderr from the channel.
+		// Even if there is no stderr message and we send an empty string to the channel,
+		// we will still be unblocked.
 		stderrMsg = <-ch
 
 		// Wait for the command to complete.

--- a/src/golang/lib/models/shared/integration_config.go
+++ b/src/golang/lib/models/shared/integration_config.go
@@ -192,10 +192,12 @@ func (config *DynamicK8sConfig) Update(newConfig *DynamicK8sConfig) {
 }
 
 type AWSConfig struct {
-	AccessKeyId     string            `json:"access_key_id"`
-	SecretAccessKey string            `json:"secret_access_key"`
-	Region          string            `json:"region"`
-	K8s             *DynamicK8sConfig `json:"k8s"`
+	AccessKeyId       string            `json:"access_key_id"`
+	SecretAccessKey   string            `json:"secret_access_key"`
+	Region            string            `json:"region"`
+	ConfigFilePath    string            `json:"config_file_path"`
+	ConfigFileProfile string            `json:"config_file_profile"`
+	K8s               *DynamicK8sConfig `json:"k8s"`
 }
 
 type SparkIntegrationConfig struct {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Previously, when we set the `stream` flag to true, we are only streaming the error message to the server log but not returning the error to the user. This PR make it so that the error log is also captured and returned to the user (instead of just saying "Error waiting for command to complete" which is not useful).

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


