### PR TITLE
Adds v2 route to retrieve workflow historical results

### DIFF
--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -7,6 +7,7 @@ const (
 
 	WorkflowRoute                  = "/api/v2/workflow/{workflowID}"
 	DAGRoute                       = "/api/v2/workflow/{workflowID}/dag/{dagID}"
+	DAGResultsRoute                = "/api/v2/workflow/{workflowID}/results"
 	DAGResultRoute                 = "/api/v2/workflow/{workflowID}/result/{dagResultID}"
 	NodesRoute                     = "/api/v2/workflow/{workflowID}/dag/{dagID}/nodes"
 	NodeArtifactRoute              = "/api/v2/workflow/{workflowID}/dag/{dagID}/node/artifact/{nodeID}"

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -23,6 +23,11 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			WorkflowRepo:  s.WorkflowRepo,
 			DAGResultRepo: s.DAGResultRepo,
 		},
+		routes.DAGResultsRoute: &v2.DAGResultsGetHandler{
+			Database:      s.Database,
+			WorkflowRepo:  s.WorkflowRepo,
+			DAGResultRepo: s.DAGResultRepo,
+		},
 		routes.ListStorageMigrationRoute: &v2.ListStorageMigrationsHandler{
 			Database:             s.Database,
 			StorageMigrationRepo: s.StorageMigrationRepo,

--- a/src/ui/common/src/handlers/AqueductApi.ts
+++ b/src/ui/common/src/handlers/AqueductApi.ts
@@ -9,6 +9,11 @@ import {
   DagResultGetResponse,
 } from './v2/DagResultGet';
 import {
+  dagResultsGetQuery,
+  DagResultsGetRequest,
+  DagResultsGetResponse,
+} from './v2/DagResultsGet';
+import {
   storageMigrationListQuery,
   storageMigrationListRequest,
   storageMigrationListResponse,
@@ -71,6 +76,10 @@ export const aqueductApi = createApi({
     }),
     dagResultGet: builder.query<DagResultGetResponse, DagResultGetRequest>({
       query: (req) => dagResultGetQuery(req),
+      transformErrorResponse,
+    }),
+    dagResultsGet: builder.query<DagResultsGetResponse, DagResultsGetRequest>({
+      query: (req) => dagResultsGetQuery(req),
       transformErrorResponse,
     }),
     nodeArtifactGet: builder.query<
@@ -136,6 +145,7 @@ export const aqueductApi = createApi({
 export const {
   useDagGetQuery,
   useDagResultGetQuery,
+  useDagResultsGetQuery,
   useStorageMigrationListQuery,
   useNodeArtifactGetQuery,
   useNodeArtifactResultContentGetQuery,

--- a/src/ui/common/src/handlers/v2/DagResultsGet.ts
+++ b/src/ui/common/src/handlers/v2/DagResultsGet.ts
@@ -1,0 +1,15 @@
+// This file should map exactly to
+// src/golang/cmd/server/handler/v2/dag_results_get.go
+
+import { APIKeyParameter } from '../parameters/Header';
+import { WorkflowIdParameter } from '../parameters/Path';
+import { DagResultResponse } from '../responses/Workflow';
+
+export type DagResultsGetRequest = APIKeyParameter & WorkflowIdParameter;
+
+export type DagResultsGetResponse = DagResultResponse[];
+
+export const dagResultsGetQuery = (req: DagResultsGetRequest) => ({
+  url: `workflow/${req.workflowId}/results`,
+  headers: { 'api-key': req.apiKey },
+});


### PR DESCRIPTION
## Describe your changes and why you are making these changes

This PR adds `wf/<id>/results` that retrieves all results for a given workflow

## Related issue number (if any)
ENG-2793

## Loom demo (if any)
Go compiles. UI didn't crash with a full build

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


