### PR TITLE
Add system_metric function to GenericArtifact

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -63,6 +63,23 @@ def test_system_max_memory_metric(client, data_integration):
     max_mem = max_mem_metric.get()
     assert max_mem > 10
 
+def test_system_runtime_metric_generic(client, data_integration):
+    table = extract(data_integration, DataObject.SENTIMENT, lazy=True)
+    timed_table = timed_function(table)
+
+    runtime_metric = timed_table.system_metric("runtime")
+    runtime = runtime_metric.get()
+    assert runtime > SLEEP_TIME
+
+
+def test_system_max_memory_metric_generic(client, data_integration):
+    table = extract(data_integration, DataObject.SENTIMENT, lazy=True)
+    timed_table = mem_intensive_function(table)
+
+    max_mem_metric = timed_table.system_metric("max_memory")
+    max_mem = max_mem_metric.get()
+    assert max_mem > 10
+
 
 def test_number_of_missing_values(client, data_integration):
     table = extract(data_integration, DataObject.SENTIMENT)

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -63,7 +63,9 @@ def test_system_max_memory_metric(client, data_integration):
     max_mem = max_mem_metric.get()
     assert max_mem > 10
 
+
 def test_system_runtime_metric_generic(client, data_integration):
+    global_config({"lazy": True})
     table = extract(data_integration, DataObject.SENTIMENT, lazy=True)
     timed_table = timed_function(table)
 
@@ -73,6 +75,7 @@ def test_system_runtime_metric_generic(client, data_integration):
 
 
 def test_system_max_memory_metric_generic(client, data_integration):
+    global_config({"lazy": True})
     table = extract(data_integration, DataObject.SENTIMENT, lazy=True)
     timed_table = mem_intensive_function(table)
 

--- a/sdk/aqueduct/artifacts/create.py
+++ b/sdk/aqueduct/artifacts/create.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import uuid
 from typing import Any, Optional
 
-from aqueduct.artifacts import bool_artifact, generic_artifact, numeric_artifact, table_artifact
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.constants.enums import ArtifactType
 from aqueduct.error import InvalidUserArgumentException
@@ -22,6 +21,13 @@ def to_artifact_class(
     artifact_type: ArtifactType = ArtifactType.UNTYPED,
     content: Optional[Any] = None,
 ) -> BaseArtifact:
+    """
+    This function uses the `ArtifactType` parameter to determine the appropriate `BaseArtifact` class to instantiate.
+    This function imports `TableArtifact`, `NumericArtifact`, `BoolArtifact`, and `GenericArtifact` from the `aqueduct.artifacts`
+    module, so ensure that module is importable before calling this function.
+    """
+    from aqueduct.artifacts import bool_artifact, generic_artifact, numeric_artifact, table_artifact
+
     if artifact_type == ArtifactType.TABLE:
         return table_artifact.TableArtifact(
             dag,

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -2,21 +2,17 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
-from aqueduct.artifacts import bool_artifact, numeric_artifact
+from aqueduct.artifacts import numeric_artifact
 from aqueduct.artifacts import preview as artifact_utils
 from aqueduct.artifacts import system_metric
-from aqueduct.artifacts._create import create_metric_or_check_artifact
 from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.constants.enums import ArtifactType, ExecutionMode, ExecutionStatus
+from aqueduct.constants.enums import ArtifactType, ExecutionStatus
 from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
 from aqueduct.error import ArtifactNeverComputedException
-from aqueduct.models.artifact import ArtifactMetadata
 from aqueduct.models.dag import DAG
-from aqueduct.models.operators import Operator, OperatorSpec, SystemMetricSpec
-from aqueduct.utils.naming import default_artifact_name_from_op_name
-from aqueduct.utils.utils import format_header_for_print, generate_uuid
+from aqueduct.utils.utils import format_header_for_print
 
 from aqueduct import globals
 

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-from aqueduct.artifacts import numeric_artifact
 from aqueduct.artifacts import preview as artifact_utils
 from aqueduct.artifacts import system_metric
 from aqueduct.artifacts.base_artifact import BaseArtifact
@@ -13,8 +12,6 @@ from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
 from aqueduct.error import ArtifactNeverComputedException
 from aqueduct.models.dag import DAG
 from aqueduct.utils.utils import format_header_for_print
-
-from aqueduct import globals
 
 
 class GenericArtifact(BaseArtifact, system_metric.SystemMetricMixin):

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -95,23 +95,3 @@ class GenericArtifact(BaseArtifact, system_metric.SystemMetricMixin):
         ]
         print(format_header_for_print(f"'{input_operator.name}' {self.type()} Artifact"))
         print(json.dumps(readable_dict, sort_keys=False, indent=4))
-
-    def system_metric(
-        self, metric_name: str, lazy: bool = False
-    ) -> numeric_artifact.NumericArtifact:
-        """Creates a system metric that represents the given system information from the previous @op that ran on the table.
-
-        Args:
-            metric_name:
-                name of system metric to retrieve for the table.
-                valid metrics are:
-                    runtime: runtime of previous @op func in seconds
-                    max_memory: maximum memory usage of previous @op func in Mb
-
-        Returns:
-            A numeric artifact that represents the requested system metric
-        """
-        if globals.__GLOBAL_CONFIG__.lazy:
-            lazy = True
-
-        return self.system_metric_helper(self._dag, self._artifact_id, metric_name, lazy)

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -2,23 +2,26 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
-from aqueduct.artifacts import preview as artifact_utils
-from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.artifacts._create import create_metric_or_check_artifact
-from aqueduct.constants.enums import ArtifactType, ExecutionMode, ExecutionStatus
-from aqueduct.error import ArtifactNeverComputedException
-from aqueduct.models.dag import DAG
-from aqueduct.utils.utils import format_header_for_print, generate_uuid
 from aqueduct.artifacts import bool_artifact, numeric_artifact
+from aqueduct.artifacts import preview as artifact_utils
+from aqueduct.artifacts import system_metric
+from aqueduct.artifacts._create import create_metric_or_check_artifact
+from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.constants.enums import ArtifactType, ExecutionMode, ExecutionStatus
 from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
-from aqueduct.models.operators import Operator, OperatorSpec, SystemMetricSpec
+from aqueduct.error import ArtifactNeverComputedException
 from aqueduct.models.artifact import ArtifactMetadata
+from aqueduct.models.dag import DAG
+from aqueduct.models.operators import Operator, OperatorSpec, SystemMetricSpec
 from aqueduct.utils.naming import default_artifact_name_from_op_name
+from aqueduct.utils.utils import format_header_for_print, generate_uuid
+
+from aqueduct import globals
 
 
-class GenericArtifact(BaseArtifact):
+class GenericArtifact(BaseArtifact, system_metric.SystemMetricMixin):
     """This class represents a generic artifact within the flow's DAG.
 
     Currently, a generic artifact can be any artifact other than table, numeric, bool, or parameter
@@ -96,7 +99,7 @@ class GenericArtifact(BaseArtifact):
         ]
         print(format_header_for_print(f"'{input_operator.name}' {self.type()} Artifact"))
         print(json.dumps(readable_dict, sort_keys=False, indent=4))
-    
+
     def system_metric(
         self, metric_name: str, lazy: bool = False
     ) -> numeric_artifact.NumericArtifact:
@@ -114,72 +117,5 @@ class GenericArtifact(BaseArtifact):
         """
         if globals.__GLOBAL_CONFIG__.lazy:
             lazy = True
-        execution_mode = ExecutionMode.EAGER if not lazy else ExecutionMode.LAZY
 
-        operator = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
-        system_metric_description, system_metric_unit = SYSTEM_METRICS_INFO[metric_name]
-        system_metric_name = "%s %s(%s) metric" % (operator.name, metric_name, system_metric_unit)
-        op_spec = OperatorSpec(system_metric=SystemMetricSpec(metric_name=metric_name))
-        new_artifact = self._apply_operator_to_table(
-            op_spec,
-            system_metric_name,
-            system_metric_description,
-            output_artifact_type_hint=ArtifactType.NUMERIC,
-            execution_mode=execution_mode,
-        )
-
-        assert isinstance(new_artifact, numeric_artifact.NumericArtifact)
-
-        return new_artifact
-
-    def _apply_operator_to_table(
-        self,
-        op_spec: OperatorSpec,
-        op_name: str,
-        op_description: str,
-        output_artifact_type_hint: ArtifactType,
-        execution_mode: ExecutionMode = ExecutionMode.EAGER,
-    ) -> Union[numeric_artifact.NumericArtifact, bool_artifact.BoolArtifact]:
-        assert (
-            output_artifact_type_hint == ArtifactType.NUMERIC
-            or output_artifact_type_hint == ArtifactType.BOOL
-        )
-
-        operator_id = generate_uuid()
-        output_artifact_id = generate_uuid()
-        artifact_name = default_artifact_name_from_op_name(op_name)
-
-        create_metric_or_check_artifact(
-            dag=self._dag,
-            op=Operator(
-                id=operator_id,
-                name=op_name,
-                description=op_description,
-                spec=op_spec,
-                inputs=[self._artifact_id],
-                outputs=[output_artifact_id],
-            ),
-            output_artifacts=[
-                ArtifactMetadata(
-                    id=output_artifact_id,
-                    name=artifact_name,
-                    type=output_artifact_type_hint,
-                    explicitly_named=False,
-                )
-            ],
-        )
-
-        if execution_mode == ExecutionMode.EAGER:
-            # Issue preview request since this is an eager execution.
-            artifact = artifact_utils.preview_artifact(self._dag, output_artifact_id)
-
-            assert isinstance(artifact, numeric_artifact.NumericArtifact) or isinstance(
-                artifact, bool_artifact.BoolArtifact
-            )
-            return artifact
-        else:
-            # We are in lazy mode.
-            if output_artifact_type_hint == ArtifactType.NUMERIC:
-                return numeric_artifact.NumericArtifact(self._dag, output_artifact_id)
-            else:
-                return bool_artifact.BoolArtifact(self._dag, output_artifact_id)
+        return self.system_metric_helper(self._dag, self._artifact_id, metric_name, lazy)

--- a/sdk/aqueduct/artifacts/system_metric.py
+++ b/sdk/aqueduct/artifacts/system_metric.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 from aqueduct.artifacts import bool_artifact, numeric_artifact
 from aqueduct.artifacts import preview as artifact_utils
@@ -18,7 +18,7 @@ from aqueduct import globals
 class SystemMetricMixin:
     """A mixin class for the system_metric function. This is used by GenericArtifacts and TableArtifacts."""
 
-    def list_system_metrics(self) -> Dict[str]:
+    def list_system_metrics(self) -> Dict[str, Any]:
         """Returns a dictionary of all system metrics available on the table artifact.
         These system metrics can be set via the invoking the system_metric() method the table.
 
@@ -26,26 +26,6 @@ class SystemMetricMixin:
             A list of available system metrics on a table
         """
         return SYSTEM_METRICS_INFO
-
-    def system_metric(
-        self, metric_name: str, lazy: bool = False
-    ) -> numeric_artifact.NumericArtifact:
-        """Creates a system metric that represents the given system information from the previous @op that ran on the table.
-
-        Args:
-            metric_name:
-                Name of system metric to retrieve for the table.
-                Valid metrics are:
-                    runtime: runtime of previous @op func in seconds
-                    max_memory: maximum memory usage of previous @op func in Mb
-
-        Returns:
-            A numeric artifact that represents the requested system metric
-        """
-        if globals.__GLOBAL_CONFIG__.lazy:
-            lazy = True
-
-        return self._system_metric_helper(self._dag, self._artifact_id, metric_name, lazy)
 
     def _system_metric_helper(
         self, dag: DAG, artifact_id: uuid.UUID, metric_name: str, lazy: bool

--- a/sdk/aqueduct/artifacts/system_metric.py
+++ b/sdk/aqueduct/artifacts/system_metric.py
@@ -1,0 +1,115 @@
+import uuid
+from typing import List, Union
+
+from aqueduct.artifacts import bool_artifact, numeric_artifact
+from aqueduct.artifacts import preview as artifact_utils
+from aqueduct.artifacts._create import create_metric_or_check_artifact
+from aqueduct.constants.enums import ArtifactType, ExecutionMode
+from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
+from aqueduct.models.artifact import ArtifactMetadata
+from aqueduct.models.dag import DAG
+from aqueduct.models.operators import Operator, OperatorSpec, SystemMetricSpec
+from aqueduct.utils.naming import default_artifact_name_from_op_name
+from aqueduct.utils.utils import generate_uuid
+
+
+class SystemMetricMixin:
+    """A mixin class for the system_metric function. This is used by GenericArtifacts and TableArtifacts."""
+
+    def list_system_metrics(self) -> List[str]:
+        """Returns a list of all system metrics available on the table artifact.
+        These system metrics can be set via the invoking the system_metric() method the table.
+
+        Returns:
+            A list of available system metrics on a table
+        """
+        return list(SYSTEM_METRICS_INFO.keys())
+
+    def system_metric_helper(
+        self, dag: DAG, artifact_id: uuid.UUID, metric_name: str, lazy: bool
+    ) -> numeric_artifact.NumericArtifact:
+        """Creates a system metric that represents the given system information from the previous @op that ran on the table.
+
+        Args:
+            metric_name:
+                name of system metric to retrieve for the table.
+                valid metrics are:
+                    runtime: runtime of previous @op func in seconds
+                    max_memory: maximum memory usage of previous @op func in Mb
+
+        Returns:
+            A numeric artifact that represents the requested system metric
+        """
+        execution_mode = ExecutionMode.EAGER if not lazy else ExecutionMode.LAZY
+
+        operator = dag.must_get_operator(with_output_artifact_id=artifact_id)
+        system_metric_description, system_metric_unit = SYSTEM_METRICS_INFO[metric_name]
+        system_metric_name = "%s %s(%s) metric" % (operator.name, metric_name, system_metric_unit)
+        op_spec = OperatorSpec(system_metric=SystemMetricSpec(metric_name=metric_name))
+        new_artifact = self._apply_operator_to_table(
+            dag,
+            artifact_id,
+            op_spec,
+            system_metric_name,
+            system_metric_description,
+            output_artifact_type_hint=ArtifactType.NUMERIC,
+            execution_mode=execution_mode,
+        )
+
+        assert isinstance(new_artifact, numeric_artifact.NumericArtifact)
+
+        return new_artifact
+
+    def _apply_operator_to_table(
+        self,
+        dag: DAG,
+        artifact_id: uuid.UUID,
+        op_spec: OperatorSpec,
+        op_name: str,
+        op_description: str,
+        output_artifact_type_hint: ArtifactType,
+        execution_mode: ExecutionMode = ExecutionMode.EAGER,
+    ) -> Union[numeric_artifact.NumericArtifact, bool_artifact.BoolArtifact]:
+        assert (
+            output_artifact_type_hint == ArtifactType.NUMERIC
+            or output_artifact_type_hint == ArtifactType.BOOL
+        )
+
+        operator_id = generate_uuid()
+        output_artifact_id = generate_uuid()
+        artifact_name = default_artifact_name_from_op_name(op_name)
+
+        create_metric_or_check_artifact(
+            dag=dag,
+            op=Operator(
+                id=operator_id,
+                name=op_name,
+                description=op_description,
+                spec=op_spec,
+                inputs=[artifact_id],
+                outputs=[output_artifact_id],
+            ),
+            output_artifacts=[
+                ArtifactMetadata(
+                    id=output_artifact_id,
+                    name=artifact_name,
+                    type=output_artifact_type_hint,
+                    explicitly_named=False,
+                )
+            ],
+        )
+
+        if execution_mode == ExecutionMode.EAGER:
+            # Issue preview request since this is an eager execution.
+            artifact = artifact_utils.preview_artifact(dag, output_artifact_id)
+
+            assert isinstance(artifact, numeric_artifact.NumericArtifact) or isinstance(
+                artifact, bool_artifact.BoolArtifact
+            )
+            return artifact
+        else:
+            # We are in lazy mode.
+            if output_artifact_type_hint == ArtifactType.NUMERIC:
+                return numeric_artifact.NumericArtifact(dag, output_artifact_id)
+            else:
+                return bool_artifact.BoolArtifact(dag, output_artifact_id)

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 import pandas as pd
 from aqueduct.artifacts import bool_artifact, numeric_artifact
@@ -18,7 +18,6 @@ from aqueduct.constants.enums import (
     FunctionType,
     OperatorType,
 )
-from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
 from aqueduct.error import AqueductError, ArtifactNeverComputedException
 from aqueduct.models.dag import DAG
 from aqueduct.models.operators import CheckSpec, FunctionSpec, MetricSpec, OperatorSpec
@@ -28,7 +27,7 @@ from aqueduct.utils.describe import (
     get_readable_description_for_metric,
 )
 from aqueduct.utils.function_packaging import serialize_function
-from aqueduct.utils.utils import format_header_for_print, generate_uuid
+from aqueduct.utils.utils import format_header_for_print
 from ruamel import yaml
 
 from aqueduct import globals

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -21,16 +21,8 @@ from aqueduct.constants.enums import (
 from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
 from aqueduct.error import AqueductError, ArtifactNeverComputedException
 from aqueduct.models.dag import DAG
-from aqueduct.models.operators import (
-    CheckSpec,
-    FunctionSpec,
-    MetricSpec,
-    OperatorSpec,
-)
-from aqueduct.utils.dag_deltas import (
-    RemoveCheckOperatorDelta,
-    apply_deltas_to_dag,
-)
+from aqueduct.models.operators import CheckSpec, FunctionSpec, MetricSpec, OperatorSpec
+from aqueduct.utils.dag_deltas import RemoveCheckOperatorDelta, apply_deltas_to_dag
 from aqueduct.utils.describe import (
     get_readable_description_for_check,
     get_readable_description_for_metric,

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -580,6 +580,26 @@ class TableArtifact(BaseArtifact, system_metric.SystemMetricMixin):
 
         return new_artifact
 
+    def system_metric(
+        self, metric_name: str, lazy: bool = False
+    ) -> numeric_artifact.NumericArtifact:
+        """Creates a system metric that represents the given system information from the previous @op that ran on the table.
+
+        Args:
+            metric_name:
+                Name of system metric to retrieve for the table.
+                Valid metrics are:
+                    runtime: runtime of previous @op func in seconds
+                    max_memory: maximum memory usage of previous @op func in Mb
+
+        Returns:
+            A numeric artifact that represents the requested system metric
+        """
+        if globals.__GLOBAL_CONFIG__.lazy:
+            lazy = True
+
+        return self._system_metric_helper(self._dag, self._artifact_id, metric_name, lazy)
+
     def _get_table_name(self) -> str:
         return self._dag.must_get_artifact(self._artifact_id).name
 

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -20,21 +20,15 @@ from aqueduct.constants.enums import (
 )
 from aqueduct.constants.metrics import SYSTEM_METRICS_INFO
 from aqueduct.error import AqueductError, ArtifactNeverComputedException
-from aqueduct.models.artifact import ArtifactMetadata
 from aqueduct.models.dag import DAG
 from aqueduct.models.operators import (
     CheckSpec,
     FunctionSpec,
     MetricSpec,
-    Operator,
     OperatorSpec,
-    SystemMetricSpec,
 )
 from aqueduct.utils.dag_deltas import (
-    AddOperatorDelta,
-    DAGDelta,
     RemoveCheckOperatorDelta,
-    RemoveOperatorDelta,
     apply_deltas_to_dag,
 )
 from aqueduct.utils.describe import (
@@ -42,7 +36,6 @@ from aqueduct.utils.describe import (
     get_readable_description_for_metric,
 )
 from aqueduct.utils.function_packaging import serialize_function
-from aqueduct.utils.naming import default_artifact_name_from_op_name
 from aqueduct.utils.utils import format_header_for_print, generate_uuid
 from ruamel import yaml
 

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Optional, Union
 import pandas as pd
 from aqueduct.artifacts import bool_artifact, numeric_artifact
 from aqueduct.artifacts import preview as artifact_utils
+from aqueduct.artifacts import system_metric
 from aqueduct.artifacts._create import create_metric_or_check_artifact
 from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.constants.enums import (
@@ -48,7 +49,7 @@ from ruamel import yaml
 from aqueduct import globals
 
 
-class TableArtifact(BaseArtifact):
+class TableArtifact(BaseArtifact, system_metric.SystemMetricMixin):
     """This class represents a computed table within the flow's DAG.
 
     Any `@op`-annotated python function that returns a dataframe will
@@ -155,15 +156,6 @@ class TableArtifact(BaseArtifact):
             A list of available preset metrics on a table
         """
         return self.PRESET_METRIC_LIST
-
-    def list_system_metrics(self) -> List[str]:
-        """Returns a list of all system metrics available on the table artifact.
-        These system metrics can be set via the invoking the system_metric() method the table.
-
-        Returns:
-            A list of available system metrics on a table
-        """
-        return list(SYSTEM_METRICS_INFO.keys())
 
     def validate_with_expectation(
         self,
@@ -277,6 +269,8 @@ class TableArtifact(BaseArtifact):
         check_spec = OperatorSpec(check=CheckSpec(level=severity, function=function_spec))
         check_description = "Check table with built in expectations from great expectations"
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             check_spec,
             check_name,
             check_description,
@@ -352,6 +346,8 @@ class TableArtifact(BaseArtifact):
         )
         op_spec = OperatorSpec(metric=MetricSpec(function=function_spec))
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             op_spec,
             metric_name,
             metric_description,
@@ -393,6 +389,8 @@ class TableArtifact(BaseArtifact):
         )
         op_spec = OperatorSpec(metric=MetricSpec(function=function_spec))
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             op_spec,
             metric_name,
             metric_description,
@@ -439,6 +437,8 @@ class TableArtifact(BaseArtifact):
         )
         op_spec = OperatorSpec(metric=MetricSpec(function=function_spec))
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             op_spec,
             metric_name,
             metric_description,
@@ -485,6 +485,8 @@ class TableArtifact(BaseArtifact):
         )
         op_spec = OperatorSpec(metric=MetricSpec(function=function_spec))
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             op_spec,
             metric_name,
             metric_description,
@@ -531,6 +533,8 @@ class TableArtifact(BaseArtifact):
         )
         op_spec = OperatorSpec(metric=MetricSpec(function=function_spec))
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             op_spec,
             metric_name,
             metric_description,
@@ -579,6 +583,8 @@ class TableArtifact(BaseArtifact):
         )
         op_spec = OperatorSpec(metric=MetricSpec(function=function_spec))
         new_artifact = self._apply_operator_to_table(
+            self._dag,
+            self._artifact_id,
             op_spec,
             metric_name,
             metric_description,
@@ -607,75 +613,8 @@ class TableArtifact(BaseArtifact):
         """
         if globals.__GLOBAL_CONFIG__.lazy:
             lazy = True
-        execution_mode = ExecutionMode.EAGER if not lazy else ExecutionMode.LAZY
 
-        operator = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)
-        system_metric_description, system_metric_unit = SYSTEM_METRICS_INFO[metric_name]
-        system_metric_name = "%s %s(%s) metric" % (operator.name, metric_name, system_metric_unit)
-        op_spec = OperatorSpec(system_metric=SystemMetricSpec(metric_name=metric_name))
-        new_artifact = self._apply_operator_to_table(
-            op_spec,
-            system_metric_name,
-            system_metric_description,
-            output_artifact_type_hint=ArtifactType.NUMERIC,
-            execution_mode=execution_mode,
-        )
-
-        assert isinstance(new_artifact, numeric_artifact.NumericArtifact)
-
-        return new_artifact
-
-    def _apply_operator_to_table(
-        self,
-        op_spec: OperatorSpec,
-        op_name: str,
-        op_description: str,
-        output_artifact_type_hint: ArtifactType,
-        execution_mode: ExecutionMode = ExecutionMode.EAGER,
-    ) -> Union[numeric_artifact.NumericArtifact, bool_artifact.BoolArtifact]:
-        assert (
-            output_artifact_type_hint == ArtifactType.NUMERIC
-            or output_artifact_type_hint == ArtifactType.BOOL
-        )
-
-        operator_id = generate_uuid()
-        output_artifact_id = generate_uuid()
-        artifact_name = default_artifact_name_from_op_name(op_name)
-
-        create_metric_or_check_artifact(
-            dag=self._dag,
-            op=Operator(
-                id=operator_id,
-                name=op_name,
-                description=op_description,
-                spec=op_spec,
-                inputs=[self._artifact_id],
-                outputs=[output_artifact_id],
-            ),
-            output_artifacts=[
-                ArtifactMetadata(
-                    id=output_artifact_id,
-                    name=artifact_name,
-                    type=output_artifact_type_hint,
-                    explicitly_named=False,
-                )
-            ],
-        )
-
-        if execution_mode == ExecutionMode.EAGER:
-            # Issue preview request since this is an eager execution.
-            artifact = artifact_utils.preview_artifact(self._dag, output_artifact_id)
-
-            assert isinstance(artifact, numeric_artifact.NumericArtifact) or isinstance(
-                artifact, bool_artifact.BoolArtifact
-            )
-            return artifact
-        else:
-            # We are in lazy mode.
-            if output_artifact_type_hint == ArtifactType.NUMERIC:
-                return numeric_artifact.NumericArtifact(self._dag, output_artifact_id)
-            else:
-                return bool_artifact.BoolArtifact(self._dag, output_artifact_id)
+        return self.system_metric_helper(self._dag, self._artifact_id, metric_name, lazy)
 
     def _get_table_name(self) -> str:
         return self._dag.must_get_artifact(self._artifact_id).name

--- a/sdk/aqueduct/artifacts/table_artifact.py
+++ b/sdk/aqueduct/artifacts/table_artifact.py
@@ -581,26 +581,6 @@ class TableArtifact(BaseArtifact, system_metric.SystemMetricMixin):
 
         return new_artifact
 
-    def system_metric(
-        self, metric_name: str, lazy: bool = False
-    ) -> numeric_artifact.NumericArtifact:
-        """Creates a system metric that represents the given system information from the previous @op that ran on the table.
-
-        Args:
-            metric_name:
-                name of system metric to retrieve for the table.
-                valid metrics are:
-                    runtime: runtime of previous @op func in seconds
-                    max_memory: maximum memory usage of previous @op func in Mb
-
-        Returns:
-            A numeric artifact that represents the requested system metric
-        """
-        if globals.__GLOBAL_CONFIG__.lazy:
-            lazy = True
-
-        return self.system_metric_helper(self._dag, self._artifact_id, metric_name, lazy)
-
     def _get_table_name(self) -> str:
         return self._dag.must_get_artifact(self._artifact_id).name
 

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -7,8 +7,8 @@ from typing import Any, DefaultDict, Dict, List, Optional, Union
 
 import __main__ as main
 import yaml
-from aqueduct.artifacts import bool_artifact
 from aqueduct.artifacts.base_artifact import BaseArtifact
+from aqueduct.artifacts.bool_artifact import BoolArtifact
 from aqueduct.artifacts.create import create_param_artifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.backend.response_models import SavedObjectUpdate
@@ -444,7 +444,7 @@ class Client:
         engine: Optional[str] = None,
         artifacts: Optional[Union[BaseArtifact, List[BaseArtifact]]] = None,
         metrics: Optional[List[NumericArtifact]] = None,
-        checks: Optional[List[bool_artifact.BoolArtifact]] = None,
+        checks: Optional[List[BoolArtifact]] = None,
         k_latest_runs: Optional[int] = None,
         source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
         run_now: Optional[bool] = None,

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -7,8 +7,8 @@ from typing import Any, DefaultDict, Dict, List, Optional, Union
 
 import __main__ as main
 import yaml
+from aqueduct.artifacts import bool_artifact
 from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.artifacts.bool_artifact import BoolArtifact
 from aqueduct.artifacts.create import create_param_artifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
 from aqueduct.backend.response_models import SavedObjectUpdate
@@ -444,7 +444,7 @@ class Client:
         engine: Optional[str] = None,
         artifacts: Optional[Union[BaseArtifact, List[BaseArtifact]]] = None,
         metrics: Optional[List[NumericArtifact]] = None,
-        checks: Optional[List[BoolArtifact]] = None,
+        checks: Optional[List[bool_artifact.BoolArtifact]] = None,
         k_latest_runs: Optional[int] = None,
         source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
         run_now: Optional[bool] = None,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds the `system_metric` capability to GenericArtifacts. Creates a mixin SystemMetricMixin that both GenericArtifact and TableArtifact use.
## Related issue number (if any)
[Eng-2436](eng-2436-fix-regression-in-system-metrics)
## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


