### PR TITLE
Reduce concurrency of k8s tests to 1

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run-k8s-tests:
     runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 600
+    timeout-minutes: 180
     name: SDK Integration Tests against K8s Compute
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   run-k8s-tests:
-    runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 180
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
     name: SDK Integration Tests against K8s Compute
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run the SDK Integration Tests
         working-directory: integration_tests/sdk
-        run: pytest aqueduct_tests/ -rP -vv -n 4
+        run: pytest aqueduct_tests/ -rP -vv -n 1
 
       - name: Teardown K8s Cluster
         id: k8s_cleanup # so that we only upload the state on this specific failure.

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run-k8s-tests:
     runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 90
+    timeout-minutes: 600
     name: SDK Integration Tests against K8s Compute
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Reduces concurrency of K8s tests to 1 for stability reasons. Sets the timeout to 180 min to account for test time. Created a [task](https://linear.app/aqueducthq/issue/ENG-2815/investigate-why-k8s-tests-fail-with-increased-concurrency) to track the investigation of the test failures with higher concurrency.
## Related issue number (if any)
Eng-2811
## Loom demo (if any)
https://github.com/aqueducthq/aqueduct/actions/runs/4726107721 Run of the periodic tests.
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


