### PR TITLE
[ENG-2687] Reduce the number of shades of blue on workflow details page

### DIFF
--- a/src/ui/common/src/components/primitives/Button.styles.tsx
+++ b/src/ui/common/src/components/primitives/Button.styles.tsx
@@ -13,13 +13,14 @@ const AqueductButton = styled(Button)(() => {
 
       // Theming for primary colored buttons.
       [`&.${buttonClasses.textPrimary}`]: {
-        color: theme.palette.blue[600],
+        color: theme.palette.blue[900],
         backgroundColor: 'white',
         '&:hover': {
           backgroundColor: theme.palette.gray[50],
         },
         [`&.${buttonClasses.disabled}`]: {
-          color: theme.palette.blue[200],
+          color: theme.palette.blue[900],
+          opacity: '0.5',
         },
       },
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Based on feedback, updating the color of the action buttons on the workflow details page to be more consistent with the rest of the UI.

## Related issue number (if any)

## Loom demo (if any)

<img width="166" alt="image" src="https://user-images.githubusercontent.com/867892/228026067-f6803ca7-7876-4b3e-8031-45d879e15a8b.png">

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


