### PR TITLE
Make resource logo sizing more consistent

### DIFF
--- a/src/ui/common/src/components/pages/workflows/components/ResourceItem.tsx
+++ b/src/ui/common/src/components/pages/workflows/components/ResourceItem.tsx
@@ -25,7 +25,7 @@ const ResourceItemIcons = {
   [EngineType.Databricks]:
     'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/databricks-white.png',
   [EngineType.Spark]:
-    'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/spark-logo-only.png',
+    'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/resources/spark-logo-only.png',
   [EngineType.K8s]:
     'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/kubernetes-white.png',
   [EngineType.Lambda]:

--- a/src/ui/common/src/stories/ResourceLogoStory.stories.tsx
+++ b/src/ui/common/src/stories/ResourceLogoStory.stories.tsx
@@ -1,41 +1,47 @@
-import {ComponentMeta, ComponentStory} from "@storybook/react";
-import React from "react";
-import IntegrationLogo from "../components/integrations/logo";
 import Box from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
-import {theme} from "../styles/theme/theme";
-import SupportedIntegrations from "../utils/SupportedIntegrations";
-import {Service} from "../utils/integrations";
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+
+import IntegrationLogo from '../components/integrations/logo';
+import { theme } from '../styles/theme/theme';
+import { Service } from '../utils/integrations';
+import SupportedIntegrations from '../utils/SupportedIntegrations';
 
 // Darken the background so that we can see the component's bounding box.
 const BackgroundHighlighter = styled(Box)(() => {
   return {
     backgroundColor: theme.palette.gray[25],
     display: 'inline-flex',
-  }
+  };
 });
 
 const ResourceLogos: React.FC = () => {
   return (
-      <Box
-          sx={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            alignItems: 'flex-start',
-          }}
-      >{Object.keys(SupportedIntegrations).map((service) => (
-          // TODO: note the padding!
-          <BackgroundHighlighter sx={{ml: 2, mt: 2, padding: 1}}>
-            <IntegrationLogo service={service as Service} size="large" activated={true} />
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'flex-start',
+      }}
+    >
+      {Object.keys(SupportedIntegrations).map((service, idx) => (
+        <Box key={idx}>
+          <BackgroundHighlighter sx={{ ml: 2, mt: 2, padding: 1 }}>
+            <IntegrationLogo
+              service={service as Service}
+              size="large"
+              activated={true}
+            />
           </BackgroundHighlighter>
+        </Box>
       ))}
-      </Box>
-  )
-
+    </Box>
+  );
 };
 
 const ResourceLogosTemplate: ComponentStory<typeof ResourceLogos> = (args) => (
-    <ResourceLogos {...args} />
+  <ResourceLogos {...args} />
 );
 
 export const ResourceLogosStory = ResourceLogosTemplate.bind({});

--- a/src/ui/common/src/stories/ResourceLogoStory.stories.tsx
+++ b/src/ui/common/src/stories/ResourceLogoStory.stories.tsx
@@ -1,0 +1,47 @@
+import {ComponentMeta, ComponentStory} from "@storybook/react";
+import React from "react";
+import IntegrationLogo from "../components/integrations/logo";
+import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import {theme} from "../styles/theme/theme";
+import SupportedIntegrations from "../utils/SupportedIntegrations";
+import {Service} from "../utils/integrations";
+
+// Darken the background so that we can see the component's bounding box.
+const BackgroundHighlighter = styled(Box)(() => {
+  return {
+    backgroundColor: theme.palette.gray[25],
+    display: 'inline-flex',
+  }
+});
+
+const ResourceLogos: React.FC = () => {
+  return (
+      <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            alignItems: 'flex-start',
+          }}
+      >{Object.keys(SupportedIntegrations).map((service) => (
+          // TODO: note the padding!
+          <BackgroundHighlighter sx={{ml: 2, mt: 2, padding: 1}}>
+            <IntegrationLogo service={service as Service} size="large" activated={true} />
+          </BackgroundHighlighter>
+      ))}
+      </Box>
+  )
+
+};
+
+const ResourceLogosTemplate: ComponentStory<typeof ResourceLogos> = (args) => (
+    <ResourceLogos {...args} />
+);
+
+export const ResourceLogosStory = ResourceLogosTemplate.bind({});
+
+export default {
+  title: 'Test/ResourceLogos',
+  component: ResourceLogos,
+  argTypes: {},
+} as ComponentMeta<typeof ResourceLogos>;

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -428,7 +428,7 @@ export const ServiceLogos: ServiceLogo = {
   ['Databricks']: `${integrationLogosBucket}/databricks_logo.png`,
   ['Email']: `${integrationLogosBucket}/email.png`,
   ['Slack']: `${integrationLogosBucket}/slack.png`,
-  ['Spark']: `${integrationLogosBucket}/spark-logo-trademark.png`,
+  ['Spark']: `${logoBucket}/spark-logo-only.png`,
   ['AWS']: `${integrationLogosBucket}/aws-logo-trademark.png`,
   ['GCP']: `${integrationLogosBucket}/gcp.png`,
   ['Azure']: `${integrationLogosBucket}/azure.png`,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -399,11 +399,6 @@ const logoBucket =
 const integrationLogosBucket =
   'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations';
 
-const resourceLogosBucket = 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos';
-
-// TODO: REMOVE
-const testLogosBucket = 'https://test-kenny.s3.us-east-2.amazonaws.com';
-
 export const IntegrationCategories = {
   DATA: 'data',
   COMPUTE: 'compute',
@@ -417,23 +412,23 @@ export const ServiceLogos: ServiceLogo = {
   ['Aqueduct']: `${logoBucket}/aqueduct-logo-two-tone/small/2x/aqueduct-logo-two-tone-small%402x.png`,
   ['Postgres']: `${integrationLogosBucket}/440px-Postgresql_elephant.svg.png`,
   ['Snowflake']: `${integrationLogosBucket}/51-513957_periscope-data-partners-snowflake-computing-logo.png`,
-  ['Redshift']: `${testLogosBucket}/amazon-redshift.png`,
+  ['Redshift']: `${integrationLogosBucket}/amazon-redshift.png`,
   ['BigQuery']: `${integrationLogosBucket}/google-bigquery-logo-1.svg`,
-  ['MySQL']: `${testLogosBucket}/mysql.png`,
-  ['MariaDB']: `${testLogosBucket}/mariadb.png`,
-  ['S3']: `${testLogosBucket}/s3.png`,
+  ['MySQL']: `${integrationLogosBucket}/mysql.png`,
+  ['MariaDB']: `${integrationLogosBucket}/mariadb.png`,
+  ['S3']: `${integrationLogosBucket}/s3.png`,
   ['GCS']: `${integrationLogosBucket}/google-cloud-storage.png`,
   ['SQLite']: `${integrationLogosBucket}/sqlite-square-icon-256x256.png`,
   ['Athena']: `${integrationLogosBucket}/athena.png`,
   ['Airflow']: `${integrationLogosBucket}/airflow.png`,
   ['Kubernetes']: `${integrationLogosBucket}/kubernetes.png`,
-  ['Lambda']: `${testLogosBucket}/Lambda.png`,
+  ['Lambda']: `${integrationLogosBucket}/Lambda.png`,
   ['MongoDB']: `${integrationLogosBucket}/mongo.png`,
   ['Conda']: `${integrationLogosBucket}/conda.png`,
   ['Databricks']: `${integrationLogosBucket}/databricks_logo.png`,
   ['Email']: `${integrationLogosBucket}/email.png`,
   ['Slack']: `${integrationLogosBucket}/slack.png`,
-  ['Spark']: `${resourceLogosBucket}/spark-logo-only.png`,
+  ['Spark']: `${integrationLogosBucket}/spark-logo-trademark.png`,
   ['AWS']: `${integrationLogosBucket}/aws-logo-trademark.png`,
   ['GCP']: `${integrationLogosBucket}/gcp.png`,
   ['Azure']: `${integrationLogosBucket}/azure.png`,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -1,7 +1,6 @@
 import { apiAddress } from '../components/hooks/useAqueductConsts';
 import UserProfile from './auth';
 import ExecutionStatus, { AWSCredentialType, ExecState } from './shared';
-import { AqueductComputeConfig } from './SupportedIntegrations';
 
 export const aqueductDemoName = 'Demo';
 export const aqueductComputeName = 'Aqueduct Server';
@@ -400,6 +399,11 @@ const logoBucket =
 const integrationLogosBucket =
   'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations';
 
+const resourceLogosBucket = 'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos';
+
+// TODO: REMOVE
+const testLogosBucket = 'https://test-kenny.s3.us-east-2.amazonaws.com';
+
 export const IntegrationCategories = {
   DATA: 'data',
   COMPUTE: 'compute',
@@ -413,23 +417,23 @@ export const ServiceLogos: ServiceLogo = {
   ['Aqueduct']: `${logoBucket}/aqueduct-logo-two-tone/small/2x/aqueduct-logo-two-tone-small%402x.png`,
   ['Postgres']: `${integrationLogosBucket}/440px-Postgresql_elephant.svg.png`,
   ['Snowflake']: `${integrationLogosBucket}/51-513957_periscope-data-partners-snowflake-computing-logo.png`,
-  ['Redshift']: `${integrationLogosBucket}/amazon-redshift.png`,
+  ['Redshift']: `${testLogosBucket}/amazon-redshift.png`,
   ['BigQuery']: `${integrationLogosBucket}/google-bigquery-logo-1.svg`,
-  ['MySQL']: `${integrationLogosBucket}/mysql.png`,
-  ['MariaDB']: `${integrationLogosBucket}/mariadb.png`,
-  ['S3']: `${integrationLogosBucket}/s3.png`,
+  ['MySQL']: `${testLogosBucket}/mysql.png`,
+  ['MariaDB']: `${testLogosBucket}/mariadb.png`,
+  ['S3']: `${testLogosBucket}/s3.png`,
   ['GCS']: `${integrationLogosBucket}/google-cloud-storage.png`,
   ['SQLite']: `${integrationLogosBucket}/sqlite-square-icon-256x256.png`,
   ['Athena']: `${integrationLogosBucket}/athena.png`,
   ['Airflow']: `${integrationLogosBucket}/airflow.png`,
   ['Kubernetes']: `${integrationLogosBucket}/kubernetes.png`,
-  ['Lambda']: `${integrationLogosBucket}/Lambda.png`,
+  ['Lambda']: `${testLogosBucket}/Lambda.png`,
   ['MongoDB']: `${integrationLogosBucket}/mongo.png`,
   ['Conda']: `${integrationLogosBucket}/conda.png`,
   ['Databricks']: `${integrationLogosBucket}/databricks_logo.png`,
   ['Email']: `${integrationLogosBucket}/email.png`,
   ['Slack']: `${integrationLogosBucket}/slack.png`,
-  ['Spark']: `${integrationLogosBucket}/spark-logo-trademark.png`,
+  ['Spark']: `${resourceLogosBucket}/spark-logo-only.png`,
   ['AWS']: `${integrationLogosBucket}/aws-logo-trademark.png`,
   ['GCP']: `${integrationLogosBucket}/gcp.png`,
   ['Azure']: `${integrationLogosBucket}/azure.png`,

--- a/src/ui/common/src/utils/integrations.ts
+++ b/src/ui/common/src/utils/integrations.ts
@@ -397,7 +397,7 @@ const logoBucket =
 
 // S3 bucket folder for Integration logos.
 const integrationLogosBucket =
-  'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/pages/integrations';
+  'https://aqueduct-public-assets-bucket.s3.us-east-2.amazonaws.com/webapp/logos/resources';
 
 export const IntegrationCategories = {
   DATA: 'data',
@@ -422,13 +422,13 @@ export const ServiceLogos: ServiceLogo = {
   ['Athena']: `${integrationLogosBucket}/athena.png`,
   ['Airflow']: `${integrationLogosBucket}/airflow.png`,
   ['Kubernetes']: `${integrationLogosBucket}/kubernetes.png`,
-  ['Lambda']: `${integrationLogosBucket}/Lambda.png`,
+  ['Lambda']: `${integrationLogosBucket}/lambda.png`,
   ['MongoDB']: `${integrationLogosBucket}/mongo.png`,
   ['Conda']: `${integrationLogosBucket}/conda.png`,
   ['Databricks']: `${integrationLogosBucket}/databricks_logo.png`,
   ['Email']: `${integrationLogosBucket}/email.png`,
   ['Slack']: `${integrationLogosBucket}/slack.png`,
-  ['Spark']: `${logoBucket}/spark-logo-only.png`,
+  ['Spark']: `${integrationLogosBucket}/spark-logo-only.png`,
   ['AWS']: `${integrationLogosBucket}/aws-logo-trademark.png`,
   ['GCP']: `${integrationLogosBucket}/gcp.png`,
   ['Azure']: `${integrationLogosBucket}/azure.png`,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This has been bothering me for a while. Our logos have been uploaded in a very adhoc fashion, so the sizing is significantly off sometimes.

This PR:
1) Fixes a storybook bug with circular imports.
2) Adds a story that puts all our resource logos side by side, with padding=1 so we can easily visualize the logos side by side.
3) Uses the Spark-only logo instead of the wordy one.

I have the uploaded logo png files on my local filesystem. Once I merge this in, I'll update the public assets bucket with the updated ones on the next release.

This is what things used to look like:

<img width="1692" alt="Screen Shot 2023-05-16 at 3 09 27 PM" src="https://github.com/aqueducthq/aqueduct/assets/6466121/8557415d-a525-4432-86cf-b870c41915dd">
<img width="1510" alt="Screen Shot 2023-05-16 at 3 09 15 PM" src="https://github.com/aqueducthq/aqueduct/assets/6466121/641f3dd4-2b67-4802-937b-c095462a2216">

The Redshift, S3, Lambda, MariaDB, and MySQL logos were sized way too small. After adjusting, we get the following (MySQL and MariaDB still seem a little small, but that's just what their logos look like)

<img width="1429" alt="Screen Shot 2023-05-16 at 3 07 34 PM" src="https://github.com/aqueducthq/aqueduct/assets/6466121/95a23313-a777-47ad-82d1-6c3a3814bd31">
<img width="1505" alt="Screen Shot 2023-05-16 at 3 07 59 PM" src="https://github.com/aqueducthq/aqueduct/assets/6466121/01a95855-bcd5-4aad-8f19-63272ac2d352">

I realize these all look bigger than the before, that's just cus my window size changed, just focus on the relative sizes.

## Related issue number (if any)
ENG-2951

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


