### PR TITLE
ENG-2979: Fixes bigquery and gcs dialogs that were crashing after file uploads.

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/bigqueryDialog.tsx
@@ -20,22 +20,12 @@ const Placeholders: BigQueryConfig = {
 export const BigQueryDialog: React.FC<IntegrationDialogProps> = ({
   editMode = false,
 }) => {
-  const { setValue, getValues } = useFormContext();
-
-  const [fileName, setFileName] = useState<string>(null);
-
+  const { setValue } = useFormContext();
+  const [fileData, setFileData] = useState<FileData | null>(null);
   const setFile = (fileData: FileData | null) => {
-    setFileName(fileData?.name ?? '');
     setValue('service_account_credentials', fileData?.data);
+    setFileData(fileData);
   };
-
-  const fileData =
-    fileName && !!getValues('service_account_credentials')
-      ? {
-          name: fileName,
-          data: getValues('service_account_credentials'),
-        }
-      : null;
 
   const fileUploadDescription = (
     <>
@@ -100,9 +90,15 @@ export function readCredentialsFile(
 
 export function getBigQueryValidationSchema() {
   return Yup.object().shape({
+    name: Yup.string().required('Please enter a name'),
     project_id: Yup.string().required('Please enter a project ID'),
-    service_account_credentials: Yup.string().required(
-      'Please upload a service account key file'
-    ),
+    service_account_credentials: Yup.string()
+      .transform((value) => {
+        if (!value?.data) {
+          return null;
+        }
+        return value.data;
+      })
+      .required('Please upload a service account key file'),
   });
 }

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -38,7 +38,7 @@ export const S3Dialog: React.FC<S3DialogProps> = ({
   editMode = false,
   setMigrateStorage,
 }) => {
-  const [fileData, setFileData] = useState<FileData | null>(null);
+  const [fileData, setFileData] = useState<string | null>(null);
 
   const { register, setValue } = useFormContext();
   register('use_as_storage');
@@ -54,7 +54,7 @@ export const S3Dialog: React.FC<S3DialogProps> = ({
     // Update the react-hook-form value
     setValue('config_file_content', fileData?.data);
     // Set state to trigger re-render of file upload field.
-    setFileData(fileData);
+    setFileData(fileData?.data);
   };
 
   const configProfileInput = (
@@ -263,7 +263,15 @@ export function getS3ValidationSchema() {
     }),
     config_file_content: Yup.string().when('type', {
       is: 'config_file_content',
-      then: Yup.string().required('Please upload a credentials file'),
+      then: Yup.string()
+        .transform((value) => { 
+          if (!value?.data) {
+            return null;
+          }
+
+          return value.data;
+        })
+        .required('Please upload a credentials file'),
     }),
   });
 }

--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -38,7 +38,7 @@ export const S3Dialog: React.FC<S3DialogProps> = ({
   editMode = false,
   setMigrateStorage,
 }) => {
-  const [fileData, setFileData] = useState<string | null>(null);
+  const [fileData, setFileData] = useState<FileData | null>(null);
 
   const { register, setValue } = useFormContext();
   register('use_as_storage');
@@ -54,7 +54,7 @@ export const S3Dialog: React.FC<S3DialogProps> = ({
     // Update the react-hook-form value
     setValue('config_file_content', fileData?.data);
     // Set state to trigger re-render of file upload field.
-    setFileData(fileData?.data);
+    setFileData(fileData);
   };
 
   const configProfileInput = (
@@ -263,15 +263,7 @@ export function getS3ValidationSchema() {
     }),
     config_file_content: Yup.string().when('type', {
       is: 'config_file_content',
-      then: Yup.string()
-        .transform((value) => { 
-          if (!value?.data) {
-            return null;
-          }
-
-          return value.data;
-        })
-        .required('Please upload a credentials file'),
+      then: Yup.string().required('Please upload a credentials file'),
     }),
   });
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where the GCS and BigQuery dialogs were crashing after a file upload.

## Related issue number (if any)
ENG-2979

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


