### PR TITLE
ENG-2620 DAG Line Crossing Fix

### DIFF
--- a/src/golang/cmd/server/handler/get_node_positions.go
+++ b/src/golang/cmd/server/handler/get_node_positions.go
@@ -141,8 +141,8 @@ func orderNodes(operatorIdToInputOutput map[uuid.UUID]request.OperatorMapping) (
 func positionNodes(operators map[uuid.UUID]request.OperatorMapping) (map[uuid.UUID]nodePositions, map[uuid.UUID]nodePositions) {
 	NodeBaseX := 100
 	NodeBaseY := 200
-	IndentX := 325
-	IndentY := 300
+	IndentX := 500
+	IndentY := 250
 
 	layers, activeLayerEdges := orderNodes(operators)
 

--- a/src/ui/common/src/reducers/workflow.ts
+++ b/src/ui/common/src/reducers/workflow.ts
@@ -458,7 +458,6 @@ export const handleGetSelectDagPosition = createAsyncThunk<
     const { apiKey, operators, artifacts, onChange, onConnect } = args;
     // NOTE: This should get us better line drawing in terms of less edge overlaps.
     // You will still notice that edges are too long where we collapse nodes
-
     // ... the positioning code on our backend only takes into account a uuid:operator and uuid:artifact mapping
     // so it's not so easy to check an operator/artifact's spec type on the backend since we're just dealing
     // with a map of UUIds.
@@ -482,7 +481,9 @@ export const handleGetSelectDagPosition = createAsyncThunk<
       .filter((op) => {
         return op.spec.type != OperatorType.Param;
       })
-      .map((op) => getOperatorNode(op, opPositions[op.id], onChange, onConnect));
+      .map((op) =>
+        getOperatorNode(op, opPositions[op.id], onChange, onConnect)
+      );
     const artfNodes = Object.values(artifacts).map((artf) =>
       getArtifactNode(artf, artfPositions[artf.id], onChange, onConnect)
     );
@@ -494,7 +495,6 @@ export const handleGetSelectDagPosition = createAsyncThunk<
     const dag = thunkAPI.getState().workflowReducer.selectedDag;
     const artifactResults =
       thunkAPI.getState().workflowReducer.artifactResults ?? {};
-
 
     if (!!dag) {
       return collapsePosition(allNodes, dag, artifactResults);

--- a/src/ui/common/src/utils/reactflow.ts
+++ b/src/ui/common/src/utils/reactflow.ts
@@ -45,7 +45,7 @@ export function getOperatorNode(
   op: Operator,
   pos: NodePos,
   onChange: () => void,
-  onConnect: (any) => void,
+  onConnect: (any) => void
 ): Node<ReactFlowNodeData> {
   return {
     id: op.id,
@@ -58,8 +58,6 @@ export function getOperatorNode(
       nodeId: op.id,
       label: op.name,
     },
-    // Give an initial position. We will reposition this node later.
-    //position: { x: 0, y: 0 },
     position: pos,
   };
 }
@@ -68,7 +66,7 @@ export function getArtifactNode(
   artf: Artifact,
   pos: NodePos,
   onChange: () => void,
-  onConnect: (any) => void,
+  onConnect: (any) => void
 ): Node<ReactFlowNodeData> {
   return {
     id: artf.id,
@@ -81,9 +79,7 @@ export function getArtifactNode(
       nodeId: artf.id,
       label: artf.name,
     },
-    // Give an initial position. We will reposition this node later.
-    //position: { x: 0, y: 0 },
-    position: pos
+    position: pos,
   };
 }
 

--- a/src/ui/common/src/utils/reactflow.ts
+++ b/src/ui/common/src/utils/reactflow.ts
@@ -43,8 +43,9 @@ type NodePos = { x: number; y: number };
 
 export function getOperatorNode(
   op: Operator,
+  pos: NodePos,
   onChange: () => void,
-  onConnect: (any) => void
+  onConnect: (any) => void,
 ): Node<ReactFlowNodeData> {
   return {
     id: op.id,
@@ -58,14 +59,16 @@ export function getOperatorNode(
       label: op.name,
     },
     // Give an initial position. We will reposition this node later.
-    position: { x: 0, y: 0 },
+    //position: { x: 0, y: 0 },
+    position: pos,
   };
 }
 
 export function getArtifactNode(
   artf: Artifact,
+  pos: NodePos,
   onChange: () => void,
-  onConnect: (any) => void
+  onConnect: (any) => void,
 ): Node<ReactFlowNodeData> {
   return {
     id: artf.id,
@@ -79,7 +82,8 @@ export function getArtifactNode(
       label: artf.name,
     },
     // Give an initial position. We will reposition this node later.
-    position: { x: 0, y: 0 },
+    //position: { x: 0, y: 0 },
+    position: pos
   };
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR removes elk and brings back the old positioning algorithm.

Edge crossings should be much less likely, however they might seem a little long when there is a collapsed DAG node.

## Related issue number (if any)
ENG-2620

## Loom demo (if any)
Screehshots:
<img width="1881" alt="image" src="https://user-images.githubusercontent.com/1031759/226148890-78bfdf0a-dbbe-4925-b20c-da63a5c391da.png">

<img width="1875" alt="image" src="https://user-images.githubusercontent.com/1031759/226148896-f73cb33f-5172-489f-9199-f9ff6ab62ffb.png">

<img width="1882" alt="image" src="https://user-images.githubusercontent.com/1031759/226148897-973675fe-5086-4b2b-b4b8-043648b6c12c.png">


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


