### PR TITLE
ENG 2154 Add parameter information to save operator

### DIFF
--- a/src/ui/common/src/components/operators/WithOperatorHeader.tsx
+++ b/src/ui/common/src/components/operators/WithOperatorHeader.tsx
@@ -14,6 +14,7 @@ import { theme } from '../../styles/theme/theme';
 import { OperatorType } from '../../utils/operators';
 import { CheckLevel } from '../../utils/operators';
 import DetailsPageHeader from '../pages/components/DetailsPageHeader';
+import SaveDetails from '../pages/components/SaveDetails';
 import ArtifactSummaryList from '../workflows/artifact/summaryList';
 
 type Props = {
@@ -97,8 +98,13 @@ const WithOperatorHeader: React.FC<Props> = ({
           )}
         </Box>
       )}
+      
       <Box width="100%" paddingTop={sideSheetMode ? '16px' : '24px'}>
         {checkLevelDisplay}
+      </Box>
+
+      <Box width="100%" paddingTop={sideSheetMode ? '16px' : '24px'}>
+        <SaveDetails parameters={operator?.spec?.load?.parameters} />
       </Box>
 
       <Box display="flex" width="100%">

--- a/src/ui/common/src/components/pages/components/SaveDetails.tsx
+++ b/src/ui/common/src/components/pages/components/SaveDetails.tsx
@@ -1,0 +1,93 @@
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { isGoogleSheetsLoadParams, isRelationalDBLoadParams, isS3LoadParams, LoadParameters } from '../../../utils/operators';
+
+type SaveDetailsProps = {
+  parameters: LoadParameters;
+};
+
+export const SaveDetails: React.FC<SaveDetailsProps> = ({
+  parameters
+}) => {
+  let paramsDisplay = null;
+  if (parameters) {
+    if (isRelationalDBLoadParams(parameters)) {
+      paramsDisplay = (
+        <Box>
+          <Box mb={1}>
+            <Typography variant="body2" sx={{ color: 'gray.800' }}>
+              Table
+            </Typography>
+            <Typography variant="body1" sx={{ mx: 1 }}>
+              {parameters.table}
+            </Typography>
+          </Box>
+          <Box mb={1}>
+            <Typography variant="body2" sx={{ color: 'gray.800' }}>
+              Update Mode
+            </Typography>
+            <Typography variant="body1" sx={{ mx: 1 }}>
+              {parameters.update_mode}
+            </Typography>
+          </Box>
+        </Box>
+      );
+    } else if (isGoogleSheetsLoadParams(parameters)) {
+      paramsDisplay = (
+        <Box>
+          <Box mb={1}>
+            <Typography variant="body2" sx={{ color: 'gray.800' }}>
+              Filepath
+            </Typography>
+            <Typography variant="body1" sx={{ mx: 1 }}>
+              {parameters.filepath}
+            </Typography>
+          </Box>
+          <Box mb={1}>
+            <Typography variant="body2" sx={{ color: 'gray.800' }}>
+              Save Mode
+            </Typography>
+            <Typography variant="body1" sx={{ mx: 1 }}>
+              {parameters.save_mode}
+            </Typography>
+          </Box>
+        </Box>
+      );
+    } else if (isS3LoadParams(parameters)) {
+      paramsDisplay = (
+        <Box>
+          <Box mb={1}>
+            <Typography variant="body2" sx={{ color: 'gray.800' }}>
+              Filepath
+            </Typography>
+            <Typography variant="body1" sx={{ mx: 1 }}>
+              {parameters.filepath}
+            </Typography>
+          </Box>
+          <Box mb={1}>
+            <Typography variant="body2" sx={{ color: 'gray.800' }}>
+              Format
+            </Typography>
+            <Typography variant="body1" sx={{ mx: 1 }}>
+              {parameters.format}
+            </Typography>
+          </Box>
+        </Box>
+      );
+    } else {
+      return null;
+    }
+    return (
+      <Box mb={2}>
+        <Typography variant="h6" mb="8px" fontWeight="normal">
+          Parameters
+        </Typography>
+
+        {paramsDisplay}
+      </Box>
+    )
+  }
+};
+
+export default SaveDetails;

--- a/src/ui/common/src/utils/operators.ts
+++ b/src/ui/common/src/utils/operators.ts
@@ -141,11 +141,13 @@ export type RelationalDBLoadParams = {
   table: string;
   update_mode: UpdateMode;
 };
+export const isRelationalDBLoadParams = (input: any): input is RelationalDBLoadParams => input.table !== undefined && input.update_mode !== undefined
 
 export type GoogleSheetsLoadParams = {
   filepath: string;
   save_mode: string;
 };
+export const isGoogleSheetsLoadParams = (input: any): input is GoogleSheetsLoadParams => input.filepath !== undefined && input.save_mode !== undefined
 
 export enum S3TableFormat {
   Csv = 'CSV',
@@ -157,6 +159,8 @@ export type S3LoadParams = {
   filepath: string;
   format: S3TableFormat;
 };
+export const isS3LoadParams = (input: any): input is S3LoadParams => input.filepath !== undefined && input.format !== undefined
+
 
 export type Load = {
   service: ServiceType;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
In the UI, when I click on a save operator, there is nothing in the sidesheet that is helpful for discovering where the operator is: e.g. where in the integration it is saved (table_name, path, etc).

This PR adds parameter information. Combined with https://github.com/aqueducthq/aqueduct/pull/1121, which will add the integration information, will provide all necessary information.

## Related issue number (if any)
ENG 2154

## Loom demo (if any)
![image](https://user-images.githubusercontent.com/30596854/227663900-941ec862-1933-4980-b8c0-88628c7103ec.png)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


