### PR TITLE
Only upload terraform directory when the K8s cleanup fails

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -53,6 +53,7 @@ jobs:
         run: pytest aqueduct_tests/ -rP -vv -n 4
 
       - name: Teardown K8s Cluster
+        id: k8s_cleanup # so that we only upload the state on this specific failure.
         if: always()
         uses: nick-fields/retry@v2
         with:
@@ -66,7 +67,7 @@ jobs:
 
       # This directory is quite large, so we only upload it on failure.
       - uses: actions/upload-artifact@v3
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.k8s_cleanup.outcome == 'failure' }}
         with:
           name: Terraform State
           path: |

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -250,7 +250,7 @@ func ConnectIntegration(
 	// Extract non-confidential config
 	publicConfig := args.Config.PublicConfig()
 
-	var integrationObject *models.Integration Needs to update `storage_migration` table.
+	var integrationObject *models.Integration
 	var err error
 	if args.UserOnly {
 		// This is a user-specific integration

--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -250,7 +250,7 @@ func ConnectIntegration(
 	// Extract non-confidential config
 	publicConfig := args.Config.PublicConfig()
 
-	var integrationObject *models.Integration
+	var integrationObject *models.Integration Needs to update `storage_migration` table.
 	var err error
 	if args.UserOnly {
 		// This is a user-specific integration


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This is a small tweak to make sure we aren't uploading 0.5 GBs of artifact data on every periodic failure - only when the cluster cleanup fails, since the point of uploading this artifact is to finish cluster deletion in such cases.


## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


