### PR TITLE
Eng 2635 Add automated periodic testing coverage for MariaDB

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -149,7 +149,7 @@ jobs:
           --health-retries 5
         ports:
           # Maps tcp port 3306 on service container to 3808 on the host
-          - 3306:3808
+          - 3808:3306
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
-          s3_test_config_path: periodic-data-integration-test-config.yml
+          s3_test_config_path: periodic-data-integration-test-config-eunice-chan.yml
 
       - name: Install any data connector packages
         run: |

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -134,6 +134,22 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
+
+      mariadb:
+        image: mariadb:10.7
+        env:
+          MARIADB_USER: aqueduct
+          MARIADB_PASSWORD: aqueduct
+          MARIADB_ROOT_PASSWORD: aqueduct
+          MARIADB_DATABASE: aqueducttest
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 3306 on service container to 3808 on the host
+          - 3306:3808
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           aws_access_key_id: ${{ secrets.KENNY_AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.KENNY_AWS_SECRET_ACCESS_KEY }}
-          s3_test_config_path: periodic-data-integration-test-config-eunice-chan.yml
+          s3_test_config_path: periodic-data-integration-test-config.yml
 
       - name: Install any data connector packages
         run: |

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -164,10 +164,6 @@ def _setup_postgres_db():
     _execute_command(["aqueduct", "install", "postgres"])
 
 
-def _setup_maria_db():
-    _execute_command(["aqueduct", "install", "mariadb"])
-
-
 def _setup_mysql_db():
     _execute_command(["aqueduct", "install", "mysql"])
 
@@ -225,11 +221,9 @@ def setup_data_integrations(client: Client, filter_to: Optional[str] = None) -> 
                 _setup_external_sqlite_db(integration_config["database"])
             elif integration_config["type"] == ServiceType.POSTGRES:
                 _setup_postgres_db()
-            elif integration_config["type"] == ServiceType.MARIADB:
-                _setup_maria_db()
-            elif integration_config["type"] == ServiceType.MYSQL:
+            elif integration_config["type"] == ServiceType.MYSQL or integration_config["type"] == ServiceType.MARIADB:
                 _setup_mysql_db()
-
+                
             client.connect_integration(
                 integration_name,
                 integration_config["type"],

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -163,6 +163,7 @@ def _setup_external_sqlite_db(path: str):
 def _setup_postgres_db():
     _execute_command(["aqueduct", "install", "postgres"])
 
+
 def _setup_maria_db():
     _execute_command(["aqueduct", "install", "mariadb"])
 

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -163,6 +163,9 @@ def _setup_external_sqlite_db(path: str):
 def _setup_postgres_db():
     _execute_command(["aqueduct", "install", "postgres"])
 
+def _setup_maria_db():
+    _execute_command(["aqueduct", "install", "mariadb"])
+
 
 def _setup_mysql_db():
     _execute_command(["aqueduct", "install", "mysql"])
@@ -219,11 +222,11 @@ def setup_data_integrations(client: Client, filter_to: Optional[str] = None) -> 
             # Stand up the external integration first.
             if integration_config["type"] == ServiceType.SQLITE:
                 _setup_external_sqlite_db(integration_config["database"])
-
-            if integration_config["type"] == ServiceType.POSTGRES:
+            elif integration_config["type"] == ServiceType.POSTGRES:
                 _setup_postgres_db()
-
-            if integration_config["type"] == ServiceType.MYSQL:
+            elif integration_config["type"] == ServiceType.MARIADB:
+                _setup_maria_db()
+            elif integration_config["type"] == ServiceType.MYSQL:
                 _setup_mysql_db()
 
             client.connect_integration(

--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -221,9 +221,12 @@ def setup_data_integrations(client: Client, filter_to: Optional[str] = None) -> 
                 _setup_external_sqlite_db(integration_config["database"])
             elif integration_config["type"] == ServiceType.POSTGRES:
                 _setup_postgres_db()
-            elif integration_config["type"] == ServiceType.MYSQL or integration_config["type"] == ServiceType.MARIADB:
+            elif (
+                integration_config["type"] == ServiceType.MYSQL
+                or integration_config["type"] == ServiceType.MARIADB
+            ):
                 _setup_mysql_db()
-                
+
             client.connect_integration(
                 integration_name,
                 integration_config["type"],


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds automated periodic testing coverage for MariaDB.

TODO: Once merged, update the `periodic-data-integration-test-config.yml` file and delete `periodic-data-integration-test-config-eunice-chan.yml`.

## Related issue number (if any)
ENG 2635

## Loom demo (if any)
Successfully ran: https://github.com/aqueducthq/aqueduct/actions/runs/4734950881/jobs/8404563971

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [N/A] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [N/A] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [N/A] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


