### PR TITLE
ENG-3010: S3 Dialog Use as Metadata Checkbox fix

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -289,5 +289,12 @@ export function getS3ValidationSchema() {
         .required('Please upload a credentials file'),
       otherwise: null,
     }),
+    use_as_storage: Yup.string().transform((value) => {
+      if (value === 'true') {
+        return 'true';
+      }
+
+      return 'false';
+    }),
   });
 }

--- a/src/ui/common/src/handlers/AqueductApi.ts
+++ b/src/ui/common/src/handlers/AqueductApi.ts
@@ -64,16 +64,6 @@ import {
   NodeCheckGetResponse,
 } from './v2/NodeCheckGet';
 import {
-  nodeCheckGetQuery,
-  NodeCheckGetRequest,
-  NodeCheckGetResponse,
-} from './v2/NodeCheckGet';
-import {
-  nodeCheckResultContentGetQuery,
-  NodeCheckResultContentGetRequest,
-  NodeCheckResultContentGetResponse,
-} from './v2/NodeCheckResultContentGet';
-import {
   nodeCheckResultContentGetQuery,
   NodeCheckResultContentGetRequest,
   NodeCheckResultContentGetResponse,
@@ -83,16 +73,6 @@ import {
   NodeMetricGetRequest,
   NodeMetricGetResponse,
 } from './v2/NodeMetricGet';
-import {
-  nodeMetricGetQuery,
-  NodeMetricGetRequest,
-  NodeMetricGetResponse,
-} from './v2/NodeMetricGet';
-import {
-  nodeMetricResultContentGetQuery,
-  NodeMetricResultContentGetRequest,
-  NodeMetricResultContentGetResponse,
-} from './v2/NodeMetricResultContentGet';
 import {
   nodeMetricResultContentGetQuery,
   NodeMetricResultContentGetRequest,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where the S3 Dialog was not sending down the proper type for use_as_metadata.

## Related issue number (if any)
ENG-3010

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


