### PR TITLE
Fix ondemand k8s showing aws icon rather than k8s

### DIFF
--- a/src/ui/common/src/components/resources/cards/card.tsx
+++ b/src/ui/common/src/components/resources/cards/card.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import React from 'react';
 
 import {
-  resolveDisplayService,
+  resolveLogoService,
   Resource,
   resourceExecState,
 } from '../../../utils/resources';
@@ -39,7 +39,7 @@ export const ResourceCard: React.FC<ResourceProps> = ({
           </TruncatedText>
         </Box>
         <ResourceLogo
-          service={resolveDisplayService(resource)}
+          service={resolveLogoService(resource)}
           size="small"
           activated
         />

--- a/src/ui/common/src/components/resources/cards/headerDetailsCard.tsx
+++ b/src/ui/common/src/components/resources/cards/headerDetailsCard.tsx
@@ -3,7 +3,7 @@ import Typography from '@mui/material/Typography';
 import React from 'react';
 
 import {
-  resolveDisplayService,
+  resolveLogoService,
   Resource,
   resourceExecState,
 } from '../../../utils/resources';
@@ -29,7 +29,7 @@ export const ResourceHeaderDetailsCard: React.FC<
     >
       <Box display="flex" flexDirection="row" alignItems="center">
         <ResourceLogo
-          service={resolveDisplayService(resource)}
+          service={resolveLogoService(resource)}
           size="medium"
           activated
         />

--- a/src/ui/common/src/utils/resources.ts
+++ b/src/ui/common/src/utils/resources.ts
@@ -42,15 +42,22 @@ export function resourceExecState(resource: Resource): ExecState {
   return resource.exec_state || { status: ExecutionStatus.Succeeded };
 }
 
-// The only resource that does not necessarily display the same service type as
-// on the resource itself is Conda.
-export function resolveDisplayService(resource: Resource): Service {
+// The resolve the service logo to display.
+// This can be different from the actual service. For example:
+// Aq with conda should display conda.
+// AWS, GCP using on-demand K8s should display K8s.
+export function resolveLogoService(resource: Resource): Service {
   if (resource.service === 'Aqueduct') {
     const aqConfig = resource.config as AqueductComputeConfig;
     if (aqConfig.conda_config_serialized) {
       return 'Conda';
     }
   }
+
+  if (resource.service === 'AWS' || resource.service === 'GCP') {
+    return 'Kubernetes';
+  }
+
   return resource.service;
 }
 


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixed the issue where we are showing aws icon rather than k8s. This is introduced in #1380
## Related issue number (if any)

## Loom demo (if any)
Verified the icon is correct and the add resource dialog still showing AWS:
![Screenshot 2023-05-30 at 5 57 31 PM](https://github.com/aqueducthq/aqueduct/assets/10411887/d0ae03bd-0763-4322-9b38-c159170f3bf9)
![Screenshot 2023-05-30 at 5 53 22 PM](https://github.com/aqueducthq/aqueduct/assets/10411887/e04917ae-9336-4f56-8604-85e2f2bb493f)

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


