### PR TITLE
Eng 2762 add aqueduct ml version to spark docker

### DIFF
--- a/src/dockerfiles/spark/spark-py310-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py310-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py310_env
-RUN pip install aqueduct-ml==0.2.3 conda-pack
+RUN pip install aqueduct-ml==0.2.9 conda-pack
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py310-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py310-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py310_env
-RUN pip install aqueduct-ml==0.2.9 conda-pack
+RUN pip install conda-pack aqueduct-ml==0.2.9
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py37-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py37-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py37_env
-RUN pip install aqueduct-ml==0.2.3 conda-pack
+RUN pip install aqueduct-ml==0.2.9 conda-pack
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py37-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py37-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py37_env
-RUN pip install aqueduct-ml==0.2.9 conda-pack
+RUN pip install conda-pack aqueduct-ml==0.2.9
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py38-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py38-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py38_env
-RUN pip install aqueduct-ml==0.2.3 conda-pack
+RUN pip install aqueduct-ml==0.2.9 conda-pack
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py38-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py38-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py38_env
-RUN pip install aqueduct-ml==0.2.9 conda-pack
+RUN pip install conda-pack aqueduct-ml==0.2.9
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py39-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py39-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py39_env
-RUN pip install aqueduct-ml==0.2.9 conda-pack
+RUN pip install conda-pack aqueduct-ml==0.2.9
 
 COPY ./spark/create-conda-env.sh /
 

--- a/src/dockerfiles/spark/spark-py39-env.dockerfile
+++ b/src/dockerfiles/spark/spark-py39-env.dockerfile
@@ -25,7 +25,7 @@ RUN	wget --quiet https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -O aws
     unzip awscliv2.zip && ./aws/install 
 
 RUN conda activate py39_env
-RUN pip install aqueduct-ml==0.2.3 conda-pack
+RUN pip install aqueduct-ml==0.2.9 conda-pack
 
 COPY ./spark/create-conda-env.sh /
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Corrects the version of aqueduct-ml in spark containers. With the changes https://github.com/aqueducthq/release/pull/8, this issue is fixed moving forwards.
## Related issue number (if any)
Eng 2762
## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


