### PR TITLE
ENG-2964 GetEnvironment RTKQuery

### DIFF
--- a/src/golang/cmd/server/handler/v2/get_server_environment.go
+++ b/src/golang/cmd/server/handler/v2/get_server_environment.go
@@ -11,7 +11,7 @@ import (
 
 const inK8sClusterEnvVarName = "AQUEDUCT_IN_K8S_CLUSTER"
 
-type getServerEnvironmentResponse struct {
+type getEnvironmentResponse struct {
 	// Whether the server is running within a k8s cluster.
 	InK8sCluster bool   `json:"inK8sCluster"`
 	Version      string `json:"version"`
@@ -20,6 +20,7 @@ type getServerEnvironmentResponse struct {
 // Route: /api/v2/environment
 // This file should map directly to
 // src/ui/common/src/handlers/v2/EnvironmentGet.tsx
+//
 // Method: GET
 // Request:
 //
@@ -27,25 +28,25 @@ type getServerEnvironmentResponse struct {
 //		`api-key`: user's API Key
 //
 // Response: Aqueduct server's environment variables.
-type GetServerEnvironmentHandler struct {
+type EnvironmentHandler struct {
 	handler.GetHandler
 }
 
-func (*GetServerEnvironmentHandler) Name() string {
-	return "GetServerEnvironment"
+func (*EnvironmentHandler) Name() string {
+	return "GetEnvironment"
 }
 
-func (*GetServerEnvironmentHandler) Prepare(r *http.Request) (interface{}, int, error) {
+func (*EnvironmentHandler) Prepare(r *http.Request) (interface{}, int, error) {
 	return nil, http.StatusOK, nil
 }
 
-func (h *GetServerEnvironmentHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
+func (h *EnvironmentHandler) Perform(ctx context.Context, interfaceArgs interface{}) (interface{}, int, error) {
 	inCluster := false
 	if os.Getenv(inK8sClusterEnvVarName) == "1" {
 		inCluster = true
 	}
 
-	return getServerEnvironmentResponse{
+	return getEnvironmentResponse{
 		InK8sCluster: inCluster,
 		Version:      lib.ServerVersionNumber,
 	}, http.StatusOK, nil

--- a/src/golang/cmd/server/handler/v2/get_server_environment.go
+++ b/src/golang/cmd/server/handler/v2/get_server_environment.go
@@ -1,10 +1,11 @@
-package handler
+package v2
 
 import (
 	"context"
 	"net/http"
 	"os"
 
+	"github.com/aqueducthq/aqueduct/cmd/server/handler"
 	"github.com/aqueducthq/aqueduct/lib"
 )
 
@@ -16,7 +17,9 @@ type getServerEnvironmentResponse struct {
 	Version      string `json:"version"`
 }
 
-// Route: /api/environment
+// Route: /api/v2/environment
+// This file should map directly to
+// src/ui/common/src/handlers/v2/EnvironmentGet.tsx
 // Method: GET
 // Request:
 //
@@ -25,7 +28,7 @@ type getServerEnvironmentResponse struct {
 //
 // Response: Aqueduct server's environment variables.
 type GetServerEnvironmentHandler struct {
-	GetHandler
+	handler.GetHandler
 }
 
 func (*GetServerEnvironmentHandler) Name() string {

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -24,7 +24,7 @@ const (
 	NodeDagOperatorsRoute          = "/api/v2/workflow/{workflowID}/dag/{dagID}/node/operators"
 	NodeOperatorContentRoute       = "/api/v2/workflow/{workflowID}/dag/{dagID}/node/operator/{nodeID}/content"
 	NodesResultsRoute              = "/api/v2/workflow/{workflowID}/result/{dagResultID}/nodes/results"
-	GetServerEnvironmentRoute      = "/api/v2/environment"
+	EnvironmentRoute               = "/api/v2/environment"
 
 	// V1 routes
 	GetArtifactVersionsRoute = "/api/artifact/versions"

--- a/src/golang/cmd/server/routes/routes.go
+++ b/src/golang/cmd/server/routes/routes.go
@@ -24,6 +24,7 @@ const (
 	NodeDagOperatorsRoute          = "/api/v2/workflow/{workflowID}/dag/{dagID}/node/operators"
 	NodeOperatorContentRoute       = "/api/v2/workflow/{workflowID}/dag/{dagID}/node/operator/{nodeID}/content"
 	NodesResultsRoute              = "/api/v2/workflow/{workflowID}/result/{dagResultID}/nodes/results"
+	GetServerEnvironmentRoute      = "/api/v2/environment"
 
 	// V1 routes
 	GetArtifactVersionsRoute = "/api/artifact/versions"
@@ -73,6 +74,5 @@ const (
 	GetWorkflowDagResultRoute    = "/api/workflow/{workflowId}/result/{workflowDagResultId}"
 	GetWorkflowHistoryRoute      = "/api/workflow/{workflowId}/history"
 
-	GetServerVersionRoute     = "/api/version"
-	GetServerEnvironmentRoute = "/api/environment"
+	GetServerVersionRoute = "/api/version"
 )

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -132,7 +132,7 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			DAGResultRepo:   s.DAGResultRepo,
 			OperatorRepo:    s.OperatorRepo,
 		},
-		routes.GetServerEnvironmentRoute: &v2.GetServerEnvironmentHandler{},
+		routes.EnvironmentRoute: &v2.EnvironmentHandler{},
 
 		// V1 Handlers
 		// (ENG-2715) Remove deprecated ones

--- a/src/golang/cmd/server/server/handlers.go
+++ b/src/golang/cmd/server/server/handlers.go
@@ -132,6 +132,7 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 			DAGResultRepo:   s.DAGResultRepo,
 			OperatorRepo:    s.OperatorRepo,
 		},
+		routes.GetServerEnvironmentRoute: &v2.GetServerEnvironmentHandler{},
 
 		// V1 Handlers
 		// (ENG-2715) Remove deprecated ones
@@ -425,7 +426,6 @@ func (s *AqServer) Handlers() map[string]handler.Handler {
 
 			IntegrationRepo: s.IntegrationRepo,
 		},
-		routes.GetServerVersionRoute:     &handler.GetServerVersionHandler{},
-		routes.GetServerEnvironmentRoute: &handler.GetServerEnvironmentHandler{},
+		routes.GetServerVersionRoute: &handler.GetServerVersionHandler{},
 	}
 }

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -11,6 +11,8 @@ import {
 } from '../../../utils/integrations';
 import { apiAddress } from '../../hooks/useAqueductConsts';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
+import { useEnvironmentGetQuery } from '../../../handlers/AqueductApi';
+import { APIKeyParameter } from '../../../handlers/parameters/Header';
 
 const Placeholders: KubernetesConfig = {
   kubeconfig_path: '/home/ubuntu/.kube/config',
@@ -24,6 +26,13 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
 }) => {
   const { register, setValue, getValues } = useFormContext();
   const use_same_cluster = getValues('use_same_cluster');
+  if (user) {
+    const { data, error, isLoading } = useEnvironmentGetQuery({ apiKey: user.apiKey });
+    console.log('error: ', error);
+    console.log('isLoading: ', isLoading);
+    console.log('data: ', data);
+  }
+
 
   register('use_same_cluster');
 
@@ -34,24 +43,24 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
   const [inK8sCluster, setInK8sCluster] = useState(false);
 
   // TODO: https://linear.app/aqueducthq/issue/ENG-2964/move-k8s-use-same-cluster-request-to-rtkquery
-  useEffect(() => {
-    const fetchEnvironment = async () => {
-      const environmentResponse = await fetch(`${apiAddress}/api/environment`, {
-        method: 'GET',
-        headers: {
-          'api-key': user.apiKey,
-        },
-      });
+  // useEffect(() => {
+  //   const fetchEnvironment = async () => {
+  //     const environmentResponse = await fetch(`${apiAddress}/api/environment`, {
+  //       method: 'GET',
+  //       headers: {
+  //         'api-key': user.apiKey,
+  //       },
+  //     });
 
-      const responseBody = await environmentResponse.json();
-      console.log('responseBody: ', responseBody);
-      setInK8sCluster(responseBody['inK8sCluster']);
-    };
+  //     const responseBody = await environmentResponse.json();
+  //     console.log('responseBody: ', responseBody);
+  //     //setInK8sCluster(responseBody['inK8sCluster']);
+  //   };
 
-    if (user) {
-      fetchEnvironment().catch(console.error);
-    }
-  }, [user]);
+  //   if (user) {
+  //     fetchEnvironment().catch(console.error);
+  //   }
+  // }, [user]);
 
   return (
     <Box sx={{ mt: 2 }}>

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -26,12 +26,12 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
 }) => {
   const { register, setValue, getValues } = useFormContext();
   const use_same_cluster = getValues('use_same_cluster');
-  if (user) {
-    const { data, error, isLoading } = useEnvironmentGetQuery({ apiKey: user.apiKey });
-    console.log('error: ', error);
-    console.log('isLoading: ', isLoading);
-    console.log('data: ', data);
-  }
+  // if (user) {
+  //   const { data, error, isLoading } = useEnvironmentGetQuery({ apiKey: user.apiKey });
+  //   console.log('error: ', error);
+  //   console.log('isLoading: ', isLoading);
+  //   console.log('data: ', data);
+  // }
 
 
   register('use_same_cluster');
@@ -43,24 +43,24 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
   const [inK8sCluster, setInK8sCluster] = useState(false);
 
   // TODO: https://linear.app/aqueducthq/issue/ENG-2964/move-k8s-use-same-cluster-request-to-rtkquery
-  // useEffect(() => {
-  //   const fetchEnvironment = async () => {
-  //     const environmentResponse = await fetch(`${apiAddress}/api/environment`, {
-  //       method: 'GET',
-  //       headers: {
-  //         'api-key': user.apiKey,
-  //       },
-  //     });
+  useEffect(() => {
+    const fetchEnvironment = async () => {
+      const environmentResponse = await fetch(`${apiAddress}/api/v2/environment`, {
+        method: 'GET',
+        headers: {
+          'api-key': user.apiKey,
+        },
+      });
 
-  //     const responseBody = await environmentResponse.json();
-  //     console.log('responseBody: ', responseBody);
-  //     //setInK8sCluster(responseBody['inK8sCluster']);
-  //   };
+      const responseBody = await environmentResponse.json();
+      console.log('responseBody: ', responseBody);
+      setInK8sCluster(responseBody['inK8sCluster']);
+    };
 
-  //   if (user) {
-  //     fetchEnvironment().catch(console.error);
-  //   }
-  // }, [user]);
+    if (user) {
+      fetchEnvironment().catch(console.error);
+    }
+  }, [user]);
 
   return (
     <Box sx={{ mt: 2 }}>

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, FormControlLabel } from '@mui/material';
 import Box from '@mui/material/Box';
 import React from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import * as Yup from 'yup';
 
@@ -9,9 +9,7 @@ import {
   IntegrationDialogProps,
   KubernetesConfig,
 } from '../../../utils/integrations';
-import { apiAddress } from '../../hooks/useAqueductConsts';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
-import { useEnvironmentGetQuery } from '../../../handlers/AqueductApi';
 
 const Placeholders: KubernetesConfig = {
   kubeconfig_path: '/home/ubuntu/.kube/config',
@@ -19,43 +17,23 @@ const Placeholders: KubernetesConfig = {
   use_same_cluster: 'false',
 };
 
-export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
+interface KuberentesDialogProps extends IntegrationDialogProps {
+  inK8sCluster: boolean;
+}
+
+export const KubernetesDialog: React.FC<KuberentesDialogProps> = ({
   editMode = false,
   user,
+  inK8sCluster = false,
 }) => {
   const { register, setValue, getValues } = useFormContext();
   const use_same_cluster = getValues('use_same_cluster');
-
 
   register('use_same_cluster');
 
   useEffect(() => {
     setValue('use_same_cluster', 'false');
   }, []);
-
-  const [inK8sCluster, setInK8sCluster] = useState(false);
-
-  // NOTE: Having an issue turning this into an RTKQuery, as it's causing an infinite loop here.
-  // const { data, error, isLoading } = useEnvironmentGetQuery({ apiKey: user.apiKey } as any, { skip: !user?.apiKey });
-  // TODO: https://linear.app/aqueducthq/issue/ENG-2964/move-k8s-use-same-cluster-request-to-rtkquery
-  useEffect(() => {
-    const fetchEnvironment = async () => {
-      const environmentResponse = await fetch(`${apiAddress}/api/v2/environment`, {
-        method: 'GET',
-        headers: {
-          'api-key': user.apiKey,
-        },
-      });
-
-      const responseBody = await environmentResponse.json();
-      console.log('responseBody: ', responseBody);
-      setInK8sCluster(responseBody['inK8sCluster']);
-    };
-
-    if (user) {
-      fetchEnvironment().catch(console.error);
-    }
-  }, [user]);
 
   return (
     <Box sx={{ mt: 2 }}>

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -44,6 +44,7 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
       });
 
       const responseBody = await environmentResponse.json();
+      console.log('responseBody: ', responseBody);
       setInK8sCluster(responseBody['inK8sCluster']);
     };
 

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -12,7 +12,6 @@ import {
 import { apiAddress } from '../../hooks/useAqueductConsts';
 import { IntegrationTextInputField } from './IntegrationTextInputField';
 import { useEnvironmentGetQuery } from '../../../handlers/AqueductApi';
-import { APIKeyParameter } from '../../../handlers/parameters/Header';
 
 const Placeholders: KubernetesConfig = {
   kubeconfig_path: '/home/ubuntu/.kube/config',
@@ -26,12 +25,6 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
 }) => {
   const { register, setValue, getValues } = useFormContext();
   const use_same_cluster = getValues('use_same_cluster');
-  // if (user) {
-  //   const { data, error, isLoading } = useEnvironmentGetQuery({ apiKey: user.apiKey });
-  //   console.log('error: ', error);
-  //   console.log('isLoading: ', isLoading);
-  //   console.log('data: ', data);
-  // }
 
 
   register('use_same_cluster');
@@ -42,6 +35,8 @@ export const KubernetesDialog: React.FC<IntegrationDialogProps> = ({
 
   const [inK8sCluster, setInK8sCluster] = useState(false);
 
+  // NOTE: Having an issue turning this into an RTKQuery, as it's causing an infinite loop here.
+  // const { data, error, isLoading } = useEnvironmentGetQuery({ apiKey: user.apiKey } as any, { skip: !user?.apiKey });
   // TODO: https://linear.app/aqueducthq/issue/ENG-2964/move-k8s-use-same-cluster-request-to-rtkquery
   useEffect(() => {
     const fetchEnvironment = async () => {

--- a/src/ui/common/src/components/integrations/dialogs/onDemandKubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/onDemandKubernetesDialog.tsx
@@ -9,6 +9,7 @@ import { useFormContext } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import * as Yup from 'yup';
 
+import { useEnvironmentGetQuery } from '../../../handlers/AqueductApi';
 import { handleConnectToNewIntegration } from '../../../reducers/integration';
 import { AppDispatch } from '../../../stores/store';
 import { IntegrationDialogProps } from '../../../utils/integrations';
@@ -42,6 +43,11 @@ export const OnDemandKubernetesDialog: React.FC<IntegrationDialogProps> = ({
   loading,
   onCloseDialog,
 }) => {
+  const {
+    data: environment,
+    error,
+    isLoading,
+  } = useEnvironmentGetQuery({ apiKey: user.apiKey });
   const { register, setValue } = useFormContext();
 
   const [currentStep, setCurrentStep] = useState('INITIAL');
@@ -137,14 +143,19 @@ export const OnDemandKubernetesDialog: React.FC<IntegrationDialogProps> = ({
     );
   };
 
+  interface RegularK8sStepLayoutProps extends IntegrationDialogProps {
+    inK8sCluster?: boolean;
+  }
+
   // We're going to need to share some more info with the dialogs, as they're not all just forms that we can
   // register anymore in the case of this layout.
-  const RegularK8sStepLayout: React.FC<IntegrationDialogProps> = ({
+  const RegularK8sStepLayout: React.FC<RegularK8sStepLayoutProps> = ({
     user,
     editMode,
     onCloseDialog,
     loading,
     disabled,
+    inK8sCluster = false,
   }) => {
     const methods = useFormContext();
     const dispatch: AppDispatch = useDispatch();
@@ -170,6 +181,7 @@ export const OnDemandKubernetesDialog: React.FC<IntegrationDialogProps> = ({
           onCloseDialog={onCloseDialog}
           loading={loading}
           disabled={disabled}
+          inK8sCluster={inK8sCluster}
         />
         <DialogActionButtons
           onCloseDialog={onCloseDialog}
@@ -376,6 +388,7 @@ export const OnDemandKubernetesDialog: React.FC<IntegrationDialogProps> = ({
           loading={loading}
           onCloseDialog={onCloseDialog}
           editMode={editMode}
+          inK8sCluster={environment?.inK8sCluster}
         />
       );
     case 'ONDEMAND_K8S':

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -27,6 +27,7 @@ import {
   menuSidebarLogoLink,
   notificationAlert,
 } from './menuSidebar.styles';
+import { useEnvironmentGetQuery } from '../../handlers/AqueductApi';
 
 // Left padding = 8px
 // Right padding = 8px
@@ -123,22 +124,17 @@ const MenuSidebar: React.FC<{
   const [versionNumber, setVersionNumber] = useState('');
   const location = useLocation();
 
+  const { data } = useEnvironmentGetQuery({ apiKey: user.apiKey } as any, { skip: !user?.apiKey });
+
   useEffect(() => {
     setCurrentPage(location.pathname);
   }, [dispatch, location.pathname]);
 
   useEffect(() => {
-    async function fetchVersionNumber() {
-      const res = await fetch(`${apiAddress}/api/version`, {
-        method: 'GET',
-        headers: { 'api-key': user.apiKey },
-      });
-      const versionNumberResponse = await res.json();
-      setVersionNumber(versionNumberResponse.version);
+    if (data) {
+      setVersionNumber(data.version);
     }
-
-    fetchVersionNumber();
-  }, [user.apiKey]);
+  }, [user.apiKey, data]);
 
   const pathPrefix = getPathPrefix();
   return (

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -15,9 +15,9 @@ import { useDispatch } from 'react-redux';
 import { Link as RouterLink, useLocation } from 'react-router-dom';
 import UserProfile from 'src/utils/auth';
 
+import { useEnvironmentGetQuery } from '../../handlers/AqueductApi';
 import { AppDispatch } from '../../stores/store';
 import { getPathPrefix } from '../../utils/getPathPrefix';
-import { apiAddress } from '../hooks/useAqueductConsts';
 import {
   menuSidebar,
   menuSidebarContent,
@@ -27,7 +27,6 @@ import {
   menuSidebarLogoLink,
   notificationAlert,
 } from './menuSidebar.styles';
-import { useEnvironmentGetQuery } from '../../handlers/AqueductApi';
 
 // Left padding = 8px
 // Right padding = 8px
@@ -124,7 +123,9 @@ const MenuSidebar: React.FC<{
   const [versionNumber, setVersionNumber] = useState('');
   const location = useLocation();
 
-  const { data } = useEnvironmentGetQuery({ apiKey: user.apiKey } as any, { skip: !user?.apiKey });
+  const { data } = useEnvironmentGetQuery({ apiKey: user.apiKey } as any, {
+    skip: !user?.apiKey,
+  });
 
   useEffect(() => {
     setCurrentPage(location.pathname);

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -120,22 +120,17 @@ const MenuSidebar: React.FC<{
 }> = ({ onSidebarItemClicked, user }) => {
   const dispatch: AppDispatch = useDispatch();
   const [currentPage, setCurrentPage] = useState(undefined);
-  const [versionNumber, setVersionNumber] = useState('');
   const location = useLocation();
 
-  const { data } = useEnvironmentGetQuery({ apiKey: user.apiKey } as any, {
+  const { data } = useEnvironmentGetQuery({ apiKey: user.apiKey }, {
     skip: !user?.apiKey,
   });
+
+  console.log('data: ', data);
 
   useEffect(() => {
     setCurrentPage(location.pathname);
   }, [dispatch, location.pathname]);
-
-  useEffect(() => {
-    if (data) {
-      setVersionNumber(data.version);
-    }
-  }, [user.apiKey, data]);
 
   const pathPrefix = getPathPrefix();
   return (
@@ -267,7 +262,7 @@ const MenuSidebar: React.FC<{
         </Box>
         <Box marginLeft="14px" marginBottom="16px">
           <Typography variant="caption" sx={{ color: 'white' }}>
-            {versionNumber.length > 0 ? `v${versionNumber}` : ''}
+            {data?.version ? `v${data.version}` : ''}
           </Typography>
         </Box>
       </Box>

--- a/src/ui/common/src/components/layouts/menuSidebar.tsx
+++ b/src/ui/common/src/components/layouts/menuSidebar.tsx
@@ -122,9 +122,12 @@ const MenuSidebar: React.FC<{
   const [currentPage, setCurrentPage] = useState(undefined);
   const location = useLocation();
 
-  const { data } = useEnvironmentGetQuery({ apiKey: user.apiKey }, {
-    skip: !user?.apiKey,
-  });
+  const { data } = useEnvironmentGetQuery(
+    { apiKey: user.apiKey },
+    {
+      skip: !user?.apiKey,
+    }
+  );
 
   console.log('data: ', data);
 

--- a/src/ui/common/src/handlers/AqueductApi.ts
+++ b/src/ui/common/src/handlers/AqueductApi.ts
@@ -138,7 +138,10 @@ export const aqueductApi = createApi({
       query: (req) => dagResultsGetQuery(req),
       transformErrorResponse,
     }),
-    environmentGet: builder.query<EnvironmentGetResponse, EnvironmentGetRequest>({
+    environmentGet: builder.query<
+      EnvironmentGetResponse,
+      EnvironmentGetRequest
+    >({
       query: (req) => environmentGetQuery(req),
       transformErrorResponse,
     }),

--- a/src/ui/common/src/handlers/AqueductApi.ts
+++ b/src/ui/common/src/handlers/AqueductApi.ts
@@ -19,6 +19,10 @@ import {
   DagResultsGetResponse,
 } from './v2/DagResultsGet';
 import {
+  environmentGetQuery,
+  EnvironmentGetRequest,
+} from './v2/EnvironmentGet';
+import {
   integrationOperatorsGetQuery,
   IntegrationOperatorsGetRequest,
   IntegrationOperatorsGetResponse,
@@ -103,7 +107,6 @@ import {
   WorkflowsGetRequest,
   WorkflowsGetResponse,
 } from './v2/WorkflowsGet';
-import { EnvironmentPlugin } from 'webpack';
 
 const { createApi, fetchBaseQuery } = ((rtkQueryRaw as any).default ??
   rtkQueryRaw) as typeof rtkQueryRaw;

--- a/src/ui/common/src/handlers/AqueductApi.ts
+++ b/src/ui/common/src/handlers/AqueductApi.ts
@@ -103,6 +103,7 @@ import {
   WorkflowsGetRequest,
   WorkflowsGetResponse,
 } from './v2/WorkflowsGet';
+import { EnvironmentPlugin } from 'webpack';
 
 const { createApi, fetchBaseQuery } = ((rtkQueryRaw as any).default ??
   rtkQueryRaw) as typeof rtkQueryRaw;
@@ -132,6 +133,10 @@ export const aqueductApi = createApi({
     }),
     dagResultsGet: builder.query<DagResultsGetResponse, DagResultsGetRequest>({
       query: (req) => dagResultsGetQuery(req),
+      transformErrorResponse,
+    }),
+    environmentGet: builder.query<EnvironmentGetResponse, EnvironmentGetRequest>({
+      query: (req) => environmentGetQuery(req),
       transformErrorResponse,
     }),
     integrationOperatorsGet: builder.query<
@@ -246,6 +251,7 @@ export const {
   useDagOperatorsGetQuery,
   useDagResultGetQuery,
   useDagResultsGetQuery,
+  useEnvironmentGetQuery,
   useIntegrationOperatorsGetQuery,
   useIntegrationWorkflowsGetQuery,
   useIntegrationsWorkflowsGetQuery,

--- a/src/ui/common/src/handlers/v2/EnvironmentGet.ts
+++ b/src/ui/common/src/handlers/v2/EnvironmentGet.ts
@@ -1,0 +1,14 @@
+import { APIKeyParameter } from '../parameters/Header';
+
+export type EnvironmentGetRequest = APIKeyParameter;
+
+export type EnvironeGetResponse = {
+    inK8sCluster: boolean;
+};
+
+// TODO: Move this endpoint to the v2 API
+export const dagOperatorsGetQuery = (req: EnvironmentGetRequest) => ({
+  //url: `workflows/${req.workflowId}/dag/${req.dagId}/nodes/operators`,
+  url: 'environment',
+  headers: { 'api-key': req.apiKey },
+});

--- a/src/ui/common/src/handlers/v2/EnvironmentGet.ts
+++ b/src/ui/common/src/handlers/v2/EnvironmentGet.ts
@@ -4,11 +4,10 @@ export type EnvironmentGetRequest = APIKeyParameter;
 
 export type EnvironmentGetResponse = {
     inK8sCluster: boolean;
+    version: string;
 };
 
-// TODO: Move this endpoint to the v2 API
 export const environmentGetQuery = (req: EnvironmentGetRequest) => ({
-  //url: `workflows/${req.workflowId}/dag/${req.dagId}/nodes/operators`,
   url: 'environment',
   headers: { 'api-key': req.apiKey },
 });

--- a/src/ui/common/src/handlers/v2/EnvironmentGet.ts
+++ b/src/ui/common/src/handlers/v2/EnvironmentGet.ts
@@ -3,8 +3,8 @@ import { APIKeyParameter } from '../parameters/Header';
 export type EnvironmentGetRequest = APIKeyParameter;
 
 export type EnvironmentGetResponse = {
-    inK8sCluster: boolean;
-    version: string;
+  inK8sCluster: boolean;
+  version: string;
 };
 
 export const environmentGetQuery = (req: EnvironmentGetRequest) => ({

--- a/src/ui/common/src/handlers/v2/EnvironmentGet.ts
+++ b/src/ui/common/src/handlers/v2/EnvironmentGet.ts
@@ -2,12 +2,12 @@ import { APIKeyParameter } from '../parameters/Header';
 
 export type EnvironmentGetRequest = APIKeyParameter;
 
-export type EnvironeGetResponse = {
+export type EnvironmentGetResponse = {
     inK8sCluster: boolean;
 };
 
 // TODO: Move this endpoint to the v2 API
-export const dagOperatorsGetQuery = (req: EnvironmentGetRequest) => ({
+export const environmentGetQuery = (req: EnvironmentGetRequest) => ({
   //url: `workflows/${req.workflowId}/dag/${req.dagId}/nodes/operators`,
   url: 'environment',
   headers: { 'api-key': req.apiKey },


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR moves the getEnvironment API call from the kubernetes dialog and the menusidebar to use RTKQuery. 

Also moves the getEnvironment route to the new v2 routes.

## Related issue number (if any)
ENG-2964

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


