### PR TITLE
ENG-3011 and ENG-3012 Kubernetes/OnDemandKubernetes Dialog Fixes

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -29,15 +29,12 @@ export const KubernetesDialog: React.FC<KuberentesDialogProps> = ({
   const { register, setValue, getValues } = useFormContext();
   const use_same_cluster = getValues('use_same_cluster');
 
-  //register('use_same_cluster');
-
   useEffect(() => {
     if (!use_same_cluster) {
       setValue('use_same_cluster', 'false');
     }
   }, []);
 
-  
   return (
     <Box sx={{ mt: 2 }}>
       {inK8sCluster && (
@@ -86,7 +83,6 @@ export function getKubernetesValidationSchema() {
   return Yup.object().shape({
     name: Yup.string().required('Please enter a name.'),
     use_same_cluster: Yup.string().transform((value) => {
-      console.log('usesamecluster transformer: ', value);
       if (value === 'true') {
         return 'true';
       }

--- a/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/kubernetesDialog.tsx
@@ -29,12 +29,15 @@ export const KubernetesDialog: React.FC<KuberentesDialogProps> = ({
   const { register, setValue, getValues } = useFormContext();
   const use_same_cluster = getValues('use_same_cluster');
 
-  register('use_same_cluster');
+  //register('use_same_cluster');
 
   useEffect(() => {
-    setValue('use_same_cluster', 'false');
+    if (!use_same_cluster) {
+      setValue('use_same_cluster', 'false');
+    }
   }, []);
 
+  
   return (
     <Box sx={{ mt: 2 }}>
       {inK8sCluster && (
@@ -81,7 +84,15 @@ export const KubernetesDialog: React.FC<KuberentesDialogProps> = ({
 
 export function getKubernetesValidationSchema() {
   return Yup.object().shape({
-    use_same_cluster: Yup.string(),
+    name: Yup.string().required('Please enter a name.'),
+    use_same_cluster: Yup.string().transform((value) => {
+      console.log('usesamecluster transformer: ', value);
+      if (value === 'true') {
+        return 'true';
+      }
+
+      return 'false';
+    }),
     kubeconfig_path: Yup.string().when('use_same_cluster', {
       is: 'false',
       then: Yup.string().required('Please enter a kubeconfig path'),

--- a/src/ui/common/src/components/integrations/dialogs/onDemandKubernetesDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/onDemandKubernetesDialog.tsx
@@ -48,7 +48,6 @@ export const OnDemandKubernetesDialog: React.FC<IntegrationDialogProps> = ({
     error,
     isLoading,
   } = useEnvironmentGetQuery({ apiKey: user.apiKey });
-  console.log('k8s dialog', environment);
   const { register, setValue } = useFormContext();
 
   const [currentStep, setCurrentStep] = useState('INITIAL');
@@ -174,10 +173,7 @@ const InitialStepLayout: React.FC<InitialStepLayoutProps> = ({
             activated={true}
             size="small"
           />
-          <Typography
-            variant="body2"
-            sx={{ color: 'black', fontSize: '18px' }}
-          >
+          <Typography variant="body2" sx={{ color: 'black', fontSize: '18px' }}>
             I have an existing Kubernetes cluster I&apos;d like to use
           </Typography>
         </Button>
@@ -195,10 +191,7 @@ const InitialStepLayout: React.FC<InitialStepLayoutProps> = ({
             activated={SupportedIntegrations['Aqueduct'].activated}
             size="small"
           />
-          <Typography
-            variant="body2"
-            sx={{ color: 'black', fontSize: '18px' }}
-          >
+          <Typography variant="body2" sx={{ color: 'black', fontSize: '18px' }}>
             I&apos;d like Aqueduct to create & manage a cluster for me
           </Typography>
         </Button>
@@ -306,7 +299,7 @@ const OnDemandK8sStep: React.FC<OnDemandK8sStepProps> = ({
   loading,
   disabled,
   handlePrevious,
-  handleAWSClick
+  handleAWSClick,
 }) => {
   return (
     <>
@@ -428,8 +421,6 @@ const RegularK8sStepLayout: React.FC<RegularK8sStepLayoutProps> = ({
             // Remove extraneous fields if they are added when filling out the form.
             delete data.k8s_type;
             delete data.type;
-
-            console.log('handleSubmit data: ', data);
 
             dispatch(
               handleConnectToNewIntegration({


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes infinite rendering issues with the Kubernetes dialog and OnDemandKubernetes dialogs.

## Related issue number (if any)
ENG-3011
https://linear.app/aqueducthq/issue/ENG-3011/confusing-dialog-behavior-when-connecting-to-integrations

ENG-3012
https://linear.app/aqueducthq/issue/ENG-3012/k8s-dialog-calling-environments-endpoints-in-infinite-loop

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


