### PR TITLE
Bumps up timeout for conda integration tests

### DIFF
--- a/.github/workflows/periodic-integration-tests.yml
+++ b/.github/workflows/periodic-integration-tests.yml
@@ -100,7 +100,7 @@ jobs:
 
   run-tests-conda:
     runs-on: ubuntu-latest-4-cores
-    timeout-minutes: 40
+    timeout-minutes: 50
     name: All Integration Tests with Conda
     steps:
       - uses: actions/checkout@v2
@@ -128,7 +128,7 @@ jobs:
           s3_test_config_path: periodic-conda-test-config.yml
 
       - name: Run the SDK Integration Tests
-        timeout-minutes: 30
+        timeout-minutes: 40
         working-directory: integration_tests/sdk
         run: python3 run_tests.py -n 8
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Based on a few instances this past week of seeing timeouts for the conda tests after >95% of the test cases have finished successfully, this PR increases the timeout from 40 to 50 min.

## Related issue number (if any)
ENG 2945

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


