### PR TITLE
Fix a bug where sidesheet is showing unexpected spaces

### DIFF
--- a/src/ui/common/src/components/operators/WithOperatorHeader.tsx
+++ b/src/ui/common/src/components/operators/WithOperatorHeader.tsx
@@ -99,6 +99,9 @@ const WithOperatorHeader: React.FC<Props> = ({
   const integrationId =
     operator?.spec?.load?.integration_id ||
     operator?.spec?.extract?.integration_id;
+  const integrationName = integrationId
+    ? integrationsState?.integrations[integrationId]?.name
+    : undefined;
 
   return (
     <Box width="100%">
@@ -118,17 +121,21 @@ const WithOperatorHeader: React.FC<Props> = ({
         {checkLevelDisplay}
       </Box>
 
-      <ResourceItem
-        resource={service}
-        resourceCustomName={
-          integrationsState?.integrations[integrationId]?.name
-        }
-      />
+      {integrationName && (
+        <ResourceItem
+          resource={service}
+          resourceCustomName={
+            integrationsState?.integrations[integrationId]?.name
+          }
+        />
+      )}
 
       <Box display="flex" width="100%">
-        <Box width="100%" paddingTop={sideSheetMode ? '16px' : '24px'}>
-          <SaveDetails parameters={operator?.spec?.load?.parameters} />
-        </Box>
+        {operator?.spec?.load?.parameters && (
+          <Box width="100%" paddingTop={sideSheetMode ? '16px' : '24px'}>
+            <SaveDetails parameters={operator?.spec?.load?.parameters} />
+          </Box>
+        )}
 
         {operator?.spec?.load && <Box width="96px" />}
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a bug where we attemp to render integration and save details on all operators. This causes unexpected space in sidesheet when the information is missing.

## Related issue number (if any)

## Loom demo (if any)
save page (should be the same as current main)
![Screenshot 2023-04-05 at 11 22 59 AM](https://user-images.githubusercontent.com/10411887/230171163-c373bc1b-dbf5-48d2-8669-5da601881650.png)
metrics page
![Screenshot 2023-04-05 at 11 24 14 AM](https://user-images.githubusercontent.com/10411887/230171167-51a83a7b-bb35-49a3-9148-7bc93d6893dc.png)
check page
![Screenshot 2023-04-05 at 11 24 55 AM](https://user-images.githubusercontent.com/10411887/230171169-35237d32-a344-4ecc-adf2-6263cb145397.png)
also verified on regular operators and op / artf details page (instead of sidesheet)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


