### PR TITLE
[ENG-2645] Fixes bug where next run button was broken on the UI

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -167,8 +167,11 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
       ) {
         // this is where selectedDag gets set
         dispatch(selectResultIdx(workflowDagResultIndex));
-        setSelectedResultIdx(workflowDagResultIndex);
       }
+
+      // This is outside the if statement because this is not automatically kept in sync with
+      // the Redux store.
+      setSelectedResultIdx(workflowDagResultIndex);
     }
   }, [
     workflow.dagResults,
@@ -483,7 +486,7 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
         )}
 
         {/*Show any workflow-level errors at the top of the workflow details page.*/}
-        {workflow.selectedResult.exec_state.error && (
+        {workflow.selectedResult?.exec_state?.error && (
           <Box
             sx={{
               backgroundColor: theme.palette.red[100],


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR fixes a bug where the internal state management of the workflow details page wasn't correctly being kept in sync with the Redux store. As a result, the next/previous navigation buttons were broken. 

This PR also fixes a bug where a workflow without an error wouldn't render properly because we didn't have undefined guards (introduced in #1107, I think?). 

## Related issue number (if any)

ENG-2645

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


