### PR TITLE
Adds instance pool option to Databricks integration

### DIFF
--- a/src/golang/lib/databricks/jobs.go
+++ b/src/golang/lib/databricks/jobs.go
@@ -68,13 +68,10 @@ func CreateJob(
 			MinWorkers: DefaultMinNumWorkers,
 			MaxWorkers: DefaultMaxNumWorkers,
 		},
-		// NodeTypeId: DefaultNodeTypeID,
 		AwsAttributes: &clusters.AwsAttributes{
 			InstanceProfileArn: s3InstanceProfileArn,
 		},
-		InstancePoolId: "0410-195714-julep1-pool-sf9ui7f5",
 	}
-
 	if instancePoolID != nil {
 		jobCluster.InstancePoolId = *instancePoolID
 	} else {

--- a/src/golang/lib/job/config.go
+++ b/src/golang/lib/job/config.go
@@ -64,6 +64,8 @@ type DatabricksJobManagerConfig struct {
 	// storage in S3. Information on how to create this can be found here:
 	// https://docs.databricks.com/aws/iam/instance-profile-tutorial.html
 	S3InstanceProfileARN string `yaml:"s3InstanceProfileArn" json:"s3_instance_profile_arn"`
+	// [Optional] ID of instance pool that Aqueduct-created JobClusters should use.
+	InstancePoolID *string `yaml:"instancePoolID" json:"instance_pool_id"`
 	// AWS Access Key ID is passed from the StorageConfig.
 	AwsAccessKeyID string `yaml:"awsAccessKeyId" json:"aws_access_key_id"`
 	// AWS Secret Access Key is passed from the StorageConfig.
@@ -251,6 +253,7 @@ func GenerateJobManagerConfig(
 			WorkspaceURL:         databricksConfig.WorkspaceURL,
 			AccessToken:          databricksConfig.AccessToken,
 			S3InstanceProfileARN: databricksConfig.S3InstanceProfileARN,
+			InstancePoolID:       databricksConfig.InstancePoolID,
 			AwsAccessKeyID:       awsAccessKeyId,
 			AwsSecretAccessKey:   awsSecretAccessKey,
 		}, nil

--- a/src/golang/lib/job/databricks.go
+++ b/src/golang/lib/job/databricks.go
@@ -51,7 +51,7 @@ func (j *DatabricksJobManager) Launch(
 		return systemError(err)
 	}
 
-	jobID, err := databricks_lib.CreateJob(ctx, j.databricksClient, name, j.conf.S3InstanceProfileARN, []jobs.JobTaskSettings{*task})
+	jobID, err := databricks_lib.CreateJob(ctx, j.databricksClient, name, j.conf.S3InstanceProfileARN, j.conf.InstancePoolID, []jobs.JobTaskSettings{*task})
 	if err != nil {
 		return systemError(errors.Wrap(err, "Error creating job in Databricks."))
 	}
@@ -156,7 +156,7 @@ func (j *DatabricksJobManager) LaunchMultipleTaskJob(
 	taskList []jobs.JobTaskSettings,
 ) (int64, JobError) {
 	// Create and register the job with Databricks.
-	jobID, err := databricks_lib.CreateJob(ctx, j.databricksClient, name, j.conf.S3InstanceProfileARN, taskList)
+	jobID, err := databricks_lib.CreateJob(ctx, j.databricksClient, name, j.conf.S3InstanceProfileARN, j.conf.InstancePoolID, taskList)
 	if err != nil {
 		return -1, systemError(errors.Wrap(err, "Error creating job in Databricks."))
 	}

--- a/src/golang/lib/models/shared/integration_config.go
+++ b/src/golang/lib/models/shared/integration_config.go
@@ -109,6 +109,8 @@ type DatabricksIntegrationConfig struct {
 	// storage in S3. Information on how to create this can be found here:
 	// https://docs.databricks.com/aws/iam/instance-profile-tutorial.html
 	S3InstanceProfileARN string `json:"s3_instance_profile_arn" yaml:"s3InstanceProfileArn"`
+	// [Optional] ID of instance pool that Aqueduct-created JobClusters should use.
+	InstancePoolID *string `json:"instance_pool_id" yaml:"instancePoolID"`
 }
 
 type EmailConfig struct {

--- a/src/golang/lib/models/shared/integration_config.go
+++ b/src/golang/lib/models/shared/integration_config.go
@@ -110,7 +110,7 @@ type DatabricksIntegrationConfig struct {
 	// https://docs.databricks.com/aws/iam/instance-profile-tutorial.html
 	S3InstanceProfileARN string `json:"s3_instance_profile_arn" yaml:"s3InstanceProfileArn"`
 	// [Optional] ID of instance pool that Aqueduct-created JobClusters should use.
-	InstancePoolID *string `json:"instance_pool_id" yaml:"instancePoolID"`
+	InstancePoolID *string `json:"instance_pool_id,omitempty" yaml:"instancePoolID"`
 }
 
 type EmailConfig struct {

--- a/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
@@ -98,7 +98,7 @@ export const DatabricksDialog: React.FC<Props> = ({
       <IntegrationTextInputField
         label={'Instance Pool ID'}
         description={
-          'The ID of the Datbricks Instance Pool that Aqueduct will run compute on.'
+          'The ID of the Databricks Instance Pool that Aqueduct will run compute on.'
         }
         spellCheck={false}
         required={false}

--- a/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
@@ -11,6 +11,7 @@ const Placeholders: DatabricksConfig = {
   workspace_url: 'workspace_url',
   access_token: 'access_token',
   s3_instance_profile_arn: 's3_instance_profile_arn',
+  instance_pool_id: 'instance_pool_id',
 };
 
 type Props = {
@@ -84,6 +85,28 @@ export const DatabricksDialog: React.FC<Props> = ({
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
+      />
+
+      <Typography variant="body2">
+        For more details on Databricks Instance Pools, please see{' '}
+        <Link href="https://docs.databricks.com/aws/iam/instance-profile-tutorial.html">
+          the Databricks documentation
+        </Link>
+        .
+      </Typography>
+
+      <IntegrationTextInputField
+        label={'Instance Pool ID'}
+        description={
+          'The ID of the Datbricks Instance Pool that Aqueduct will run compute on.'
+        }
+        spellCheck={false}
+        required={false}
+        placeholder={Placeholders.instance_pool_id}
+        onChange={(event) =>
+          onUpdateField('instance_pool_id', event.target.value)
+        }
+        value={value?.instance_pool_id ?? null}
       />
     </Box>
   );

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -168,6 +168,7 @@ export type DatabricksConfig = {
   workspace_url: string;
   access_token: string;
   s3_instance_profile_arn: string;
+  instance_pool_id: string;
 };
 
 export type NotificationIntegrationConfig = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds option for users to specify a Databricks instance pool. All JobClusters that Aqueduct creates will create clusters using instances from this pool. If not specified, we default to a node type and request spot instances from AWS.
## Related issue number (if any)
Eng-2765
## Loom demo (if any)
https://www.loom.com/share/a12b0ca34fc04ad495b39b69422e72ec
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


