### PR TITLE
Improves error message returned to user when Airflow creds are incorrect

### DIFF
--- a/src/golang/cmd/server/handler/connect_integration.go
+++ b/src/golang/cmd/server/handler/connect_integration.go
@@ -593,7 +593,7 @@ func validateAirflowConfig(
 	config auth.Config,
 ) (int, error) {
 	if err := airflow.Authenticate(ctx, config); err != nil {
-		return http.StatusBadRequest, err
+		return http.StatusBadRequest, errors.Wrap(err, "Unable to authenticate Airflow credentials. Please check them.")
 	}
 
 	return http.StatusOK, nil


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Improves the error message that users will see so it is not some vague message that is simply forwarded along from Airflow. Instead, we wrap some context that the credentials are probably incorrect.

## Related issue number (if any)
ENG 2894

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


