### PR TITLE
ENG-2577 Fix bug where warning state is not properly reflected on metadata list views

### DIFF
--- a/manual_qa_tests/initialize.py
+++ b/manual_qa_tests/initialize.py
@@ -4,6 +4,7 @@ import deploy_example
 from aqueduct.constants.enums import NotificationLevel
 from notification import connect_slack
 from workflows import (
+    check_status_test,
     fail_bad_check,
     fail_bad_operator,
     no_run,
@@ -17,6 +18,7 @@ import aqueduct as aq
 # when adding new deployments, keep the order of `fail`, `warning`, and `succeed`
 # such that the UI would approximately show these workflows in reverse order.
 WORKFLOW_PKGS = [
+    check_status_test,
     fail_bad_check,
     warning_bad_check,
     succeed_parameters,

--- a/manual_qa_tests/workflows/check_status_test.py
+++ b/manual_qa_tests/workflows/check_status_test.py
@@ -1,0 +1,76 @@
+import aqueduct as aq
+
+NAME = "check_status_test"
+DESCRIPTION = """
+    * Workflows Page: "Check Status Test" should fail.
+    * There should be four checks:
+        * warning_level_pass which shows success icon.
+        * warning_level_fail which shows warning icon.
+        * error_level_fail which shows error icon.
+        * error_level_pass which shows success icon.
+    * Workflow Details Page:
+        * Error message should appear below workflow header:
+            A workflow-level error occurred!
+            Error executing workflow
+            Operator execution failed due to user error.
+
+            <stack trace>
+        * Two DAGs should appear - one for success and one for failure cases.
+            * Success Test Dag:
+                - test_pass operator (succeeded) -> test_pass_artifact (created) -> warning_level_pass (passed)
+                                                                                 -> error_level_pass (passed)
+            * Fail Test Dag:
+                -test_fail operator (succeeded) -> test_fail_artifact (created) -> warning_level_fail (warning)
+                                                                                -> error_level_pass (failed)
+"""
+
+
+@aq.op
+def test_fail():
+    return 1
+
+
+@aq.op
+def test_pass():
+    return 0
+
+
+@aq.check(severity="warning")
+def warning_level_pass(res):
+    return res == 0
+
+
+@aq.check(severity="warning")
+def warning_level_fail(res):
+    return res == 0
+
+
+@aq.check(severity="error")
+def error_level_pass(res):
+    return res == 0
+
+
+@aq.check(severity="error")
+def error_level_fail(res):
+    return res == 0
+
+
+def deploy(client, integration_name):
+    fail_artf = test_fail()
+    success_artf = test_pass()
+
+    pass_level_warning_artf = warning_level_pass(success_artf)
+    failure_level_warning_arf = warning_level_fail(fail_artf)
+    pass_level_error_artf = error_level_pass(success_artf)
+
+    # TODO: Get this to work without the whole workflow erroring out.
+    # failure_level_error_artifact = error_level_fail.lazy(fail_artf)
+
+    client.publish_flow(
+        "Checks Status Test",
+        artifacts=[
+            pass_level_warning_artf,
+            failure_level_warning_arf,
+            pass_level_error_artf,
+            # failure_level_error_artifact
+        ])

--- a/manual_qa_tests/workflows/check_status_test.py
+++ b/manual_qa_tests/workflows/check_status_test.py
@@ -73,4 +73,5 @@ def deploy(client, integration_name):
             failure_level_warning_arf,
             pass_level_error_artf,
             # failure_level_error_artifact
-        ])
+        ],
+    )

--- a/manual_qa_tests/workflows/check_status_test.py
+++ b/manual_qa_tests/workflows/check_status_test.py
@@ -2,11 +2,10 @@ import aqueduct as aq
 
 NAME = "check_status_test"
 DESCRIPTION = """
-    * Workflows Page: "Check Status Test" should fail.
+    * Workflows Page: "Check Status Test" should succeed.
     * There should be four checks:
         * warning_level_pass which shows success icon.
         * warning_level_fail which shows warning icon.
-        * error_level_fail which shows error icon.
         * error_level_pass which shows success icon.
     * Workflow Details Page:
         * Error message should appear below workflow header:
@@ -21,7 +20,6 @@ DESCRIPTION = """
                                                                                  -> error_level_pass (passed)
             * Fail Test Dag:
                 -test_fail operator (succeeded) -> test_fail_artifact (created) -> warning_level_fail (warning)
-                                                                                -> error_level_pass (failed)
 """
 
 
@@ -63,15 +61,11 @@ def deploy(client, integration_name):
     failure_level_warning_arf = warning_level_fail(fail_artf)
     pass_level_error_artf = error_level_pass(success_artf)
 
-    # TODO: Get this to work without the whole workflow erroring out.
-    # failure_level_error_artifact = error_level_fail.lazy(fail_artf)
-
     client.publish_flow(
         "Checks Status Test",
         artifacts=[
             pass_level_warning_artf,
             failure_level_warning_arf,
             pass_level_error_artf,
-            # failure_level_error_artifact
         ],
     )

--- a/manual_qa_tests/workflows/succeed_parameters.py
+++ b/manual_qa_tests/workflows/succeed_parameters.py
@@ -15,9 +15,11 @@ DESCRIPTION = """* Workflows Page: should succeed.
 def check(df, bound):
     return df.shape[0] > bound
 
+
 @aq.check(requirements=[])
 def empty_str_check(df, empty_str):
     return len(empty_str) == 0
+
 
 def deploy(client, integration_name):
     integration = client.integration(integration_name)

--- a/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
@@ -61,7 +61,6 @@ export const getCheckStatusIcon = (
         if (check.level === CheckLevel.Error) {
           statusIcon = errorIcon;
         } else {
-          console.log('made it to warning case');
           statusIcon = warningIcon;
         }
       }

--- a/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
@@ -26,33 +26,54 @@ export const getCheckStatusIcon = (
   check: CheckPreview,
   tooltipText?: string
 ): JSX.Element => {
-  let statusIcon = (
+  const successIcon = (
     <StatusIndicator
       status={ExecutionStatus.Succeeded}
       tooltipText={tooltipText}
     />
   );
 
+  const errorIcon = (
+    <StatusIndicator
+      status={ExecutionStatus.Failed}
+      tooltipText={tooltipText}
+    />
+  );
+
+  const warningIcon = (
+    <StatusIndicator
+      status={ExecutionStatus.Warning}
+      tooltipText={tooltipText}
+    />
+  );
+
+  let statusIcon = successIcon;
+
   switch (check.status) {
     case ExecutionStatus.Succeeded: {
+      statusIcon = successIcon;
+
       // now we check the value to see if we should show warning or error icon
+      // Can this case even happen, or is the ExecutionState always going to be failed in this case?
+      // I thought ExecutionState of failed meant there was a runtime error ...
+      // May not need this if statement after all.      
       if (check.value === 'False') {
         if (check.level === CheckLevel.Error) {
-          statusIcon = (
-            <StatusIndicator
-              status={ExecutionStatus.Failed}
-              tooltipText={tooltipText}
-            />
-          );
+          statusIcon = errorIcon;
         } else {
-          statusIcon = (
-            <StatusIndicator
-              status={ExecutionStatus.Warning}
-              tooltipText={tooltipText}
-            />
-          );
+          console.log('made it to warning case')
+          statusIcon = warningIcon;
         }
       }
+      break;
+    }
+    case ExecutionStatus.Failed: {
+      if (check.level === CheckLevel.Error) {
+        statusIcon = errorIcon;
+      } else { // CheckLevel.Warning
+        statusIcon = warningIcon;
+      }
+
       break;
     }
     default: {

--- a/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
@@ -52,18 +52,6 @@ export const getCheckStatusIcon = (
   switch (check.status) {
     case ExecutionStatus.Succeeded: {
       statusIcon = successIcon;
-
-      // now we check the value to see if we should show warning or error icon
-      // Can this case even happen, or is the ExecutionState always going to be failed in this case?
-      // I thought ExecutionState of failed meant there was a runtime error ...
-      // May not need this if statement after all.
-      if (check.value === 'False') {
-        if (check.level === CheckLevel.Error) {
-          statusIcon = errorIcon;
-        } else {
-          statusIcon = warningIcon;
-        }
-      }
       break;
     }
     case ExecutionStatus.Failed: {

--- a/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/CheckItem.tsx
@@ -56,12 +56,12 @@ export const getCheckStatusIcon = (
       // now we check the value to see if we should show warning or error icon
       // Can this case even happen, or is the ExecutionState always going to be failed in this case?
       // I thought ExecutionState of failed meant there was a runtime error ...
-      // May not need this if statement after all.      
+      // May not need this if statement after all.
       if (check.value === 'False') {
         if (check.level === CheckLevel.Error) {
           statusIcon = errorIcon;
         } else {
-          console.log('made it to warning case')
+          console.log('made it to warning case');
           statusIcon = warningIcon;
         }
       }
@@ -70,7 +70,8 @@ export const getCheckStatusIcon = (
     case ExecutionStatus.Failed: {
       if (check.level === CheckLevel.Error) {
         statusIcon = errorIcon;
-      } else { // CheckLevel.Warning
+      } else {
+        // CheckLevel.Warning
         statusIcon = warningIcon;
       }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR fixes an issue where failed checks with level of warning showed as error icons on workflow metadata page. Also includes a manual QA integration tests to check that this functionality is working in the future.

## Related issue number (if any)
ENG-2577

## Loom demo (if any)
https://www.loom.com/share/d4aab8cdf1c24ceab6e821304638bf94

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


