### PR TITLE
Check for data in response payload for failed execution

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/checks_test.py
+++ b/integration_tests/sdk/aqueduct_tests/checks_test.py
@@ -122,13 +122,7 @@ def test_edit_check(client, data_integration, engine, flow_name):
     flow = publish_flow_test(client, artifacts=[pass2, fail], engine=engine, name=flow_name())
     flow_run = flow.latest()
     assert flow_run.artifact("foo artifact").get()
-
-    # TODO(ENG-2629): Fetching a warning check should not raise an exception.
-    with pytest.raises(
-        ArtifactNeverComputedException,
-        match="This artifact was part of an existing flow run but was never computed successfully",
-    ):
-        assert not flow_run.artifact("foo artifact (1)").get()
+    assert not flow_run.artifact("foo artifact (1)").get()
 
 
 def test_delete_check(client, data_integration):

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -558,13 +558,14 @@ class APIClient:
         parsed_response = _parse_artifact_result_response(resp)
         execution_status = parsed_response["metadata"]["exec_state"]["status"]
 
-        if execution_status != ExecutionStatus.SUCCEEDED:
-            print("Artifact result unavailable due to unsuccessful execution.")
-            return None, execution_status
-
         serialization_type = parsed_response["metadata"]["serialization_type"]
         artifact_type = parsed_response["metadata"]["artifact_type"]
-        return (
-            deserialize(serialization_type, artifact_type, parsed_response["data"]),
-            execution_status,
-        )
+
+        return_value = None
+        if "data" in parsed_response:
+            return_value = deserialize(serialization_type, artifact_type, parsed_response["data"])
+
+        if execution_status != ExecutionStatus.SUCCEEDED:
+            logger().warning("Artifact result unavailable due to unsuccessful execution.")
+
+        return (return_value, execution_status)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Check for data in failed workflow execution response payload. If there is valid data, it is deserialized and returned as artifact result. This is helpful for boolean operator that returns True or False

## Related issue number (if any)
ENG-2629

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


