### PR TITLE
ENG-2804 Check PyPI to determine whether to show Announcement Banner

### DIFF
--- a/src/ui/common/src/components/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/ui/common/src/components/AnnouncementBanner/AnnouncementBanner.tsx
@@ -33,7 +33,6 @@ export const AnnouncementBanner: React.FC<AnnouncementBannerProps> = ({
         method: 'GET',
       });
       const pyPiResponse = await pypiRes.json();
-      console.log('pyPiVersion:  ', pyPiResponse.info.version);
       const pyPiVersionString = pyPiResponse.info.version;
 
       const res = await fetch(`${apiAddress}/api/version`, {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR sends a GET request to PyPI to check if there is a newer version of aqueduct than the version currently installed. If a new version is available we now show announcement banner.

## Related issue number (if any)
ENG-2804

## Loom demo (if any)
https://www.loom.com/share/216e9952b6de4d5f84e691fec26e5606

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


