### PR TITLE
Add flags for finer control of compute engines in testing.

### DIFF
--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -9,7 +9,8 @@ from sdk.setup_integration import (
     get_aqueduct_config,
     get_artifact_store_name,
     has_storage_config,
-    is_preview_enabled,
+    is_global_engine_set,
+    is_lazy_set,
     list_compute_integrations,
     list_data_integrations,
     setup_compute_integrations,
@@ -139,17 +140,18 @@ def engine(request, pytestconfig):
 
 @pytest.fixture(scope="function", autouse=True)
 def set_global_config(engine):
-    # If we are using the aqueduct engine (where the engine fixture is None), we
-    # assume that previews are enabled and thus don't have to change the existing
-    # global_config.
+    # If we are using the aqueduct engine (where the engine fixture is None), we don't
+    # have to change the existing global_config.
     if engine != None:
-        # If we are using an external compute engine, we check if the `enable_previews` tag
-        # has been set in test-credentials.yml. If it is, we set lazy execution to False
-        # to force the external engine to run previews. If not set (in the case we want to save
-        # on costs) we set lazy to True and thus do not run previews unless we force execution
-        # via <artifact>.get().
-        lazy_config = not is_preview_enabled(engine)
-        global_config({"engine": engine, "lazy": lazy_config})
+        # Enables lazy execution by default if `set_global_lazy` flag is added in conf.
+        lazy_config = is_lazy_set(engine)
+
+        # Enables the compute engine as global default if `set_global_engine` flag is added in conf.
+        engine_config = "aqueduct"
+        if is_global_engine_set(engine):
+            engine_config = engine
+
+        global_config({"engine": engine_config, "lazy": lazy_config})
 
     yield
     # Reset the global_config after the end of the function.

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -332,16 +332,28 @@ def _fetch_integration_credentials(section: str, name: str) -> Dict[str, Any]:
     return test_credentials[section][name]
 
 
-def is_preview_enabled(name: str) -> bool:
+def is_global_engine_set(name: str) -> bool:
     """
-    Returns whether or not the provided compute integration has `enable_previews` set.
+    Returns whether or not the provided compute integration has `set_global_engine` set.
     """
     test_credentials = _parse_credentials_file()
 
     assert "compute" in test_credentials, "compute section expected in test-credentials.yml"
     assert name in test_credentials["compute"].keys(), "%s not in test-credentials.yml." % name
 
-    return "enable_previews" in test_credentials["compute"][name].keys()
+    return "set_global_engine" in test_credentials["compute"][name].keys()
+
+
+def is_lazy_set(name: str) -> bool:
+    """
+    Returns whether or not the provided compute integration has `set_global_lazy` set.
+    """
+    test_credentials = _parse_credentials_file()
+
+    assert "compute" in test_credentials, "compute section expected in test-credentials.yml"
+    assert name in test_credentials["compute"].keys(), "%s not in test-credentials.yml." % name
+
+    return "set_global_lazy" in test_credentials["compute"][name].keys()
 
 
 def list_data_integrations() -> List[str]:

--- a/integration_tests/sdk/test-credentials-example.yml
+++ b/integration_tests/sdk/test-credentials-example.yml
@@ -83,5 +83,7 @@ compute:
     kubeconfig_path:
     # This key name should be globally unique since we do a find-and-replace.
     cluster_name: <CLUSTER_NAME>
-    # This key name should be set if you want previews to be run on all tests.
-    # enable_previews:
+    # This key name should be set if engine should be the global default.
+    # set_global_engine:
+    # This key name should be set if you want lazy execution to be global default.
+    # set_global_lazy:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds 2 flags for compute engines:
`set_global_engine` - enables the engine as global default
`set_global_lazy` - enables lazy execution as global default

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


