### PR TITLE
Fix regression of fetching flow by name

### DIFF
--- a/sdk/aqueduct/tests/flow_test.py
+++ b/sdk/aqueduct/tests/flow_test.py
@@ -20,7 +20,7 @@ def test_find_flow_with_user_supplied_id_and_name():
     assert flow_id == str(flow_1_id)
 
     flow_id = find_flow_with_user_supplied_id_and_name(flows, flow_identifier="flow_2")
-    assert flow_id == "flow_2"
+    assert flow_id == str(flow_2_id)
 
     with pytest.raises(InvalidUserArgumentException):
         find_flow_with_user_supplied_id_and_name(flows, flow_identifier=flow_3_id)

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -233,5 +233,11 @@ def find_flow_with_user_supplied_id_and_name(
     elif isinstance(flow_identifier, str):
         if all(flow_id_str != flow[1] for flow in flows):
             raise InvalidUserArgumentException("Unable to find a flow with name %s" % flow_id_str)
+        # You land here if found matching flow name, return corresponding uuid
+        # backend api's look for uuid instead of name
+        for flow in flows:
+            if flow_id_str == flow[1]:
+                flow_id_str = str(flow[0])
+                break
 
     return flow_id_str


### PR DESCRIPTION
## Describe your changes and why you are making these changes

Map flow name to uuid before before fetching from backend instead of using name.

## Related issue number (if any)
ENG-3019

## Loom demo (if any)

## Checklist before requesting a review
- [ X] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ X] I have performed a self-review of my code.
- [X ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ X] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [X ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


