### PR TITLE
Fix creating local tensorflow model data fails with module import and tensorflow versioning

### DIFF
--- a/.github/actions/setup-server/action.yml
+++ b/.github/actions/setup-server/action.yml
@@ -62,7 +62,7 @@ runs:
 
     - name: Install packages needed for testing
       shell: bash
-      run: python3 -m pip install nltk pytest-xdist tensorflow
+      run: python3 -m pip install nltk pytest-xdist
 
     - name: Wait for server again
       shell: bash

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -525,7 +525,7 @@ def test_invalid_local_data(client):
         )
 
 
-# TODO: Remove this pytest fixture on next release.
+# TODO(ENG-2798): Enable this test on next release.
 @pytest.mark.enable_only_for_engine_type(ServiceType.AQUEDUCT_ENGINE)
 def test_all_local_data_types(client, flow_name, engine):
     @op

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -628,7 +628,7 @@ def test_all_local_data_types(client, flow_name, engine):
     )
 
 
-# TODO(ENG-2798): Unable to publish flow using TF_KERAS parameter.
+# TODO(ENG-2798): Currented we can't publish a flow with tensorflow model as parameter.
 @pytest.mark.skip()
 def test_local_tf_keras_data(client, flow_name, engine):
     from tensorflow import keras

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from aqueduct.artifacts.generic_artifact import GenericArtifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
-from aqueduct.constants.enums import ArtifactType, ExecutionStatus, ServiceType
+from aqueduct.constants.enums import ArtifactType, ExecutionStatus
 from aqueduct.error import (
     AqueductError,
     ArtifactNeverComputedException,

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -525,8 +525,6 @@ def test_invalid_local_data(client):
         )
 
 
-# TODO(ENG-2798): Enable this test on next release.
-@pytest.mark.enable_only_for_engine_type(ServiceType.AQUEDUCT_ENGINE)
 def test_all_local_data_types(client, flow_name, engine):
     @op
     def must_be_picklable(input):
@@ -614,6 +612,25 @@ def test_all_local_data_types(client, flow_name, engine):
     assert isinstance(image_output, GenericArtifact)
     assert isinstance(image_output.get(), Image.Image)
 
+    publish_flow_test(
+        client,
+        name=flow_name(),
+        artifacts=[
+            pickle_output,
+            bytes_output,
+            string_output,
+            tuple_output,
+            list_output,
+            image_output,
+        ],
+        engine=engine,
+        use_local=True,
+    )
+
+
+# TODO(ENG-2798): Unable to publish flow using TF_KERAS parameter.
+@pytest.mark.skip()
+def test_local_tf_keras_data(client, flow_name, engine):
     from tensorflow import keras
 
     model = keras.models.load_model("data/tf_model")
@@ -634,15 +651,7 @@ def test_all_local_data_types(client, flow_name, engine):
     publish_flow_test(
         client,
         name=flow_name(),
-        artifacts=[
-            pickle_output,
-            bytes_output,
-            string_output,
-            tuple_output,
-            list_output,
-            image_output,
-            tf_keras_output,
-        ],
+        artifacts=[tf_keras_output],
         engine=engine,
         use_local=True,
     )

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from aqueduct.artifacts.generic_artifact import GenericArtifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
-from aqueduct.constants.enums import ArtifactType, ExecutionStatus,ServiceType
+from aqueduct.constants.enums import ArtifactType, ExecutionStatus, ServiceType
 from aqueduct.error import (
     AqueductError,
     ArtifactNeverComputedException,
@@ -523,6 +523,7 @@ def test_invalid_local_data(client):
             use_local=True,
             as_type=ArtifactType.TABLE,
         )
+
 
 # TODO: Remove this pytest fixture on next release.
 @pytest.mark.enable_only_for_engine_type(ServiceType.AQUEDUCT_ENGINE)

--- a/integration_tests/sdk/aqueduct_tests/param_test.py
+++ b/integration_tests/sdk/aqueduct_tests/param_test.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from aqueduct.artifacts.generic_artifact import GenericArtifact
 from aqueduct.artifacts.numeric_artifact import NumericArtifact
-from aqueduct.constants.enums import ArtifactType, ExecutionStatus
+from aqueduct.constants.enums import ArtifactType, ExecutionStatus,ServiceType
 from aqueduct.error import (
     AqueductError,
     ArtifactNeverComputedException,
@@ -524,7 +524,8 @@ def test_invalid_local_data(client):
             as_type=ArtifactType.TABLE,
         )
 
-
+# TODO: Remove this pytest fixture on next release.
+@pytest.mark.enable_only_for_engine_type(ServiceType.AQUEDUCT_ENGINE)
 def test_all_local_data_types(client, flow_name, engine):
     @op
     def must_be_picklable(input):

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -114,7 +114,7 @@ def _read_local_bytes_content(path: str) -> bytes:
 def _read_local_tf_keras_model(path: str) -> Any:
     from tensorflow import keras
 
-    return keras.saving.load_model(path)
+    return keras.models.load_model(path)
 
 
 # Returns a tf.keras.Model type. We don't assume that every user has it installed,

--- a/src/dockerfiles/param/param.dockerfile
+++ b/src/dockerfiles/param/param.dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
   boto3 \ 
   pandas \
   pydantic \
-  tensorflow==2.12.0
+  tensorflow>=2.12.0
 
 ENV PYTHONUNBUFFERED 1
 

--- a/src/dockerfiles/param/param.dockerfile
+++ b/src/dockerfiles/param/param.dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update && \
   aqueduct-ml \
   boto3 \ 
   pandas \
-  pydantic \
-  tensorflow>=2.12.0
+  pydantic 
 
 ENV PYTHONUNBUFFERED 1
 

--- a/src/dockerfiles/param/param.dockerfile
+++ b/src/dockerfiles/param/param.dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && \
   aqueduct-ml \
   boto3 \ 
   pandas \
-  pydantic
+  pydantic \
+  tensorflow==2.12.0
 
 ENV PYTHONUNBUFFERED 1
 

--- a/src/dockerfiles/param/param.dockerfile
+++ b/src/dockerfiles/param/param.dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
   aqueduct-ml \
   boto3 \ 
   pandas \
-  pydantic 
+  pydantic
 
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR contains two changes regarding local tensorflow data parameter test:
1. Latest Tensorflow does not support Python 3.7. With older tensorflow, it does not have package module `keras.saving.load_model`. Therefore, we change the loading method to `keras.models.load_model` which presents in both new and older version of tensorflow.
2. Local tensorflow model parameter tests fail with our Periodic Integration test. The reason is that we didn't have tensorflow as a part of param docker image. I added the image with latest version of tensorflow and mark the failed test inactive to k8s which should be reverted next release. 
## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


