### PR TITLE
ENG-3028: Use string to validate port for email dialog and maria db dialog

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/emailDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/emailDialog.tsx
@@ -162,7 +162,7 @@ export const EmailDialog: React.FC<IntegrationDialogProps> = ({
 export function getEmailValidationSchema() {
   return Yup.object().shape({
     host: Yup.string().required('Please enter a host'),
-    port: Yup.number().required('Please enter a port'),
+    port: Yup.string().required('Please enter a port'),
     user: Yup.string().required('Please enter a sender address'),
     password: Yup.string().required('Please enter a sender password'),
     targets_serialized: Yup.string().required(

--- a/src/ui/common/src/components/integrations/dialogs/emailDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/emailDialog.tsx
@@ -170,6 +170,8 @@ export function getEmailValidationSchema() {
       'Please enter at least one receiver'
     ),
     level: Yup.string().required('Please select a notification level'),
-    enabled: Yup.string().transform((value) => { value ? value : EmailDefaultsOnCreate.enabled }),
+    enabled: Yup.string().transform((value) => {
+      value ? value : EmailDefaultsOnCreate.enabled;
+    }),
   });
 }

--- a/src/ui/common/src/components/integrations/dialogs/emailDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/emailDialog.tsx
@@ -1,7 +1,7 @@
 import { Divider } from '@mui/material';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import React from 'react';
+import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import * as Yup from 'yup';
 
@@ -34,18 +34,18 @@ export const EmailDefaultsOnCreate = {
   enabled: 'false',
 };
 
-type Props = {
-  onUpdateField: (field: keyof EmailConfig, value: string) => void;
-  value?: EmailConfig;
-};
-
 export const EmailDialog: React.FC<IntegrationDialogProps> = ({
   editMode = false,
 }) => {
-  // Retrieve the form context.
-  const { register, setValue, getValues } = useFormContext();
+  const [selectedLevel, setSelectedLevel] = useState(
+    EmailDefaultsOnCreate.level
+  );
 
-  // Register forms with custom logic.
+  const [notificationsEnabled, setNotificationsEnabled] = useState(
+    EmailDefaultsOnCreate.enabled
+  );
+
+  const { register, setValue, getValues } = useFormContext();
   register('enabled', { value: EmailDefaultsOnCreate.enabled });
   register('level', { value: EmailDefaultsOnCreate.level });
   register('targets_serialized', {
@@ -108,7 +108,6 @@ export const EmailDialog: React.FC<IntegrationDialogProps> = ({
         description="The email address(es) of the receiver(s). Use comma to separate different addresses."
         placeholder={Placeholders.reciever}
         onChange={(event) => {
-          //setValue('receivers', event.target.value);
           const receiversList = event.target.value
             .split(',')
             .map((r) => r.trim());
@@ -120,9 +119,10 @@ export const EmailDialog: React.FC<IntegrationDialogProps> = ({
 
       <Box sx={{ mt: 2 }}>
         <CheckboxEntry
-          checked={enabled === 'true'}
+          checked={notificationsEnabled === 'true'}
           disabled={false}
           onChange={(checked) => {
+            setNotificationsEnabled(checked ? 'true' : 'false');
             setValue('enabled', checked ? 'true' : 'false');
           }}
         >
@@ -134,7 +134,7 @@ export const EmailDialog: React.FC<IntegrationDialogProps> = ({
         </Typography>
       </Box>
 
-      {enabled === 'true' && (
+      {notificationsEnabled === 'true' && (
         <Box sx={{ mt: 2 }}>
           <Box sx={{ my: 1 }}>
             <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
@@ -147,11 +147,12 @@ export const EmailDialog: React.FC<IntegrationDialogProps> = ({
             </Typography>
           </Box>
           <NotificationLevelSelector
-            level={level as NotificationLogLevel}
+            level={selectedLevel as NotificationLogLevel}
             onSelectLevel={(level) => {
+              setSelectedLevel(level);
               setValue('level', level);
             }}
-            enabled={enabled === 'true'}
+            enabled={notificationsEnabled === 'true'}
           />
         </Box>
       )}
@@ -168,6 +169,7 @@ export function getEmailValidationSchema() {
     targets_serialized: Yup.string().required(
       'Please enter at least one receiver'
     ),
-    enabled: Yup.string(),
+    level: Yup.string().required('Please select a notification level'),
+    enabled: Yup.string().transform((value) => { value ? value : EmailDefaultsOnCreate.enabled }),
   });
 }

--- a/src/ui/common/src/components/integrations/dialogs/mariadbDialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/mariadbDialog.tsx
@@ -91,7 +91,7 @@ export const MariaDbDialog: React.FC<IntegrationDialogProps> = ({
 export function getMariaDBValidationSchema() {
   return Yup.object().shape({
     host: Yup.string().required('Please enter a host'),
-    port: Yup.number().required('Please enter a port'),
+    port: Yup.string().required('Please enter a port'),
     database: Yup.string().required('Please enter a database'),
     username: Yup.string().required('Please enter a username'),
     password: Yup.string().required('Please enter a password'),


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR makes it so strings are used for port field in the email dialog and mariadb dialog.

## Related issue number (if any)
ENG-3028

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


