### PR TITLE
ENG-2339 Empty String Parameter Rendering Fix

### DIFF
--- a/manual_qa_tests/workflows/succeed_parameters.py
+++ b/manual_qa_tests/workflows/succeed_parameters.py
@@ -7,21 +7,27 @@ DESCRIPTION = """* Workflows Page: should succeed.
 * Workflow Details Page: everything should be green.
     * There should be 2 versions.
     * Click into `bound` parameters, the value of the later version should be 5.
-    The value of the older version should be 10."""
+    The value of the older version should be 10.
+    * Click into `empty_str` parameter. Nothing should show underneath Preview header."""
 
 
 @aq.check(requirements=[])
 def check(df, bound):
     return df.shape[0] > bound
 
+@aq.check(requirements=[])
+def empty_str_check(df, empty_str):
+    return len(empty_str) == 0
 
 def deploy(client, integration_name):
     integration = client.integration(integration_name)
     client.create_param("table", default="hotel_reviews")
     bound = client.create_param("bound", default=10)
+    empty_str = client.create_param("empty_str", default="")
 
     reviews = integration.sql("SELECT * FROM {{ table }}")
     check(reviews, bound)
+    empty_str_check(reviews, empty_str)
     flow = client.publish_flow(
         artifacts=[reviews],
         name=NAME,
@@ -29,4 +35,4 @@ def deploy(client, integration_name):
         schedule="",
     )
     time.sleep(5)
-    client.trigger(flow.id(), parameters={"bound": 5})
+    client.trigger(flow.id(), parameters={"bound": 5, "empty_str": ""})


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds a case to the manual ui tests to check that a parameter with an empty string is able to render properly in a workflow.

As is, the parameter is now rendering on the UI, so I was not able to reproduce this bug. However I did update the test case so that we can be sure to check for this in the future.


## Related issue number (if any)
ENG-2339

## Loom demo (if any)
https://www.loom.com/share/4f11dbb49dc74269b5010200b778ac6f

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


