### PR TITLE
ENG-3027: Require Integration Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## 0.3.4
-Released on May 24, 2023.
-
-### Enhancements
-* Improves consistency of icon sizing on resources page.
-* Merges `flow_id` and `name` into a single argument when retrieving workflows
-    from the SDK.
-* Adds ability to parametrize save operators when using AWS S3.
-
-### Bugfixes
-* Fixes bug where race condition could occur when syncing Airflow workflows to
-    Aqueduct.
-* Fixes bug where listing Snowflake data objects would return an error.
-
 ## 0.3.3
 Released on May 17, 2023.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.3.4
+Released on May 24, 2023.
+
+### Enhancements
+* Improves consistency of icon sizing on resources page.
+* Merges `flow_id` and `name` into a single argument when retrieving workflows
+    from the SDK.
+* Adds ability to parametrize save operators when using AWS S3.
+
+### Bugfixes
+* Fixes bug where race condition could occur when syncing Airflow workflows to
+    Aqueduct.
+* Fixes bug where listing Snowflake data objects would return an error.
+
 ## 0.3.3
 Released on May 17, 2023.
 

--- a/src/ui/common/src/components/resources/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/resources/dialogs/dialog.tsx
@@ -63,8 +63,16 @@ const ResourceDialog: React.FC<Props> = ({
   const [submitDisabled, setSubmitDisabled] = useState<boolean>(true);
   const [migrateStorage, setMigrateStorage] = useState(false);
 
+  let hasNameField = service !== 'Kubernetes' && service !== 'Conda';
+
+  const combinedSchema = !hasNameField ? validationSchema : Yup.object().shape({
+    // Kubernetes and Conda manage their own name fields, so we just return validation schema.
+    ...validationSchema.fields,
+    name: Yup.string().required('Please enter a name'),
+  });
+
   const methods = useForm({
-    resolver: yupResolver(validationSchema),
+    resolver: yupResolver(combinedSchema),
   });
 
   const editMode = !!resourceToEdit;

--- a/src/ui/common/src/components/resources/dialogs/dialog.tsx
+++ b/src/ui/common/src/components/resources/dialogs/dialog.tsx
@@ -63,13 +63,15 @@ const ResourceDialog: React.FC<Props> = ({
   const [submitDisabled, setSubmitDisabled] = useState<boolean>(true);
   const [migrateStorage, setMigrateStorage] = useState(false);
 
-  let hasNameField = service !== 'Kubernetes' && service !== 'Conda';
+  const hasNameField = service !== 'Kubernetes' && service !== 'Conda';
 
-  const combinedSchema = !hasNameField ? validationSchema : Yup.object().shape({
-    // Kubernetes and Conda manage their own name fields, so we just return validation schema.
-    ...validationSchema.fields,
-    name: Yup.string().required('Please enter a name'),
-  });
+  const combinedSchema = !hasNameField
+    ? validationSchema
+    : Yup.object().shape({
+        // Kubernetes and Conda manage their own name fields, so we just return validation schema.
+        ...validationSchema.fields,
+        name: Yup.string().required('Please enter a name'),
+      });
 
   const methods = useForm({
     resolver: yupResolver(combinedSchema),

--- a/src/ui/common/src/components/resources/dialogs/garDialog.tsx
+++ b/src/ui/common/src/components/resources/dialogs/garDialog.tsx
@@ -70,7 +70,6 @@ export function readCredentialsFile(
 
 export function getGARValidationSchema(editMode: boolean) {
   return Yup.object().shape({
-    name: Yup.string().required('Please enter a name'),
     service_account_key: requiredAtCreate(
       Yup.string().transform((value) => {
         if (!value?.data) {


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where integrations are able to be registered without a name field present on the UI.

## Related issue number (if any)
ENG-3027

## Loom demo (if any)
Before:
<img width="1179" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/1031759/86ba84ec-7472-44e1-ad85-31078f2eb148">

After fix:
<img width="1129" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/1031759/004e7c6f-dd67-495e-a838-e9fe9b885d08">

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


