### PR TITLE
Eng 1187 Script to automatically run gitbook snippets

### DIFF
--- a/regression_tests/tests/gitbook/requirements.txt
+++ b/regression_tests/tests/gitbook/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+scikit-learn

--- a/regression_tests/tests/gitbook/test_docs.py
+++ b/regression_tests/tests/gitbook/test_docs.py
@@ -1,0 +1,164 @@
+import os
+import re
+import argparse
+import subprocess
+from glob import glob
+from pathlib import Path
+from typing import NamedTuple, List
+
+class SnippetExec(NamedTuple):
+    snippet: List[str]
+    success: bool
+    output: str
+    last_successful_block: int
+    error: str
+
+# Not in-scope for testing now
+blacklist_sections = [
+    "integrations",
+    "api-reference",
+    "installation-and-configuration",
+    "example-workflows",  # Already tested elsewhere
+]
+
+blacklist_files = [
+    "operators/configuring-resource-constraints.md",  # Header snippets. The GPU Access one require the operator to be executed on Kubernetes
+    "workflows/deleting-a-workflow.md",  # Referencing workflow UUIDs.
+    "operators/specifying-a-requirements.txt.md", # Requires specific requirements.txt
+]
+
+blacklist_snippets = {
+    "workflows/managing-workflow-schedules.md": [
+# Skipping because references workflows by UUID.
+"""workflow_a = client.flow('8fb25dc4-62ed-44a3-872d-c3ff988c8dd3')
+
+# source_flow can be a Flow object, workflow name, or workflow ID
+flow = client.publish_flow(name='workflow_b', 
+                           artifacts=[data],
+                           source_flow=source_flow)""",
+# Skipping because references workflows by UUID.
+"""workflow_id = "0c007eff-6ae0-4a1a-a114-5f16164ffcdf" # Set your workflow ID here.
+client.trigger(id=workflow_id)""",
+    ],
+}
+def get_code(page):
+    contents = Path(page).read_text()
+    return re.findall("`{3}python\n([\s\S]*?)\n`{3}", contents)
+
+def run_in_order(snippet_list, filename):
+    success = True
+    error = ""
+    output = ""
+    i = len(snippet_list)
+
+    try:
+        # Create a temporary file
+        with open(filename, "w") as f:
+            f.write("\n".join(snippet_list))
+
+        # Execute the code in the file and capture the output
+        result = subprocess.run(["python3", filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True)
+
+        output = result.stdout
+    except subprocess.CalledProcessError as e:
+        if i <= 1:
+            success = False
+            output = e.stdout
+            error = e.stderr
+        else:
+            # Determine which block is the issue.
+            for i in range(1, i):
+                try:
+                    with open(filename, "w") as f:
+                        f.write("\n".join(snippet_list[:i]))
+                    result = subprocess.run(["python3", filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True, text=True)
+                except subprocess.CalledProcessError as e:
+                    success = False
+                    output = e.stdout
+                    error = e.stderr
+                    i -= 1
+                    break
+    # Delete the temporary file
+    os.remove(filename)
+    return SnippetExec(snippet_list, success, output, i, error)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--docs-folder",
+        dest="docs_folder",
+        default="gitbook",
+        action="store",
+        help="Path to gitbook directory.",
+    )
+
+    parser.add_argument(
+        "--run-subset",
+        dest="run_subset",
+        default=False,
+        action="store_true",
+        help="Run a subset of the gitbook sections.",
+    )
+
+    parser.add_argument(
+        "--sections",
+        dest="sections",
+        default=[],
+        nargs='+',
+        action="store",
+        help="Subset of gitbook sections to run.",
+    )
+
+    args = parser.parse_args()
+
+    if args.run_subset:
+        args.sections = [(section, 0) for section in args.sections_subset]
+    else:
+        args.sections = os.walk(args.docs_folder)
+
+    snippets_by_page = {}
+
+    successfully_ran_all = True
+    for item in args.sections:
+        skip = False
+        for blacklist_section in blacklist_sections:
+            current_section = item[0].split("gitbook/")[-1]
+            if current_section == blacklist_section or current_section.startswith(blacklist_section+"/"):
+                skip = True
+                print(">> SKIPPING ", current_section)
+                break
+        if not skip:
+            for file in glob(os.path.join(item[0], '*.md')):
+                file_name = file.split("gitbook/")[-1]
+                skip = False
+                for blacklist_file in blacklist_files:
+                    if file_name == blacklist_file:
+                        skip = True
+                        print(">> SKIPPING ", file_name)
+                if not skip:
+                    snippets = get_code(file)
+                    if file_name in blacklist_snippets.keys():
+                        snippets = [snippet for snippet in snippets if snippet not in blacklist_snippets[file_name]]
+                    if len(snippets) > 0:
+                        snippets_by_page[file] = run_in_order(snippets, file.replace(r"/", "_")[:-2] + "py")
+                        if not snippets_by_page[file].success:
+                            successfully_ran_all = False
+                            print(">> FAILED   ", file_name)
+                            print("-"*25 + "[CODE]" + "-"*25)
+                            for i, snippet in enumerate(snippets_by_page[file].snippet):
+                                if i == snippets_by_page[file].last_successful_block:
+                                    print("-"*25 + "[FAILED BLOCK]" + "-"*25)
+                                print(snippet)
+                                if i == snippets_by_page[file].last_successful_block:
+                                    break
+                            print("-"*25 + "[ERROR]" + "-"*25)
+                            print(snippets_by_page[file].error)
+                        else:
+                            print(">> OK       ", file_name)
+                    else:
+                        print(">> SKIPPING  (no Python snippets found)", file_name)
+
+
+    if successfully_ran_all:
+        print("Congrats! You've successfully ran all code snippets in the documentation.")

--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -183,7 +183,8 @@ class NumericArtifact(BaseArtifact):
                 % (",".join(input_mapping.keys()))
             )
 
-        assert bound_name and bound_value
+        # Specify is not None because 0 is a Falsey value
+        assert bound_name is not None and bound_value is not None
 
         accepted_types = [float, int]
         if type(bound_value) not in accepted_types:

--- a/sdk/aqueduct/schedule.py
+++ b/sdk/aqueduct/schedule.py
@@ -28,7 +28,7 @@ class DayOfWeek(Enum):
 class DayOfMonth:
     def __init__(self, day: int):
         if day < 0 or day >= 32:
-            raise Exception("Invalid hour value %s." % day)
+            raise Exception("Invalid day value %s." % day)
         self.val = day
 
 
@@ -70,7 +70,7 @@ def weekly(day: DayOfWeek, hour: Hour = Hour(0), minute: Minute = Minute(0)) -> 
 
 
 def monthly(day: DayOfMonth, hour: Hour = Hour(0), minute: Minute = Minute(0)) -> str:
-    if not isinstance(day, DayOfWeek):
+    if not isinstance(day, DayOfMonth):
         raise Exception(
             "Invalid types provided in parameters: aqueduct.schedule.DayOfMonth required for first argument."
         )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Script to run through Gitbook Python code snippets. Run through all of them except the ones that require lots of set up (integrations) or have workflow UUIDs hard-coded in.

Also fixes bugs discovered via running through the code snippets:
- The `monthly` function instance type check incorrect for `day` (`DayOfWeek` --> `DayOfMonth`).
- Fix `DayOfMonth` exception statement from "Invalid *hour* value" to "Invalid *day* value".
- Fix assertion for bounds to work when bound_value is falsey (e.g. 0).

TODO: Get integrated into our Github Actions. Will work as a follow up task to determine the frequency to run this & get it set up (https://linear.app/aqueducthq/issue/ENG-2748/integrate-into-github-actions).

## Related issue number (if any)
Eng 1187

## Loom demo (if any)
Script output:
```
>> OK        parameters.md
>> OK        quickstart-guide.md
>> SKIPPING  (no Python snippets found) metrics-and-checks.md
>> SKIPPING  (no Python snippets found) faqs.md
>> SKIPPING  (no Python snippets found) SUMMARY.md
>> OK        artifacts.md
>> SKIPPING  (no Python snippets found) the-aqueduct-philosophy.md
>> SKIPPING  (no Python snippets found) operators.md
>> OK        README.md
>> OK        metrics-and-checks/preset-metrics-and-checks.md
>> OK        metrics-and-checks/checks-ensuring-correctness.md
>> OK        metrics-and-checks/metrics-measuring-your-predictions.md
>> SKIPPING  operators/configuring-resource-constraints.md
>> OK        operators/file-dependencies-in-python.md
>> SKIPPING  operators/specifying-a-requirements.txt.md
>> OK        operators/lazy-vs-eager-execution.md
>> OK        operators/creating-a-python-operator.md
>> SKIPPING  api-reference
>> SKIPPING  api-reference/sdk-reference
>> SKIPPING  api-reference/sdk-reference/package-aqueduct
>> SKIPPING  api-reference/sdk-reference/package-aqueduct/package-aqueduct.artifacts
>> SKIPPING  api-reference/sdk-reference/package-aqueduct/package-aqueduct.constants
>> SKIPPING  api-reference/sdk-reference/package-aqueduct/package-aqueduct.integrations
>> SKIPPING  api-reference/sdk-reference/package-aqueduct/package-aqueduct.models
>> OK        workflows/managing-workflow-schedules.md
>> OK        workflows/editing-a-workflow.md
>> SKIPPING  (no Python snippets found) workflows/README.md
>> OK        workflows/workflow-versions.md
>> SKIPPING  workflows/deleting-a-workflow.md
>> OK        workflows/creating-a-workflow.md
>> SKIPPING  integrations
>> SKIPPING  integrations/on-demand-resources
>> SKIPPING  integrations/data-systems
>> SKIPPING  integrations/data-systems/sql-systems
>> SKIPPING  integrations/data-systems/non-sql-systems
>> SKIPPING  integrations/compute-systems
>> SKIPPING  integrations/compute-systems/on-demand-resources
>> SKIPPING  integrations/adding-an-integration
>> SKIPPING  example-workflows
>> OK        guides/porting-a-workflow-to-aqueduct.md
>> SKIPPING  (no Python snippets found) guides/conquering-the-python-environment.md
>> SKIPPING  (no Python snippets found) guides/README.md
>> SKIPPING  (no Python snippets found) guides/debugging-a-failed-workflow.md
>> SKIPPING  installation-and-configuration
>> SKIPPING  installation-and-configuration/installing-aqueduct
>> SKIPPING  (no Python snippets found) notifications/connecting-to-email.md
>> SKIPPING  (no Python snippets found) notifications/connecting-to-slack.md
>> SKIPPING  (no Python snippets found) notifications/README.md
Congrats! You've successfully ran all code snippets in the documentation.
```
Error Output:
```
TODO: Add
```

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


