### PR TITLE
ENG-2753: Fix issue where warning level checks show as failed in history list.

### DIFF
--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -6,11 +6,13 @@ import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactR
 import { theme } from '../../../../styles/theme/theme';
 import { Data, DataSchema } from '../../../../utils/data';
 import ExecutionStatus, {
+  CheckStatus,
   getArtifactExecStateAsTableRow,
   stringToExecutionStatus,
 } from '../../../../utils/shared';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import { StatusIndicator } from '../../workflowStatus';
+import {CheckLevel} from "../../../../utils/operators";
 
 type CheckHistoryProps = {
   historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
@@ -76,12 +78,20 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
         if (entry.status === ExecutionStatus.Succeeded) {
           backgroundColor = theme.palette.green[100];
           hoverColor = theme.palette.green[200];
-        } else if (entry.status === ExecutionStatus.Failed) {
+        } else if (entry.status === ExecutionStatus.Failed && checkLevel === CheckLevel.Error) {
           backgroundColor = theme.palette.red[25];
           hoverColor = theme.palette.red[100];
-        } else {
+        } else if (entry.status === ExecutionStatus.Failed && checkLevel === CheckLevel.Warning) {
+          backgroundColor = theme.palette.yellow[100];
+          hoverColor = theme.palette.yellow[200];
+        } else { // unknown or canceled status
           backgroundColor = theme.palette.gray[100];
           hoverColor = theme.palette.gray[200];
+        }
+
+        let checkStatus = entry.status as string;
+        if (checkLevel === CheckLevel.Warning && entry.status === ExecutionStatus.Failed) {
+          checkStatus = ExecutionStatus.Warning as string;
         }
 
         return (
@@ -102,7 +112,7 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
           >
             <Box sx={{ display: 'flex', alignItems: 'center' }}>
               <StatusIndicator
-                status={stringToExecutionStatus(entry.status as string)}
+                status={stringToExecutionStatus(checkStatus)}
                 size={'16px'}
                 monochrome={false}
               />

--- a/src/ui/common/src/components/workflows/artifact/check/history.tsx
+++ b/src/ui/common/src/components/workflows/artifact/check/history.tsx
@@ -5,14 +5,13 @@ import React from 'react';
 import { ArtifactResultsWithLoadingStatus } from '../../../../reducers/artifactResults';
 import { theme } from '../../../../styles/theme/theme';
 import { Data, DataSchema } from '../../../../utils/data';
+import { CheckLevel } from '../../../../utils/operators';
 import ExecutionStatus, {
-  CheckStatus,
   getArtifactExecStateAsTableRow,
   stringToExecutionStatus,
 } from '../../../../utils/shared';
 import { isFailed, isInitial, isLoading } from '../../../../utils/shared';
 import { StatusIndicator } from '../../workflowStatus';
-import {CheckLevel} from "../../../../utils/operators";
 
 type CheckHistoryProps = {
   historyWithLoadingStatus?: ArtifactResultsWithLoadingStatus;
@@ -78,19 +77,29 @@ const CheckHistory: React.FC<CheckHistoryProps> = ({
         if (entry.status === ExecutionStatus.Succeeded) {
           backgroundColor = theme.palette.green[100];
           hoverColor = theme.palette.green[200];
-        } else if (entry.status === ExecutionStatus.Failed && checkLevel === CheckLevel.Error) {
+        } else if (
+          entry.status === ExecutionStatus.Failed &&
+          checkLevel === CheckLevel.Error
+        ) {
           backgroundColor = theme.palette.red[25];
           hoverColor = theme.palette.red[100];
-        } else if (entry.status === ExecutionStatus.Failed && checkLevel === CheckLevel.Warning) {
+        } else if (
+          entry.status === ExecutionStatus.Failed &&
+          checkLevel === CheckLevel.Warning
+        ) {
           backgroundColor = theme.palette.yellow[100];
           hoverColor = theme.palette.yellow[200];
-        } else { // unknown or canceled status
+        } else {
+          // unknown or canceled status
           backgroundColor = theme.palette.gray[100];
           hoverColor = theme.palette.gray[200];
         }
 
         let checkStatus = entry.status as string;
-        if (checkLevel === CheckLevel.Warning && entry.status === ExecutionStatus.Failed) {
+        if (
+          checkLevel === CheckLevel.Warning &&
+          entry.status === ExecutionStatus.Failed
+        ) {
           checkStatus = ExecutionStatus.Warning as string;
         }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where check history list items are incorrectly rendered for warning checks that fail.

Now they should show up with the warning logo and warning background color.

## Related issue number (if any)
ENG-2753

## Loom demo (if any)
https://www.loom.com/share/461760bd7c344397b04fe34e3615e69f

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


