### PR TITLE
ENG-2862, ENG-2863 Fix broken sidebar styling and add integration list item box styling.

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -116,6 +116,7 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
             ? theme.palette.gray['300']
             : 'white',
         },
+        boxSizing: 'initial',
       }}
     >
       <Box

--- a/src/ui/common/src/components/layouts/menuSidebar.styles.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.styles.tsx
@@ -45,8 +45,8 @@ export const menuSidebarLink = {
 
 export const menuSidebarLogoLink = {
   /* contains logo of size 48px */
-  width: '48px',
-  height: '48px',
+  width: '100%',
+  height: '64px',
   /* ensures border width is 80px, which maps sidebar */
   paddingLeft: '16px',
   paddingRight: '16px',


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes broken sidebar styling around Aqueduct logo and box sizing issue with AddIntegration list items.

## Related issue number (if any)
ENG-2862

## Loom demo (if any)
Screenshot:
<img width="1881" alt="image" src="https://user-images.githubusercontent.com/1031759/235008355-a01646e1-75ab-4a54-b104-a7fb8e1658ae.png">


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


