### PR TITLE
Fixes cloudpickle serialization for Python 3.7

### DIFF
--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -272,7 +272,7 @@ def _write_bytes_output(output: bytes) -> bytes:
 
 
 def _write_pickle_output(output: Any) -> bytes:
-    return bytes(pickle.dumps(output))
+    return bytes(pickle.dumps(output, protocol=pickle.DEFAULT_PROTOCOL))
 
 
 def _write_json_output(output: Any) -> bytes:

--- a/sdk/aqueduct/utils/serialization.py
+++ b/sdk/aqueduct/utils/serialization.py
@@ -272,6 +272,8 @@ def _write_bytes_output(output: bytes) -> bytes:
 
 
 def _write_pickle_output(output: Any) -> bytes:
+    # Setting the protocol to pickle.DEFAULT_PROTOCOL is necessary for
+    # compatibility with Python 3.7.
     return bytes(pickle.dumps(output, protocol=pickle.DEFAULT_PROTOCOL))
 
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
There are known problems with `cloudpickle` for Python 3.7. This was causing issues with our `PICKLEABLE` artifact type. 

## Related issue number (if any)
ENG 2815

## Loom demo (if any)

## Tests
Ran the full integration test suite for Python [3.7](https://github.com/aqueducthq/aqueduct/actions/runs/4994381162/jobs/8944891978) and [3.10](https://github.com/aqueducthq/aqueduct/actions/runs/4994381162/jobs/8944891978). (They are in progress.) 

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


