### PR TITLE
Improve performance and solving the sizing bug for LocalData

### DIFF
--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -179,6 +179,7 @@ class S3SerializationType(str, Enum, metaclass=MetaEnum):
 
 class SerializationType(str, Enum, metaclass=MetaEnum):
     TABLE = "table"
+    PARAM_TABLE = "param_table"
     BSON_TABLE = "bson_table"
     JSON = "json"
     PICKLE = "pickle"

--- a/sdk/aqueduct/tests/serialization_test.py
+++ b/sdk/aqueduct/tests/serialization_test.py
@@ -503,6 +503,7 @@ def test_serialization_of_pickled_collection_types():
         list_input,
         SerializationType.PICKLE,
         False,
+        False,
     )
 
     picklable_collection = PickleableCollectionSerializationFormat(

--- a/sdk/aqueduct/tests/serialization_test.py
+++ b/sdk/aqueduct/tests/serialization_test.py
@@ -491,7 +491,10 @@ def test_serialization_of_pickled_collection_types():
 
     assert (
         artifact_type_to_serialization_type(
-            ArtifactType.PICKLABLE, derived_from_bson=False, content=list_input
+            ArtifactType.PICKLABLE,
+            derived_from_bson=False,
+            derived_from_param=False,
+            content=list_input,
         )
         == SerializationType.PICKLE
     )

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -265,7 +265,7 @@ def _write_table_output(output: pd.DataFrame) -> bytes:
 
 
 def _write_param_table_output(output: pd.DataFrame) -> bytes:
-    return output.to_parquet()
+    return bytes(output.to_parquet())
 
 
 def _write_bson_table_output(output: pd.DataFrame) -> bytes:

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -52,7 +52,10 @@ def _read_table_content(content: bytes) -> pd.DataFrame:
 
 
 def _read_param_table_content(content: bytes) -> pd.DataFrame:
-    return pd.read_parquet(io.BytesIO(content))
+    try:
+        return pd.read_parquet(io.BytesIO(content))
+    except:
+        return _read_table_content(content)
 
 
 def _read_bson_table_content(content: bytes) -> pd.DataFrame:

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -52,15 +52,17 @@ def _read_table_content(content: bytes) -> pd.DataFrame:
     return pd.read_json(io.BytesIO(content), orient="table")
 
 
-# Check if the file is parquet deserializable first. If not,
-# we deserialize it as json since existing param artifact is
-# serialized in json.
+# Check if the content is json deserializable first. This assumes
+# that deprecated json deserializable parameters are serialized
+# correctly. If errors, this means the content is serialized by
+# parquet.
+# TODO(ENG-1729): Does not need this when when switch to parquet
+# serialization for all table artifacts.
 def _read_param_table_content(content: bytes) -> pd.DataFrame:
     try:
-        pq.ParquetFile(io.BytesIO(content))
+        return pd.read_json(io.BytesIO(content), orient="table")
     except:
-        return _read_table_content(content)
-    return pd.read_parquet(io.BytesIO(content))
+        return pd.read_parquet(io.BytesIO(content))
 
 
 def _read_bson_table_content(content: bytes) -> pd.DataFrame:

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import cloudpickle as pickle
 import pandas as pd
+import pyarrow.parquet as pq
 from aqueduct.constants.enums import (
     ArtifactType,
     LocalDataSerializationType,
@@ -18,6 +19,7 @@ from aqueduct.utils.type_inference import infer_artifact_type
 from bson import json_util as bson_json_util
 from PIL import Image
 from pydantic import BaseModel
+from pyarrow.lib import ArrowInvalid
 
 from .format import DEFAULT_ENCODING
 from .function_packaging import _make_temp_dir
@@ -50,12 +52,15 @@ class PickleableCollectionSerializationFormat(BaseModel):
 def _read_table_content(content: bytes) -> pd.DataFrame:
     return pd.read_json(io.BytesIO(content), orient="table")
 
-
+# Check if the file is parquet deserializable first. If not,
+# we deserialize it as json since existing param artifact is
+# serialized in json.
 def _read_param_table_content(content: bytes) -> pd.DataFrame:
     try:
-        return pd.read_parquet(io.BytesIO(content))
+        pq.ParquetFile(io.BytesIO(content))
     except:
         return _read_table_content(content)
+    return pd.read_parquet(io.BytesIO(content))
 
 
 def _read_bson_table_content(content: bytes) -> pd.DataFrame:

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -19,7 +19,6 @@ from aqueduct.utils.type_inference import infer_artifact_type
 from bson import json_util as bson_json_util
 from PIL import Image
 from pydantic import BaseModel
-from pyarrow.lib import ArrowInvalid
 
 from .format import DEFAULT_ENCODING
 from .function_packaging import _make_temp_dir
@@ -51,6 +50,7 @@ class PickleableCollectionSerializationFormat(BaseModel):
 
 def _read_table_content(content: bytes) -> pd.DataFrame:
     return pd.read_json(io.BytesIO(content), orient="table")
+
 
 # Check if the file is parquet deserializable first. If not,
 # we deserialize it as json since existing param artifact is
@@ -370,7 +370,6 @@ def artifact_type_to_serialization_type(
     derived_from_param: bool,
     content: Any,
 ) -> SerializationType:
-    print(derived_from_param)
     if artifact_type == ArtifactType.TABLE:
         if derived_from_bson:
             serialization_type = SerializationType.BSON_TABLE

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -129,17 +129,20 @@ def construct_param_spec(
     # Not derived from bson.
     # For now, bson_table applies only to tables read from mongo.
     derived_from_bson = False
+    derived_from_param = True
 
     serialization_type = artifact_type_to_serialization_type(
         artifact_type,
         derived_from_bson,
+        derived_from_param,
         val,
     )
-
     # We must base64 encode the resulting bytes, since we can't be sure
     # what encoding it was written in (eg. Image types are not encoded as "utf8").
     return ParamSpec(
-        val=_bytes_to_base64_string(serialize_val(val, serialization_type, derived_from_bson)),
+        val=_bytes_to_base64_string(
+            serialize_val(val, serialization_type, derived_from_bson, derived_from_param)
+        ),
         serialization_type=serialization_type,
     )
 

--- a/src/python/aqueduct_executor/operators/utils/enums.py
+++ b/src/python/aqueduct_executor/operators/utils/enums.py
@@ -75,6 +75,7 @@ class ArtifactType(str, Enum, metaclass=MetaEnum):
 class SerializationType(str, Enum, metaclass=MetaEnum):
     TABLE = "table"
     BSON_TABLE = "bson_table"
+    PARAM_TABLE = "param_table"
     JSON = "json"
     PICKLE = "pickle"
     IMAGE = "image"


### PR DESCRIPTION
## Describe your changes and why you are making these changes

**Purpose**

The PR is a first cut of effort to replace json with parquet serialization. The current work only focus on making Table Artifact from `create_param()` serialized as Parquet Table. There has been no change made to Server and UI.

**What does the implementation exactly optimize?** 

The current flow to run a preview on param : serialize(JSON) table in `construct_param_spec` -> deserialize(JSON) table in `param_executor`

Now:   serialize(Parquet) table in `construct_param_spec` -> deserialize(Parquet) table in `param_executor` -> serialize(JSON) table in 'param_executor' (This is because UI and server doesn't have appropriate handle for parquet)

**Benchmark:**
The Serialization size is measured in Megabytes(MB), the time is measured in second(s).
<img width="1131" alt="Screen Shot 2023-04-21 at 3 59 37 PM" src="https://user-images.githubusercontent.com/78303449/233746414-123c26a9-9949-4f82-98f9-26137eb3ecff.png">

The improvement comes in:
1. Sending significantly less request size because of serialization
2. pd.to_parquet read_parquet is fast 

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


