### PR TITLE
Update automated terraform destroy

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -52,8 +52,21 @@ jobs:
         working-directory: integration_tests/sdk
         run: pytest aqueduct_tests/ -rP -vv -n 4
 
-      - uses: actions/upload-artifact@v3
+     - name: Teardown K8s Cluster
         if: always()
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 2
+          retry_on: error
+          timeout-minutes: 20
+          retry_wait_seconds: 300
+          command: |
+            cd integration_tests/sdk/compute/k8s
+            terraform destroy --auto-approve
+
+      # This directory is quite large, so we only upload it on failure.
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
         with:
           name: Terraform State
           path: |
@@ -63,16 +76,6 @@ jobs:
         if: always()
         with:
           prefix: K8s Compute
-
-      - name: Teardown K8s Cluster
-        if: always()
-        uses: nick-fields/retry@v2
-        with:
-          max_attempts: 2
-          retry_on: error
-          command: |
-            cd integration_tests/sdk/compute/k8s
-            terraform destroy --auto-approve
 
       # Sets it as an environmental variable.
       - name: Get the Slack ID for the current oncall

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: integration_tests/sdk
         run: pytest aqueduct_tests/ -rP -vv -n 4
 
-     - name: Teardown K8s Cluster
+      - name: Teardown K8s Cluster
         if: always()
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           max_attempts: 2
           retry_on: error
-          timeout-minutes: 20
+          timeout_minutes: 20
           retry_wait_seconds: 300
           command: |
             cd integration_tests/sdk/compute/k8s


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Fixed a bug in the usage of the nick-fields/retry. 
Validated that the full terraform folder allows us to destroy the resources locally. However, the folder is 404MB which is quite large, so I also changed it to only run on failures.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


