### PR TITLE
Adjust padding around icons in resources/ and dag view

### DIFF
--- a/src/ui/common/src/components/integrations/addIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/addIntegrations.tsx
@@ -120,7 +120,8 @@ const AddIntegrationListItem: React.FC<AddIntegrationListItemProps> = ({
       sx={{
         width: '64px',
         height: '80px',
-        m: 1,
+        mr: 1,
+        my: 1,
         px: 1,
         py: 1,
         borderRadius: 2,

--- a/src/ui/common/src/components/integrations/connectedIntegrations.tsx
+++ b/src/ui/common/src/components/integrations/connectedIntegrations.tsx
@@ -136,7 +136,7 @@ export const ConnectedIntegrations: React.FC<ConnectedIntegrationsProps> = ({
             }
 
             return (
-              <Box key={idx} sx={{ mx: 1, my: 1 }}>
+              <Box key={idx} sx={{ mr: 1, my: 1 }}>
                 <Link
                   underline="none"
                   color="inherit"

--- a/src/ui/common/src/components/pages/account/MetadataStorageInfo.tsx
+++ b/src/ui/common/src/components/pages/account/MetadataStorageInfo.tsx
@@ -120,7 +120,7 @@ export const MetadataStorageInfo: React.FC<MetadataStorageInfoProps> = ({
   }
 
   return (
-    <Box sx={{ mx: 1, my: 1, display: 'flex', alignItems: 'flex-start' }}>
+    <Box sx={{ my: 1, display: 'flex', alignItems: 'flex-start' }}>
       <Link
         underline="none"
         color="inherit"


### PR DESCRIPTION
## Describe your changes and why you are making these changes
I'm actually not sure if these are actually improvements anymore, but wanted to send it out just in case any of these appealed to you guys.

On the DAG view, for operators, I removed the padding so that there wasn't as large of a gap between the header icon the text.
On the resources/ page, I made everything justified with the left side since it looked a little funny, but I'm not sure it looks any better.

OLD:
<img width="1374" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/6466121/897c7bf1-1272-4c40-96b3-03dd7f967869">


NEW:
<img width="1450" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/6466121/2c0cc041-908e-44b6-93cd-0a519558321f">

------------------------------------------------------------------------------------------

OLD:
<img width="1666" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/6466121/60ea2b9e-1cbc-4baa-b54a-866377abc013">


NEW:



<img width="1878" alt="image" src="https://github.com/aqueducthq/aqueduct/assets/6466121/04c33289-e085-4dd6-a716-66af1c26a479">


## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


