### PR TITLE
ENG-2790 Set Default Tabs for Integrations Dialog

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/athenaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/athenaDialog.tsx
@@ -39,7 +39,7 @@ export const AthenaDialog: React.FC<Props> = ({
   const [fileName, setFileName] = useState<string>(null);
 
   const setFile = (fileData: FileData | null) => {
-    setFileName(fileData?.name ?? null);
+    setFileName(fileData?.name ?? '');
     onUpdateField('config_file_content', fileData?.data);
   };
 
@@ -67,7 +67,7 @@ export const AthenaDialog: React.FC<Props> = ({
       onChange={(event) =>
         onUpdateField('config_file_profile', event.target.value)
       }
-      value={value?.config_file_profile ?? null}
+      value={value?.config_file_profile ?? ''}
     />
   );
 
@@ -83,7 +83,7 @@ export const AthenaDialog: React.FC<Props> = ({
         description="The access key ID of your AWS account."
         placeholder={Placeholders.access_key_id}
         onChange={(event) => onUpdateField('access_key_id', event.target.value)}
-        value={value?.access_key_id ?? null}
+        value={value?.access_key_id ?? ''}
       />
 
       <IntegrationTextInputField
@@ -95,7 +95,7 @@ export const AthenaDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('secret_access_key', event.target.value)
         }
-        value={value?.secret_access_key ?? null}
+        value={value?.secret_access_key ?? ''}
       />
 
       <IntegrationTextInputField
@@ -105,7 +105,7 @@ export const AthenaDialog: React.FC<Props> = ({
         description="The region the Athena database belongs to."
         placeholder={Placeholders.region}
         onChange={(event) => onUpdateField('region', event.target.value)}
-        value={value?.region ?? null}
+        value={value?.region ?? ''}
       />
     </Box>
   );
@@ -129,7 +129,7 @@ export const AthenaDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('config_file_path', event.target.value)
         }
-        value={value?.config_file_path ?? null}
+        value={value?.config_file_path ?? ''}
       />
 
       {configProfileInput}
@@ -177,7 +177,7 @@ export const AthenaDialog: React.FC<Props> = ({
         description="The name of the Athena database."
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -194,7 +194,7 @@ export const AthenaDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('output_location', event.target.value)
         }
-        value={value?.output_location ?? null}
+        value={value?.output_location ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -202,7 +202,7 @@ export const AthenaDialog: React.FC<Props> = ({
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
         <Tabs
-          value={value?.type}
+          value={value?.type ?? 'access_key'}
           onChange={(_, value) => onUpdateField('type', value)}
         >
           <Tab value={AWSCredentialType.AccessKey} label="Enter Access Keys" />

--- a/src/ui/common/src/components/integrations/dialogs/awsDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/awsDialog.tsx
@@ -59,7 +59,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
       onChange={(event) =>
         onUpdateField('config_file_profile', event.target.value)
       }
-      value={value?.config_file_profile ?? null}
+      value={value?.config_file_profile ?? ''}
     />
   );
 
@@ -75,7 +75,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         description="The access key ID of your AWS account."
         placeholder={Placeholders.access_key_id}
         onChange={(event) => onUpdateField('access_key_id', event.target.value)}
-        value={value?.access_key_id ?? null}
+        value={value?.access_key_id ?? ''}
       />
 
       <IntegrationTextInputField
@@ -87,7 +87,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         onChange={(event) =>
           onUpdateField('secret_access_key', event.target.value)
         }
-        value={value?.secret_access_key ?? null}
+        value={value?.secret_access_key ?? ''}
       />
 
       <IntegrationTextInputField
@@ -97,7 +97,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         description="The region of your AWS account."
         placeholder={Placeholders.region}
         onChange={(event) => onUpdateField('region', event.target.value)}
-        value={value?.region ?? null}
+        value={value?.region ?? ''}
       />
     </Box>
   );
@@ -121,7 +121,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         onChange={(event) =>
           onUpdateField('config_file_path', event.target.value)
         }
-        value={value?.config_file_path ?? null}
+        value={value?.config_file_path ?? ''}
       />
 
       {configProfileInput}
@@ -143,7 +143,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['keepalive'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['keepalive'] ?? null}
+        value={k8sConfigs['keepalive'] ?? ''}
       />
       <IntegrationTextInputField
         spellCheck={false}
@@ -155,7 +155,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['cpu_node_type'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['cpu_node_type'] ?? null}
+        value={k8sConfigs['cpu_node_type'] ?? ''}
       />
 
       <IntegrationTextInputField
@@ -168,7 +168,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['gpu_node_type'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['gpu_node_type'] ?? null}
+        value={k8sConfigs['gpu_node_type'] ?? ''}
       />
       <IntegrationTextInputField
         spellCheck={false}
@@ -180,7 +180,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['min_cpu_node'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['min_cpu_node'] ?? null}
+        value={k8sConfigs['min_cpu_node'] ?? ''}
       />
       <IntegrationTextInputField
         spellCheck={false}
@@ -192,7 +192,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['max_cpu_node'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['max_cpu_node'] ?? null}
+        value={k8sConfigs['max_cpu_node'] ?? ''}
       />
       <IntegrationTextInputField
         spellCheck={false}
@@ -204,7 +204,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['min_gpu_node'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['min_gpu_node'] ?? null}
+        value={k8sConfigs['min_gpu_node'] ?? ''}
       />
       <IntegrationTextInputField
         spellCheck={false}
@@ -216,7 +216,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
           k8sConfigs['max_gpu_node'] = event.target.value;
           onUpdateField('k8s_serialized', JSON.stringify(k8sConfigs));
         }}
-        value={k8sConfigs['max_gpu_node'] ?? null}
+        value={k8sConfigs['max_gpu_node'] ?? ''}
       />
     </Box>
   );
@@ -225,7 +225,7 @@ export const AWSDialog: React.FC<Props> = ({ onUpdateField, value }) => {
     <Box sx={{ mt: 2 }}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
         <Tabs
-          value={value?.type}
+          value={value?.type ?? 'access_key'}
           onChange={(_, value) => onUpdateField('type', value)}
         >
           <Tab value={AWSCredentialType.AccessKey} label="Enter Access Keys" />

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -75,7 +75,7 @@ export const S3Dialog: React.FC<Props> = ({
       onChange={(event) =>
         onUpdateField('config_file_profile', event.target.value)
       }
-      value={value?.config_file_profile ?? null}
+      value={value?.config_file_profile ?? ''}
     />
   );
 
@@ -91,7 +91,7 @@ export const S3Dialog: React.FC<Props> = ({
         description="The access key ID of your AWS account."
         placeholder={Placeholders.access_key_id}
         onChange={(event) => onUpdateField('access_key_id', event.target.value)}
-        value={value?.access_key_id ?? null}
+        value={value?.access_key_id ?? ''}
       />
 
       <IntegrationTextInputField
@@ -103,7 +103,7 @@ export const S3Dialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('secret_access_key', event.target.value)
         }
-        value={value?.secret_access_key ?? null}
+        value={value?.secret_access_key ?? ''}
       />
     </Box>
   );
@@ -127,7 +127,7 @@ export const S3Dialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('config_file_path', event.target.value)
         }
-        value={value?.config_file_path ?? null}
+        value={value?.config_file_path ?? ''}
       />
 
       {configProfileInput}
@@ -175,7 +175,7 @@ export const S3Dialog: React.FC<Props> = ({
         description="The name of the S3 bucket."
         placeholder={Placeholders.bucket}
         onChange={(event) => onUpdateField('bucket', event.target.value)}
-        value={value?.bucket ?? null}
+        value={value?.bucket ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -188,7 +188,7 @@ export const S3Dialog: React.FC<Props> = ({
         description="The region the S3 bucket belongs to."
         placeholder={Placeholders.region}
         onChange={(event) => onUpdateField('region', event.target.value)}
-        value={value?.region ?? null}
+        value={value?.region ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -201,7 +201,7 @@ export const S3Dialog: React.FC<Props> = ({
         description="Only applicable when also setting this integration to be the artifact store. This is an optional path to an existing directory in the bucket, to be used as the root of the artifact store. Defaults to the root of the bucket."
         placeholder={Placeholders.root_dir}
         onChange={(event) => onUpdateField('root_dir', event.target.value)}
-        value={value?.root_dir ?? null}
+        value={value?.root_dir ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -209,7 +209,7 @@ export const S3Dialog: React.FC<Props> = ({
 
       <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
         <Tabs
-          value={value?.type}
+          value={value?.type ?? 'access_key'}
           onChange={(_, value) => onUpdateField('type', value)}
         >
           <Tab value={AWSCredentialType.AccessKey} label="Enter Access Keys" />


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes JavaScript console errors related to integrations dialogs not having default tab values set.

It also fixes error messages related to using null instead of empty string when there is no value to be rendered in a text field (react prefers empty strings in our case)

## Related issue number (if any)
ENG-2790

## Loom demo (if any)
Loom demo to come in morning :)


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


