### PR TITLE
Fix leftover integration renaming on the UI

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/dialog.tsx
@@ -430,8 +430,8 @@ const IntegrationDialog: React.FC<Props> = ({
       spellCheck={false}
       required={true}
       label="Name*"
-      description="Provide a unique name to refer to this integration."
-      placeholder={'my_' + formatService(service) + '_integration'}
+      description="Provide a unique name to refer to this resource."
+      placeholder={'my_' + formatService(service) + '_resource'}
       onChange={(event) => {
         setName(event.target.value);
         setShouldShowNameError(false);
@@ -447,7 +447,7 @@ const IntegrationDialog: React.FC<Props> = ({
       <DialogContent>
         {editMode && numWorkflows > 0 && (
           <Alert sx={{ mb: 2 }} severity="info">
-            {`Changing this integration will automatically update ${numWorkflows} ${
+            {`Changing this resource will automatically update ${numWorkflows} ${
               numWorkflows === 1 ? 'workflow' : 'workflows'
             }.`}
           </Alert>
@@ -466,9 +466,9 @@ const IntegrationDialog: React.FC<Props> = ({
 
         {shouldShowNameError && (
           <Alert sx={{ mt: 2 }} severity="error">
-            <AlertTitle>Naming Error</AlertTitle>A connected integration already
+            <AlertTitle>Naming Error</AlertTitle>A connected resource already
             exists with this name. Please provide a unique name for your
-            integration.
+            resource.
           </Alert>
         )}
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


