### PR TITLE
Get sdk integration tests working with Spark

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/checks_test.py
+++ b/integration_tests/sdk/aqueduct_tests/checks_test.py
@@ -189,7 +189,7 @@ def test_check_with_numpy_bool_output(client, data_integration):
         else:
             from pyspark.sql.functions import mean
 
-            return df.select(mean("total_charges")).collect()[0][0]
+            return df.select(mean("total_charges")).collect()[0][0] < 2500
 
     check_artifact = success_check_return_numpy_bool(table_artifact)
     assert check_artifact.get()

--- a/integration_tests/sdk/aqueduct_tests/checks_test.py
+++ b/integration_tests/sdk/aqueduct_tests/checks_test.py
@@ -21,6 +21,7 @@ from .test_metrics.constant.model import constant_metric
 def success_on_single_table_input(df):
     if not isinstance(df, pd.DataFrame):
         from pyspark.sql import DataFrame
+
         if not isinstance(df, DataFrame):
             raise Exception("Expected dataframe as input to check, got %s" % type(df).__name__)
     return True
@@ -39,6 +40,7 @@ def success_on_multiple_mixed_inputs(metric, df):
         raise Exception("Expected float as input to check, got %s" % type(metric).__name__)
     if not isinstance(df, pd.DataFrame):
         from pyspark.sql import DataFrame
+
         if not isinstance(df, DataFrame):
             raise Exception("Expected dataframe as input to check, got %s" % type(df).__name__)
     return True
@@ -187,7 +189,8 @@ def test_check_with_numpy_bool_output(client, data_integration):
             return df["total_charges"].mean() < 2500
         else:
             from pyspark.sql.functions import mean
-            return df.select(mean('total_charges')).collect()[0][0]
+
+            return df.select(mean("total_charges")).collect()[0][0]
 
     check_artifact = success_check_return_numpy_bool(table_artifact)
     assert check_artifact.get()

--- a/integration_tests/sdk/aqueduct_tests/checks_test.py
+++ b/integration_tests/sdk/aqueduct_tests/checks_test.py
@@ -179,7 +179,6 @@ def test_check_wrong_number_of_inputs(client, data_integration):
         check_artifact.get()
 
 
-@pytest.mark.skip
 def test_check_with_numpy_bool_output(client, data_integration):
     table_artifact = extract(data_integration, DataObject.CHURN)
 

--- a/integration_tests/sdk/aqueduct_tests/checks_test.py
+++ b/integration_tests/sdk/aqueduct_tests/checks_test.py
@@ -20,7 +20,9 @@ from .test_metrics.constant.model import constant_metric
 @check()
 def success_on_single_table_input(df):
     if not isinstance(df, pd.DataFrame):
-        raise Exception("Expected dataframe as input to check, got %s" % type(df).__name__)
+        from pyspark.sql import DataFrame
+        if not isinstance(df, DataFrame):
+            raise Exception("Expected dataframe as input to check, got %s" % type(df).__name__)
     return True
 
 
@@ -36,7 +38,9 @@ def success_on_multiple_mixed_inputs(metric, df):
     if not isinstance(metric, float):
         raise Exception("Expected float as input to check, got %s" % type(metric).__name__)
     if not isinstance(df, pd.DataFrame):
-        raise Exception("Expected dataframe as input to check, got %s" % type(df).__name__)
+        from pyspark.sql import DataFrame
+        if not isinstance(df, DataFrame):
+            raise Exception("Expected dataframe as input to check, got %s" % type(df).__name__)
     return True
 
 
@@ -98,7 +102,10 @@ def test_edit_check(client, data_integration, engine, flow_name):
 
     @check
     def foo(table):
-        return len(table) < 200
+        if isinstance(table, pd.DataFrame):
+            return len(table) < 200
+        else:
+            return table.count() < 200
 
     pass1 = foo(table)
     pass2 = foo(table)
@@ -150,6 +157,7 @@ def test_check_wrong_input_type(client, data_integration):
     # User function receives a dataframe when it's expecting a metric.
     with pytest.raises(AqueductError):
         check_artifact = success_on_single_metric_input(table_artifact)
+        check_artifact.get()
 
     # TODO(ENG-862): the following code should not surface an internal error,
     #  since its the user's fault.
@@ -165,15 +173,21 @@ def test_check_wrong_number_of_inputs(client, data_integration):
 
     # TODO(ENG-863): Do we want a more specific error here?
     with pytest.raises(AqueductError):
-        success_on_single_table_input(table_artifact1, table_artifact2)
+        check_artifact = success_on_single_table_input(table_artifact1, table_artifact2)
+        check_artifact.get()
 
 
+@pytest.mark.skip
 def test_check_with_numpy_bool_output(client, data_integration):
     table_artifact = extract(data_integration, DataObject.CHURN)
 
     @check()
     def success_check_return_numpy_bool(df):
-        return df["total_charges"].mean() < 2500
+        if isinstance(df, pd.DataFrame):
+            return df["total_charges"].mean() < 2500
+        else:
+            from pyspark.sql.functions import mean
+            return df.select(mean('total_charges')).collect()[0][0]
 
     check_artifact = success_check_return_numpy_bool(table_artifact)
     assert check_artifact.get()
@@ -227,4 +241,5 @@ def test_check_failure_with_varying_severity(client, flow_name, data_integration
 
     # In eager execution, this check should fail before we can publish the flow.
     with pytest.raises(AqueductError):
-        failure_blocking_check(table_artifact)
+        check_artifact = failure_blocking_check(table_artifact)
+        check_artifact.get()

--- a/integration_tests/sdk/aqueduct_tests/error_handling_test.py
+++ b/integration_tests/sdk/aqueduct_tests/error_handling_test.py
@@ -26,10 +26,8 @@ TIP_OP_EXECUTION = "Error executing operator. Please refer to the stack trace fo
 def test_handle_bad_op_error(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    try:
+    with pytest.raises(AqueductError, match=TIP_OP_EXECUTION):
         bad_op(table_artifact)
-    except AqueductError as e:
-        assert TIP_OP_EXECUTION in e.message
 
 
 def test_handle_bad_op_with_multiple_outputs(client, data_integration):

--- a/integration_tests/sdk/aqueduct_tests/error_handling_test.py
+++ b/integration_tests/sdk/aqueduct_tests/error_handling_test.py
@@ -27,14 +27,16 @@ def test_handle_bad_op_error(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(AqueductError, match=TIP_OP_EXECUTION):
-        bad_op(table_artifact)
+        output_artifact = bad_op(table_artifact)
+        output_artifact.get()
 
 
 def test_handle_bad_op_with_multiple_outputs(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(AqueductError, match=TIP_OP_EXECUTION):
-        bad_op_multiple_outputs(table_artifact)
+        output_artifact = bad_op_multiple_outputs(table_artifact)
+        output_artifact.get()
 
 
 def test_file_dependencies_invalid(client):

--- a/integration_tests/sdk/aqueduct_tests/external_compute_test.py
+++ b/integration_tests/sdk/aqueduct_tests/external_compute_test.py
@@ -32,6 +32,7 @@ def test_flow_with_multiple_compute_using_op_spec(client, flow_name, data_integr
     assert flow_run.artifact("noop_on_third_party artifact").get().equals(table_artifact.get())
 
 
+@pytest.mark.skip_for_spark_engines(reason="Cannot switch between Spark and Aqueduct engines.")
 @pytest.mark.enable_only_for_external_compute()
 def test_global_config_engine_switching(client, engine):
     """Test that we can freely switch between Aqueduct to External compute and back again."""

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -385,7 +385,7 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
     )
 
 
-@pytest.mark.skip_for_spark_engines(reason="requires implicit pandas requirement.")
+@pytest.mark.skip_for_spark_engines(reason="Requires implicit Pandas requirement.")
 def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
     # Write a new table into the data integration.
     initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
@@ -440,6 +440,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
     assert artifact.get().equals(initial_table)
 
 
+@pytest.mark.skip_for_spark_engines(reason="Cannot use implicit imports with Spark engines.")
 def test_flow_with_args(client):
     str_val = "this is a string"
     num_val = 1234

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -40,7 +40,7 @@ def test_basic_flow(client, flow_name, data_integration, engine, data_validator)
     )
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Uses sentiment model with pandas-specific code.")
 def test_sentiment_flow(client, flow_name, data_integration, engine, data_validator):
     """Actually run the full sentiment model (with nltk dependency)."""
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
@@ -385,7 +385,7 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
     )
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="requires implicit pandas requirement.")
 def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
     # Write a new table into the data integration.
     initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
@@ -440,7 +440,6 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
     assert artifact.get().equals(initial_table)
 
 
-@pytest.mark.skip_for_spark_engines()
 def test_flow_with_args(client):
     str_val = "this is a string"
     num_val = 1234
@@ -464,7 +463,8 @@ def test_flow_with_args(client):
 
     # Implicit parameter creation is disallowed for variable-length parameters.
     with pytest.raises(InvalidUserArgumentException):
-        foo_with_args(*[str_val, num_val])
+        output_artifact = foo_with_args(*[str_val, num_val])
+        output_artifact.get()
 
 
 def test_flow_list_saved_objects_none(client, flow_name, engine):

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -40,6 +40,7 @@ def test_basic_flow(client, flow_name, data_integration, engine, data_validator)
     )
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_sentiment_flow(client, flow_name, data_integration, engine, data_validator):
     """Actually run the full sentiment model (with nltk dependency)."""
     table_artifact = extract(data_integration, DataObject.SENTIMENT)

--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -385,6 +385,7 @@ def test_multiple_flows_with_same_schedule(client, flow_name, data_integration, 
     )
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integration, engine):
     # Write a new table into the data integration.
     initial_table = pd.DataFrame([1, 2, 3, 4, 5, 6], columns=["numbers"])
@@ -439,6 +440,7 @@ def test_fetching_historical_flows_uses_old_data(client, flow_name, data_integra
     assert artifact.get().equals(initial_table)
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_flow_with_args(client):
     str_val = "this is a string"
     num_val = 1234

--- a/integration_tests/sdk/aqueduct_tests/local_test.py
+++ b/integration_tests/sdk/aqueduct_tests/local_test.py
@@ -1,3 +1,4 @@
+import pytest
 from pandas import DataFrame
 from pandas._testing import assert_frame_equal
 
@@ -15,6 +16,8 @@ def test_local_operator(client, data_integration):
 
     output_local = dummy_sentiment_model.local(table_artifact)
     assert output_cloud.count()[0] == output_local.count()[0]
+    output_cloud.columns = output_cloud.columns.str.lower()
+    output_local.columns = output_local.columns.str.lower()
     assert_frame_equal(output_cloud, output_local)
 
 
@@ -39,6 +42,8 @@ def test_local_dataframe_input(client, data_integration):
     output_cloud = dummy_sentiment_model(table_artifact).get()
     output_local = dummy_sentiment_model.local(table_artifact.get())
     assert type(output_local) is DataFrame
+    output_cloud.columns = output_cloud.columns.str.lower()
+    output_local.columns = output_local.columns.str.lower()
     assert_frame_equal(output_cloud, output_local)
 
 
@@ -49,4 +54,6 @@ def test_local_on_multiple_inputs(client, data_integration):
     output_cloud = dummy_sentiment_model_multiple_input(table_artifact, table_artifact2).get()
     output_local = dummy_sentiment_model_multiple_input.local(table_artifact, table_artifact2)
     assert type(output_local) is DataFrame
+    output_cloud.columns = output_cloud.columns.str.lower()
+    output_local.columns = output_local.columns.str.lower()
     assert_frame_equal(output_cloud, output_local)

--- a/integration_tests/sdk/aqueduct_tests/metrics_test.py
+++ b/integration_tests/sdk/aqueduct_tests/metrics_test.py
@@ -56,6 +56,7 @@ def test_register_metric(client, flow_name, data_integration, engine):
 def metric_with_multiple_inputs(df1, m, df2):
     if not isinstance(df1, pd.DataFrame) or not isinstance(df2, pd.DataFrame):
         from pyspark.sql import DataFrame
+
         if not isinstance(df1, DataFrame) or not isinstance(df2, DataFrame):
             raise Exception(
                 "Expected dataframes as first and third args, got %s and %s"
@@ -92,6 +93,7 @@ def test_edit_metric(client, data_integration, engine, flow_name):
             return len(table)
         else:
             from pyspark.sql import DataFrame
+
             if isinstance(table, DataFrame):
                 return table.count()
 

--- a/integration_tests/sdk/aqueduct_tests/metrics_test.py
+++ b/integration_tests/sdk/aqueduct_tests/metrics_test.py
@@ -55,10 +55,12 @@ def test_register_metric(client, flow_name, data_integration, engine):
 @metric()
 def metric_with_multiple_inputs(df1, m, df2):
     if not isinstance(df1, pd.DataFrame) or not isinstance(df2, pd.DataFrame):
-        raise Exception(
-            "Expected dataframes as first and third args, got %s and %s"
-            % (type(df1).__name__, type(df2).__name__)
-        )
+        from pyspark.sql import DataFrame
+        if not isinstance(df1, DataFrame) or not isinstance(df2, DataFrame):
+            raise Exception(
+                "Expected dataframes as first and third args, got %s and %s"
+                % (type(df1).__name__, type(df2).__name__)
+            )
     if not isinstance(m, float):
         raise Exception("Expected float as input to check, got %s" % type(m).__name__)
     return m + 10
@@ -86,7 +88,12 @@ def test_edit_metric(client, data_integration, engine, flow_name):
 
     @metric
     def foo(table):
-        return len(table)
+        if isinstance(table, pd.DataFrame):
+            return len(table)
+        else:
+            from pyspark.sql import DataFrame
+            if isinstance(table, DataFrame):
+                return table.count()
 
     output1 = foo(table)
     output2 = foo(table)

--- a/integration_tests/sdk/aqueduct_tests/multiple_output_test.py
+++ b/integration_tests/sdk/aqueduct_tests/multiple_output_test.py
@@ -49,4 +49,5 @@ def test_multiple_outputs_user_failure(client):
         return "hello", 1234
 
     with pytest.raises(AqueductError):
-        generate_two_outputs()
+        output_artifact = generate_two_outputs()
+        output_artifact.get()

--- a/integration_tests/sdk/aqueduct_tests/naming_test.py
+++ b/integration_tests/sdk/aqueduct_tests/naming_test.py
@@ -57,7 +57,7 @@ def test_extract_with_default_name_collision(client, flow_name, engine, data_int
 
     fn_artifact = dummy_sentiment_model_multiple_input(table_artifact_1, table_artifact_2)
     fn_df = fn_artifact.get()
-    assert list(fn_df) == [
+    assert [col.lower() for col in list(fn_df)] == [
         "hotel_name",
         "review_date",
         "reviewer_nationality",
@@ -89,7 +89,7 @@ def test_extract_with_op_name_collision(client, data_integration, engine, flow_n
     table_1 = table_artifact_1.get()
     table_2 = table_artifact_2.get()
     assert table_1.equals(table_2)
-    assert list(table_1) == [
+    assert [col.lower() for col in list(table_1)] == [
         "hotel_name",
         "review_date",
         "reviewer_nationality",

--- a/integration_tests/sdk/aqueduct_tests/no_input_test.py
+++ b/integration_tests/sdk/aqueduct_tests/no_input_test.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from aqueduct import op
 
@@ -17,12 +18,18 @@ def join(x: pd.DataFrame, y: pd.DataFrame) -> pd.DataFrame:
     return x
 
 
+@pytest.mark.skip_for_spark_engines(
+    reason="Expect a Spark Dataframe as return type, not Pandas Dataframe."
+)
 def test_basic_no_input_function(client):
     expected = pd.DataFrame(data={"col1": [1, 2], "col2": [3, 4]})
     result = no_input().get()
     assert result.equals(expected)
 
 
+@pytest.mark.skip_for_spark_engines(
+    reason="Expect a Spark Dataframe as return type, not Pandas Dataframe."
+)
 def test_flow_with_no_input_function(client, data_integration):
     customers_table = extract(data_integration, DataObject.CUSTOMERS)
 

--- a/integration_tests/sdk/aqueduct_tests/operator_test.py
+++ b/integration_tests/sdk/aqueduct_tests/operator_test.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 from aqueduct.decorator import to_operator
 from aqueduct.error import ArtifactNotFoundException
@@ -12,13 +13,25 @@ from .extract import extract
 def test_to_operator_local_function(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
-    @op
+    @op()
     def dummy_sentiment_model(df):
-        df["positivity"] = 123
+        if isinstance(df, pd.DataFrame):
+            df["POSITIVITY"] = 123
+        else:
+            from pyspark.sql.functions import lit
+
+            df = df.withColumn("POSITIVITY", lit(123.0))
+
         return df
 
     def dummy_sentiment_model_func(df):
-        df["positivity"] = 123
+        if isinstance(df, pd.DataFrame):
+            df["POSITIVITY"] = 123
+        else:
+            from pyspark.sql.functions import lit
+
+            df = df.withColumn("POSITIVITY", lit(123.0))
+
         return df
 
     output_artifact_from_decorator = dummy_sentiment_model(table_artifact)
@@ -26,7 +39,7 @@ def test_to_operator_local_function(client, data_integration):
     output_artifact_from_to_operator = to_operator(dummy_sentiment_model_func)(table_artifact)
     df_func = output_artifact_from_to_operator.get()
 
-    assert df_normal["positivity"].equals(df_func["positivity"])
+    assert df_normal["POSITIVITY"].equals(df_func["POSITIVITY"])
 
 
 def test_operator_reuse_chain(data_integration):

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -42,6 +42,9 @@ def convert_dict_to_df(kv: Dict[str, List[float]]):
     return pd.DataFrame(data=kv)
 
 
+@pytest.mark.skip_for_spark_engines(
+    reason="Expect a Spark Dataframe as return type, not Pandas Dataframe."
+)
 def test_basic_param_creation(client):
     # Parameter of integer type
     param = client.create_param(name="number", default=8)
@@ -140,6 +143,7 @@ def append_row_to_df(df, row):
     return df
 
 
+@pytest.mark.skip_for_spark_engines(reason="append_row_to_df doesn't work for Spark Dataframes")
 def test_parameter_in_basic_flow(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
     row_to_add = ["new hotel", "09-28-1996", "US", "It was new."]
@@ -153,6 +157,7 @@ def test_parameter_in_basic_flow(client, data_integration):
     assert output_df.equals(input_df)
 
 
+@pytest.mark.skip_for_spark_engines(reason="append_row_to_df doesn't work for Spark Dataframes")
 def test_edit_param_for_flow(client, flow_name, data_integration, engine):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
     row_to_add = ["new hotel", "09-28-1996", "US", "It was new."]
@@ -440,6 +445,7 @@ def test_parameter_type_changes(client, flow_name, engine):
     )
 
 
+@pytest.mark.skip_for_spark_engines(reason="append_row_to_df doesn't work for Spark Dataframes")
 def test_local_table_data_parameter(client, flow_name, engine):
     row_to_add = ["new hotel", "09-28-1996", "US", "It was new."]
 

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -31,7 +31,7 @@ def test_basic_get(client, data_integration, engine):
 
     output_artifact = dummy_sentiment_model(table_artifact)
     output_df = output_artifact.get()
-    assert list(output_df) == [
+    assert [col.lower() for col in list(output_df)] == [
         "hotel_name",
         "review_date",
         "reviewer_nationality",
@@ -48,7 +48,7 @@ def test_multiple_input_get(client, data_integration):
     fn_artifact = dummy_sentiment_model_multiple_input(table_artifact1, table_artifact2)
     fn_df = fn_artifact.get()
 
-    assert list(fn_df) == [
+    assert [col.lower() for col in list(fn_df)] == [
         "hotel_name",
         "review_date",
         "reviewer_nationality",
@@ -60,7 +60,7 @@ def test_multiple_input_get(client, data_integration):
 
     output_artifact = dummy_model(fn_artifact)
     output_df = output_artifact.get()
-    assert list(output_df) == [
+    assert [col.lower() for col in list(output_df)] == [
         "hotel_name",
         "review_date",
         "reviewer_nationality",
@@ -77,7 +77,7 @@ def test_basic_file_dependencies(client, data_integration):
 
     output_artifact = model_with_file_dependency(table_artifact)
     output_df = output_artifact.get()
-    assert list(output_df) == [
+    assert [col.lower() for col in list(output_df)] == [
         "hotel_name",
         "review_date",
         "reviewer_nationality",

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -26,7 +26,12 @@ def test_basic_get(client, data_integration, engine):
 
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
     sql_df = table_artifact.get()
-    assert list(sql_df) == ["hotel_name", "review_date", "reviewer_nationality", "review"]
+    assert [col.lower() for col in list(sql_df)] == [
+        "hotel_name",
+        "review_date",
+        "reviewer_nationality",
+        "review",
+    ]
     assert sql_df.shape[0] == 100
 
     output_artifact = dummy_sentiment_model(table_artifact)

--- a/integration_tests/sdk/aqueduct_tests/preview_test.py
+++ b/integration_tests/sdk/aqueduct_tests/preview_test.py
@@ -91,16 +91,20 @@ def test_invalid_file_dependencies(client, data_integration):
     table_artifact = extract(data_integration, DataObject.SENTIMENT)
 
     with pytest.raises(AqueductError):
-        model_with_invalid_dependencies(table_artifact)
+        output_artifact = model_with_invalid_dependencies(table_artifact)
+        output_artifact.get()
 
     with pytest.raises(AqueductError):
-        model_with_missing_file_dependencies(table_artifact)
+        output_artifact = model_with_missing_file_dependencies(table_artifact)
+        output_artifact.get()
 
     with pytest.raises(InvalidFunctionException):
-        model_with_improper_dependency_path(table_artifact)
+        output_artifact = model_with_improper_dependency_path(table_artifact)
+        output_artifact.get()
 
     with pytest.raises(InvalidDependencyFilePath):
-        model_with_out_of_package_file_dependency(table_artifact)
+        output_artifact = model_with_out_of_package_file_dependency(table_artifact)
+        output_artifact.get()
 
 
 def test_table_with_non_string_column_name(client):
@@ -109,4 +113,5 @@ def test_table_with_non_string_column_name(client):
         return pd.DataFrame([0, 1, 2, 3], columns=[123])
 
     with pytest.raises(AqueductError):
-        bad_return()
+        output_artifact = bad_return()
+        output_artifact.get()

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -2,6 +2,7 @@ import math
 import time
 
 import pandas as pd
+import pytest
 
 from aqueduct import global_config, op
 
@@ -84,6 +85,7 @@ def test_system_max_memory_metric_generic(client, data_integration):
     assert max_mem > 10
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_number_of_missing_values(client, data_integration):
     table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_missing_values(column_id="hotel_name")
@@ -97,6 +99,7 @@ def test_number_of_missing_values(client, data_integration):
     assert missing_metric.get() == 4
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_number_of_rows(client, data_integration):
     table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_rows()
@@ -107,6 +110,7 @@ def test_number_of_rows(client, data_integration):
     assert missing_metric.get() == 101
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_max(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.max(column_id="fixed_acidity")
@@ -116,6 +120,7 @@ def test_max(client, data_integration):
     assert math.isclose(missing_metric.get(), 440, rel_tol=1e-3)
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_min(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.min(column_id="fixed_acidity")
@@ -125,6 +130,7 @@ def test_min(client, data_integration):
     assert math.isclose(missing_metric.get(), 6, rel_tol=1e-3)
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_mean(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.mean(column_id="fixed_acidity")
@@ -134,6 +140,7 @@ def test_mean(client, data_integration):
     assert math.isclose(missing_metric.get(), 115.7445, rel_tol=1e-3)
 
 
+@pytest.mark.skip_for_spark_engines()
 def test_std(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.std(column_id="fixed_acidity")

--- a/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
+++ b/integration_tests/sdk/aqueduct_tests/table_artifact_test.py
@@ -10,6 +10,7 @@ from ..shared.data_objects import DataObject
 from .extract import extract
 
 
+@pytest.mark.skip_for_spark_engines(reason="GE checks don't work with Spark")
 def test_great_expectations_check(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     ge_check = table.validate_with_expectation(
@@ -85,7 +86,7 @@ def test_system_max_memory_metric_generic(client, data_integration):
     assert max_mem > 10
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_number_of_missing_values(client, data_integration):
     table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_missing_values(column_id="hotel_name")
@@ -99,7 +100,7 @@ def test_number_of_missing_values(client, data_integration):
     assert missing_metric.get() == 4
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_number_of_rows(client, data_integration):
     table = extract(data_integration, DataObject.SENTIMENT)
     missing_metric = table.number_of_rows()
@@ -110,7 +111,7 @@ def test_number_of_rows(client, data_integration):
     assert missing_metric.get() == 101
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_max(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.max(column_id="fixed_acidity")
@@ -120,7 +121,7 @@ def test_max(client, data_integration):
     assert math.isclose(missing_metric.get(), 440, rel_tol=1e-3)
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_min(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.min(column_id="fixed_acidity")
@@ -130,7 +131,7 @@ def test_min(client, data_integration):
     assert math.isclose(missing_metric.get(), 6, rel_tol=1e-3)
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_mean(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.mean(column_id="fixed_acidity")
@@ -140,7 +141,7 @@ def test_mean(client, data_integration):
     assert math.isclose(missing_metric.get(), 115.7445, rel_tol=1e-3)
 
 
-@pytest.mark.skip_for_spark_engines()
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_std(client, data_integration):
     table = extract(data_integration, DataObject.WINE)
     missing_metric = table.std(column_id="fixed_acidity")
@@ -150,6 +151,7 @@ def test_std(client, data_integration):
     assert math.isclose(missing_metric.get(), 56.5218, rel_tol=1e-3)
 
 
+@pytest.mark.skip_for_spark_engines(reason="Built in table metrics don't work with Spark")
 def test_head_standard(client, data_integration):
     table = extract(data_integration, DataObject.SENTIMENT)
     assert table.get().shape[0] == 100

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/file_dependency_model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/file_dependency_model.py
@@ -1,5 +1,7 @@
 import os
 
+import pandas as pd
+
 from aqueduct import op
 
 
@@ -8,7 +10,13 @@ def model_with_file_dependency(df):
     if not os.path.exists("data"):
         raise Exception("Data does not exist!")
 
-    df["newcol"] = 999
+    if isinstance(df, pd.DataFrame):
+        df["newcol"] = 999
+    else:
+        from pyspark.sql.functions import lit
+
+        df = df.withColumn("NEWCOL", lit(999).cast("integer"))
+
     return df
 
 

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
@@ -8,7 +8,7 @@ def dummy_sentiment_model(df):
         df["positivity"] = 123
     else:
         from pyspark.sql.functions import lit
-        df = df.withColumn("positivity", lit(123))
+        df = df.withColumn("POSITIVITY", lit(123.0))
 
     return df
 
@@ -18,20 +18,20 @@ def dummy_sentiment_model_function(df):
         df["positivity"] = 123
     else:
         from pyspark.sql.functions import lit
-        df = df.withColumn("positivity", lit(123))
+        df = df.withColumn("POSITIVITY", lit(123.0))
 
     return df
 
 
 @op
 def dummy_sentiment_model_multiple_input(df1, df2):
-    if isinstance(df, pd.DataFrame):
+    if isinstance(df1, pd.DataFrame):
         df1["positivity"] = 123
         df1["positivity_2"] = 456
     else:
         from pyspark.sql.functions import lit
-        df1 = df1.withColumn("positivity", lit(123))
-        df1 = df1.withColumn("positivity_2", lit(456))
+        df1 = df1.withColumn("POSITIVITY", lit(123.0))
+        df1 = df1.withColumn("POSITIVITY_2", lit(456.0))
 
     return df1
 
@@ -42,7 +42,7 @@ def dummy_model(df):
         df["newcol"] = "value"
     else:
         from pyspark.sql.functions import lit
-        df = df.withColumn("newcol", lit("value"))
+        df = df.withColumn("NEWCOL", lit("value"))
 
     return df
 
@@ -53,6 +53,6 @@ def dummy_model_2(df):
         df["newcol_2"] = "value"
     else:
         from pyspark.sql.functions import lit
-        df = df.withColumn("newcol_2", lit("value"))
+        df = df.withColumn("NEWCOL_2", lit("value"))
 
     return df

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
@@ -34,12 +34,12 @@ def dummy_sentiment_model_function(df):
 def dummy_sentiment_model_multiple_input(df1, df2):
     if isinstance(df1, pd.DataFrame):
         df1["positivity"] = 123
-        df1["positivity_2"] = 456
+        df2["positivity_2"] = 456
     else:
         from pyspark.sql.functions import lit
 
         df1 = df1.withColumn("POSITIVITY", lit(123).cast("integer"))
-        df2 = df2.withColumn("POSITIVITY", lit(456).cast("integer"))
+        df2 = df2.withColumn("POSITIVITY_2", lit(456).cast("integer"))
 
     return df1
 

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
@@ -1,31 +1,58 @@
 from aqueduct import op
+import pandas as pd
 
 
 @op()
 def dummy_sentiment_model(df):
-    df["positivity"] = 123
+    if isinstance(df, pd.DataFrame):
+        df["positivity"] = 123
+    else:
+        from pyspark.sql.functions import lit
+        df = df.withColumn("positivity", lit(123))
+
     return df
 
 
 def dummy_sentiment_model_function(df):
-    df["positivity"] = 123
+    if isinstance(df, pd.DataFrame):
+        df["positivity"] = 123
+    else:
+        from pyspark.sql.functions import lit
+        df = df.withColumn("positivity", lit(123))
+
     return df
 
 
 @op
 def dummy_sentiment_model_multiple_input(df1, df2):
-    df1["positivity"] = 123
-    df1["positivity_2"] = 456
+    if isinstance(df, pd.DataFrame):
+        df1["positivity"] = 123
+        df1["positivity_2"] = 456
+    else:
+        from pyspark.sql.functions import lit
+        df1 = df1.withColumn("positivity", lit(123))
+        df1 = df1.withColumn("positivity_2", lit(456))
+
     return df1
 
 
 @op()
 def dummy_model(df):
-    df["newcol"] = "value"
+    if isinstance(df, pd.DataFrame):
+        df["newcol"] = "value"
+    else:
+        from pyspark.sql.functions import lit
+        df = df.withColumn("newcol", lit("value"))
+
     return df
 
 
 @op()
 def dummy_model_2(df):
-    df["newcol_2"] = "value"
+    if isinstance(df, pd.DataFrame):
+        df["newcol_2"] = "value"
+    else:
+        from pyspark.sql.functions import lit
+        df = df.withColumn("newcol_2", lit("value"))
+
     return df

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
@@ -1,5 +1,6 @@
-from aqueduct import op
 import pandas as pd
+
+from aqueduct import op
 
 
 @op()
@@ -8,6 +9,7 @@ def dummy_sentiment_model(df):
         df["positivity"] = 123
     else:
         from pyspark.sql.functions import lit
+
         df = df.withColumn("POSITIVITY", lit(123.0))
 
     return df
@@ -18,6 +20,7 @@ def dummy_sentiment_model_function(df):
         df["positivity"] = 123
     else:
         from pyspark.sql.functions import lit
+
         df = df.withColumn("POSITIVITY", lit(123.0))
 
     return df
@@ -30,6 +33,7 @@ def dummy_sentiment_model_multiple_input(df1, df2):
         df1["positivity_2"] = 456
     else:
         from pyspark.sql.functions import lit
+
         df1 = df1.withColumn("POSITIVITY", lit(123.0))
         df1 = df1.withColumn("POSITIVITY_2", lit(456.0))
 
@@ -42,6 +46,7 @@ def dummy_model(df):
         df["newcol"] = "value"
     else:
         from pyspark.sql.functions import lit
+
         df = df.withColumn("NEWCOL", lit("value"))
 
     return df
@@ -53,6 +58,7 @@ def dummy_model_2(df):
         df["newcol_2"] = "value"
     else:
         from pyspark.sql.functions import lit
+
         df = df.withColumn("NEWCOL_2", lit("value"))
 
     return df

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
@@ -3,6 +3,10 @@ import pandas as pd
 from aqueduct import op
 
 
+# In order to use these functions with spark compute engines, we add a clause
+# with equivalent pyspark code. the `lit` function creates a full column of the
+# given value. `lit(123)` automatically is casted to a double, so we case back
+# to an integer type.
 @op()
 def dummy_sentiment_model(df):
     if isinstance(df, pd.DataFrame):
@@ -10,7 +14,7 @@ def dummy_sentiment_model(df):
     else:
         from pyspark.sql.functions import lit
 
-        df = df.withColumn("POSITIVITY", lit(123.0))
+        df = df.withColumn("POSITIVITY", lit(123).cast("integer"))
 
     return df
 
@@ -21,7 +25,7 @@ def dummy_sentiment_model_function(df):
     else:
         from pyspark.sql.functions import lit
 
-        df = df.withColumn("POSITIVITY", lit(123.0))
+        df = df.withColumn("POSITIVITY", lit(123).cast("integer"))
 
     return df
 
@@ -34,8 +38,8 @@ def dummy_sentiment_model_multiple_input(df1, df2):
     else:
         from pyspark.sql.functions import lit
 
-        df1 = df1.withColumn("POSITIVITY", lit(123.0))
-        df1 = df1.withColumn("POSITIVITY_2", lit(456.0))
+        df1 = df1.withColumn("POSITIVITY", lit(123).cast("integer"))
+        df2 = df2.withColumn("POSITIVITY", lit(456).cast("integer"))
 
     return df1
 

--- a/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
+++ b/integration_tests/sdk/aqueduct_tests/test_functions/simple/model.py
@@ -34,12 +34,12 @@ def dummy_sentiment_model_function(df):
 def dummy_sentiment_model_multiple_input(df1, df2):
     if isinstance(df1, pd.DataFrame):
         df1["positivity"] = 123
-        df2["positivity_2"] = 456
+        df1["positivity_2"] = 456
     else:
         from pyspark.sql.functions import lit
 
         df1 = df1.withColumn("POSITIVITY", lit(123).cast("integer"))
-        df2 = df2.withColumn("POSITIVITY_2", lit(456).cast("integer"))
+        df1 = df1.withColumn("POSITIVITY_2", lit(456).cast("integer"))
 
     return df1
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -215,8 +215,7 @@ def skip_for_spark_engines(request, client, engine):
     if request.node.get_closest_marker("skip_for_spark_engines"):
         if _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
             pytest.skip(
-                "Skipped for engine integration `%s`, since it is a spark-based engine."
-                % engine
+                "Skipped for engine integration `%s`, since it is a spark-based engine." % engine
             )
 
 

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -213,7 +213,7 @@ def skip_for_spark_engines(request, client, engine):
     (Databricks or Spark)
     """
     if request.node.get_closest_marker("skip_for_spark_engines"):
-        if (not engine) and _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
+        if engine and _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
             pytest.skip(
                 "Skipped for engine integration `%s`, since it is a spark-based engine." % engine
             )

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -213,7 +213,7 @@ def skip_for_spark_engines(request, client, engine):
     (Databricks or Spark)
     """
     if request.node.get_closest_marker("skip_for_spark_engines"):
-        if _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
+        if (not engine) and _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
             pytest.skip(
                 "Skipped for engine integration `%s`, since it is a spark-based engine." % engine
             )

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -208,6 +208,19 @@ def enable_only_for_engine_type(request, client, engine):
 
 
 @pytest.fixture(autouse=True)
+def skip_for_spark_engines(request, client, engine):
+    """When a test is marked with this, we skip if we are using a spark based engine
+    (Databricks or Spark)
+    """
+    if request.node.get_closest_marker("skip_for_spark_engines"):
+        if _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
+            pytest.skip(
+                "Skipped for engine integration `%s`, since it is a spark-based engine."
+                % engine
+            )
+
+
+@pytest.fixture(autouse=True)
 def enable_only_for_local_storage(request, client, engine):
     """When a test is marked with this, we run it only when the local file system is used as storage."""
     if not request.node.get_closest_marker("enable_only_for_local_storage"):

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -213,7 +213,10 @@ def skip_for_spark_engines(request, client, engine):
     (Databricks or Spark)
     """
     if request.node.get_closest_marker("skip_for_spark_engines"):
-        if engine and _type_from_engine_name(client, engine) in [ServiceType.DATABRICKS, ServiceType.SPARK]:
+        if engine and _type_from_engine_name(client, engine) in [
+            ServiceType.DATABRICKS,
+            ServiceType.SPARK,
+        ]:
             pytest.skip(
                 "Skipped for engine integration `%s`, since it is a spark-based engine." % engine
             )

--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -59,6 +59,10 @@ def pytest_configure(config):
         "markers",
         "enable_only_for_local_storage: the test is expected to run in an environment with local storage.",
     )
+    config.addinivalue_line(
+        "markers",
+        "skip_for_spark_engines: the test only runs for non-Spark compute engines.",
+    )
 
 
 def pytest_cmdline_main(config):
@@ -208,7 +212,7 @@ def enable_only_for_engine_type(request, client, engine):
 
 
 @pytest.fixture(autouse=True)
-def skip_for_spark_engines(request, client, engine):
+def skip_for_spark_engines(request, client, engine, reason=None):
     """When a test is marked with this, we skip if we are using a spark based engine
     (Databricks or Spark)
     """

--- a/scripts/data/redshift_test.py
+++ b/scripts/data/redshift_test.py
@@ -1,5 +1,6 @@
-import boto3
 import sys
+
+import boto3
 
 CLUSTER_NAME = "integration-test-shared"
 
@@ -12,15 +13,11 @@ def resume_redshift(aws_access_key_id, aws_secret_access_key):
 
     status = _get_cluster_status(client, CLUSTER_NAME)
     if status == STATUS_AVAILABLE:
-        print(
-            f"The {CLUSTER_NAME} cluster is already available, it does not need to be resumed"
-        )
+        print(f"The {CLUSTER_NAME} cluster is already available, it does not need to be resumed")
     elif status == STATUS_PAUSED:
         client.resume_cluster(ClusterIdentifier=CLUSTER_NAME)
     else:
-        sys.exit(
-            f"Cannot resume {CLUSTER_NAME} cluster because it is in the {status} state"
-        )
+        sys.exit(f"Cannot resume {CLUSTER_NAME} cluster because it is in the {status} state")
 
 
 def pause_redshift(aws_access_key_id, aws_secret_access_key):
@@ -28,15 +25,11 @@ def pause_redshift(aws_access_key_id, aws_secret_access_key):
 
     status = _get_cluster_status(client, CLUSTER_NAME)
     if status == STATUS_PAUSED:
-        print(
-            f"The {CLUSTER_NAME} cluster is already paused, it does not need to be paused"
-        )
+        print(f"The {CLUSTER_NAME} cluster is already paused, it does not need to be paused")
     elif status == STATUS_AVAILABLE:
         client.pause_cluster(ClusterIdentifier=CLUSTER_NAME)
     else:
-        sys.exit(
-            f"Cannot pause {CLUSTER_NAME} cluster because it is in the {status} state"
-        )
+        sys.exit(f"Cannot pause {CLUSTER_NAME} cluster because it is in the {status} state")
 
 
 def _create_client(aws_access_key_id, aws_secret_access_key):

--- a/src/golang/lib/job/spark.go
+++ b/src/golang/lib/job/spark.go
@@ -27,7 +27,7 @@ func NewSparkJobManager(conf *SparkJobManagerConfig) (*SparkJobManager, error) {
 
 	session, err := livyClient.CreateSession(&spark.CreateSessionRequest{
 		Kind:                     "pyspark",
-		HeartbeatTimeoutInSecond: 600,
+		HeartbeatTimeoutInSecond: 10,
 		Archives:                 []string{fmt.Sprintf("%s#environment", conf.EnvironmentPathURI)},
 		Conf: map[string]string{
 			"spark.yarn.appMasterEnv.PYSPARK_PYTHON": "./environment/bin/python",


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Modifies tests to work with Spark. Most of the changes involve adding a case in the test functions to use Pyspark Dataframe specific code. I also add the `pytest.mark.skip_for_spark_engines() `fixture to skip tests that don't work with Spark.
## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


