### PR TITLE
Add wildcard prefix to test-config file in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,6 @@ sdk/docs/build/
 
 # Integration Configuration Files - which may have sensitive credentials.
 integration_tests/sdk/test-credentials.yml
-integration_tests/sdk/test-config.yml
-integration_tests/sdk/test-config-run.yml
+integration_tests/sdk/*test-config.yml
 
 **/.devcontainer/


### PR DESCRIPTION
## Describe your changes and why you are making these changes
It would be nice to be able to keep multiple versions of `test-config.yml` in `integration_tests/sdk` to easily switch between them (eg. periodic-conda-test-config.yml)

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


