### PR TITLE
Fix default GCS store metadata value

### DIFF
--- a/src/ui/common/src/components/resources/dialogs/gcsDialog.tsx
+++ b/src/ui/common/src/components/resources/dialogs/gcsDialog.tsx
@@ -18,7 +18,7 @@ import { requiredAtCreate } from './schema';
 
 const Placeholders: GCSConfig = {
   bucket: 'aqueduct',
-  use_as_storage: '',
+  use_as_storage: 'true',
 };
 
 interface GCSDialogProps extends ResourceDialogProps<GCSConfig> {
@@ -38,7 +38,7 @@ export const GCSDialog: React.FC<GCSDialogProps> = ({
     });
   }
 
-  const initialUseAsStorage = resourceToEdit?.use_as_storage ?? 'false';
+  const initialUseAsStorage = resourceToEdit?.use_as_storage ?? 'true';
 
   const [fileData, setFileData] = useState<FileData | null>(null);
   const { field } = useController({


### PR DESCRIPTION
## Describe your changes and why you are making these changes
Default GCS for being used as metadata storage. https://github.com/aqueducthq/aqueduct/pull/1380/files#diff-c1f12a54b37e8b729377f7edfa3df5d38166dbc6bd9398b1555858776e420817 wrongly changed this default value to try to make it consistent with S3.

## Related issue number (if any)
ENG-3050

## Loom demo (if any)
![Screenshot 2023-05-30 at 4 13 50 PM](https://github.com/aqueducthq/aqueduct/assets/10411887/63abf2d6-4fe2-4799-bc0b-7ff41c1b2c5d)

* Confirmed on dialog box.
* Confirmed `use_as_storage` is true in server logs.

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


