### PR TITLE
Merge id and name arguments to one field

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -571,15 +571,13 @@ def test_get_flow_with_name(client, flow_name, engine):
     )
 
     fetched_with_id = client.flow(flow.id())
-    fetched_with_name = client.flow(flow_name=flow.name())
-    fetched_with_id_and_name = client.flow(flow_id=flow.id(), flow_name=flow.name())
+    # fetched_with_name = client.flow(flow_identifier=flow.name())
 
-    assert fetched_with_id.id() == fetched_with_name.id()
-    assert fetched_with_id.id() == fetched_with_id_and_name.id()
+    # assert fetched_with_id.id() == fetched_with_name.id()
 
-    # Failure case: flow id and name do not match
+    # Failure case: flow name does not match
     with pytest.raises(InvalidUserArgumentException):
-        client.flow(flow_id=flow.id(), flow_name="not a real flow")
+        client.flow(flow_identifier="not a real flow")
 
 
 def test_refresh_flow_with_name(client, flow_name, engine):
@@ -598,11 +596,11 @@ def test_refresh_flow_with_name(client, flow_name, engine):
         engine=engine,
     )
 
-    # Failure case: flow id and name do not match
+    # Failure case: name does not match
     with pytest.raises(InvalidUserArgumentException):
-        client.trigger(flow_id=flow.id(), flow_name="not a real flow")
+        client.trigger(flow_identifier="not a real flow")
 
-    client.trigger(flow_name=flow.name())
+    client.trigger(flow_identifier=flow.id())
 
 
 def test_delete_flow_with_name(client, flow_name, engine):
@@ -623,9 +621,9 @@ def test_delete_flow_with_name(client, flow_name, engine):
 
     # Failure case: flow id and name do not match
     with pytest.raises(InvalidUserArgumentException):
-        client.delete_flow(flow_id=flow.id(), flow_name="not a real flow")
+        client.delete_flow(flow_identifier="not a real flow")
 
-    client.delete_flow(flow_name=flow.name())
+    client.delete_flow(flow_identifier=flow.id())
 
 
 def test_flow_with_failed_compute_operators(

--- a/integration_tests/sdk/data_integration_tests/s3_test.py
+++ b/integration_tests/sdk/data_integration_tests/s3_test.py
@@ -327,7 +327,7 @@ def test_s3_fetch_directory_with_delete(flow_manager, data_integration):
     # Delete the workflow and include artifact into deletion.
     tables = flow.list_saved_objects()
     flow_manager._client.delete_flow(
-        flow_id=str(flow.id()),
+        flow_identifier=str(flow.id()),
         saved_objects_to_delete=tables,
         force=True,
     )

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -107,7 +107,7 @@ def publish_flow_test(
         time.sleep(30)
 
         # Manually trigger a run to match behavior of non-Airflow engines
-        client.trigger(flow_id=flow.id())
+        client.trigger(flow_identifier=flow.id())
 
     if should_block:
         wait_for_flow_runs(
@@ -168,7 +168,7 @@ def wait_for_flow_runs(
         if all(str(flow_id) != flow_dict["flow_id"] for flow_dict in client.list_flows()):
             return False
 
-        flow = client.flow(flow_id)
+        flow = client.flow(flow_identifier=flow_id)
 
         # Last run is prepended to this list. We need to reverse it in order to compare with expected statuses,
         # which is sorted in chronologically ascending order.
@@ -227,20 +227,20 @@ def delete_flow(client: aqueduct.Client, workflow_id: uuid.UUID) -> None:
 def delete_all_flows(client: aqueduct.Client) -> None:
     flows = client.list_flows()
     for flow in flows:
-        flow_name = flow["name"]
+        flow_id = flow["flow_id"]
         try:
             client.delete_flow(
-                flow_name=flow_name,
-                saved_objects_to_delete=client.flow(flow_name=flow_name).list_saved_objects(),
+                flow_identifier=flow_id,
+                saved_objects_to_delete=client.flow(flow_identifier=flow_id).list_saved_objects(),
             )
         except Exception as e:
-            print("Error deleting workflow %s with exception: %s" % (flow_name, e))
+            print("Error deleting workflow %s with exception: %s" % (flow_id, e))
         else:
-            print("Successfully deleted workflow %s" % flow_name)
+            print("Successfully deleted workflow %s" % flow_id)
 
         # Try deleting Airflow DAG file if it exists
         # TODO ENG-2868 - Only do this for Airflow workflows
-        dag_path = f"{flow_name}_airflow.py"
+        dag_path = f"{flow_id}_airflow.py"
         if os.path.exists(dag_path):
             os.remove(dag_path)
 

--- a/sdk/aqueduct/tests/flow_test.py
+++ b/sdk/aqueduct/tests/flow_test.py
@@ -7,26 +7,20 @@ from aqueduct.utils.utils import find_flow_with_user_supplied_id_and_name
 
 
 def test_find_flow_with_user_supplied_id_and_name():
-    flow_1_id = "9740eb10-d77d-4393-a9bc-42862d7008e0"
-    flow_2_id = "6d9d7b93-028f-48b1-b723-ebd9e66ac867"
-    flow_3_id = "431841d6-aac5-450f-b395-66e110ba547b"
+    flow_1_id = uuid.UUID("9740eb10-d77d-4393-a9bc-42862d7008e0")
+    flow_2_id = uuid.UUID("6d9d7b93-028f-48b1-b723-ebd9e66ac867")
+    flow_3_id = uuid.UUID("431841d6-aac5-450f-b395-66e110ba547b")
 
     flows = [
-        (uuid.UUID(flow_1_id), "flow_1"),
-        (uuid.UUID(flow_2_id), "flow_2"),
-        (uuid.UUID(flow_3_id), "flow_3"),
+        (flow_1_id, "flow_1"),
+        (flow_2_id, "flow_2"),
     ]
 
-    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_id=flow_1_id)
-    assert flow_id == flow_1_id
+    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_identifier=flow_1_id)
+    assert flow_id == str(flow_1_id)
 
-    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_name="flow_1")
-    assert flow_id == flow_1_id
-
-    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_id=flow_1_id, flow_name="flow_1")
-    assert flow_id == flow_1_id
+    flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_identifier="flow_2")
+    assert flow_id == "flow_2"
 
     with pytest.raises(InvalidUserArgumentException):
-        flow_id = find_flow_with_user_supplied_id_and_name(
-            flows, flow_id=flow_1_id, flow_name="flow_2"
-        )
+        find_flow_with_user_supplied_id_and_name(flows, flow_identifier=flow_3_id)


### PR DESCRIPTION
## Describe your changes and why you are making these changes
The Flow API had 2 distinct arguments for UUID and Name. This PR merges both of them to one argument as 
a Union[uuid, str]

## Related issue number (if any)
ENG-2760

## Loom demo (if any)

## Checklist before requesting a review
- [ x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [x ] I have run the integration tests locally and they are passing.
- [x ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


