### PR TITLE
[ENG-2718] Fix bug where loading different workflow DAGs causes the UI to crash

### DIFF
--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -33,6 +33,22 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
   );
 
   const { edges, nodes } = dagPositionState.result ?? { edges: [], nodes: [] };
+  if (edges.length === 0 || nodes.length === 0) { // The DAG position state is still loading.
+    return null;
+  }
+
+  // This is a bit of a tricky check; when we switch between workflow versions, the selected DAG
+  // does not load in sync with the DAG positioning. As a result, we need to ensure 
+  // that we only render the graph once the two sets of Redux state are in sync before
+  // proceeding; otherwise, our node IDs will be mismatched. Here, we simply check to see
+  // if the UUIDs for one of the nodes exists in the selected DAG. If it doesn't, that 
+  // means the state has synced yet, so we return null and wait for it to sync.
+  const testNode = nodes[0];
+  if ((testNode.data.nodeType === ReactflowNodeType.Operator && !selectedDag.operators[testNode.id])
+    || (testNode.data.nodeType === ReactflowNodeType.Artifact && !selectedDag.artifacts[testNode.id])
+  ) {
+    return null;
+  }
 
   const defaultViewport = { x: 0, y: 0, zoom: 1 };
 

--- a/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
+++ b/src/ui/common/src/components/workflows/ReactFlowCanvas.tsx
@@ -33,19 +33,23 @@ const ReactFlowCanvas: React.FC<ReactFlowCanvasProps> = ({
   );
 
   const { edges, nodes } = dagPositionState.result ?? { edges: [], nodes: [] };
-  if (edges.length === 0 || nodes.length === 0) { // The DAG position state is still loading.
+  if (edges.length === 0 || nodes.length === 0) {
+    // The DAG position state is still loading.
     return null;
   }
 
   // This is a bit of a tricky check; when we switch between workflow versions, the selected DAG
-  // does not load in sync with the DAG positioning. As a result, we need to ensure 
+  // does not load in sync with the DAG positioning. As a result, we need to ensure
   // that we only render the graph once the two sets of Redux state are in sync before
   // proceeding; otherwise, our node IDs will be mismatched. Here, we simply check to see
-  // if the UUIDs for one of the nodes exists in the selected DAG. If it doesn't, that 
+  // if the UUIDs for one of the nodes exists in the selected DAG. If it doesn't, that
   // means the state has synced yet, so we return null and wait for it to sync.
   const testNode = nodes[0];
-  if ((testNode.data.nodeType === ReactflowNodeType.Operator && !selectedDag.operators[testNode.id])
-    || (testNode.data.nodeType === ReactflowNodeType.Artifact && !selectedDag.artifacts[testNode.id])
+  if (
+    (testNode.data.nodeType === ReactflowNodeType.Operator &&
+      !selectedDag.operators[testNode.id]) ||
+    (testNode.data.nodeType === ReactflowNodeType.Artifact &&
+      !selectedDag.artifacts[testNode.id])
   ) {
     return null;
   }


### PR DESCRIPTION
## Describe your changes and why you are making these changes

#1121 introduced a somewhat insidious bug. As of that PR, when we render the workflow DAG, we don't just depend on the node position state but also on the workflow DAG state. However, the selected DAG state seems to always load after the node position state loads. 

Since the node position state loads first, we trigger a re-render of the ReactFlow canvas, but we don't have the right node state yet since the `selectedDag` is out of date (still pointing at the old version).

This PR adds two state synchronization checks to make sure that everything has loaded correctly before we render the DAG to avoid crashes.

## Related issue number (if any)

ENG-2718

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


