### PR TITLE
Fix data page loading

### DIFF
--- a/src/ui/common/src/components/pages/data/index.tsx
+++ b/src/ui/common/src/components/pages/data/index.tsx
@@ -12,9 +12,7 @@ import getPathPrefix from '../../../utils/getPathPrefix';
 import { CheckLevel } from '../../../utils/operators';
 import ExecutionStatus from '../../../utils/shared';
 import DefaultLayout from '../../layouts/default';
-import PaginatedSearchTable, {
-  PaginatedSearchTableData,
-} from '../../tables/PaginatedSearchTable';
+import PaginatedSearchTable from '../../tables/PaginatedSearchTable';
 import { LayoutProps } from '../types';
 import CheckItem from '../workflows/components/CheckItem';
 import ExecutionStatusLink from '../workflows/components/ExecutionStatusLink';
@@ -50,38 +48,27 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
   }, []);
 
   const onGetColumnValue = (row, column) => {
-    let value = row[column.name];
-
-    switch (column.name) {
+    const value = row[column];
+    switch (column) {
       case 'workflow':
       case 'name':
         const { name, url, status } = value;
-        value = <ExecutionStatusLink name={name} url={url} status={status} />;
-        break;
+        return <ExecutionStatusLink name={name} url={url} status={status} />;
       case 'created_at':
-        value = row[column.name].toLocaleString();
-        break;
+        return value.toLocaleString();
       case 'metrics': {
-        value = <MetricItem metrics={value} />;
-        break;
+        return <MetricItem metrics={value} />;
       }
       case 'checks': {
-        value = <CheckItem checks={value} />;
-        break;
+        return <CheckItem checks={value} />;
       }
       case 'type': {
-        value = (
-          <Typography fontFamily="monospace">{row[column.name]}</Typography>
-        );
-        break;
+        return <Typography fontFamily="monospace">{value}</Typography>;
       }
       default: {
-        value = row[column.name];
-        break;
+        return value;
       }
     }
-
-    return value;
   };
 
   let tableData = [];
@@ -184,21 +171,6 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
     },
   ];
 
-  const artifactList: PaginatedSearchTableData = {
-    schema: {
-      fields: [
-        { name: 'name', type: 'varchar' },
-        { name: 'created_at', displayName: 'Created At', type: 'varchar' },
-        { name: 'workflow', type: 'varchar' },
-        { name: 'type', type: 'varchar' },
-        { name: 'metrics', type: 'varchar' },
-        { name: 'checks', type: 'varchar' },
-      ],
-      pandas_version: '1.5.1',
-    },
-    data: tableData,
-  };
-
   const noItemsMessage = (
     <Typography variant="h5">
       There are no data artifacts created yet. Create one right by running a
@@ -252,9 +224,17 @@ const DataPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
       breadcrumbs={[BreadcrumbLink.HOME, BreadcrumbLink.DATA]}
       user={user}
     >
-      {artifactList.data?.length && artifactList.data?.length > 0 ? (
+      {tableData?.length && tableData?.length > 0 ? (
         <PaginatedSearchTable
-          data={artifactList}
+          data={tableData}
+          columns={[
+            'name',
+            'created_at',
+            'workflow',
+            'type',
+            'metrics',
+            'checks',
+          ]}
           searchEnabled={true}
           onGetColumnValue={onGetColumnValue}
           onChangeRowsPerPage={onChangeRowsPerPage}


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes data page crash by adding proper changes that should have been introduced in #1345

## Related issue number (if any)
ENG-3041
## Loom demo (if any)
* Verified data page is working
![Screenshot 2023-05-24 at 1 06 44 PM](https://github.com/aqueducthq/aqueduct/assets/10411887/542ad6c8-90f4-43fe-b2b2-c5ce3a095636)

* Verified workflow list page does not have any regressions
## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


