### PR TITLE
Create user supplied root directory on s3 bucket if it does not exist

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/s3_serialization.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/s3_serialization.py
@@ -160,6 +160,14 @@ class S3UnknownFileFormatException(Exception):
     pass
 
 
+class S3InsufficientPermissionsException(Exception):
+    pass
+
+
+class S3RootFolderCreationException(Exception):
+    pass
+
+
 def artifact_type_to_s3_serialization_type(
     artifact_type: ArtifactType,
     format: Optional[S3TableFormat],


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Create user supplied root directory (path) on s3 storage bucket if one does not exist. This object path is used for storing Aqueduct workflow artifacts.

## Related issue number (if any)
ENG-1269

## Loom demo (if any)

## Checklist before requesting a review
- [ x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


