### PR TITLE
[1/2]: ENG-2805: Integration Form Empty State Console Error Fixes

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
@@ -59,7 +59,7 @@ export const BigQueryDialog: React.FC<Props> = ({
         description="The BigQuery project ID."
         placeholder={Placeholders.project_id}
         onChange={(event) => onUpdateField('project_id', event.target.value)}
-        value={value?.project_id ?? null}
+        value={value?.project_id ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}

--- a/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
@@ -41,7 +41,7 @@ export const DatabricksDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.workspace_url}
         onChange={(event) => onUpdateField('workspace_url', event.target.value)}
-        value={value?.workspace_url ?? null}
+        value={value?.workspace_url ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -56,7 +56,7 @@ export const DatabricksDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.access_token}
         onChange={(event) => onUpdateField('access_token', event.target.value)}
-        value={value?.access_token ?? null}
+        value={value?.access_token ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -81,7 +81,7 @@ export const DatabricksDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('s3_instance_profile_arn', event.target.value)
         }
-        value={value?.s3_instance_profile_arn ?? null}
+        value={value?.s3_instance_profile_arn ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -106,7 +106,7 @@ export const DatabricksDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('instance_pool_id', event.target.value)
         }
-        value={value?.instance_pool_id ?? null}
+        value={value?.instance_pool_id ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/gcsDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/gcsDialog.tsx
@@ -68,7 +68,7 @@ export const GCSDialog: React.FC<Props> = ({
         description="The name of the GCS bucket."
         placeholder={Placeholders.bucket}
         onChange={(event) => onUpdateField('bucket', event.target.value)}
-        value={value?.bucket ?? null}
+        value={value?.bucket ?? ''}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disabled={editMode}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -75,7 +75,7 @@ export const KubernetesDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('kubeconfig_path', event.target.value)
         }
-        value={value?.kubeconfig_path ?? null}
+        value={value?.kubeconfig_path ?? ''}
         disabled={value?.use_same_cluster === 'true'}
       />
 
@@ -86,7 +86,7 @@ export const KubernetesDialog: React.FC<Props> = ({
         description="The name of the cluster that will be used."
         placeholder={Placeholders.cluster_name}
         onChange={(event) => onUpdateField('cluster_name', event.target.value)}
-        value={value?.cluster_name ?? null}
+        value={value?.cluster_name ?? ''}
         disabled={value?.use_same_cluster === 'true'}
       />
     </Box>

--- a/src/ui/common/src/components/integrations/dialogs/lambdaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/lambdaDialog.tsx
@@ -23,7 +23,7 @@ export const LambdaDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         description="ARN for Lambda executor role."
         placeholder={Placeholders.role_arn}
         onChange={(event) => onUpdateField('role_arn', event.target.value)}
-        value={value?.role_arn ?? null}
+        value={value?.role_arn ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/mariadbDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/mariadbDialog.tsx
@@ -33,7 +33,7 @@ export const MariaDbDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.host}
         onChange={(event) => onUpdateField('host', event.target.value)}
-        value={value?.host ?? null}
+        value={value?.host ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -46,7 +46,7 @@ export const MariaDbDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.port}
         onChange={(event) => onUpdateField('port', event.target.value)}
-        value={value?.port ?? null}
+        value={value?.port ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -59,7 +59,7 @@ export const MariaDbDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -72,7 +72,7 @@ export const MariaDbDialog: React.FC<Props> = ({
         description="The username of a user with access to the above database."
         placeholder={Placeholders.username}
         onChange={(event) => onUpdateField('username', event.target.value)}
-        value={value?.username ?? null}
+        value={value?.username ?? ''}
       />
 
       <IntegrationTextInputField
@@ -83,7 +83,7 @@ export const MariaDbDialog: React.FC<Props> = ({
         placeholder={Placeholders.password}
         type="password"
         onChange={(event) => onUpdateField('password', event.target.value)}
-        value={value?.password ?? null}
+        value={value?.password ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/mongoDbDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/mongoDbDialog.tsx
@@ -30,7 +30,7 @@ export const MongoDBDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.auth_uri}
         onChange={(event) => onUpdateField('auth_uri', event.target.value)}
-        value={value?.auth_uri ?? null}
+        value={value?.auth_uri ?? ''}
       />
 
       <IntegrationTextInputField
@@ -40,7 +40,7 @@ export const MongoDBDialog: React.FC<Props> = ({
         required={true}
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}

--- a/src/ui/common/src/components/integrations/dialogs/mysqlDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/mysqlDialog.tsx
@@ -33,7 +33,7 @@ export const MysqlDialog: React.FC<Props> = ({
         description="The hostname or IP address of the MySQL server."
         placeholder={Placeholders.host}
         onChange={(event) => onUpdateField('host', event.target.value)}
-        value={value?.host ?? null}
+        value={value?.host ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -46,7 +46,7 @@ export const MysqlDialog: React.FC<Props> = ({
         description="The port number of the MySQL server."
         placeholder={Placeholders.port}
         onChange={(event) => onUpdateField('port', event.target.value)}
-        value={value?.port ?? null}
+        value={value?.port ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -59,7 +59,7 @@ export const MysqlDialog: React.FC<Props> = ({
         description="The name of the specific database to connect to."
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -72,7 +72,7 @@ export const MysqlDialog: React.FC<Props> = ({
         description="The username of a user with access to the above database."
         placeholder={Placeholders.username}
         onChange={(event) => onUpdateField('username', event.target.value)}
-        value={value?.username ?? null}
+        value={value?.username ?? ''}
       />
 
       <IntegrationTextInputField
@@ -83,7 +83,7 @@ export const MysqlDialog: React.FC<Props> = ({
         placeholder={Placeholders.password}
         type="password"
         onChange={(event) => onUpdateField('password', event.target.value)}
-        value={value?.password ?? null}
+        value={value?.password ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/postgresDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/postgresDialog.tsx
@@ -33,7 +33,7 @@ export const PostgresDialog: React.FC<Props> = ({
         description="The hostname or IP address of the Postgres server."
         placeholder={Placeholders.host}
         onChange={(event) => onUpdateField('host', event.target.value)}
-        value={value?.host ?? null}
+        value={value?.host ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -46,7 +46,7 @@ export const PostgresDialog: React.FC<Props> = ({
         description="The port number of the Postgres server."
         placeholder={Placeholders.port}
         onChange={(event) => onUpdateField('port', event.target.value)}
-        value={value?.port ?? null}
+        value={value?.port ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -59,7 +59,7 @@ export const PostgresDialog: React.FC<Props> = ({
         description="The name of the specific database to connect to."
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -72,7 +72,7 @@ export const PostgresDialog: React.FC<Props> = ({
         description="The username of a user with access to the above database."
         placeholder={Placeholders.username}
         onChange={(event) => onUpdateField('username', event.target.value)}
-        value={value?.username ?? null}
+        value={value?.username ?? ''}
       />
 
       <IntegrationTextInputField
@@ -87,7 +87,7 @@ export const PostgresDialog: React.FC<Props> = ({
             onUpdateField('password', event.target.value);
           }
         }}
-        value={value?.password ?? null}
+        value={value?.password ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/redshiftDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/redshiftDialog.tsx
@@ -33,7 +33,7 @@ export const RedshiftDialog: React.FC<Props> = ({
         description="The public endpoint of the Redshift cluster."
         placeholder={Placeholders.host}
         onChange={(event) => onUpdateField('host', event.target.value)}
-        value={value?.host ?? null}
+        value={value?.host ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -46,7 +46,7 @@ export const RedshiftDialog: React.FC<Props> = ({
         description="The port number of the Redshift cluster."
         placeholder={Placeholders.port}
         onChange={(event) => onUpdateField('port', event.target.value)}
-        value={value?.port ?? null}
+        value={value?.port ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -59,7 +59,7 @@ export const RedshiftDialog: React.FC<Props> = ({
         description="The name of the specific database to connect to."
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -72,7 +72,7 @@ export const RedshiftDialog: React.FC<Props> = ({
         description="The username of a user with access to the above database."
         placeholder={Placeholders.username}
         onChange={(event) => onUpdateField('username', event.target.value)}
-        value={value?.username ?? null}
+        value={value?.username ?? ''}
       />
 
       <IntegrationTextInputField
@@ -83,7 +83,7 @@ export const RedshiftDialog: React.FC<Props> = ({
         placeholder={Placeholders.password}
         type="password"
         onChange={(event) => onUpdateField('password', event.target.value)}
-        value={value?.password ?? null}
+        value={value?.password ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
@@ -49,9 +49,6 @@ export const SlackDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         type="password"
         onChange={(event) => {
           onUpdateField('token', event.target.value);
-          // if (!!event.target.value) {
-          //   onUpdateField('token', event.target.value);
-          // }
         }}
         value={value?.token ?? null}
       />

--- a/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/slackDialog.tsx
@@ -48,9 +48,10 @@ export const SlackDialog: React.FC<Props> = ({ onUpdateField, value }) => {
         placeholder={Placeholders.token}
         type="password"
         onChange={(event) => {
-          if (!!event.target.value) {
-            onUpdateField('token', event.target.value);
-          }
+          onUpdateField('token', event.target.value);
+          // if (!!event.target.value) {
+          //   onUpdateField('token', event.target.value);
+          // }
         }}
         value={value?.token ?? null}
       />

--- a/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/snowflakeDialog.tsx
@@ -49,7 +49,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('account_identifier', event.target.value)
         }
-        value={value?.account_identifier ?? null}
+        value={value?.account_identifier ?? ''}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disabled={editMode}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -62,7 +62,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         description="The name of the Snowflake warehouse to connect to."
         placeholder={Placeholders.warehouse}
         onChange={(event) => onUpdateField('warehouse', event.target.value)}
-        value={value?.warehouse ?? null}
+        value={value?.warehouse ?? ''}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disabled={editMode}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -75,7 +75,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         description="The name of the database to connect to."
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disabled={editMode}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -88,7 +88,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         description="The name of the schema to connect to. The public schema will be used if none is provided."
         placeholder={Placeholders.schema}
         onChange={(event) => setSchema(event.target.value)}
-        value={schema !== Placeholders.schema ? schema : null}
+        value={schema !== Placeholders.schema ? schema : ''}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disabled={editMode}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}
@@ -101,7 +101,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         description="The username of a user with permission to access the database above."
         placeholder={Placeholders.username}
         onChange={(event) => onUpdateField('username', event.target.value)}
-        value={value?.username ?? null}
+        value={value?.username ?? ''}
       />
 
       <IntegrationTextInputField
@@ -112,7 +112,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         placeholder={Placeholders.password}
         type="password"
         onChange={(event) => onUpdateField('password', event.target.value)}
-        value={value?.password ?? null}
+        value={value?.password ?? ''}
       />
 
       <IntegrationTextInputField
@@ -122,7 +122,7 @@ export const SnowflakeDialog: React.FC<Props> = ({
         description="The role to use when accessing the database above."
         placeholder={Placeholders.role}
         onChange={(event) => onUpdateField('role', event.target.value)}
-        value={value?.role ?? null}
+        value={value?.role ?? ''}
       />
     </Box>
   );

--- a/src/ui/common/src/components/integrations/dialogs/sparkDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/sparkDialog.tsx
@@ -31,7 +31,7 @@ export const SparkDialog: React.FC<Props> = ({
         onChange={(event) =>
           onUpdateField('livy_server_url', event.target.value)
         }
-        value={value?.livy_server_url ?? null}
+        value={value?.livy_server_url ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}

--- a/src/ui/common/src/components/integrations/dialogs/sqliteDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/sqliteDialog.tsx
@@ -29,7 +29,7 @@ export const SQLiteDialog: React.FC<Props> = ({
         description="The path to the SQLite file on your Aqueduct server machine."
         placeholder={Placeholders.database}
         onChange={(event) => onUpdateField('database', event.target.value)}
-        value={value?.database ?? null}
+        value={value?.database ?? ''}
         disabled={editMode}
         warning={editMode ? undefined : readOnlyFieldWarning}
         disableReason={editMode ? readOnlyFieldDisableReason : undefined}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR resolves error messages that appeared in integrations dialogs related to passing in null when the input's state was empty.

To resolve this, we use empty strings for empty input values. This change impacts some of the validation functions in our integrations, which will be resolved in another PR.

## Related issue number (if any)
ENG-2805

## Loom demo (if any)
https://linear.app/aqueducthq/issue/ENG-2805/fix-console-errors-on-existing-integrations-dialogs

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


