### PR TITLE
Increase server setup timeouts in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       # TODO(ENG-2537): Use our separate GH actions credentials.
       - uses: ./.github/actions/fetch-test-config
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       # TODO(ENG-2537): Use our separate GH actions credentials.
       - uses: ./.github/actions/fetch-test-config
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       # TODO(ENG-2537): Use our separate GH actions credentials.
       - uses: ./.github/actions/fetch-test-config

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'src/golang/**'
+      - "src/golang/**"
 
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     steps:
       - uses: actions/checkout@v2
 
@@ -49,4 +49,3 @@ jobs:
 
           # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
           # skip-build-cache: true
-

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -3,8 +3,8 @@ name: Mypy
 on:
   pull_request:
     paths:
-      - 'sdk/aqueduct/**'
-      - 'src/python/**'
+      - "sdk/aqueduct/**"
+      - "src/python/**"
 
 jobs:
   sdk:
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     name: Mypy SDK
     steps:
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
 
     name: Mypy Executor
     steps:

--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       # TODO(ENG-2537): Use our separate GH actions credentials.
       - uses: ./.github/actions/fetch-test-config
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
@@ -204,7 +204,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: ./.github/actions/setup-server
-        timeout-minutes: 5
+        timeout-minutes: 7
 
       - uses: ./.github/actions/fetch-test-config
         with:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # These are all the Python versions that we want to regression test with.
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     name: Run Regressions Tests with Python Version ${{ matrix.python-version }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
       - name: Set filename for the prev ver server's output logs
         run: echo "SERVER_LOGS_PREV_FILE=logs/server_logs_prev_ver_${{ matrix.python-version }}" >> $GITHUB_ENV
-      
+
       - name: Set filename for the current ver server's output logs
         run: echo "SERVER_LOGS_CURRENT_FILE=logs/server_logs_curr_ver_${{ matrix.python-version }}" >> $GITHUB_ENV
 
@@ -51,7 +51,7 @@ jobs:
       - name: Wait for server
         timeout-minutes: 1
         run: while ! echo exit | nc localhost 8080; do sleep 1; done
-      
+
       - name: Fetch the API key
         run: echo "API_KEY=$(aqueduct apikey)" >> $GITHUB_ENV
 
@@ -68,7 +68,7 @@ jobs:
         timeout-minutes: 5
         run: imgname=old-flow-run-1 npx playwright test tests/screenshot.test.ts
 
-      - name: Trigger new workflow run 
+      - name: Trigger new workflow run
         working-directory: regression_tests
         timeout-minutes: 5
         run: npx playwright test tests/trigger.test.ts --project=chromium
@@ -82,22 +82,22 @@ jobs:
         working-directory: regression_tests
         timeout-minutes: 5
         run: sleep 5 && python3 tests/workflow_comparer.py --server_address localhost:8080 --checkpoint=create --path=checkpoint
-      
+
       # Grabs the pid of the process bound to port 8080 and kills it
       - name: Kill the server
         run: kill -9 $(lsof -nP -iTCP -sTCP:LISTEN | grep 8080 | awk '{print $2}')
-      
+
       # install_local.py requires ~/.aqueduct to exist.
       - name: Update aqueduct with latest code
         run: python3 scripts/install_local.py --gobinary --sdk --executor
 
       - name: Start the server again
         run: (aqueduct start --verbose > $SERVER_LOGS_CURRENT_FILE 2>&1 &)
-      
+
       - name: Wait for server again
         timeout-minutes: 5
         run: while ! echo exit | nc localhost 8080; do sleep 1; done
-      
+
       - name: Compare checkpoint of workflow
         working-directory: regression_tests
         timeout-minutes: 5
@@ -107,16 +107,16 @@ jobs:
         working-directory: regression_tests
         timeout-minutes: 5
         run: imgname=old-flow-run-2 npx playwright test tests/screenshot.test.ts
-      
+
       - name: Kill the server
         run: kill -9 $(lsof -nP -iTCP -sTCP:LISTEN | grep 8080 | awk '{print $2}')
-      
+
       - name: clear the server
         run: aqueduct clear
 
       - name: Start the server again
         run: (aqueduct start --verbose > $SERVER_LOGS_CURRENT_FILE 2>&1 &)
-      
+
       - name: Wait for server again
         timeout-minutes: 5
         run: while ! echo exit | nc localhost 8080; do sleep 1; done
@@ -145,7 +145,7 @@ jobs:
         with:
           name: Executor Logs
           path: ~/.aqueduct/server/logs/*
-      
+
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/run-notebooks.yml
+++ b/.github/workflows/run-notebooks.yml
@@ -3,14 +3,14 @@ name: Run Notebooks
 on:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'src/golang/**'
-      - 'src/python/**'
-      - 'sdk/aqueduct/**'
+      - "src/golang/**"
+      - "src/python/**"
+      - "sdk/aqueduct/**"
   pull_request:
     paths:
-      - '.github/workflows/run-notebooks.yml'
+      - ".github/workflows/run-notebooks.yml"
       - "examples/churn_prediction/Customer Churn Tutorial.ipynb"
       - "examples/sentiment_analysis/Sentiment Model.ipynb"
       - "examples/diabetes-classifier/Classifying Diabetes Risk.ipynb"
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Set up GOPATH variable
         run: echo "GOPATH=$(echo $HOME)" >> $GITHUB_ENV
@@ -117,7 +117,7 @@ jobs:
       - name: Run Imported Function Notebook
         timeout-minutes: 10
         run: python3 examples/run_notebook.py --path "integration_tests/notebook/imported_function.ipynb"
-      
+
       - name: Run Util File Dependency Notebook
         timeout-minutes: 10
         run: python3 examples/run_notebook.py --path "integration_tests/notebook/util_dependency.ipynb"
@@ -133,10 +133,10 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         with:
           status: ${{ job.status }}
-          notification_title: ''
-          message_format: '{emoji} *{workflow}* has {status_message}'
-          footer: '{run_url}'
-          notify_when: 'failure,warnings'
-          mention_users: 'U025MDH5KS6,U01JEUX1J2Y,U01J8Q1HUBC'
+          notification_title: ""
+          message_format: "{emoji} *{workflow}* has {status_message}"
+          footer: "{run_url}"
+          notify_when: "failure,warnings"
+          mention_users: "U025MDH5KS6,U01JEUX1J2Y,U01J8Q1HUBC"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/.github/workflows/skipped-integration-tests.yml
+++ b/.github/workflows/skipped-integration-tests.yml
@@ -30,5 +30,4 @@ jobs:
     name: SDK Data Integration Tests
     steps:
       - run: |
-          exit 0          
-            
+          exit 0


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR increases server setup timeouts from 5 min to 7 min. Based on recent integration test failures, the current setup time appear to start reaching the boundary.

```
Installing collected packages: tomli, regex, pluggy, joblib, iniconfig, execnet, exceptiongroup, pytest, nltk, pytest-xdist
Successfully installed exceptiongroup-1.1.1 execnet-1.9.0 iniconfig-2.0.0 joblib-1.2.0 nltk-3.8.1 pluggy-1.0.0 pytest-7.3.1 pytest-xdist-3.2.1 regex-2023.3.23 tomli-2.0.1

Notice:  A new release of pip is available: 22.0.4 -> 23.1.2
Notice:  To update, run: pip install --upgrade pip

# We never reach the line that polls the server state

Error: The action has timed out.
```

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


