### PR TITLE
Fix k8s bug introduced by resource renaming

### DIFF
--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -313,7 +313,7 @@ class APIClient:
         for op in dag.operators.values():
             if op.spec.engine_config and op.spec.engine_config.type == RuntimeType.K8S:
                 assert op.spec.engine_config.k8s_config is not None
-                engine_resource_ids.add(str(op.spec.engine_config.k8s_config.resource_id))
+                engine_resource_ids.add(str(op.spec.engine_config.k8s_config.integration_id))
 
         return self.get_dynamic_engine_status(list(engine_resource_ids))
 

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -309,7 +309,7 @@ class APIClient:
         dag_engine_config = dag.engine_config
         if dag_engine_config.type == RuntimeType.K8S:
             assert dag_engine_config.k8s_config is not None
-            engine_resource_ids.add(str(dag_engine_config.k8s_config.resource_id))
+            engine_resource_ids.add(str(dag_engine_config.k8s_config.integration_id))
         for op in dag.operators.values():
             if op.spec.engine_config and op.spec.engine_config.type == RuntimeType.K8S:
                 assert op.spec.engine_config.k8s_config is not None

--- a/sdk/aqueduct/models/config.py
+++ b/sdk/aqueduct/models/config.py
@@ -23,7 +23,7 @@ class AirflowEngineConfig(BaseModel):
 
 
 class K8sEngineConfig(BaseModel):
-    resource_id: uuid.UUID
+    integration_id: uuid.UUID
 
 
 class LambdaEngineConfig(BaseModel):

--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -179,7 +179,7 @@ def generate_engine_config(
             type=RuntimeType.K8S,
             name=resource_name,
             k8s_config=K8sEngineConfig(
-                resource_id=resource.id,
+                integration_id=resource.id,
             ),
         )
     elif resource.service == ServiceType.LAMBDA:


### PR DESCRIPTION
## Describe your changes and why you are making these changes
In the SDK, when we assemble the engine config, we are using a field called resource_id , but when it reaches the backend, we are trying to parse json tag integration_id , which caused the zero UUID issue.

## Related issue number (if any)

## Loom demo (if any)

## Checklist before requesting a review
- [x] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [x] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


