### PR TITLE
Fix bug where all errors were surfaced as workflow-level errors

### DIFF
--- a/src/golang/.golangci.yml
+++ b/src/golang/.golangci.yml
@@ -11,13 +11,10 @@ output:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - staticcheck
-    - structcheck
     - unused
-    - varcheck
     - bidichk
     - decorder
     - exhaustive

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -950,7 +950,7 @@ func (eng *aqEngine) execute(
 
 	for len(inProgressOps) > 0 {
 		if time.Since(start) > timeConfig.ExecTimeout {
-			return errors.New("Reached timeout waiting for workflow to complete.")
+			return errors.Newf("Reached timeout %s waiting for workflow to complete.", timeConfig.ExecTimeout)
 		}
 
 		for _, op := range inProgressOps {

--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -189,9 +189,14 @@ func (eng *aqEngine) ExecuteWorkflow(
 		if err != nil {
 			// Mark the workflow dag result as failed
 			execState.Status = shared.FailedExecutionStatus
-			execState.Error = &shared.Error{
-				Context: err.Error(),
-				Tip:     "A workflow-level error occurred!",
+
+			// Only set the workflow-level error if the error occurred outside the context
+			// of any single operator's execution. (eg. workflow timed out)
+			if !isOpFailureError(err) {
+				execState.Error = &shared.Error{
+					Context: err.Error(),
+					Tip:     "A workflow-level error occurred!",
+				}
 			}
 
 			now := time.Now()

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 func waitForInProgressOperators(

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -3,8 +3,6 @@ package engine
 import (
 	"context"
 	"time"
-
-
 	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator"

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -3,11 +3,13 @@ package engine
 import (
 	"context"
 	"time"
+
 	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"time"
 )
 
 func waitForInProgressOperators(

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -2,11 +2,11 @@ package engine
 
 import (
 	"context"
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"time"
 
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator"
-	"github.com/dropbox/godropbox/errors"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,6 +36,8 @@ func waitForInProgressOperators(
 	}
 }
 
+// The two error types returned here indicate that the issue happened within the context
+// of the operator.
 func opFailureError(failureType shared.FailureType, op operator.Operator) error {
 	if failureType == shared.SystemFailure {
 		return ErrOpExecSystemFailure
@@ -44,4 +46,8 @@ func opFailureError(failureType shared.FailureType, op operator.Operator) error 
 		return ErrOpExecBlockingUserFailure
 	}
 	return errors.Newf("Internal error: Unsupported failure type %v", failureType)
+}
+
+func isOpFailureError(err error) bool {
+	return errors.Is(err, ErrOpExecSystemFailure) || errors.Is(err, ErrOpExecBlockingUserFailure)
 }

--- a/src/golang/lib/engine/utils.go
+++ b/src/golang/lib/engine/utils.go
@@ -2,9 +2,10 @@ package engine
 
 import (
 	"context"
-	"github.com/aqueducthq/aqueduct/lib/errors"
 	"time"
 
+
+	"github.com/aqueducthq/aqueduct/lib/errors"
 	"github.com/aqueducthq/aqueduct/lib/models/shared"
 	"github.com/aqueducthq/aqueduct/lib/workflow/operator"
 	"github.com/google/uuid"

--- a/src/golang/lib/errors/errors.go
+++ b/src/golang/lib/errors/errors.go
@@ -4,19 +4,10 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-// Fetches the error message from the error. For Dropbox errors, we exclude the stack trace.
-func getMessage(err error) string {
-	if dbxErr, isDbxErr := err.(errors.DropboxError); isDbxErr {
-		return dbxErr.GetMessage()
-	} else {
-		return err.Error()
-	}
-}
-
 // Is is our custom error comparison method. The candidate error can be arbitrarily wrapped,
 // but the root error is one we care about and want to compare.
 //
-// The assumption for the target error is that it unwrapped, hence why we do no such unwrapping
+// The assumption for the target error is that it is unwrapped, hence why we do no such unwrapping
 // for that error. This is because the target error is expected to be simple. Eg. `db.ErrNotFound`.
 //
 // To compare errors, we compare the root error message with the target error message. Any stack traces
@@ -27,14 +18,14 @@ func Is(err, target error) bool {
 		return true
 	}
 
-	// Otherwise, we'll have to perform a comparison of the error strings.
+	// Otherwise, we must perform a comparison of the error strings.
 	rootErrStr := ""
 	rootErr := errors.RootError(err)
 	if rootErr != nil {
-		rootErrStr = getMessage(rootErr)
+		rootErrStr = errors.GetMessage(rootErr)
 	}
 
-	targetMsg := getMessage(target)
+	targetMsg := errors.GetMessage(target)
 	return rootErrStr == targetMsg
 }
 

--- a/src/golang/lib/errors/errors.go
+++ b/src/golang/lib/errors/errors.go
@@ -4,7 +4,7 @@ import (
 	"github.com/dropbox/godropbox/errors"
 )
 
-// TODO: Same as Dropbox's IsError(), but ...
+// Fetches the error message from the error. For Dropbox errors, we exclude the stack trace.
 func getMessage(err error) string {
 	if dbxErr, isDbxErr := err.(errors.DropboxError); isDbxErr {
 		return dbxErr.GetMessage()
@@ -13,7 +13,14 @@ func getMessage(err error) string {
 	}
 }
 
-// TODO: Is() is our custom error comparison method.
+// Is is our custom error comparison method. The candidate error can be arbitrarily wrapped,
+// but the root error is one we care about and want to compare.
+//
+// The assumption for the target error is that it unwrapped, hence why we do no such unwrapping
+// for that error. This is because the target error is expected to be simple. Eg. `db.ErrNotFound`.
+//
+// To compare errors, we compare the root error message with the target error message. Any stack traces
+// provided by Dropbox errors are excluded.
 func Is(err, target error) bool {
 	// If the errors, directly match, we're done.
 	if err == target {

--- a/src/golang/lib/errors/errors_test.go
+++ b/src/golang/lib/errors/errors_test.go
@@ -1,42 +1,97 @@
 package errors
 
 import (
-	stderrors "errors"
-	"io"
+	"errors"
 	"testing"
 
-	"github.com/dropbox/godropbox/errors"
 	"github.com/stretchr/testify/require"
 )
 
-func TestIs(t *testing.T) {
+func createErrWithDbxRoot(errMsgs []string) error {
+	err := New(errMsgs[0])
+
+	for i := 1; i < len(errMsgs); i++ {
+		err = Wrap(err, errMsgs[i])
+	}
+	return err
+}
+
+func createErrWithStdRoot(errMsgs []string) error {
+	err := errors.New(errMsgs[0])
+
+	// Assumption: Standard errors are still wrapped with our custom Wrap() function.
+	for i := 1; i < len(errMsgs); i++ {
+		err = Wrap(err, errMsgs[i])
+	}
+	return err
+}
+
+func TestErrorIs(t *testing.T) {
+
+	// For each test case, we compare all four permutations of DbxError vs Non-DbxError.
+	// The results should be the same in all cases.
 	type test struct {
-		err1     error
-		err2     error
+		// Sorted so that the first error in the list is the root error and subsequent ones perform wrapping.
+		// We always perform the wrapping with our custom Wrap() function.
+		err      []string
+		target   []string
 		areEqual bool
 	}
 
+	// NOTE: we never expect the target error to be multi-layered.
 	tests := []test{
-		// Dropbox Errors
-		{err1: errors.New("This is a sample error."), err2: errors.New("This is a sample error."), areEqual: true},
-		{err1: errors.New("This is a sample error."), err2: errors.New("This is NOT a sample error."), areEqual: false},
-
-		// Standard Errors
-		{err1: stderrors.New("This is a sample error."), err2: stderrors.New("This is a sample error."), areEqual: true},
-		{err1: stderrors.New("This is a sample error."), err2: stderrors.New("This is NOT a sample error."), areEqual: false},
-
-		// Mix Dropbox and Standard Errors
-		{err1: stderrors.New("This is a sample error."), err2: errors.New("This is a sample error."), areEqual: false},
-
-		// Wrapped Errors
+		// Simple comparison with single-layered error.
 		{
-			err1:     Wrap(io.EOF, "This is a sample error."),
-			err2:     errors.New("This is a sample error."),
+			err:      []string{"This is a sample error."},
+			target:   []string{"This is a sample error."},
 			areEqual: true,
+		},
+		{
+			err:      []string{"This is a sample error."},
+			target:   []string{"This is NOT a sample error."},
+			areEqual: false,
+		},
+
+		// Multiple layered errors.
+		{
+			err: []string{
+				"This is the root error",
+				"This is the outermost layer",
+			},
+			target: []string{
+				"This is the root error",
+			},
+			areEqual: true,
+		},
+		{
+			err: []string{
+				"This is the root error",
+				"This is the outermost layer",
+			},
+			target: []string{
+				"This is NOT the root error",
+			},
+			areEqual: false,
+		},
+
+		// The target matching the outermost error message is still not equal, since
+		// we only compare the root error.
+		{
+			err: []string{
+				"This is the root error",
+				"This is the outermost layer",
+			},
+			target: []string{
+				"This is the outermost layer",
+			},
+			areEqual: false,
 		},
 	}
 
 	for _, tc := range tests {
-		require.Equal(t, tc.areEqual, Is(tc.err1, tc.err2))
+		require.Equal(t, tc.areEqual, Is(createErrWithDbxRoot(tc.err), createErrWithDbxRoot(tc.target)))
+		require.Equal(t, tc.areEqual, Is(createErrWithDbxRoot(tc.err), createErrWithStdRoot(tc.target)))
+		require.Equal(t, tc.areEqual, Is(createErrWithStdRoot(tc.err), createErrWithDbxRoot(tc.target)))
+		require.Equal(t, tc.areEqual, Is(createErrWithStdRoot(tc.err), createErrWithStdRoot(tc.target)))
 	}
 }

--- a/src/golang/lib/execution_environment/execution_environment.go
+++ b/src/golang/lib/execution_environment/execution_environment.go
@@ -144,7 +144,6 @@ func CreateMissingAndSyncExistingEnvs(
 	// This helps reduce the number of DB access.
 	visitedResults := make(map[uuid.UUID]ExecutionEnvironment, len(envs))
 	results := make(map[uuid.UUID]ExecutionEnvironment, len(envs))
-	var err error = nil
 	txn, err := db.BeginTx(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Describe your changes and why you are making these changes
https://github.com/aqueducthq/aqueduct/pull/1107 introduced a bug where all errors, includes those that happen within an operator's context, were surfaced as workflow-level, which meant that every failing workflow got a banner.

This PR does the following:
1) Fixes the immediate error, so that workflow-level errors only occur when the workflow doesn't have an op failure exception.
2) In the process of fixing the above bug, I noticed that our error comparison method was only comparing the top-level errors. I think for our error comparisons, we should be completely unwrapping our candidate error and matching it against the target error. It doesn't make sense to compare just agains the outermost layer since it's much harder to control how much an error is wrapped as it works it way out of our system. I thiiink what really matters is the innermost error, so that's the one we should be comparing. @saurav-c curious what you think? 

Also tested that workfow timeout errors are appropriately surfaced as workflow-level errors:
<img width="1529" alt="image" src="https://user-images.githubusercontent.com/6466121/226259306-f002c1db-59a7-4114-af0f-bed9cfd8a9d7.png">


## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


