### PR TITLE
Improve logging when operator failed before generating artifact

### DIFF
--- a/src/golang/lib/engine/aq_engine.go
+++ b/src/golang/lib/engine/aq_engine.go
@@ -1003,6 +1003,10 @@ func (eng *aqEngine) execute(
 			// and check operators with warning severity.
 			if execState.HasBlockingFailure() {
 				log.Infof("Stopping execution of operator %v", op.ID())
+				if execState.Error != nil {
+					log.Infof("Reason: %s", execState.Error.Message())
+				}
+
 				for id, dagOp := range workflowDag.Operators() {
 					log.Infof("Checking status of operator %v", id)
 					// Skip if this operator has already been completed or is in progress.

--- a/src/golang/lib/workflow/artifact/artifact.go
+++ b/src/golang/lib/workflow/artifact/artifact.go
@@ -207,7 +207,9 @@ func (a *ArtifactImpl) updateArtifactResultAfterComputation(
 	execState *shared.ExecutionState,
 ) {
 	changes := map[string]interface{}{
-		models.ArtifactResultMetadata: nil,
+		models.ArtifactResultMetadata:  nil,
+		models.ArtifactResultStatus:    execState.Status,
+		models.ArtifactResultExecState: execState,
 	}
 
 	metadataExists := utils.ObjectExistsInStorage(ctx, a.storageConfig, a.execPaths.ArtifactMetadataPath)
@@ -226,9 +228,6 @@ func (a *ArtifactImpl) updateArtifactResultAfterComputation(
 		}
 		changes[models.ArtifactResultMetadata] = &artifactResultMetadata
 	}
-
-	changes[models.ArtifactResultStatus] = execState.Status
-	changes[models.ArtifactResultExecState] = execState
 
 	_, err := a.resultRepo.Update(
 		ctx,

--- a/src/golang/lib/workflow/utils/storage.go
+++ b/src/golang/lib/workflow/utils/storage.go
@@ -24,6 +24,10 @@ func CleanupStorageFiles(ctx context.Context, storageConfig *shared.StorageConfi
 }
 
 func ObjectExistsInStorage(ctx context.Context, storageConfig *shared.StorageConfig, path string) bool {
+	if path == "" {
+		return false
+	}
+
 	return storage.NewStorage(storageConfig).Exists(ctx, path)
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR improves logging when a operator failed without generating artifact metadata. The current situation being:
* operator failed without generating artifact metadata
* we attempt to upload artifact metadata
* we failed to read that metadata and thus result in showing a missing storage object failure in most error logs
As the improvements, we modifies the logging with minimum change on current life-cycle management behavior:
* If artif metadata is failed to read, we will log the error rather than fail the function call. We expect orchestration to handle downstream execution based on operator's state.
  * when reading the metadata, we assume empty metadata path + metadata field implies empty metadata, rather than an error state.
* In orchestrator, we log operator's failure reason together with operator's ID when wf execution is stopped due to operator failures.

## Related issue number (if any)
ENG-2815

## Testings
We are not expecting to change any life-cycle management behavior. I'd consider it as success as long as all integration tests passed

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


