### PR TITLE
Fix generated docstrings when viewing resource methods in Jupyter

### DIFF
--- a/sdk/aqueduct/resources/validation.py
+++ b/sdk/aqueduct/resources/validation.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import Any, Callable
 
 from aqueduct.utils.integration_validation import validate_integration_is_connected
@@ -10,6 +11,7 @@ def validate_is_connected() -> Callable[[AnyFunc], AnyFunc]:
     ensures that the integration is connected before allowing the method to be called."""
 
     def decorator(method: AnyFunc) -> Callable[[AnyFunc], AnyFunc]:
+        @wraps(method)
         def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
             validate_integration_is_connected(self.name(), self._metadata.exec_state)
             return method(self, *args, **kwargs)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Simple bug fix that shows the docstring for even those methods using the @validate_is_connected() decorator.

<img width="1192" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/6466121/efe23635-5a2a-4813-9481-3e3e6ea433b6">


## Related issue number (if any)
ENG-2886

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


