### PR TITLE
ENG-2761 Fix issue where errors were not being shown in Metric details pages

### DIFF
--- a/src/ui/common/src/components/operators/WithOperatorHeader.tsx
+++ b/src/ui/common/src/components/operators/WithOperatorHeader.tsx
@@ -65,8 +65,6 @@ const WithOperatorHeader: React.FC<Props> = ({
   const inputs = mapArtifacts(operator.inputs);
   const outputs = mapArtifacts(operator.outputs);
 
-  console.log('integrationsState', integrationsState);
-
   let checkLevelDisplay = null;
   if (operator?.spec?.check?.level) {
     const checkLevel = operator.spec.check.level;

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -1,9 +1,11 @@
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import WithOperatorHeader from '../../../../components/operators/WithOperatorHeader';
 import UserProfile from '../../../../utils/auth';
 import DefaultLayout from '../../../layouts/default';
+import LogViewer from '../../../LogViewer';
 import RequireOperator from '../../../operators/RequireOperator';
 import MetricsHistory from '../../../workflows/artifact/metric/history';
 import RequireDagOrResult from '../../../workflows/RequireDagOrResult';
@@ -11,8 +13,6 @@ import { useArtifactHistory } from '../../artifact/id/hook';
 import useOpeartor from '../../operator/id/hook';
 import { LayoutProps } from '../../types';
 import useWorkflow from '../../workflow/id/hook';
-import Typography from '@mui/material/Typography';
-import LogViewer from '../../../LogViewer';
 
 type MetricDetailsPageProps = {
   user: UserProfile;

--- a/src/ui/common/src/components/pages/metric/id/index.tsx
+++ b/src/ui/common/src/components/pages/metric/id/index.tsx
@@ -11,6 +11,8 @@ import { useArtifactHistory } from '../../artifact/id/hook';
 import useOpeartor from '../../operator/id/hook';
 import { LayoutProps } from '../../types';
 import useWorkflow from '../../workflow/id/hook';
+import Typography from '@mui/material/Typography';
+import LogViewer from '../../../LogViewer';
 
 type MetricDetailsPageProps = {
   user: UserProfile;
@@ -63,6 +65,9 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
     workflowDagResultWithLoadingStatus
   );
 
+  const logs = operator?.result?.exec_state?.user_logs ?? {};
+  const operatorError = operator?.result?.exec_state?.error;
+
   return (
     <Layout breadcrumbs={breadcrumbs} user={user}>
       <RequireDagOrResult
@@ -80,14 +85,22 @@ const MetricDetailsPage: React.FC<MetricDetailsPageProps> = ({
             sideSheetMode={sideSheetMode}
           >
             {workflowDagResultWithLoadingStatus && (
-              <Box
-                width={sideSheetMode ? 'auto' : '49.2%'}
-                marginTop={sideSheetMode ? '16px' : '40px'}
-              >
-                <MetricsHistory
-                  historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
-                />
-              </Box>
+              <>
+                <Box>
+                  <Typography variant="h6" fontWeight="normal">
+                    Logs
+                  </Typography>
+                  {logs !== {} && <LogViewer logs={logs} err={operatorError} />}
+                </Box>
+                <Box
+                  width={sideSheetMode ? 'auto' : '49.2%'}
+                  marginTop={sideSheetMode ? '16px' : '40px'}
+                >
+                  <MetricsHistory
+                    historyWithLoadingStatus={artifactHistoryWithLoadingStatus}
+                  />
+                </Box>
+              </>
             )}
           </WithOperatorHeader>
         </RequireOperator>


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR brings back the Logs component that was missing on the metrics details page so that we can now show errors / sddout/err logs on Metric operators once again.

## Related issue number (if any)
ENG-2761

## Loom demo (if any)
https://www.loom.com/share/acdb6c3d58c141caa9abcf4b8063bca2

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


