### PR TITLE
Increases timeout for Redshift integration test cluster start and stop

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -217,7 +217,7 @@ jobs:
           aqueduct install redshift
 
       - name: Setup Hosted Data Integrations
-        timeout-minutes: 20
+        timeout-minutes: 25
         working-directory: scripts/data
         run: python3 setup_hosted.py --aws-key-id ${{ secrets.SAURAV_AWS_ACCESS_KEY_ID }} --aws-secret-key ${{ secrets.SAURAV_AWS_SECRET_ACCESS_KEY }}
 
@@ -231,7 +231,7 @@ jobs:
           prefix: Data Connectors
 
       - name: Teardown Hosted Data Integrations
-        timeout-minutes: 20
+        timeout-minutes: 25
         if: always()
         working-directory: scripts/data
         run: python3 teardown_hosted.py --aws-key-id ${{ secrets.SAURAV_AWS_ACCESS_KEY_ID }} --aws-secret-key ${{ secrets.SAURAV_AWS_SECRET_ACCESS_KEY }}

--- a/scripts/data/redshift_test.py
+++ b/scripts/data/redshift_test.py
@@ -132,7 +132,7 @@ def _get_cluster_status(client, cluster_identifier):
     return cluster["ClusterStatus"]
 
 
-def _wait_for_status(client, desired_status, timeout=600):
+def _wait_for_status(client, desired_status, timeout=900):
     """
     Waits for the test cluster to reach the desired status. Errors if the timeout
     is reached.


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Sometimes we are seeing transient issues where the Redshift cluster start process times out. This PR bumps the overall start and stop timeout from 20 to 25 min each, and for each state change (i.e. waiting from resuming to ready) the timeout has been modified from 10 to 15 min.

## Related issue number (if any)
ENG 2920

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


