### PR TITLE
Improve placeholder values for integrations

### DIFF
--- a/src/ui/common/src/components/integrations/cards/databricksCard.tsx
+++ b/src/ui/common/src/components/integrations/cards/databricksCard.tsx
@@ -22,6 +22,10 @@ export const DatabricksCard: React.FC<DatabricksCardProps> = ({
         <strong>Access Token: </strong>
         {config.access_token}
       </Typography>
+      <Typography variant="body2">
+        <strong>Instance Pool ID: </strong>
+        {config.instance_pool_id}
+      </Typography>
     </Box>
   );
 };

--- a/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/databricksDialog.tsx
@@ -8,10 +8,11 @@ import { readOnlyFieldDisableReason, readOnlyFieldWarning } from './constants';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: DatabricksConfig = {
-  workspace_url: 'workspace_url',
-  access_token: 'access_token',
-  s3_instance_profile_arn: 's3_instance_profile_arn',
-  instance_pool_id: 'instance_pool_id',
+  workspace_url: 'https://dbc-your-workspace.cloud.databricks.com',
+  access_token: 'dapi123456789',
+  s3_instance_profile_arn:
+    'arn:aws:iam::123:instance-profile/access-databuckets-arn',
+  instance_pool_id: '123-456-789',
 };
 
 type Props = {

--- a/src/ui/common/src/components/integrations/dialogs/lambdaDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/lambdaDialog.tsx
@@ -5,7 +5,8 @@ import { LambdaConfig } from '../../../utils/integrations';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: LambdaConfig = {
-  role_arn: '<my lambda role ARN>',
+  role_arn: 'arn:aws:iam::123:role/lambda-function-role-arn',
+  exec_state: '',
 };
 
 type Props = {

--- a/src/ui/common/src/components/integrations/dialogs/sparkDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/sparkDialog.tsx
@@ -6,7 +6,7 @@ import { readOnlyFieldDisableReason, readOnlyFieldWarning } from './constants';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 
 const Placeholders: SparkConfig = {
-  livy_server_url: '',
+  livy_server_url: 'http://cluster-url.com:8998',
 };
 
 type Props = {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Improved the placeholder values for the Spark, Databricks, and Lambda integrations.
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-2837/improve-the-placeholder-values-for-integration-connections
## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


