### PR TITLE
Adds error checking for whether big query dataset exists

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/bigquery.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/bigquery.py
@@ -7,6 +7,7 @@ from aqueduct_executor.operators.utils.enums import ArtifactType
 from aqueduct_executor.operators.utils.saved_object_delete import SavedObjectDelete
 from aqueduct_executor.operators.utils.utils import delete_object
 from google.cloud import bigquery
+from google.cloud.exceptions import NotFound
 from google.oauth2 import service_account
 
 
@@ -47,6 +48,22 @@ class BigQueryConnector(connector.DataConnector):
     def load(self, params: load.RelationalParams, df: Any, artifact_type: ArtifactType) -> None:
         if artifact_type != ArtifactType.TABLE:
             raise Exception("The data being loaded must be of type table, found %s" % artifact_type)
+
+        parts = params.table.split(".")
+        if len(parts) == 0:
+            raise Exception(
+                "Invalid name provided for BigQuery dataset and table: %s" % params.table
+            )
+
+        # Check if dataset actually exists
+        dataset_id = parts[0]
+        try:
+            self.client.get_dataset(dataset_id)
+        except NotFound:
+            raise Exception(
+                "The dataset %s does not exist. Please save to a dataset that already exists."
+                % dataset_id
+            )
 
         update_mode = params.update_mode
         write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE  # Default

--- a/src/python/aqueduct_executor/operators/connectors/data/bigquery.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/bigquery.py
@@ -49,6 +49,8 @@ class BigQueryConnector(connector.DataConnector):
         if artifact_type != ArtifactType.TABLE:
             raise Exception("The data being loaded must be of type table, found %s" % artifact_type)
 
+        # The expected table name format is <DATASET>.<TABLE> so we try to parse
+        # just the dataset name here.
         parts = params.table.split(".")
         if len(parts) == 0:
             raise Exception(


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds error checking to the BigQuery executor to see if the dataset exists before trying to save an artifact to it.

## Related issue number (if any)
ENG 2947

## Loom demo (if any)
<img width="758" alt="Screenshot 2023-05-15 at 11 19 24 AM" src="https://github.com/aqueducthq/aqueduct/assets/10413474/f707468b-47b0-4bca-a6bc-e90ffe17a3bb">


## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


