### PR TITLE
[K8s] Handle case where multiple tests race to create the aqueduct namespace 

### DIFF
--- a/src/golang/lib/k8s/clients.go
+++ b/src/golang/lib/k8s/clients.go
@@ -75,7 +75,10 @@ func CreateNamespaces(k8sClient *kubernetes.Clientset) error {
 
 		_, err = k8sClient.CoreV1().Namespaces().Create(context.TODO(), userNamespace, metav1.CreateOptions{})
 		if err != nil {
-			return errors.Wrap(err, "Unable to create namespace.")
+			// Double-check that we didn't race against another process to create this namespace.
+			if _, namespaceExistsErr := namespaces.Get(context.TODO(), AqueductNamespace, metav1.GetOptions{}); namespaceExistsErr != nil {
+				return errors.Wrap(err, "Unable to create namespace.")
+			}
 		}
 		log.Infof("User namespace (name: %s) created successfully.\n", AqueductNamespace)
 	}

--- a/src/golang/lib/k8s/clients.go
+++ b/src/golang/lib/k8s/clients.go
@@ -79,8 +79,10 @@ func CreateNamespaces(k8sClient *kubernetes.Clientset) error {
 			if _, namespaceExistsErr := namespaces.Get(context.TODO(), AqueductNamespace, metav1.GetOptions{}); namespaceExistsErr != nil {
 				return errors.Wrap(err, "Unable to create namespace.")
 			}
+			log.Infof("Another process raced to create the user namespace (name: %s). Continuing.\n", AqueductNamespace)
+		} else {
+			log.Infof("User namespace (name: %s) created successfully.\n", AqueductNamespace)
 		}
-		log.Infof("User namespace (name: %s) created successfully.\n", AqueductNamespace)
 	}
 	return nil
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This *should* fix at least the flaky `test_all_param_types` tests.

## Related issue number (if any)
ENG-2729

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


