### PR TITLE
Adds support for running BigQuery tests periodically

### DIFF
--- a/.github/actions/fetch-test-config/action.yml
+++ b/.github/actions/fetch-test-config/action.yml
@@ -34,3 +34,8 @@ runs:
       working-directory: integration_tests/sdk
       shell: bash
       run: aws s3 cp s3://aqueduct-assets/test-credentials.yml ./test-credentials.yml
+    
+    - name: Fetch BigQuery Test Credentials
+      working-directory: integration_tests/sdk
+      shell: bash
+      run: aws s3 cp s3://aqueduct-assets/test-bigquery-credentials.json ./test-bigquery-credentials.json


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fetches the BigQuery shared credentials to a location from which it can be used for data integration tests.

## Related issue number (if any)
ENG 2696

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


