### PR TITLE
ENG-2863 New add integrations styling

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -103,13 +103,13 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
         setShowDialog(integration.activated);
       }}
       sx={{
-        width: '160px',
-        height: '128px',
+        width: '64px',
+        height: '80px',
         m: 1,
-        px: 2,
-        py: 2,
+        px: 1,
+        py: 1,
         borderRadius: 2,
-        border: `2px solid ${theme.palette.gray['700']}`,
+        //border: `2px solid ${theme.palette.gray['700']}`,
         cursor: integration.activated ? 'pointer' : 'default',
         '&:hover': {
           backgroundColor: integration.activated
@@ -117,11 +117,13 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
             : 'white',
         },
         boxSizing: 'initial',
+        backgroundColor: '#F8F8F8', // gray/light2
       }}
     >
       <Box
-        width="160px"
-        maxWidth="160px"
+        width="100%"
+        maxWidth="100%"
+        height="48px"
         display="flex"
         flexDirection="column"
         alignItems="center"
@@ -129,15 +131,16 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
         <IntegrationLogo
           service={service}
           activated={integration.activated}
-          size="large"
+          size="medium"
         />
       </Box>
       <Typography
         variant={'body1'}
         align={'center'}
         sx={{
-          marginTop: '16px',
+          marginTop: '8px',
           color: integration.activated ? 'inherit' : 'grey',
+          fontSize: '12px',
         }}
       >
         {service}

--- a/src/ui/common/src/components/integrations/logo.tsx
+++ b/src/ui/common/src/components/integrations/logo.tsx
@@ -4,6 +4,7 @@ import { Service, SupportedIntegrations } from '../../utils/integrations';
 
 const sizeMap = {
   large: '85px',
+  medium: '48px',
   small: '24px',
 };
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR updates the styling for integration cards according to the new figma mocks. 

## Related issue number (if any)
ENG-2863

## Loom demo (if any)
Screenshot:
<img width="1686" alt="image" src="https://user-images.githubusercontent.com/1031759/235015238-2c16b790-806a-4a18-abf6-c31596c24a27.png">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


