### PR TITLE
Update workflow links after UI refactor

### DIFF
--- a/sdk/aqueduct/utils/utils.py
+++ b/sdk/aqueduct/utils/utils.py
@@ -42,7 +42,7 @@ def generate_uuid() -> uuid.UUID:
 
 
 WORKFLOW_UI_ROUTE_TEMPLATE = "/workflow/%s"
-WORKFLOW_RUN_UI_ROUTE_TEMPLATE = "?workflowDagResultId=%s"
+WORKFLOW_RUN_UI_ROUTE_TEMPLATE = "/result/%s"
 
 
 def generate_ui_url(

--- a/src/golang/lib/workflow/dag/workflow_dag.go
+++ b/src/golang/lib/workflow/dag/workflow_dag.go
@@ -126,7 +126,7 @@ func (dag *workflowDagImpl) Link() string {
 
 func (dag *workflowDagImpl) ResultLink() string {
 	return fmt.Sprintf(
-		"%s/workflow/%s?workflowDagResultId=%s",
+		"%s/workflow/%s/result/%s",
 		dag.displayIP,
 		dag.ID(),
 		dag.ResultID(),

--- a/src/ui/common/src/components/pages/workflow/id/hook.ts
+++ b/src/ui/common/src/components/pages/workflow/id/hook.ts
@@ -127,20 +127,11 @@ export function useWorkflowBreadcrumbs(
 
   const pathPrefix = getPathPrefix();
   let workflowLink = `${pathPrefix}/workflow/${workflowId}`;
-  if (dagId || dagResultId) {
-    workflowLink += '?';
-  }
-
-  if (dagId) {
-    workflowLink += `workflowDagId=${dagId}`;
-  }
-
-  if (dagId && dagResultId) {
-    workflowLink += '&';
-  }
 
   if (dagResultId) {
-    workflowLink += `workflowDagResultId=${dagResultId}`;
+    workflowLink += `/result/${dagResultId}`;
+  } else if (dagId) {
+    workflowLink += `/dag/${dagId}`;
   }
 
   return [


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR updates all user-facing workflow links after UI refactor. There are only two places we produce such links (in notifications and in sdk) and we changed the way we refer to results from `?workflowDagResultId=<value>` to `result/<value>`.

## Related issue number (if any)
ENG-3063

## Loom demo (if any)
Verified SDK, notification, and workflow breadcrumbs that they all points to the proper result / dag, for workflow with / without runs.

![Screenshot 2023-05-30 at 3 13 27 PM](https://github.com/aqueducthq/aqueduct/assets/10411887/f8c7601b-adb2-4feb-9bf2-bdc095d7059f)


## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


