### PR TITLE
Fix misaligned metrics / checks when they have long names

### DIFF
--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -254,24 +254,22 @@ export const Node: React.FC<Props> = ({ data, isConnectable }) => {
               {headerIcon}
             </Box>
 
-            <Box flex={1}>
-              <Typography
-                sx={{
-                  maxWidth: '80%',
-                  flex: 1,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  fontSize: '32px',
-                }}
-              >
-                {data.label}
-              </Typography>
-            </Box>
+            <Typography
+              sx={{
+                maxWidth: '70%',
+                flex: 1,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                fontSize: '32px',
+              }}
+            >
+              {data.label}
+            </Typography>
 
             {headerEndIcon && (
               <>
-                <Box justifySelf="end" mr={2}>
+                <Box justifySelf="end" ml={1} mr={2}>
                   <Tooltip
                     title={
                       data.spec?.type === OperatorType.Check


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes misaligned metrics / checks icons in UI when they have long names. The cause being an additional flex box that wraps the texts, and as a result the text width is extended

## Related issue number (if any)

## Loom demo (if any)
![Screenshot 2023-04-04 at 5 15 18 PM](https://user-images.githubusercontent.com/10411887/229950235-759e7f6f-534f-41d4-a9c2-ca9b0178e142.png)
![Screenshot 2023-04-04 at 5 15 26 PM](https://user-images.githubusercontent.com/10411887/229950239-9b2fb55f-feac-4e53-a417-61fdaa6bca6d.png)
![Screenshot 2023-04-04 at 5 15 34 PM](https://user-images.githubusercontent.com/10411887/229950241-a79a7228-9bc4-4042-84b4-6b3abcd87546.png)
![Screenshot 2023-04-04 at 5 15 50 PM](https://user-images.githubusercontent.com/10411887/229950243-39dfadde-a494-4cd1-9f4b-6882ff9d688a.png)
![Screenshot 2023-04-04 at 5 16 06 PM](https://user-images.githubusercontent.com/10411887/229950244-ed78f6ef-07b8-404b-bd25-0023409a8363.png)
![Screenshot 2023-04-04 at 5 16 17 PM](https://user-images.githubusercontent.com/10411887/229950249-0c267897-8713-4519-8690-47689646d2ef.png)


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


