### PR TITLE
ENG-2757 Fix SDK function arg validation failures

### DIFF
--- a/sdk/aqueduct/artifacts/numeric_artifact.py
+++ b/sdk/aqueduct/artifacts/numeric_artifact.py
@@ -182,8 +182,8 @@ class NumericArtifact(BaseArtifact):
                 "Could not find a parameter for bounding the metric please specify one of either: %s"
                 % (",".join(input_mapping.keys()))
             )
-
-        assert bound_name and bound_value
+        # Specify is not None because otherwise will incorrectly capture Falsey values e.g. 0, "" is a Falsey value
+        assert bound_name is not None and bound_value is not None
 
         accepted_types = [float, int]
         if type(bound_value) not in accepted_types:

--- a/sdk/aqueduct/schedule.py
+++ b/sdk/aqueduct/schedule.py
@@ -28,7 +28,7 @@ class DayOfWeek(Enum):
 class DayOfMonth:
     def __init__(self, day: int):
         if day < 0 or day >= 32:
-            raise Exception("Invalid hour value %s." % day)
+            raise Exception("Invalid day value %s." % day)
         self.val = day
 
 
@@ -70,7 +70,7 @@ def weekly(day: DayOfWeek, hour: Hour = Hour(0), minute: Minute = Minute(0)) -> 
 
 
 def monthly(day: DayOfMonth, hour: Hour = Hour(0), minute: Minute = Minute(0)) -> str:
-    if not isinstance(day, DayOfWeek):
+    if not isinstance(day, DayOfMonth):
         raise Exception(
             "Invalid types provided in parameters: aqueduct.schedule.DayOfMonth required for first argument."
         )


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Fixes bugs discovered via running through the code snippets in Gitbook (https://github.com/aqueducthq/aqueduct/pull/1172):
- The monthly function instance type check incorrect for day (`DayOfWeek` --> `DayOfMonth`).
- Fix `DayOfMonth` exception statement from "Invalid *hour* value" to "Invalid *day* value".
- Fix assertion for bounds to work when `bound_value` is falsey (e.g. 0).

## Related issue number (if any)
ENG-2757

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [N/A] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [N/A] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


