### PR TITLE
Adds support for running integration tests against Airflow

### DIFF
--- a/integration_tests/sdk/conftest.py
+++ b/integration_tests/sdk/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from aqueduct.constants.enums import ServiceType
 from aqueduct.models.dag import DAG, Metadata

--- a/integration_tests/sdk/shared/compute.py
+++ b/integration_tests/sdk/shared/compute.py
@@ -1,5 +1,6 @@
 from aqueduct.constants.enums import ServiceType
 
+
 def type_from_engine_name(client, engine: str) -> ServiceType:
     """
     Returns the integration type of an engine from the name.

--- a/integration_tests/sdk/shared/compute.py
+++ b/integration_tests/sdk/shared/compute.py
@@ -1,0 +1,14 @@
+from aqueduct.constants.enums import ServiceType
+
+def type_from_engine_name(client, engine: str) -> ServiceType:
+    """
+    Returns the integration type of an engine from the name.
+    """
+    if engine == "aqueduct_engine":
+        return ServiceType.AQUEDUCT_ENGINE
+
+    integration_info_by_name = client.list_integrations()
+    if engine not in integration_info_by_name.keys():
+        raise Exception("Server is not connected to integration `%s`." % engine)
+
+    return integration_info_by_name[engine].service

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -233,7 +233,7 @@ def delete_all_flows(client: aqueduct.Client) -> None:
             print("Error deleting workflow %s with exception: %s" % (flow_name, e))
         else:
             print("Successfully deleted workflow %s" % flow_name)
-        
+
         # Try deleting Airflow DAG file if it exists
         # TODO - Only do this for Airflow workflows
         dag_path = f"{flow_name}_airflow.py"

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -12,6 +12,10 @@ from aqueduct import Flow
 
 from .compute import type_from_engine_name
 
+# This is the folder where Airflow DAG files need to be copied to.
+# This is guaranteed to exist when running integration tests against
+# an Airflow cluster that was spun up using the script in
+# scripts/compute/airflow_test_setup.sh
 AIRFLOW_DAGS_FOLDER = "~/airflow/dags"
 
 
@@ -235,7 +239,7 @@ def delete_all_flows(client: aqueduct.Client) -> None:
             print("Successfully deleted workflow %s" % flow_name)
 
         # Try deleting Airflow DAG file if it exists
-        # TODO - Only do this for Airflow workflows
+        # TODO ENG-2868 - Only do this for Airflow workflows
         dag_path = f"{flow_name}_airflow.py"
         if os.path.exists(dag_path):
             os.remove(dag_path)

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -99,8 +99,8 @@ def publish_flow_test(
         folder_path = os.path.expanduser(AIRFLOW_DAGS_FOLDER)
         shutil.move(dag_path, folder_path)
 
-        print("Sleeping for 20s to wait for Airflow scheduler to pick up new DAG file")
-        time.sleep(20)
+        print("Sleeping for 30s to wait for Airflow scheduler to pick up new DAG file")
+        time.sleep(30)
 
         # Manually trigger a run to match behavior of non-Airflow engines
         client.trigger(flow_id=flow.id())

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -1,12 +1,18 @@
+import os
+import shutil
 import time
 import uuid
 from typing import Any, Dict, List, Optional, Union
 
 from aqueduct.artifacts.base_artifact import BaseArtifact
-from aqueduct.constants.enums import ExecutionStatus
+from aqueduct.constants.enums import ExecutionStatus, ServiceType
 
 import aqueduct
 from aqueduct import Flow
+
+from .compute import type_from_engine_name
+
+AIRFLOW_DAGS_FOLDER = "~/airflow/dags"
 
 
 def publish_flow_test(
@@ -81,6 +87,23 @@ def publish_flow_test(
         use_local=use_local,
     )
     print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
+
+    engine_type = type_from_engine_name(client, engine)
+    if engine_type == ServiceType.AIRFLOW:
+        # Copy over the Airflow DAG file to the Airflow DAGs folder
+        dag_path = f"{name}_airflow.py"
+        assert os.path.exists(
+            dag_path
+        ), f"The expected Airflow DAG file was not found at {dag_path}"
+
+        folder_path = os.path.expanduser(AIRFLOW_DAGS_FOLDER)
+        shutil.move(dag_path, folder_path)
+
+        print("Sleeping for 20s to wait for Airflow scheduler to pick up new DAG file")
+        time.sleep(20)
+
+        # Manually trigger a run to match behavior of non-Airflow engines
+        client.trigger(flow_id=flow.id())
 
     if should_block:
         wait_for_flow_runs(
@@ -210,6 +233,12 @@ def delete_all_flows(client: aqueduct.Client) -> None:
             print("Error deleting workflow %s with exception: %s" % (flow_name, e))
         else:
             print("Successfully deleted workflow %s" % flow_name)
+        
+        # Try deleting Airflow DAG file if it exists
+        # TODO - Only do this for Airflow workflows
+        dag_path = f"{flow_name}_airflow.py"
+        if os.path.exists(dag_path):
+            os.remove(dag_path)
 
 
 def polling(

--- a/scripts/compute/airflow_test_setup.sh
+++ b/scripts/compute/airflow_test_setup.sh
@@ -8,4 +8,10 @@ PYTHON_VERSION="$(python3 --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
 CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
 pip3 install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
-AIRFLOW__WEBSERVER__WEB_SERVER_PORT=8000 airflow standalone
+export AIRFLOW__WEBSERVER__WEB_SERVER_PORT=8000
+# Allows basic username and password based auth 
+export AIRFLOW__API__AUTH_BACKENDS=airflow.api.auth.backend.basic_auth
+# Has scheduler check for new DAGs every 15s
+export AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL=15
+
+airflow standalone

--- a/scripts/compute/airflow_test_setup.sh
+++ b/scripts/compute/airflow_test_setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+export AIRFLOW_HOME=~/airflow
+
+AIRFLOW_VERSION=2.5.3
+PYTHON_VERSION="$(python3 --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
+
+CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
+pip3 install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
+
+AIRFLOW__WEBSERVER__WEB_SERVER_PORT=8000 airflow standalone

--- a/scripts/compute/airflow_test_setup.sh
+++ b/scripts/compute/airflow_test_setup.sh
@@ -14,4 +14,7 @@ export AIRFLOW__API__AUTH_BACKENDS=airflow.api.auth.backend.basic_auth
 # Has scheduler check for new DAGs every 15s
 export AIRFLOW__SCHEDULER__DAG_DIR_LIST_INTERVAL=15
 
+# Safety check to ensure that the AIRFLOW_HOME/dags directory actually exists
+mkdir ${AIRFLOW_HOME}/dags
+
 airflow standalone

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -234,6 +234,14 @@ class _EmailConfigWithStringField(BaseConnectionConfig):
     enabled: str
 
 
+class AirflowConfig(BaseConnectionConfig):
+    host: str
+    username: str
+    password: str
+    s3_credentials_path: str
+    s3_credentials_profile: str
+
+
 class SparkConfig(BaseConnectionConfig):
     livy_server_url: str
 
@@ -262,6 +270,7 @@ IntegrationConfig = Union[
     AWSConfig,
     _AWSConfigWithSerializedConfig,
     _SlackConfigWithStringField,
+    AirflowConfig,
     SparkConfig,
     K8sConfig,
     CondaConfig,
@@ -297,6 +306,8 @@ def convert_dict_to_integration_connect_config(
         return EmailConfig(**config_dict)
     elif service == ServiceType.CONDA:
         return CondaConfig(**config_dict)
+    elif service ==  ServiceType.AIRFLOW:
+        return AirflowConfig(**config_dict)
     elif service == ServiceType.SPARK:
         return SparkConfig(**config_dict)
     elif service == ServiceType.AWS:

--- a/sdk/aqueduct/integrations/connect_config.py
+++ b/sdk/aqueduct/integrations/connect_config.py
@@ -306,7 +306,7 @@ def convert_dict_to_integration_connect_config(
         return EmailConfig(**config_dict)
     elif service == ServiceType.CONDA:
         return CondaConfig(**config_dict)
-    elif service ==  ServiceType.AIRFLOW:
+    elif service == ServiceType.AIRFLOW:
         return AirflowConfig(**config_dict)
     elif service == ServiceType.SPARK:
         return SparkConfig(**config_dict)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds initial support for running integration tests against Airflow. It has a setup script for starting a local Airflow instance. It also adds logic for manually copying the Airflow DAG file to the appropriate folder.

There is still follow on work that needs to be done before these tests can be run on Github actions:
- Fix syncing bugs https://linear.app/aqueducthq/issue/ENG-2794/fix-bug-where-airflow-dags-created-by-integration-test-are-not-syncing
- Configure running these tests on github actions https://linear.app/aqueducthq/issue/ENG-2796/configure-airflow-tests-to-run-on-github-actions

## Related issue number (if any)
ENG 2116

## Tests
Ran the basic flow_test locally and uncovered the syncing bug.

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


