### PR TITLE
Add annotation to gate a test case only for relational data integration

### DIFF
--- a/integration_tests/sdk/aqueduct_tests/flow_test.py
+++ b/integration_tests/sdk/aqueduct_tests/flow_test.py
@@ -13,6 +13,7 @@ from aqueduct import check, metric, op
 from ..shared.data_objects import DataObject
 from ..shared.flow_helpers import publish_flow_test, trigger_flow_test, wait_for_flow_runs
 from ..shared.naming import generate_new_flow_name, generate_table_name
+from ..shared.relational import all_relational_DBs
 from .extract import extract
 from .save import save
 from .test_functions.sentiment.model import sentiment_model
@@ -626,6 +627,7 @@ def test_delete_flow_with_name(client, flow_name, engine):
     client.delete_flow(flow_identifier=flow.id())
 
 
+@pytest.mark.enable_only_for_data_integration_type(*all_relational_DBs())
 def test_flow_with_failed_compute_operators(
     client, flow_name, data_integration, engine, data_validator
 ):


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Annotate a test case to restrict it for relational data integration only

## Related issue number (if any)
ENG-3017

## Loom demo (if any)

## Checklist before requesting a review
- [x ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ x] I have run the integration tests locally and they are passing.
- [x ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


