### PR TITLE
ENG-2622 Show metrics history graph temporally on the x axis.

### DIFF
--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -68,7 +68,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
         Date.parse(y['timestamp'] as string)
     );
 
-  const timestamps = dataToPlot.map((x) => x['timestamp']);
+  const timestamps = dataToPlot.map((x) => new Date(x['timestamp'] as string));
   const values = dataToPlot.map((x) => x['value']);
 
   return (
@@ -100,8 +100,8 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
               height: '100%',
               plot_bgcolor: theme.palette.gray[100],
               margin: { b: 0, t: 0, l: 0, r: 0, pad: 8 },
-              xaxis: { automargin: true },
-              yaxis: { automargin: true, ticksuffix: ' ' },
+              xaxis: { automargin: true, type: 'date' },
+              yaxis: { automargin: true, ticksuffix: ' ' }
             }}
           />
         </Box>

--- a/src/ui/common/src/components/workflows/artifact/metric/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metric/history.tsx
@@ -101,7 +101,7 @@ const MetricsHistory: React.FC<Props> = ({ historyWithLoadingStatus }) => {
               plot_bgcolor: theme.palette.gray[100],
               margin: { b: 0, t: 0, l: 0, r: 0, pad: 8 },
               xaxis: { automargin: true, type: 'date' },
-              yaxis: { automargin: true, ticksuffix: ' ' }
+              yaxis: { automargin: true, ticksuffix: ' ' },
             }}
           />
         </Box>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR uses date values in the Metrics history graph when plotting values on the x axis.

The end result here is that the values will be spread out according to how close in time they are.

Pretty short PR here :) had to give myself a crash course in plotly first before grokking what's going on.


## Related issue number (if any)
ENG-2622

## Loom demo (if any)
Screenshot with a metric from the future :)
On the left side, you'll notice a clump of values which is a result of me kicking off several workflows within minutes of eachother.

On the right, I added a value one day in the future.
<img width="749" alt="image" src="https://user-images.githubusercontent.com/1031759/227392171-a4cd6321-f685-4471-bfc2-fa4cbd427427.png">


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


