### PR TITLE
Fix bug where bigquery extracts fail due to missing import

### DIFF
--- a/src/python/aqueduct_executor/operators/connectors/data/bigquery.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/bigquery.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any, Dict, List, Optional
 
-import pandas as pd
 from aqueduct_executor.operators.connectors.data import common, config, connector, extract, load
 from aqueduct_executor.operators.utils.enums import ArtifactType
 from aqueduct_executor.operators.utils.saved_object_delete import SavedObjectDelete

--- a/src/python/aqueduct_executor/operators/connectors/data/execute.py
+++ b/src/python/aqueduct_executor/operators/connectors/data/execute.py
@@ -356,6 +356,7 @@ def setup_connector(
     elif connector_name == common.Name.BIG_QUERY:
         try:
             from google.cloud import bigquery
+            import db_dtypes
         except:
             raise MissingConnectorDependencyException(
                 "Unable to initialize the BigQuery connector. Have you run `aqueduct install bigquery`?"

--- a/src/python/bin/aqueduct
+++ b/src/python/bin/aqueduct
@@ -27,6 +27,7 @@ CHUNK_SIZE = 4096
 PYMONGO_VERSION_BOUND = "<=4.3.3"
 PSYCOPG2_VERSION_BOUND = "<=2.9.5"
 BIGQUERY_VERSION_BOUND = "<=3.5.0"
+DB_DTYPES_VERSION_BOUND = "<=1.1.1"
 SNOWFLAKE_VERSION_BOUND = "<=1.4.4"
 PYARROW_VERSION_BOUND = "<=11.0.0"
 AWS_WRANGLER_VERSION_BOUND = "<=2.19.0"
@@ -475,6 +476,7 @@ def install_postgres():
 
 def install_bigquery():
     execute_command([sys.executable, "-m", "pip", "install", "google-cloud-bigquery%s" % BIGQUERY_VERSION_BOUND])
+    execute_command([sys.executable, "-m", "pip", "install", "db-dtypes%s" % DB_DTYPES_VERSION_BOUND])
 
 
 def install_snowflake():


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Description here: https://linear.app/aqueducthq/issue/ENG-3026/aqueduct-install-bigquery-is-not-sufficient-for-bigquery-extracts-to

What the PR does:
- Better (or at least more consistent) error message if it doesn't exist:
<img width="832" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/6466121/3e2735e7-351c-424e-adfc-fa7f88483757">
- Also adds `db-dtypes` to the `aqueduct install bigquery` command.

## Related issue number (if any)
ENG-3026

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


