### PR TITLE
Adds guardrails for checks on config

### DIFF
--- a/integration_tests/sdk/setup_integration.py
+++ b/integration_tests/sdk/setup_integration.py
@@ -390,6 +390,9 @@ def is_global_engine_set(name: str) -> bool:
     assert "compute" in test_config, "compute section expected in test-config.yml"
     assert name in test_config["compute"].keys(), "%s not in test-config.yml." % name
 
+    if not isinstance(test_config["compute"][name], Dict):
+        return False
+
     return "set_global_engine" in test_config["compute"][name].keys()
 
 
@@ -406,6 +409,9 @@ def is_lazy_set(name: str) -> bool:
 
     assert "compute" in test_config, "compute section expected in test-config.yml"
     assert name in test_config["compute"].keys(), "%s not in test-config.yml." % name
+
+    if not isinstance(test_config["compute"][name], Dict):
+        return False
 
     return "set_global_lazy" in test_config["compute"][name].keys()
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Adds guardrails for checks on config
## Related issue number (if any)
https://linear.app/aqueducthq/issue/ENG-2942/fix-global-lazy-setting-for-periodic-test
## Loom demo (if any)
Periodic tests run here: https://github.com/aqueducthq/aqueduct/actions/runs/4919283902
## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


