### PR TITLE
Add more white space to the bottom of the integrations page

### DIFF
--- a/src/dockerfiles/Makefile
+++ b/src/dockerfiles/Makefile
@@ -172,9 +172,9 @@ build-llm:
 	docker build . -t aqueducthq/llm_cuda1141_py38:$(VERSION) -f llm/cuda_11_4_1/llm_cuda_1141_py38.dockerfile
 	docker build . -t aqueducthq/llm_cuda1141_py39:$(VERSION) -f llm/cuda_11_4_1/llm_cuda_1141_py39.dockerfile
 	docker build . -t aqueducthq/llm_cuda1141_py310:$(VERSION) -f llm/cuda_11_4_1/llm_cuda_1141_py310.dockerfile
-	docker build . -t aqueducthq/llm_cuda1180_py38:$(VERSION) -f llm/cuda_11_4_1/llm_cuda_1180_py38.dockerfile
-	docker build . -t aqueducthq/llm_cuda1180_py39:$(VERSION) -f llm/cuda_11_4_1/llm_cuda_1180_py39.dockerfile
-	docker build . -t aqueducthq/llm_cuda1180_py310:$(VERSION) -f llm/cuda_11_4_1/llm_cuda_1180_py310.dockerfile
+	docker build . -t aqueducthq/llm_cuda1180_py38:$(VERSION) -f llm/cuda_11_8_0/llm_cuda_1180_py38.dockerfile
+	docker build . -t aqueducthq/llm_cuda1180_py39:$(VERSION) -f llm/cuda_11_8_0/llm_cuda_1180_py39.dockerfile
+	docker build . -t aqueducthq/llm_cuda1180_py310:$(VERSION) -f llm/cuda_11_8_0/llm_cuda_1180_py310.dockerfile
 
 publish-llm:
 	docker push aqueducthq/llm_cuda1141_py38:$(VERSION)

--- a/src/ui/common/src/components/pages/integrations/index.tsx
+++ b/src/ui/common/src/components/pages/integrations/index.tsx
@@ -98,108 +98,104 @@ const IntegrationsPage: React.FC<Props> = ({
       breadcrumbs={[BreadcrumbLink.HOME, BreadcrumbLink.INTEGRATIONS]}
       user={user}
     >
-      <Box>
+      <Box paddingBottom={4}>
+        <Typography variant="h5" marginBottom={2}>
+          Available Resources
+        </Typography>
+        <ConnectedIntegrations
+          user={user}
+          forceLoad={forceLoad}
+          connectedIntegrationType={ConnectedIntegrationType.Compute}
+        />
+        <ConnectedIntegrations
+          user={user}
+          forceLoad={forceLoad}
+          connectedIntegrationType={ConnectedIntegrationType.Data}
+        />
+        <ConnectedIntegrations
+          user={user}
+          forceLoad={forceLoad}
+          connectedIntegrationType={ConnectedIntegrationType.Other}
+        />
+
         <Box>
-          <Typography variant="h5" marginBottom={2}>
-            Available Resources
+          <Typography variant="h6" marginY={2}>
+            Artifact Storage
           </Typography>
-          <ConnectedIntegrations
-            user={user}
-            forceLoad={forceLoad}
-            connectedIntegrationType={ConnectedIntegrationType.Compute}
-          />
-          <ConnectedIntegrations
-            user={user}
-            forceLoad={forceLoad}
-            connectedIntegrationType={ConnectedIntegrationType.Data}
-          />
-          <ConnectedIntegrations
-            user={user}
-            forceLoad={forceLoad}
-            connectedIntegrationType={ConnectedIntegrationType.Other}
-          />
-
-          <Box>
-            <Typography variant="h6" marginY={2}>
-              Artifact Storage
-            </Typography>
-            <MetadataStorageInfo serverConfig={serverConfig.config} />
-            {!isLoading && lastFailedFormattedTimestamp && (
-              <Box>
-                <Typography
-                  variant="body2"
-                  fontWeight="fontWeightRegular"
-                  marginTop={2}
-                  marginBottom={1}
-                >
-                  The last artifact storage migration, which started at{' '}
-                  {lastFailedFormattedTimestamp}, has failed! As a result, the
-                  artifact storage has not changed from `
-                  {serverConfig.config?.storageConfig.integration_name}`.
-                </Typography>
-                <Box
-                  sx={{
-                    borderRadius: 2,
-                    backgroundColor: theme.palette.red[100],
-                    color: theme.palette.red[600],
-                    p: 2,
-                    paddingBottom: '16px',
-                    paddingTop: '16px',
-                    height: 'fit-content',
-                  }}
-                >
-                  <pre style={{ margin: '0px' }}>
-                    {`${lastMigration[0].execution_state.error.tip}\n\n${lastMigration[0].execution_state.error.context}`}
-                  </pre>
-                </Box>
+          <MetadataStorageInfo serverConfig={serverConfig.config} />
+          {!isLoading && lastFailedFormattedTimestamp && (
+            <Box>
+              <Typography
+                variant="body2"
+                fontWeight="fontWeightRegular"
+                marginTop={2}
+                marginBottom={1}
+              >
+                The last artifact storage migration, which started at{' '}
+                {lastFailedFormattedTimestamp}, has failed! As a result, the
+                artifact storage has not changed from `
+                {serverConfig.config?.storageConfig.integration_name}`.
+              </Typography>
+              <Box
+                sx={{
+                  borderRadius: 2,
+                  backgroundColor: theme.palette.red[100],
+                  color: theme.palette.red[600],
+                  p: 2,
+                  paddingBottom: '16px',
+                  paddingTop: '16px',
+                  height: 'fit-content',
+                }}
+              >
+                <pre style={{ margin: '0px' }}>
+                  {`${lastMigration[0].execution_state.error.tip}\n\n${lastMigration[0].execution_state.error.context}`}
+                </pre>
               </Box>
-            )}
-          </Box>
-
-          <Box marginY={2}>
-            <Divider />
-          </Box>
-
-          <Typography variant="h5" marginY={2}>
-            Add New Resources
-          </Typography>
-
-          <Typography variant="h6" marginY={2}>
-            Compute
-          </Typography>
-          <AddIntegrations
-            user={user}
-            category={IntegrationCategories.COMPUTE}
-            supportedIntegrations={SupportedIntegrations}
-          />
-          <Typography variant="h6" marginY={2}>
-            Data
-          </Typography>
-          <AddIntegrations
-            user={user}
-            category={IntegrationCategories.DATA}
-            supportedIntegrations={SupportedIntegrations}
-          />
-          <Typography variant="h6" marginY={2}>
-            Container Registry
-          </Typography>
-          <AddIntegrations
-            user={user}
-            category={IntegrationCategories.CONTAINER_REGISTRY}
-            supportedIntegrations={SupportedIntegrations}
-          />
-
-          <Typography variant="h6" marginY={2}>
-            Notifications
-          </Typography>
-          <Typography variant="h6" marginY={2}>
-            <AddIntegrations
-              user={user}
-              category={IntegrationCategories.NOTIFICATION}
-              supportedIntegrations={SupportedIntegrations}
-            />
-          </Typography>
+            </Box>
+          )}
         </Box>
+
+        <Box marginY={2}>
+          <Divider />
+        </Box>
+
+        <Typography variant="h5" marginY={2}>
+          Add New Resources
+        </Typography>
+
+        <Typography variant="h6" marginY={2}>
+          Compute
+        </Typography>
+        <AddIntegrations
+          user={user}
+          category={IntegrationCategories.COMPUTE}
+          supportedIntegrations={SupportedIntegrations}
+        />
+        <Typography variant="h6" marginY={2}>
+          Data
+        </Typography>
+        <AddIntegrations
+          user={user}
+          category={IntegrationCategories.DATA}
+          supportedIntegrations={SupportedIntegrations}
+        />
+        <Typography variant="h6" marginY={2}>
+          Container Registry
+        </Typography>
+        <AddIntegrations
+          user={user}
+          category={IntegrationCategories.CONTAINER_REGISTRY}
+          supportedIntegrations={SupportedIntegrations}
+        />
+
+        <Typography variant="h6" marginY={2}>
+          Notifications
+        </Typography>
+        <AddIntegrations
+          user={user}
+          category={IntegrationCategories.NOTIFICATION}
+          supportedIntegrations={SupportedIntegrations}
+        />
       </Box>
 
       <Snackbar


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The code change appears to be a lot but all I did was removing some unneeded component wrappers and adding a `paddingBottom={4}` on line 101.

Also contains a typo fix in our Dockerfile.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


