### PR TITLE
Eng 2441 Update node statuses to cancel when workflow run is finished

### DIFF
--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -208,6 +208,8 @@ func (eng *aqEngine) ExecuteWorkflow(
 			dagResult.ID,
 			execState,
 			eng.DAGResultRepo,
+			eng.ArtifactResultRepo,
+			eng.OperatorResultRepo,
 			eng.WorkflowRepo,
 			eng.NotificationRepo,
 			eng.Database,

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -249,9 +249,9 @@ func (j *ProcessJobManager) mapJobTypeToCmd(jobName string, spec Spec) (*exec.Cm
 		spec.Type() == DiscoverJobType {
 		specStr, err := EncodeSpec(spec, JsonSerializationType)
 		if err != nil {
-			return nil, err
+		return nil, err
 		}
-
+		
 		cmd = exec.Command(
 			"python3",
 			"-m",

--- a/src/golang/lib/job/process.go
+++ b/src/golang/lib/job/process.go
@@ -249,9 +249,9 @@ func (j *ProcessJobManager) mapJobTypeToCmd(jobName string, spec Spec) (*exec.Cm
 		spec.Type() == DiscoverJobType {
 		specStr, err := EncodeSpec(spec, JsonSerializationType)
 		if err != nil {
-		return nil, err
+			return nil, err
 		}
-		
+
 		cmd = exec.Command(
 			"python3",
 			"-m",

--- a/src/golang/lib/workflow/utils/database.go
+++ b/src/golang/lib/workflow/utils/database.go
@@ -343,7 +343,9 @@ func UpdateWorkflowDagToLatest(
 }
 
 // UpdateDAGResultMetadata updates the status and execution state of the
-// specified DAGResult. It also creates the relevant notification(s).
+// specified DAGResult. If the workflow run failed or was canceled, it 
+// also updates pending and running operator and artifact results to
+// canceled. It also creates the relevant notification(s).
 func UpdateDAGResultMetadata(
 	ctx context.Context,
 	dagResultID uuid.UUID,
@@ -377,7 +379,7 @@ func UpdateDAGResultMetadata(
 	}
 
 	// Check if DAG has finished running.
-	if execState.Status == shared.CanceledExecutionStatus || execState.Status == shared.FailedExecutionStatus || execState.Status == shared.SucceededExecutionStatus {
+	if execState.Status == shared.CanceledExecutionStatus || execState.Status == shared.FailedExecutionStatus {
 		// Cancel all running or pending nodes in the DAG.
 
 		// Get all artifact results for the DAG

--- a/src/golang/lib/workflow/utils/database.go
+++ b/src/golang/lib/workflow/utils/database.go
@@ -343,7 +343,7 @@ func UpdateWorkflowDagToLatest(
 }
 
 // UpdateDAGResultMetadata updates the status and execution state of the
-// specified DAGResult. If the workflow run failed or was canceled, it 
+// specified DAGResult. If the workflow run failed or was canceled, it
 // also updates pending and running operator and artifact results to
 // canceled. It also creates the relevant notification(s).
 func UpdateDAGResultMetadata(

--- a/src/golang/lib/workflow/utils/database.go
+++ b/src/golang/lib/workflow/utils/database.go
@@ -377,7 +377,7 @@ func UpdateDAGResultMetadata(
 	}
 
 	// Check if DAG has finished running.
-	if (execState.Status == shared.CanceledExecutionStatus || execState.Status == shared.FailedExecutionStatus || execState.Status == shared.SucceededExecutionStatus) {
+	if execState.Status == shared.CanceledExecutionStatus || execState.Status == shared.FailedExecutionStatus || execState.Status == shared.SucceededExecutionStatus {
 		// Cancel all running or pending nodes in the DAG.
 
 		// Get all artifact results for the DAG
@@ -395,14 +395,14 @@ func UpdateDAGResultMetadata(
 		// ARTIFACTS
 		// Filter by running or pending status
 		for _, artifact := range artifactsForDAG {
-			if (artifact.Status == shared.PendingExecutionStatus || artifact.Status == shared.RunningExecutionStatus) {
-				artifact.ExecState.Status = shared.CanceledExecutionStatus;
+			if artifact.Status == shared.PendingExecutionStatus || artifact.Status == shared.RunningExecutionStatus {
+				artifact.ExecState.Status = shared.CanceledExecutionStatus
 				// Update status to cancelled
 				changes := map[string]interface{}{
-					models.ArtifactResultStatus: shared.CanceledExecutionStatus,
+					models.ArtifactResultStatus:    shared.CanceledExecutionStatus,
 					models.ArtifactResultExecState: &artifact.ExecState.ExecutionState,
 				}
-				result, err := artifactResultRepo.Update(ctx, artifact.ID, changes, txn)
+				_, err := artifactResultRepo.Update(ctx, artifact.ID, changes, txn)
 				if err != nil {
 					return err
 				}
@@ -412,14 +412,14 @@ func UpdateDAGResultMetadata(
 		// OPERATORS
 		// Filter by running or pending status
 		for _, operator := range operatorsForDAG {
-			if (operator.Status == shared.PendingExecutionStatus || operator.Status == shared.RunningExecutionStatus) {
-				operator.ExecState.Status = shared.CanceledExecutionStatus;
+			if operator.Status == shared.PendingExecutionStatus || operator.Status == shared.RunningExecutionStatus {
+				operator.ExecState.Status = shared.CanceledExecutionStatus
 				// Update status to cancelled
 				changes := map[string]interface{}{
-					models.OperatorResultStatus: shared.CanceledExecutionStatus,
+					models.OperatorResultStatus:    shared.CanceledExecutionStatus,
 					models.OperatorResultExecState: &operator.ExecState.ExecutionState,
 				}
-				result, err := operatorResultRepo.Update(ctx, operator.ID, changes, txn)
+				_, err := operatorResultRepo.Update(ctx, operator.ID, changes, txn)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Currently, node statuses are not updated to cancel when the workflow fails in the Golang level.
When updating the workflow run status, this fix checks to see if the workflow run is in the complete state (succeeded/canceled/failed) and marks all pending or running nodes as canceled.

## Related issue number (if any)
ENG 2441

## Loom demo (if any)
Before - workflow done but nodes marked pending
<img width="1440" alt="Screen Shot 2023-03-22 at 7 54 21 PM" src="https://user-images.githubusercontent.com/30596854/227089306-f50d7b82-8ed6-4cf8-a030-4cbe399c065d.png">
After - all nodes marked as cancelled after workflow run gets a final status (succeeded or failed)
<img width="1435" alt="Screen Shot 2023-03-22 at 7 53 44 PM" src="https://user-images.githubusercontent.com/30596854/227089300-90671e5a-220f-42f0-bfb9-450dff93a339.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


