### PR TITLE
Allow more flexibility in the run_tests.py script

### DIFF
--- a/integration_tests/sdk/README.md
+++ b/integration_tests/sdk/README.md
@@ -20,7 +20,7 @@ This file contains:
 will automatically run against each of the data integrations specified in this file, unless a `--data` argument
 is supplied, whereby the tests will filter down to just that data integration.
 
-Both these test suites share a collection of command line flags:
+Both these test suites share a collection of custom command line flags:
 * `--data`: The integration name of the data integration to run all tests against. 
 * `--engine`: The integration of the engine to compute all tests on.
 * `--keep-flows`: If set, we will not delete any flows created by the test run. This is useful for debugging.
@@ -31,25 +31,32 @@ Both these test suites share a collection of command line flags:
 For additional markers/fixtures/flags, please inspect `conftest.py` in this directory. For test-specific configurations,
 see `aqueduct_tests/conftest.py` and  `data_integration_tests/conftest.py`.
 
-## Commands
+## Running the Tests
+You can run this test suite using vanilla pytest, or you can use the `run_tests.py` script in this directory.
+
+### About run_tests.py
+`run_tests.py` is just a convenience wrapper around the pytest command. Any pytest flags can be used
+with this script too. The main difference is that run_tests.py adds some default pytest configuration,
+like setting the default concurrenty to 8.
+
+### Commands
+Note that to run tests with concurrency > 1, `pytest-xdist` must be installed.
 
 To run all SDK Integration Tests, from the `integration_tests/sdk` directory, run:
-`python3 run_tests.py [-lf] [-n CONCURRENCY]`
+`python3 run_tests.py`
 
 To run just one of the test suites:
-- `python3 run_tests.py --aqueduct [-lf] [-n CONCURRENCY] [-k TEST_CASE]`
-- `python3 run_tests.py --data-integration [-lf] [-n CONCURRENCY] [-k TEST_CASE]`
+- `python3 run_tests.py --aqueduct`
+- `python3 run_tests.py --data-integration`
 
-To run tests with concurrency > 1, `pytest-xdist` must be installed.
+To run just one of the test files:
+- `python3 run_tests.py --aqueduct --file flow_test.py`
 
-## Useful Pytest Command Flags 
+To run just one test case:
+- `python3 run_tests.py --aqueduct -k test_basic_flow`
 
-The above script simply runs the following pytest commands:
-- `pytest aqueduct_tests/ -rP -vv [-lf] [-n CONCURRENCY]`
-- `pytest data_integration_tests/ -rP -vv [-lf] [-n CONCURRENCY]`
+### Useful Command Flags 
+In addition to the custom test suite flags listed above, you can also apply generic pytest flags to the test run too.
 
-Running all the tests in a single file:
-- `pytest <path to test file> -rP -vv`
-
-Running a specific test:
-- `pytest <specific test directory> -rP -vv -k '<specific test name>'`
+For example, to only run tests that have failed in the last run, use the `--lf` flag.
+- `python3 run_tests.py --lf`

--- a/integration_tests/sdk/run_tests.py
+++ b/integration_tests/sdk/run_tests.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import subprocess
 import sys
+from typing import List, Optional
 
 
 def _execute_command(args, cwd=None) -> None:
@@ -13,26 +14,18 @@ def _execute_command(args, cwd=None) -> None:
 
 def _run_tests(
     dir_name: str,
-    test_case: str,
+    file_name: Optional[str],
     concurrency: int,
-    rerun_failed: bool,
-    skip_data_setup: bool,
-    skip_engine_setup: bool,
+    unknown_args: List[str],
 ) -> None:
     """Either test_case or rerun_failed can be set, but not both."""
-    if rerun_failed:
-        cmd = ["pytest", dir_name, "-rP", "-vv", "--lf", "-n", str(concurrency)]
-    else:
-        cmd = ["pytest", dir_name, "-rP", "-vv", "-n", str(concurrency)]
+    target_name = dir_name
+    if file_name is not None:
+        # `dir_name` already ends in a slash.
+        assert dir_name[-1] == "/"
+        target_name = dir_name + file_name
 
-    if len(test_case) > 0:
-        cmd += ["-k", test_case]
-
-    if skip_data_setup:
-        cmd.append("--skip-data-setup")
-    if skip_engine_setup:
-        cmd.append("--skip-engine-setup")
-
+    cmd = ["pytest", target_name, "-rP", "-vv"] + unknown_args + ["-n", str(concurrency)]
     _execute_command(cmd)
 
 
@@ -56,35 +49,12 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-k",
-        dest="test_case",
-        default="",
+        "--file",
+        dest="file",
+        default=None,
         action="store",
-        help="Only runs tests that match this argument",
-    )
-
-    parser.add_argument(
-        "--lf",
-        dest="rerun_failed",
-        default=False,
-        action="store_true",
-        help="Run only the tests in the suite that failed during the last run.",
-    )
-
-    parser.add_argument(
-        "--skip-data-setup",
-        dest="skip_data_setup",
-        default=False,
-        action="store_true",
-        help="If set, skips any data integration setup to speed up testing.",
-    )
-
-    parser.add_argument(
-        "--skip-engine-setup",
-        dest="skip_engine_setup",
-        default=False,
-        action="store_true",
-        help="If set, skips any engine integration setup to speed up testing.",
+        help="The file to run the tests on. For example, `python3 run_tests.py --aqueduct --file flow_test.py` is "
+        "equivalent to running `pytest aqueduct/flow_test.py`.",
     )
 
     parser.add_argument(
@@ -95,14 +65,10 @@ if __name__ == "__main__":
         help="The concurrency to run the test suite with.",
     )
 
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
     if not (args.aqueduct_tests or args.data_integration_tests):
         args.aqueduct_tests = True
         args.data_integration_tests = True
-
-    assert not (
-        args.rerun_failed and len(args.test_case) > 0
-    ), "Either -k or -lf can be set, but not both."
 
     cwd = os.getcwd()
     if not cwd.endswith("integration_tests/sdk"):
@@ -114,20 +80,16 @@ if __name__ == "__main__":
         print("Running Aqueduct Tests...")
         _run_tests(
             "aqueduct_tests/",
-            args.test_case,
+            args.file,
             args.concurrency,
-            args.rerun_failed,
-            args.skip_data_setup,
-            args.skip_engine_setup,
+            unknown_args,
         )
 
     if args.data_integration_tests:
         print("Running Data Integration Tests...")
         _run_tests(
             "data_integration_tests/",
-            args.test_case,
+            args.file,
             args.concurrency,
-            args.rerun_failed,
-            args.skip_data_setup,
-            args.skip_engine_setup,
+            unknown_args,
         )

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -1,8 +1,8 @@
 import logging
 import os
+import platform
 import uuid
 import warnings
-import platform
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional, Union
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
It's pretty annoying that there are only a subset of the pytest flags implemented in run_tests.py. It would be much better just to pass any flags down to the pytest command, and have run_tests.py be a kind of convenience helper.

## Related issue number (if any)
ENG-2766

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


