### PR TITLE
Fix documentation bug for missing local file

### DIFF
--- a/regression_tests/tests/gitbook/test_docs.py
+++ b/regression_tests/tests/gitbook/test_docs.py
@@ -38,8 +38,21 @@ blacklist_files = [
     "operators/specifying-a-requirements.txt.md",  # Requires specific requirements.txt
 ]
 
-blacklist_snippets_by_keyword = {
-    "parameters.md": "use_local" # Requires specific local file
+blacklist_snippets = {
+    "parameters.md": [
+        'from aqueduct.constants.enums import ArtifactType\nlocal_data = client.create_param(\n                    '\
+        'name ="table_data", \n                    '\
+        'default="path/to/data.csv",\n                    '\
+        'use_local=True,\n                    '\
+        'as_type=ArtifactType.TABLE,\n                    '\
+        'format="csv",\n                    ) '
+        ,
+        'client.publish_flow(\n                    '\
+        'name = "local_data_workflow",\n                    '\
+        'artifacts = [local_data, ...],\n                    '\
+        'use_local = True,\n                    ) '
+        ,
+    ]
 }
 
 
@@ -123,8 +136,8 @@ def should_skip_file(item):
 
 def remove_skipped_snippets(snippets):
     # Remove any snippet that shows up in `blacklist_snippets`.
-    if file_name in blacklist_snippets_by_keyword.keys():
-        return [snippet for snippet in snippets if blacklist_snippets_by_keyword[file_name] not in snippet]
+    if file_name in blacklist_snippets.keys():
+        return [snippet for snippet in snippets if snippet not in blacklist_snippets[file_name]]
     else:
         return snippets
 
@@ -177,7 +190,7 @@ if __name__ == "__main__":
 
             if should_skip_file(file_name):
                 continue
-
+                
             snippets = remove_skipped_snippets(get_code(file))
 
             # If we still have code to run, run it.

--- a/regression_tests/tests/gitbook/test_docs.py
+++ b/regression_tests/tests/gitbook/test_docs.py
@@ -38,7 +38,9 @@ blacklist_files = [
     "operators/specifying-a-requirements.txt.md",  # Requires specific requirements.txt
 ]
 
-blacklist_snippets = {}
+blacklist_snippets_by_keyword = {
+    "parameters.md": "use_local"
+}
 
 
 def get_code(page: str) -> List[str]:
@@ -121,8 +123,8 @@ def should_skip_file(item):
 
 def remove_skipped_snippets(snippets):
     # Remove any snippet that shows up in `blacklist_snippets`.
-    if file_name in blacklist_snippets.keys():
-        return [snippet for snippet in snippets if snippet not in blacklist_snippets[file_name]]
+    if file_name in blacklist_snippets_by_keyword.keys():
+        return [snippet for snippet in snippets if blacklist_snippets_by_keyword[file_name] not in snippet]
     else:
         return snippets
 

--- a/regression_tests/tests/gitbook/test_docs.py
+++ b/regression_tests/tests/gitbook/test_docs.py
@@ -39,7 +39,7 @@ blacklist_files = [
 ]
 
 blacklist_snippets_by_keyword = {
-    "parameters.md": "use_local"
+    "parameters.md": "use_local" # Requires specific local file
 }
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR attempts to ignore snippets that use local data parameter. The reason is that we don't have local data file in gitbook to feed into the create_params.

To ignore the specific code snippet, the current implementation is to match the exact snippet such as below:
'from aqueduct.constants.enums import ArtifactType\nlocal_data = client.create_param(\n                    name ="table_data", \n                    default="path/to/data.csv",\n                    use_local=True,\n                    as_type=ArtifactType.TABLE,\n                    format="csv",\n                    ) ', 'client.publish_flow(\n                    name = "local_data_workflow",\n                    artifacts = [local_data, ...],\n                    use_local = True,\n                    ) '

This might be a bit too much to match.

I changed that into if there is any keyword such as `use_local` in the snippet, we ignore that code snippet. @eunice-chan wondering if the change makes sense or if there is a better way to ignore code snippet? 

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


