### PR TITLE
Adds support for bigquery integration tests

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
@@ -9,7 +9,7 @@ from aqueduct import op
 from ..shared.data_objects import DataObject
 from ..shared.flow_helpers import publish_flow_test
 from ..shared.naming import generate_table_name
-from ..shared.relational import SHORT_SENTIMENT_SQL_QUERY, all_relational_DBs
+from ..shared.relational import all_relational_DBs, format_table_name
 from .extract import extract
 from .save import save
 
@@ -79,7 +79,9 @@ def test_force_delete_workflow_saved_objects(
 ):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     table_name = generate_table_name()
-    table_artifact = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    table_artifact = data_integration.sql(
+        "select * from %s limit 5" % format_table_name("hotel_reviews", data_integration.type())
+    )
     save(data_integration, table_artifact, name=table_name, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
@@ -133,7 +135,9 @@ def test_delete_workflow_saved_objects_twice(
     """
     table_name = generate_table_name()
 
-    table_artifact = data_integration.sql(query=SHORT_SENTIMENT_SQL_QUERY)
+    table_artifact = data_integration.sql(
+        "select * from %s limit 5" % format_table_name("hotel_reviews", data_integration.type())
+    )
     save(data_integration, table_artifact, name=table_name, update_mode=LoadUpdateMode.REPLACE)
 
     # Workflow 1's name not specified, so given a random workflow name.

--- a/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/delete_workflow_test.py
@@ -9,7 +9,7 @@ from aqueduct import op
 from ..shared.data_objects import DataObject
 from ..shared.flow_helpers import publish_flow_test
 from ..shared.naming import generate_table_name
-from ..shared.relational import all_relational_DBs, format_table_name
+from ..shared.relational import all_relational_DBs
 from .extract import extract
 from .save import save
 
@@ -79,9 +79,7 @@ def test_force_delete_workflow_saved_objects(
 ):
     """Check the flow with object(s) saved with update_mode=APPEND can only be deleted if in force mode."""
     table_name = generate_table_name()
-    table_artifact = data_integration.sql(
-        "select * from %s limit 5" % format_table_name("hotel_reviews", data_integration.type())
-    )
+    table_artifact = data_integration.sql("select * from hotel_reviews limit 5")
     save(data_integration, table_artifact, name=table_name, update_mode=LoadUpdateMode.REPLACE)
 
     flow = publish_flow_test(
@@ -135,9 +133,7 @@ def test_delete_workflow_saved_objects_twice(
     """
     table_name = generate_table_name()
 
-    table_artifact = data_integration.sql(
-        "select * from %s limit 5" % format_table_name("hotel_reviews", data_integration.type())
-    )
+    table_artifact = data_integration.sql("select * from hotel_reviews limit 5")
     save(data_integration, table_artifact, name=table_name, update_mode=LoadUpdateMode.REPLACE)
 
     # Workflow 1's name not specified, so given a random workflow name.

--- a/integration_tests/sdk/data_integration_tests/relational_test.py
+++ b/integration_tests/sdk/data_integration_tests/relational_test.py
@@ -13,7 +13,7 @@ from aqueduct import LoadUpdateMode, metric, op
 
 from ..shared.demo_db import demo_db_tables
 from ..shared.naming import generate_table_name
-from ..shared.relational import SHORT_SENTIMENT_SQL_QUERY
+from ..shared.relational import SHORT_SENTIMENT_SQL_QUERY, format_table_name
 from ..shared.validation import check_artifact_was_computed
 from .relational_data_validator import RelationalDataValidator
 from .save import save
@@ -112,7 +112,7 @@ def test_sql_integration_failed_query(client, data_integration):
 
 
 def test_sql_integration_table_retrieval(client, data_integration):
-    df = data_integration.table(name="hotel_reviews")
+    df = data_integration.table(name=format_table_name("hotel_reviews", data_integration.type()))
     assert len(df) == 100
     assert list(df) == [
         "hotel_name",
@@ -131,11 +131,13 @@ def test_sql_integration_list_tables(client, data_integration):
 
 def test_sql_today_tag(client, data_integration):
     table_artifact_today = data_integration.sql(
-        query="select * from hotel_reviews where review_date = {{today}}"
+        query="select * from %s where review_date = {{today}}"
+        % format_table_name("hotel_reviews", data_integration.type())
     )
     assert table_artifact_today.get().empty
     table_artifact_not_today = data_integration.sql(
-        query="select * from hotel_reviews where review_date < {{today}}"
+        query="select * from %s where review_date < {{today}}"
+        % format_table_name("hotel_reviews", data_integration.type())
     )
     assert len(table_artifact_not_today.get()) == 100
 

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -20,6 +20,7 @@ from sdk.aqueduct_tests.save import save
 from sdk.shared.demo_db import demo_db_tables
 from sdk.shared.flow_helpers import delete_flow, publish_flow_test
 from sdk.shared.naming import generate_object_name
+from sdk.shared.relational import format_table_name
 
 TEST_CREDENTIALS_FILE: str = "test-credentials.yml"
 TEST_CONFIG_FILE: str = "test-config.yml"
@@ -118,7 +119,7 @@ def _add_missing_artifacts(
         save(
             integration,
             cast(TableArtifact, data_param),
-            name=table_name,
+            name=format_table_name(table_name, integration.type()),
         )
         artifacts.append(data_param)
 
@@ -142,13 +143,6 @@ def _setup_mongo_db_data(client: Client, mongo_db: MongoDBIntegration) -> None:
             pass
 
     _add_missing_artifacts(client, mongo_db, existing_names)
-
-
-def _setup_snowflake_data(client: Client, snowflake: RelationalDBIntegration) -> None:
-    # Find all the tables that already exist.
-    existing_table_names = set(snowflake.list_tables()["tablename"])
-
-    _add_missing_artifacts(client, snowflake, existing_table_names)
 
 
 def _setup_external_sqlite_db(path: str):

--- a/integration_tests/sdk/shared/relational.py
+++ b/integration_tests/sdk/shared/relational.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from aqueduct.constants.enums import RelationalDBServices, ServiceType
-from aqueduct.constants.enums import ServiceType
 
 BIG_QUERY_TEST_DATASET = "integration_test"
 
@@ -22,4 +21,3 @@ def format_table_name(table_name: str, service: ServiceType) -> str:
         # BigQuery table names need to be prefixed with the dataset
         return BIG_QUERY_TEST_DATASET + "." + table_name
     return table_name
-

--- a/integration_tests/sdk/shared/relational.py
+++ b/integration_tests/sdk/shared/relational.py
@@ -1,6 +1,9 @@
 from typing import List
 
 from aqueduct.constants.enums import RelationalDBServices, ServiceType
+from aqueduct.constants.enums import ServiceType
+
+BIG_QUERY_TEST_DATASET = "integration_test"
 
 # We limit the number of rows to speed up a database writes a littel bit.
 SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
@@ -8,3 +11,15 @@ SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
 
 def all_relational_DBs() -> List[ServiceType]:
     return [ServiceType(relational_service.value) for relational_service in RelationalDBServices]
+
+
+def format_table_name(table_name: str, service: ServiceType) -> str:
+    """
+    Returns the table name so it is formatted according to the integration
+    service specified.
+    """
+    if service == ServiceType.BIGQUERY:
+        # BigQuery table names need to be prefixed with the dataset
+        return BIG_QUERY_TEST_DATASET + "." + table_name
+    return table_name
+

--- a/integration_tests/sdk/shared/relational.py
+++ b/integration_tests/sdk/shared/relational.py
@@ -2,10 +2,8 @@ from typing import List
 
 from aqueduct.constants.enums import RelationalDBServices, ServiceType
 
+# Default BigQuery dataset used for integration tests
 BIG_QUERY_TEST_DATASET = "integration_test"
-
-# We limit the number of rows to speed up a database writes a littel bit.
-SHORT_SENTIMENT_SQL_QUERY = "select * from hotel_reviews limit 5"
 
 
 def all_relational_DBs() -> List[ServiceType]:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes all of the references to SQL table names so it works for BigQuery as well, since BigQuery requires table names to be of the format `dataset.table`.

**REVIEWERS: Look at just `integration_tests/sdk`**. I can't fix this rebase until #1134 is rebased off of main.

## Related issue number (if any)
ENG 2387

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


