### PR TITLE
[ENG-2621] Fix bug where status in workflow header is not correctly updated

### DIFF
--- a/src/ui/common/src/components/pages/workflow/id/index.tsx
+++ b/src/ui/common/src/components/pages/workflow/id/index.tsx
@@ -656,8 +656,16 @@ const WorkflowPage: React.FC<WorkflowPageProps> = ({
                 sx={{ width: '100%', py: 1, fontSize: '32px' }}
                 variant="text"
                 onClick={() => {
-                  // When the button is clicked, load all of the metadata again.
+                  // When the button is clicked, load all of the metadata of each of the nodes again.
                   getDagResultDetails(true);
+
+                  // Also refresh the history of workflow runs to update the status.
+                  dispatch(
+                    handleGetWorkflowHistory({
+                      apiKey: user.apiKey,
+                      workflowId: workflowId,
+                    })
+                  );
                 }}
               >
                 <FontAwesomeIcon icon={faArrowRotateRight} />

--- a/src/ui/common/src/components/workflows/version_selector.tsx
+++ b/src/ui/common/src/components/workflows/version_selector.tsx
@@ -39,11 +39,12 @@ export const VersionSelector: React.FC = () => {
     return null;
   }
 
+  let historyHasLoaded = true;
   if (
     workflowHistory.status.loading === LoadingStatusEnum.Loading ||
     workflowHistory.status.loading === LoadingStatusEnum.Initial
   ) {
-    return null;
+    historyHasLoaded = false;
   }
 
   const getMenuItems = () => {
@@ -154,7 +155,7 @@ export const VersionSelector: React.FC = () => {
           horizontal: 'left',
         }}
       >
-        {getMenuItems()}
+        {historyHasLoaded && getMenuItems()}
       </Popover>
     </Box>
   );

--- a/src/ui/common/src/components/workflows/workflowHeader.tsx
+++ b/src/ui/common/src/components/workflows/workflowHeader.tsx
@@ -6,7 +6,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Alert, Collapse, Tooltip, Typography } from '@mui/material';
 import Box from '@mui/material/Box';
-import React, { useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import Markdown from 'react-markdown';
 import { useSelector } from 'react-redux';
 import { visitParents } from 'unist-util-visit-parents';
@@ -16,6 +16,7 @@ import style from '../../styles/markdown.module.css';
 import { theme } from '../../styles/theme/theme';
 import { getNextUpdateTime } from '../../utils/cron';
 import { EngineType } from '../../utils/engine';
+import ExecutionStatus, { LoadingStatusEnum } from '../../utils/shared';
 import {
   getWorkflowEngineTypes,
   WorkflowDag,
@@ -60,6 +61,32 @@ const WorkflowHeader: React.FC<Props> = ({ workflowDag }) => {
 
   const [showDescription, setShowDescription] = useState(false);
   const workflow = useSelector((state: RootState) => state.workflowReducer);
+  const workflowHistory = useSelector(
+    (state: RootState) => state.workflowHistoryReducer
+  );
+  const [selectedResultIdx, setSelectedResultIdx] = useState(0);
+
+  // Whenever the workflow reducer's selected result changes, we update our local state to
+  // have the correct index of the workflow history list. This is used to ensure that we show
+  // the correct execution status in the header.
+  useEffect(() => {
+    if (workflowHistory.status.loading !== LoadingStatusEnum.Succeeded) {
+      return;
+    }
+
+    for (let i = 0; i < workflowHistory.history.versions.length; i++) {
+      const result = workflowHistory.history.versions[i];
+      if (result.versionId === workflow.selectedResult.id) {
+        setSelectedResultIdx(i);
+      }
+    }
+  }, [workflow.selectedResult]);
+
+  let selectedWorkflowStatus = ExecutionStatus.Unknown;
+  if (workflowHistory.status.loading === LoadingStatusEnum.Succeeded) {
+    selectedWorkflowStatus =
+      workflowHistory.history.versions[selectedResultIdx].exec_state.status;
+  }
 
   const name = workflowDag.metadata?.name ?? '';
   const description = workflowDag.metadata?.description;
@@ -119,7 +146,7 @@ const WorkflowHeader: React.FC<Props> = ({ workflowDag }) => {
       >
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           {!!workflow.dagResults && workflow.dagResults.length > 0 && (
-            <StatusIndicator status={workflow.dagResults[0].status} />
+            <StatusIndicator status={selectedWorkflowStatus} />
           )}
 
           <Typography


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Previously, we were hardcoding the workflow status to show an indicator for the execution status of the most recent workflow run. That had two issues: 
1. When you switched workflow runs, it would not update accordingly.
2. If you hit the refresh button on the UI, the status would not change.

1 was fixable simply by updating the index of the status check to match the selected run, but 2 was a tougher challenge because we would have to load the whole workflow state again, which would cause the whole page to go white and then re-render.

#1108 introduced the workflow history store which enabled us to fix this problem more simply. Now, the workflow header reads the status from the workflow history rather than from the workflow reducers `dagResults` list. The refresh button can simply refresh the workflow history store, and the status will update accordingly. This PR also fixes 1 by doing the index management that I mentioned above.

This PR also does a little bit of work to prevent flashing as things render on the UI. Previously, we would return null when loading metadata, which would cause a bunch of layout shifts to happen when the metadata finally loaded. This PR's updates are not perfect, but we essentially enter some "empty" states when metadata is loading, so elements render and then update when the metadata loads. As you can see, this still causes some flashing when the state ultimately loads, but the layout does not shift.

## Related issue number (if any)

ENG-2621

## Loom demo (if any)

https://www.loom.com/share/822115ef4be14e7fa0ec9a7b5bc6862e

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


