### PR TITLE
Eng 3039 UI bug when registering a s3 resource

### DIFF
--- a/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
+++ b/src/ui/common/src/components/integrations/dialogs/s3Dialog.tsx
@@ -41,7 +41,7 @@ export const S3Dialog: React.FC<S3DialogProps> = ({
   const [fileData, setFileData] = useState<FileData | null>(null);
 
   const { register, setValue } = useFormContext();
-  register('use_as_storage');
+  register('use_as_storage', { value: 'false' });
   const [useAsMetadataStorage, setUseAsMetadataStorage] =
     useState<string>('false');
 
@@ -251,6 +251,13 @@ export function getS3ValidationSchema() {
     type: Yup.string().required('Please select a credential type'),
     bucket: Yup.string().required('Please enter a bucket name'),
     region: Yup.string().required('Please enter a region'),
+    use_as_storage: Yup.string().transform((value) => {
+      if (value === 'true') {
+        return 'true';
+      }
+
+      return 'false';
+    }),
     access_key_id: Yup.string().when('type', {
       is: 'access_key',
       then: Yup.string().required('Please enter an access key id'),
@@ -288,13 +295,6 @@ export function getS3ValidationSchema() {
         })
         .required('Please upload a credentials file'),
       otherwise: null,
-    }),
-    use_as_storage: Yup.string().transform((value) => {
-      if (value === 'true') {
-        return 'true';
-      }
-
-      return 'false';
     }),
   });
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes an issue where users were not able to register S3 integrations using the S3 dialog since there was not a default value set.

## Related issue number (if any)
ENG-3039

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [x] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [x] If this is a new feature, I have added unit tests and integration tests.
- [x] I have run the integration tests locally and they are passing.
- [x] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [x] All features on the UI continue to work correctly.
- [x] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


