### PR TITLE
Fix bug with CUDA versioning on GPUs

### DIFF
--- a/sdk/aqueduct/decorator.py
+++ b/sdk/aqueduct/decorator.py
@@ -444,7 +444,10 @@ def _update_operator_spec_with_resources(
             )
 
         spec.resources = ResourceConfig(
-            num_cpus=num_cpus, memory_mb=memory, gpu_resource_name=gpu_resource_name
+            num_cpus=num_cpus,
+            memory_mb=memory,
+            gpu_resource_name=gpu_resource_name,
+            cuda_version=cuda_version,
         )
 
 

--- a/sdk/aqueduct/models/dag_rules.py
+++ b/sdk/aqueduct/models/dag_rules.py
@@ -17,12 +17,14 @@ def check_customized_resources_are_supported(
         CustomizableResourceType.NUM_CPUS: False,
         CustomizableResourceType.MEMORY: False,
         CustomizableResourceType.GPU_RESOURCE_NAME: False,
+        CustomizableResourceType.CUDA_VERSION: False,
     }
     if engine_config.type == RuntimeType.K8S:
         allowed_customizable_resources = {
             CustomizableResourceType.NUM_CPUS: True,
             CustomizableResourceType.MEMORY: True,
             CustomizableResourceType.GPU_RESOURCE_NAME: True,
+            CustomizableResourceType.CUDA_VERSION: True,
         }
     elif engine_config.type == RuntimeType.LAMBDA:
         allowed_customizable_resources[CustomizableResourceType.MEMORY] = True

--- a/sdk/aqueduct/models/operators.py
+++ b/sdk/aqueduct/models/operators.py
@@ -201,6 +201,7 @@ class ResourceConfig(BaseModel):
     num_cpus: Optional[int]
     memory_mb: Optional[int]
     gpu_resource_name: Optional[str]
+    cuda_version: Optional[str]
 
 
 class OperatorSpec(BaseModel):


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds cuda_version to the ResourceConfig for the Operator Class.
## Related issue number (if any)
Eng-2808
## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


