### PR TITLE
Added notebook for running Simple Model with large data

### DIFF
--- a/examples/system-tests/Simple_Model_Large_Data.ipynb
+++ b/examples/system-tests/Simple_Model_Large_Data.ipynb
@@ -31,6 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#This is working with large data > 50GB.\n",
     "snowflake_warehouse = client.resource('snowflake_resource')\n",
     "hotel_reviews = snowflake_warehouse.sql('SELECT * FROM large_hotel_reviews;')"
    ]

--- a/examples/system-tests/Simple_Model_Large_Data.ipynb
+++ b/examples/system-tests/Simple_Model_Large_Data.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "bc7d2d08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aqueduct as aq\n",
+    "from aqueduct.constants.enums import ArtifactType"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9460bb78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = aq.Client(api_key=\"V3OJFILC64TRW2D9M0GQ8ZHUYXNB5ASP\", aqueduct_address=\"http://3.130.165.53:8080\")\n",
+    "\n",
+    "# client.list_resources()\n",
+    "aq.global_config({'engine':'databricks_resource', 'lazy':True})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "78f74cc8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Demo': {\n",
+       "     \"Id\": \"a7fc7d3b-f12f-4099-8e17-bb2a0b868270\",\n",
+       "     \"Name\": \"Demo\",\n",
+       "     \"Service\": \"SQLite\",\n",
+       "     \"Connected On\": \"2023-05-23 00:24:13\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " },\n",
+       " 'Aqueduct Server': {\n",
+       "     \"Id\": \"ba04f0ec-0300-4e0f-b530-9c73ed7025c7\",\n",
+       "     \"Name\": \"Aqueduct Server\",\n",
+       "     \"Service\": \"Aqueduct\",\n",
+       "     \"Connected On\": \"2023-05-23 00:24:13\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " },\n",
+       " 'Filesystem': {\n",
+       "     \"Id\": \"9d7974ff-2347-4501-a57a-fae45b2954e9\",\n",
+       "     \"Name\": \"Filesystem\",\n",
+       "     \"Service\": \"Filesystem\",\n",
+       "     \"Connected On\": \"2023-05-23 00:24:13\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " },\n",
+       " 'gcs_resource': {\n",
+       "     \"Id\": \"09b532e1-1fd0-4706-9b9e-29724cfb6f7b\",\n",
+       "     \"Name\": \"gcs_resource\",\n",
+       "     \"Service\": \"GCS\",\n",
+       "     \"Connected On\": \"2023-05-23 00:29:31\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " },\n",
+       " 'k8s_resource': {\n",
+       "     \"Id\": \"7b161baf-e7b8-463a-81db-a6f7bc23aef0\",\n",
+       "     \"Name\": \"k8s_resource\",\n",
+       "     \"Service\": \"Kubernetes\",\n",
+       "     \"Connected On\": \"2023-05-23 00:39:42\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " },\n",
+       " 'snowflake_resource': {\n",
+       "     \"Id\": \"d4909093-80a9-4d76-9422-0ebd7b706d44\",\n",
+       "     \"Name\": \"snowflake_resource\",\n",
+       "     \"Service\": \"Snowflake\",\n",
+       "     \"Connected On\": \"2023-05-23 00:42:42\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " },\n",
+       " 'databricks_resource': {\n",
+       "     \"Id\": \"882b8396-00cb-46ec-adfa-d42b9c776db8\",\n",
+       "     \"Name\": \"databricks_resource\",\n",
+       "     \"Service\": \"Databricks\",\n",
+       "     \"Connected On\": \"2023-05-23 17:37:46\",\n",
+       "     \"Status\": \"succeeded\"\n",
+       " }}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.list_resources()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "eb9e417e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "snowflake_warehouse = client.resource('snowflake_resource')\n",
+    "hotel_reviews = snowflake_warehouse.sql('SELECT * FROM large_hotel_reviews;')\n",
+    "# hotel_reviews.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c42306ba",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "fa652f83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@aq.op(requirements=[])\n",
+    "def dummy(original_df):\n",
+    "    from pyspark.sql.functions import monotonically_increasing_id\n",
+    "    from pyspark.sql.functions import rand\n",
+    "    import math\n",
+    "    \n",
+    "    original_row_count = original_df.count()\n",
+    "    num_trillion_rows = 10000000000\n",
+    "    num_partitions = int(math.ceil(num_trillion_rows / original_row_count))\n",
+    "\n",
+    "    # Step 2: Repartition the DataFrame\n",
+    "    replicated_df = original_df.repartition(num_partitions)\n",
+    "\n",
+    "    # Step 3: Persist the DataFrame\n",
+    "    replicated_df.persist()\n",
+    "\n",
+    "    # Step 4: Duplicate the rows\n",
+    "    while replicated_df.count() < num_trillion_rows:\n",
+    "        replicated_df = replicated_df.union(replicated_df)\n",
+    "\n",
+    "    print(replicated_df.count())\n",
+    "\n",
+    "    return replicated_df\n",
+    "\n",
+    "generated_df = dummy(hotel_reviews)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "324fb630",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Url:  http://3.130.165.53:8080/workflow/1939d5ec-2cda-4921-9356-ad4a6ce066cd\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<aqueduct.flow.Flow at 0x7f7f6084e910>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "snowflake_warehouse.save(generated_df, table_name=\"large_hotel_reviews\", update_mode=\"replace\")\n",
+    "\n",
+    "\n",
+    "client.publish_flow(\n",
+    "    \"Creating_Large_Dataset\",\n",
+    "    \"repartition hotel_reviews to create big dataset\",\n",
+    "    artifacts=[generated_df],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c9e16e2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/system-tests/Simple_Model_Large_Data.ipynb
+++ b/examples/system-tests/Simple_Model_Large_Data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "bc7d2d08",
    "metadata": {},
    "outputs": [],
@@ -13,123 +13,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "9460bb78",
    "metadata": {},
    "outputs": [],
    "source": [
-    "client = aq.Client(api_key=\"V3OJFILC64TRW2D9M0GQ8ZHUYXNB5ASP\", aqueduct_address=\"http://3.130.165.53:8080\")\n",
+    "client = aq.Client(api_key=\"\", aqueduct_address=\"\")\n",
     "\n",
-    "# client.list_resources()\n",
+    "\n",
     "aq.global_config({'engine':'databricks_resource', 'lazy':True})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "78f74cc8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'Demo': {\n",
-       "     \"Id\": \"a7fc7d3b-f12f-4099-8e17-bb2a0b868270\",\n",
-       "     \"Name\": \"Demo\",\n",
-       "     \"Service\": \"SQLite\",\n",
-       "     \"Connected On\": \"2023-05-23 00:24:13\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " },\n",
-       " 'Aqueduct Server': {\n",
-       "     \"Id\": \"ba04f0ec-0300-4e0f-b530-9c73ed7025c7\",\n",
-       "     \"Name\": \"Aqueduct Server\",\n",
-       "     \"Service\": \"Aqueduct\",\n",
-       "     \"Connected On\": \"2023-05-23 00:24:13\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " },\n",
-       " 'Filesystem': {\n",
-       "     \"Id\": \"9d7974ff-2347-4501-a57a-fae45b2954e9\",\n",
-       "     \"Name\": \"Filesystem\",\n",
-       "     \"Service\": \"Filesystem\",\n",
-       "     \"Connected On\": \"2023-05-23 00:24:13\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " },\n",
-       " 'gcs_resource': {\n",
-       "     \"Id\": \"09b532e1-1fd0-4706-9b9e-29724cfb6f7b\",\n",
-       "     \"Name\": \"gcs_resource\",\n",
-       "     \"Service\": \"GCS\",\n",
-       "     \"Connected On\": \"2023-05-23 00:29:31\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " },\n",
-       " 'k8s_resource': {\n",
-       "     \"Id\": \"7b161baf-e7b8-463a-81db-a6f7bc23aef0\",\n",
-       "     \"Name\": \"k8s_resource\",\n",
-       "     \"Service\": \"Kubernetes\",\n",
-       "     \"Connected On\": \"2023-05-23 00:39:42\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " },\n",
-       " 'snowflake_resource': {\n",
-       "     \"Id\": \"d4909093-80a9-4d76-9422-0ebd7b706d44\",\n",
-       "     \"Name\": \"snowflake_resource\",\n",
-       "     \"Service\": \"Snowflake\",\n",
-       "     \"Connected On\": \"2023-05-23 00:42:42\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " },\n",
-       " 'databricks_resource': {\n",
-       "     \"Id\": \"882b8396-00cb-46ec-adfa-d42b9c776db8\",\n",
-       "     \"Name\": \"databricks_resource\",\n",
-       "     \"Service\": \"Databricks\",\n",
-       "     \"Connected On\": \"2023-05-23 17:37:46\",\n",
-       "     \"Status\": \"succeeded\"\n",
-       " }}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "client.list_resources()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "eb9e417e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "snowflake_warehouse = client.resource('snowflake_resource')\n",
-    "hotel_reviews = snowflake_warehouse.sql('SELECT * FROM large_hotel_reviews;')\n",
-    "# hotel_reviews.get()"
+    "hotel_reviews = snowflake_warehouse.sql('SELECT * FROM large_hotel_reviews;')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c42306ba",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
    "id": "fa652f83",
    "metadata": {},
    "outputs": [],
    "source": [
     "@aq.op(requirements=[])\n",
-    "def dummy(original_df):\n",
+    "def dummy(original_df, num_rows):\n",
     "    from pyspark.sql.functions import monotonically_increasing_id\n",
     "    from pyspark.sql.functions import rand\n",
     "    import math\n",
     "    \n",
     "    original_row_count = original_df.count()\n",
-    "    num_trillion_rows = 10000000000\n",
-    "    num_partitions = int(math.ceil(num_trillion_rows / original_row_count))\n",
+    "    num_partitions = int(math.ceil(num_rows / original_row_count))\n",
     "\n",
     "    # Step 2: Repartition the DataFrame\n",
     "    replicated_df = original_df.repartition(num_partitions)\n",
@@ -138,40 +58,22 @@
     "    replicated_df.persist()\n",
     "\n",
     "    # Step 4: Duplicate the rows\n",
-    "    while replicated_df.count() < num_trillion_rows:\n",
+    "    while replicated_df.count() < num_rows:\n",
     "        replicated_df = replicated_df.union(replicated_df)\n",
     "\n",
     "    print(replicated_df.count())\n",
     "\n",
     "    return replicated_df\n",
     "\n",
-    "generated_df = dummy(hotel_reviews)"
+    "generated_df = dummy(hotel_reviews, 10000000000)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "324fb630",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Url:  http://3.130.165.53:8080/workflow/1939d5ec-2cda-4921-9356-ad4a6ce066cd\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<aqueduct.flow.Flow at 0x7f7f6084e910>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "snowflake_warehouse.save(generated_df, table_name=\"large_hotel_reviews\", update_mode=\"replace\")\n",
     "\n",
@@ -208,7 +110,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This notebook takes a set of data (currently "LARGE_HOTEL_REVIEWS") and generates rows of data based on the parameter provided.

Ran this with a ~400GiB sized dataset and it ran in about 40 minutes including cluster spin up time. Most of this time is reading/writing the data to the views of the SparkSession and spin up/teardown of executors. This is expected behavior, but will try and understand more deeply what is happening under the hood.
## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


