### PR TITLE
[3/n] Allows user to disable snapshots from SDK

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Type Stub Libraries
         run: |
-          python3 -m pip install types-croniter types-requests types-PyYAML types-setuptools types-PyMySQL
+          python3 -m pip install types-croniter types-requests types-PyYAML types-setuptools types-PyMySQL types-python-dateutil
 
       - name: mypy sdk
         working-directory: sdk

--- a/integration_tests/sdk/shared/flow_helpers.py
+++ b/integration_tests/sdk/shared/flow_helpers.py
@@ -32,6 +32,7 @@ def publish_flow_test(
     source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
     should_block: bool = True,
     use_local: bool = False,
+    disable_snapshots: bool = False,
 ) -> Flow:
     """Publishes a flow and waits for a specified number of runs with specified statuses to complete.
 
@@ -89,6 +90,7 @@ def publish_flow_test(
         engine=engine,
         source_flow=source_flow,
         use_local=use_local,
+        disable_snapshots=disable_snapshots,
     )
     print("Workflow registration succeeded. Workflow ID %s. Name: %s" % (flow.id(), name))
 

--- a/manual_qa_tests/initialize.py
+++ b/manual_qa_tests/initialize.py
@@ -14,6 +14,7 @@ from workflows import (
     succeed_dag_layout_test,
     succeed_march_madness_dag_layout_test,
     succeed_parameters,
+    succeed_with_snapshots_disabled,
     warning_bad_check,
 )
 
@@ -31,6 +32,7 @@ WORKFLOW_PKGS = [
     succeed_march_madness_dag_layout_test,
     fail_bad_operator,
     no_run,
+    succeed_with_snapshots_disabled,
 ]
 
 DEMO_NOTEBOOKS_PATHS = [

--- a/manual_qa_tests/workflows/succeed_with_snapshots_disabled.py
+++ b/manual_qa_tests/workflows/succeed_with_snapshots_disabled.py
@@ -1,0 +1,47 @@
+import aqueduct as aq
+
+NAME = "succeed_with_snapshots_disabled"
+DESCRIPTION = """* Workflows Page: should succeed.
+* Workflow Details Page: everything should succeed except for 'check_disabled_artf' and op_disabled_artf'."""
+
+
+@aq.op(requirements=[])
+def op_disabled(df):
+    return df
+
+
+@aq.metric(requirements=[])
+def metric(df):
+    return df.shape[0]
+
+
+@aq.check(requirements=[])
+def check(count):
+    return count > 10
+
+
+@aq.check(requirements=[])
+def check_disabled(count):
+    return count < 10
+
+
+def deploy(client, resource_name):
+    resource = client.resource(resource_name)
+    reviews = resource.sql("SELECT * FROM hotel_reviews")
+    op_artf = op_disabled(reviews)
+    metric_artf = metric(op_artf)
+    check(metric_artf)
+    check_disabled_artf = check_disabled(metric_artf)
+
+    op_artf.enable_snapshot()
+    check_disabled_artf.disable_snapshot()
+
+    resource.save(op_artf, "succeed_with_snapshots_disabled_tmp", aq.LoadUpdateMode.REPLACE)
+
+    client.publish_flow(
+        artifacts=[op_artf],
+        name=NAME,
+        description=DESCRIPTION,
+        schedule="",
+        disable_snapshots=True,
+    )

--- a/manual_qa_tests/workflows/succeed_with_snapshots_disabled.py
+++ b/manual_qa_tests/workflows/succeed_with_snapshots_disabled.py
@@ -2,7 +2,10 @@ import aqueduct as aq
 
 NAME = "succeed_with_snapshots_disabled"
 DESCRIPTION = """* Workflows Page: should succeed.
-* Workflow Details Page: everything should succeed except for 'check_disabled_artf' and op_disabled_artf'."""
+* Workflow Details Page:
+  * There artifacts are shown deleted: op_disabled artf, Demo query artf
+  * Both checks should show 'passed'.
+"""
 
 
 @aq.op(requirements=[])
@@ -22,7 +25,7 @@ def check(count):
 
 @aq.check(requirements=[])
 def check_disabled(count):
-    return count < 10
+    return count > 10
 
 
 def deploy(client, resource_name):

--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -29,6 +29,9 @@ class BaseArtifact(ABC):
     def type(self) -> ArtifactType:
         return self._dag.must_get_artifact(artifact_id=self._artifact_id).type
 
+    def snapshot_enabled(self) -> bool:
+        return self._dag.must_get_artifact(artifact_id=self._artifact_id).should_persist
+
     def _get_content(self) -> Any:
         return self._content
 
@@ -40,6 +43,12 @@ class BaseArtifact(ABC):
 
     def set_name(self, name: str) -> None:
         self._dag.update_artifact_name(self._artifact_id, sanitize_artifact_name(name))
+
+    def enable_snapshot(self) -> None:
+        self._dag.update_artifact_should_persist(self._artifact_id, True)
+
+    def disable_snapshot(self) -> None:
+        self._dag.update_artifact_should_persist(self._artifact_id, False)
 
     def _describe(self) -> Dict[str, Any]:
         input_operator = self._dag.must_get_operator(with_output_artifact_id=self._artifact_id)

--- a/sdk/aqueduct/artifacts/base_artifact.py
+++ b/sdk/aqueduct/artifacts/base_artifact.py
@@ -1,10 +1,13 @@
 import json
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
+import numpy as np
 from aqueduct.constants.enums import ArtifactType, OperatorType
 from aqueduct.models.dag import DAG
+from aqueduct.models.execution_state import ExecutionState, ExecutionStatus
+from aqueduct.type_annotations import Number
 from aqueduct.utils.naming import sanitize_artifact_name
 
 
@@ -14,6 +17,33 @@ class BaseArtifact(ABC):
     _content: Any
     _from_flow_run: bool
     _from_operator_type: Optional[OperatorType] = None
+    _execution_state: Optional[ExecutionState] = None
+
+    def __init__(
+        self,
+        dag: DAG,
+        artifact_id: uuid.UUID,
+        content: Optional[Union[bool, np.bool_, Number]] = None,
+        from_flow_run: bool = False,
+        execution_state: Optional[ExecutionState] = None,
+    ) -> None:
+        self._dag = dag
+        self._artifact_id = artifact_id
+
+        # This parameter indicates whether the artifact is fetched from flow-run or not.
+        self._from_flow_run = from_flow_run
+        self._set_content(content)
+
+        # For now, the execution_state is only relevant when it's fetched from a flow run.
+        # It stays 'None' when the artifact runs in previews.
+        self._execution_state = execution_state
+
+    def _is_content_deleted(self) -> bool:
+        if self._from_flow_run:
+            if self._execution_state and self._execution_state.status == ExecutionStatus.DELETED:
+                return True
+
+        return False
 
     def id(self) -> uuid.UUID:
         """Fetch the id associated with this artifact.
@@ -31,6 +61,9 @@ class BaseArtifact(ABC):
 
     def snapshot_enabled(self) -> bool:
         return self._dag.must_get_artifact(artifact_id=self._artifact_id).should_persist
+
+    def execution_state(self) -> Optional[ExecutionState]:
+        return self._execution_state
 
     def _get_content(self) -> Any:
         return self._content

--- a/sdk/aqueduct/artifacts/generic_artifact.py
+++ b/sdk/aqueduct/artifacts/generic_artifact.py
@@ -11,6 +11,7 @@ from aqueduct.artifacts.base_artifact import BaseArtifact
 from aqueduct.constants.enums import ArtifactType, ExecutionStatus
 from aqueduct.error import ArtifactNeverComputedException
 from aqueduct.models.dag import DAG
+from aqueduct.models.execution_state import ExecutionState
 from aqueduct.utils.utils import format_header_for_print
 
 from aqueduct import globals
@@ -30,22 +31,13 @@ class GenericArtifact(BaseArtifact, system_metric.SystemMetricMixin):
         artifact_type: ArtifactType = ArtifactType.UNTYPED,
         content: Optional[Any] = None,
         from_flow_run: bool = False,
-        execution_status: Optional[ExecutionStatus] = None,
+        execution_state: Optional[ExecutionState] = None,
     ):
         # Cannot initialize a generic artifact's content without also setting its type.
         if content is not None:
             assert artifact_type != ArtifactType.UNTYPED
 
-        self._dag = dag
-        self._artifact_id = artifact_id
-
-        # This parameter indicates whether the artifact is fetched from flow-run or not.
-        self._from_flow_run = from_flow_run
-        self._set_content(content)
-        # This is only relevant to generic artifact produced from flow_run.artifact().
-        # We need this to distinguish between when an artifact's content is None versus
-        # when it fails to compute successfully.
-        self._execution_status = execution_status
+        super().__init__(dag, artifact_id, content, from_flow_run, execution_state)
 
     def get(self, parameters: Optional[Dict[str, Any]] = None) -> Any:
         """Materializes the artifact.
@@ -59,10 +51,17 @@ class GenericArtifact(BaseArtifact, system_metric.SystemMetricMixin):
             InternalServerError:
                 An unexpected error occurred in the server.
         """
+        if self._is_content_deleted():
+            return None
+
         self._dag.must_get_artifact(self._artifact_id)
 
         if self._from_flow_run:
-            if self._execution_status != ExecutionStatus.SUCCEEDED:
+            if (
+                not self._execution_state
+                or self._execution_state.status != ExecutionStatus.SUCCEEDED
+            ):
+                # DELETED case is already covered.
                 raise ArtifactNeverComputedException(
                     "This artifact was part of an existing flow run but was never computed successfully!",
                 )

--- a/sdk/aqueduct/backend/api_client.py
+++ b/sdk/aqueduct/backend/api_client.py
@@ -19,6 +19,7 @@ from aqueduct.error import (
 from aqueduct.logger import logger
 from aqueduct.models.artifact import ArtifactMetadata
 from aqueduct.models.dag import DAG, Metadata
+from aqueduct.models.execution_state import ExecutionState
 from aqueduct.models.operators import Operator, ParamSpec
 from aqueduct.models.resource import BaseResource, ResourceInfo
 from aqueduct.models.response_models import (
@@ -43,6 +44,7 @@ from aqueduct.models.response_models import (
     WorkflowDagResultResponse,
 )
 from aqueduct.utils.serialization import deserialize
+from dateutil import parser as datetime_parser
 from pkg_resources import get_distribution, parse_version
 
 from ..resources.connect_config import DynamicK8sConfig, ResourceConfig
@@ -610,12 +612,7 @@ class APIClient:
             WorkflowDagResultResponse(
                 id=dag_result.id,
                 created_at=int(
-                    datetime.datetime.strptime(
-                        resp_dags[str(dag_result.dag_id)].created_at[:-4],
-                        "%Y-%m-%dT%H:%M:%S.%f"
-                        if resp_dags[str(dag_result.dag_id)].created_at[-1] == "Z"
-                        else "%Y-%m-%dT%H:%M:%S.%f%z",
-                    ).timestamp()
+                    datetime_parser.parse(resp_dags[str(dag_result.dag_id)].created_at).timestamp()
                 ),
                 status=dag_result.exec_state.status,
                 exec_state=dag_result.exec_state,
@@ -650,8 +647,11 @@ class APIClient:
 
     def get_artifact_result_data(
         self, dag_result_id: str, artifact_id: str
-    ) -> Tuple[Optional[Any], ExecutionStatus]:
-        """Returns an empty string if the operator was not successfully executed."""
+    ) -> Tuple[Optional[Any], Optional[ExecutionState]]:
+        """
+        Returns the artifact's result and execution state if available.
+        Prints non-blocking warning if the value if either is not available.
+        """
         headers = self._generate_auth_headers()
         url = self.construct_full_url(
             self.GET_ARTIFACT_RESULT_TEMPLATE % (dag_result_id, artifact_id)
@@ -660,7 +660,9 @@ class APIClient:
         self.raise_errors(resp)
 
         parsed_response = _parse_artifact_result_response(resp)
-        execution_status = parsed_response["metadata"]["exec_state"]["status"]
+        execution_state = None
+        if "exec_state" in parsed_response["metadata"]:
+            execution_state = ExecutionState(**parsed_response["metadata"]["exec_state"])
 
         serialization_type = parsed_response["metadata"]["serialization_type"]
         artifact_type = parsed_response["metadata"]["artifact_type"]
@@ -669,10 +671,13 @@ class APIClient:
         if "data" in parsed_response:
             return_value = deserialize(serialization_type, artifact_type, parsed_response["data"])
 
-        if execution_status != ExecutionStatus.SUCCEEDED:
-            logger().warning("Artifact result unavailable due to unsuccessful execution.")
+        if not execution_state:
+            logger().warning("Artifact execution state is unavailable.")
 
-        return (return_value, execution_status)
+        if return_value is None:
+            logger().warning("Artifact result is unavailable.")
+
+        return (return_value, execution_state)
 
     def get_image_url(
         self,

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -604,8 +604,9 @@ class Client:
             use_local:
                 Must be set if any artifact in the flow is derived from local data.
             disable_snapshots:
-                If set 'True', disables snapshots for all artifacts not generating from params / metrics / checks
-                by calling `.disable_snapshot()` on each of these artifacts.
+                If set to 'True', this option disables snapshots for all artifacts
+                that are not generated from parameters, metrics, or checks.
+                It achieves this by calling the `.disable_snapshot()` method on each of these artifacts.
 
         Raises:
             InvalidUserArgumentException:
@@ -739,7 +740,7 @@ class Client:
         dag.validate_and_resolve_artifact_names()
 
         if disable_snapshots:
-            dag.disable_snapshots_from_non_params_metrics_checks()
+            dag.disable_sensitive_snapshots()
 
         if dag.engine_config.type == RuntimeType.AIRFLOW:
             if run_now is not None:

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -553,6 +553,7 @@ class Client:
         source_flow: Optional[Union[Flow, str, uuid.UUID]] = None,
         run_now: Optional[bool] = None,
         use_local: Optional[bool] = False,
+        disable_snapshots: Optional[bool] = False,
     ) -> Flow:
         """Uploads and kicks off the given flow in the system.
 
@@ -602,6 +603,9 @@ class Client:
                 behavior is 'True'.
             use_local:
                 Must be set if any artifact in the flow is derived from local data.
+            disable_snapshots:
+                If set 'True', disables snapshots for all artifacts not generating from params / metrics / checks
+                by calling `.disable_snapshot()` on each of these artifacts.
 
         Raises:
             InvalidUserArgumentException:
@@ -733,6 +737,9 @@ class Client:
         )
 
         dag.validate_and_resolve_artifact_names()
+
+        if disable_snapshots:
+            dag.disable_snapshots_from_non_params_metrics_checks()
 
         if dag.engine_config.type == RuntimeType.AIRFLOW:
             if run_now is not None:

--- a/sdk/aqueduct/client.py
+++ b/sdk/aqueduct/client.py
@@ -740,7 +740,7 @@ class Client:
         dag.validate_and_resolve_artifact_names()
 
         if disable_snapshots:
-            dag.disable_sensitive_snapshots()
+            dag.disable_op_output_snapshots()
 
         if dag.engine_config.type == RuntimeType.AIRFLOW:
             if run_now is not None:

--- a/sdk/aqueduct/constants/enums.py
+++ b/sdk/aqueduct/constants/enums.py
@@ -111,6 +111,7 @@ class ExecutionStatus(str, Enum, metaclass=MetaEnum):
     PENDING = "pending"
     REGISTERED = "registered"
     CANCELED = "canceled"
+    DELETED = "deleted"
 
 
 class NotificationLogLevel(str, Enum, metaclass=MetaEnum):

--- a/sdk/aqueduct/flow_run.py
+++ b/sdk/aqueduct/flow_run.py
@@ -98,12 +98,12 @@ class FlowRun:
             for param_op in param_operators:
                 (
                     param_content,
-                    execution_status,
+                    execution_state,
                 ) = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(
                     self._id, str(param_op.outputs[0])
                 )
 
-                if execution_status != ExecutionStatus.SUCCEEDED:
+                if not execution_state or execution_state.status != ExecutionStatus.SUCCEEDED:
                     param_content = "Parameter not successfully initialized."
 
                 print("* " + param_op.name + ": " + str(param_content))
@@ -166,7 +166,7 @@ class FlowRun:
         if artifact_from_dag is None:
             return None
 
-        content, execution_status = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(
+        content, execution_state = globals.__GLOBAL_API_CLIENT__.get_artifact_result_data(
             self._id, str(artifact_from_dag.id)
         )
 
@@ -179,6 +179,7 @@ class FlowRun:
                 artifact_from_dag.id,
                 content=content,
                 from_flow_run=True,
+                execution_state=execution_state,
             )
         elif artifact_from_dag.type is ArtifactType.NUMERIC:
             return numeric_artifact.NumericArtifact(
@@ -186,6 +187,7 @@ class FlowRun:
                 artifact_from_dag.id,
                 content=content,
                 from_flow_run=True,
+                execution_state=execution_state,
             )
         elif artifact_from_dag.type is ArtifactType.BOOL:
             return bool_artifact.BoolArtifact(
@@ -193,6 +195,7 @@ class FlowRun:
                 artifact_from_dag.id,
                 content=content,
                 from_flow_run=True,
+                execution_state=execution_state,
             )
         else:
             return generic_artifact.GenericArtifact(
@@ -201,5 +204,5 @@ class FlowRun:
                 artifact_from_dag.type,
                 content=content,
                 from_flow_run=True,
-                execution_status=execution_status,
+                execution_state=execution_state,
             )

--- a/sdk/aqueduct/models/artifact.py
+++ b/sdk/aqueduct/models/artifact.py
@@ -14,6 +14,7 @@ class ArtifactMetadata(BaseModel):
     # If true, this artifact name is expected to be unique in the DAG.
     explicitly_named: bool = False
     from_local_data: bool = False
+    should_persist: bool = True
 
     class Config:
         fields = {"explicitly_named": {"exclude": ...}, "from_local_data": {"exclude": ...}}

--- a/sdk/aqueduct/models/artifact.py
+++ b/sdk/aqueduct/models/artifact.py
@@ -14,6 +14,8 @@ class ArtifactMetadata(BaseModel):
     # If true, this artifact name is expected to be unique in the DAG.
     explicitly_named: bool = False
     from_local_data: bool = False
+    # Whether the content of this artifact will be persisted
+    # after workflow execution.
     should_persist: bool = True
 
     class Config:

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -457,6 +457,20 @@ class DAG(BaseModel):
         artifact.name = new_name
         artifact.explicitly_named = True
 
+    def update_artifact_should_persist(self, artifact_id: uuid.UUID, should_persist: bool) -> None:
+        self.must_get_artifact(artifact_id).should_persist = should_persist
+
+    def disable_snapshots_from_non_params_metrics_checks(self) -> None:
+        for op in self.list_operators():
+            if get_operator_type(op) not in [
+                OperatorType.CHECK,
+                OperatorType.METRIC,
+                OperatorType.SYSTEM_METRIC,
+                OperatorType.PARAM,
+            ]:
+                for artf_id in op.outputs:
+                    self.update_artifact_should_persist(artf_id, False)
+
     def update_param_spec(self, name: str, new_spec: OperatorSpec) -> None:
         """Checks that:
         1) The parameter already exists, and there is not more than one with the same name.

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -460,7 +460,9 @@ class DAG(BaseModel):
     def update_artifact_should_persist(self, artifact_id: uuid.UUID, should_persist: bool) -> None:
         self.must_get_artifact(artifact_id).should_persist = should_persist
 
-    def disable_snapshots_from_non_params_metrics_checks(self) -> None:
+    def disable_sensitive_snapshots(self) -> None:
+        # Disable snapshots that may contain sensitive user data.
+        # For now, this means snapshots not from param, check, and metrics.
         for op in self.list_operators():
             if get_operator_type(op) not in [
                 OperatorType.CHECK,

--- a/sdk/aqueduct/models/dag.py
+++ b/sdk/aqueduct/models/dag.py
@@ -460,7 +460,7 @@ class DAG(BaseModel):
     def update_artifact_should_persist(self, artifact_id: uuid.UUID, should_persist: bool) -> None:
         self.must_get_artifact(artifact_id).should_persist = should_persist
 
-    def disable_sensitive_snapshots(self) -> None:
+    def disable_op_output_snapshots(self) -> None:
         # Disable snapshots that may contain sensitive user data.
         # For now, this means snapshots not from param, check, and metrics.
         for op in self.list_operators():

--- a/sdk/aqueduct/tests/serialization_test.py
+++ b/sdk/aqueduct/tests/serialization_test.py
@@ -63,6 +63,7 @@ def test_artifact_serialization():
             "id": str(artifact_id),
             "name": artifact_name,
             "type": ArtifactType.TABLE,
+            "should_persist": True,
         }
     )
 

--- a/sdk/requirements/python-3-10.txt
+++ b/sdk/requirements/python-3-10.txt
@@ -15,3 +15,4 @@ Pillow<=9.4.0
 multipart<=0.2.4
 requests_toolbelt<=0.10.1
 pymongo<=4.3.3
+python-dateutil<=2.8.2

--- a/sdk/requirements/python-3-7.txt
+++ b/sdk/requirements/python-3-7.txt
@@ -15,3 +15,4 @@ Pillow<=9.4.0
 multipart<=0.2.4
 requests_toolbelt<=0.10.1
 pymongo<=4.3.3
+python-dateutil<=2.8.2

--- a/sdk/requirements/python-3-8.txt
+++ b/sdk/requirements/python-3-8.txt
@@ -15,3 +15,4 @@ Pillow<=9.4.0
 multipart<=0.2.4
 requests_toolbelt<=0.10.1
 pymongo<=4.3.3
+python-dateutil<=2.8.2

--- a/sdk/requirements/python-3-9.txt
+++ b/sdk/requirements/python-3-9.txt
@@ -15,3 +15,4 @@ Pillow<=9.4.0
 multipart<=0.2.4
 requests_toolbelt<=0.10.1
 pymongo<=4.3.3
+python-dateutil<=2.8.2

--- a/src/golang/lib/repos/artifact.go
+++ b/src/golang/lib/repos/artifact.go
@@ -66,6 +66,7 @@ type artifactWriter interface {
 		name string,
 		description string,
 		artifactType shared.ArtifactType,
+		shouldPersist bool,
 		DB database.Database,
 	) (*models.Artifact, error)
 

--- a/src/golang/lib/repos/sqlite/artifact.go
+++ b/src/golang/lib/repos/sqlite/artifact.go
@@ -262,6 +262,7 @@ func (*artifactWriter) Create(
 	name string,
 	description string,
 	artifactType shared.ArtifactType,
+	shouldPersist bool,
 	DB database.Database,
 ) (*models.Artifact, error) {
 	cols := []string{
@@ -283,7 +284,7 @@ func (*artifactWriter) Create(
 		name,
 		description,
 		artifactType,
-		true, // should_persist
+		shouldPersist,
 	}
 	return getArtifact(ctx, DB, query, args...)
 }

--- a/src/golang/lib/repos/tests/artifact.go
+++ b/src/golang/lib/repos/tests/artifact.go
@@ -119,7 +119,14 @@ func (ts *TestSuite) TestArtifact_Create() {
 		ShouldPersist: true,
 	}
 
-	actualArtifact, err := ts.artifact.Create(ts.ctx, name, description, artifactType, ts.DB)
+	actualArtifact, err := ts.artifact.Create(
+		ts.ctx,
+		name,
+		description,
+		artifactType,
+		true,
+		ts.DB,
+	)
 	require.Nil(ts.T(), err)
 
 	require.NotEqual(ts.T(), uuid.Nil, actualArtifact.ID)

--- a/src/golang/lib/repos/tests/seed.go
+++ b/src/golang/lib/repos/tests/seed.go
@@ -122,7 +122,14 @@ func (ts *TestSuite) seedArtifact(count int) []models.Artifact {
 		name := randString(10)
 		description := randString(15)
 		artifactType := randArtifactType()
-		artifact, err := ts.artifact.Create(ts.ctx, name, description, artifactType, ts.DB)
+		artifact, err := ts.artifact.Create(
+			ts.ctx,
+			name,
+			description,
+			artifactType,
+			true,
+			ts.DB,
+		)
 		require.Nil(ts.T(), err)
 
 		artifacts = append(artifacts, *artifact)
@@ -828,6 +835,7 @@ func (ts *TestSuite) seedComplexWorkflow() (
 					artfName,
 					randString(15),
 					shared.UntypedArtifact, // for now it's fine to have all artifacts untyped.
+					true,
 					ts.DB,
 				)
 				require.Nil(ts.T(), err)

--- a/src/golang/lib/workflow/utils/database.go
+++ b/src/golang/lib/workflow/utils/database.go
@@ -81,6 +81,7 @@ func WriteDAGToDatabase(
 				artifact.Name,
 				artifact.Description,
 				artifact.Type,
+				artifact.ShouldPersist,
 				DB,
 			)
 			if err != nil {

--- a/src/ui/common/src/components/pages/artifact/id/components/Preview.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/components/Preview.tsx
@@ -1,5 +1,6 @@
-import { Alert, Box, Divider, Typography } from '@mui/material';
+import { Alert, Box, Typography } from '@mui/material';
 import React from 'react';
+import ExecutionStatus from '../../../../../utils/shared';
 
 import ArtifactContent from '../../../../../components/workflows/artifact/content';
 import { ArtifactResultResponse } from '../../../../../handlers/responses/node';
@@ -22,57 +23,49 @@ export const Preview: React.FC<PreviewProps> = ({
   contentLoading,
   contentError,
 }) => {
-  let preview = (
-    <>
-      <Divider sx={{ marginY: '32px' }} />
-
-      <Box marginBottom="32px">
-        <Alert severity="warning">
-          An upstream operator failed, causing this artifact to not be created.
-        </Alert>
-      </Box>
-    </>
-  );
-
   if (upstreamPending) {
-    preview = (
-      <>
-        <Divider sx={{ marginY: '32px' }} />
-
-        <Box marginBottom="32px">
-          <Alert severity="warning">
-            An upstream operator is in progress so this artifact is not yet
-            created.
-          </Alert>
-        </Box>
-      </>
-    );
-  } else if (previewAvailable) {
-    preview = (
-      <>
-        <Divider sx={{ marginY: '32px' }} />
-        <Box width="100%" marginTop="12px">
-          <Typography
-            variant="h6"
-            component="div"
-            marginBottom="8px"
-            fontWeight="normal"
-          >
-            Preview
-          </Typography>
-          <ArtifactContent
-            artifactResult={artifactResult}
-            content={content}
-            contentLoading={contentLoading}
-            contentError={contentError}
-          />
-        </Box>
-
-        <Divider sx={{ marginY: '32px' }} />
-      </>
+    return (
+      <Alert severity="warning">
+        An upstream operator is in progress so this artifact is not yet created.
+      </Alert>
     );
   }
-  return preview;
+
+  if (previewAvailable) {
+    if (artifactResult?.exec_state?.status === ExecutionStatus.Deleted) {
+      return (
+        <Box marginBottom="32px">
+          <Alert severity="info">
+            This artifact has succeeded, but the snapshot has been deleted.
+          </Alert>
+        </Box>
+      );
+    }
+    return (
+      <Box width="100%">
+        <Typography
+          variant="h6"
+          component="div"
+          marginBottom="8px"
+          fontWeight="normal"
+        >
+          Preview
+        </Typography>
+        <ArtifactContent
+          artifactResult={artifactResult}
+          content={content}
+          contentLoading={contentLoading}
+          contentError={contentError}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Alert severity="warning">
+      An upstream operator failed, causing this artifact to not be created.
+    </Alert>
+  );
 };
 
 export default Preview;

--- a/src/ui/common/src/components/pages/artifact/id/index.tsx
+++ b/src/ui/common/src/components/pages/artifact/id/index.tsx
@@ -1,4 +1,5 @@
 import { CircularProgress } from '@mui/material';
+import { Divider } from '@mui/material';
 import Box from '@mui/material/Box';
 import React from 'react';
 import { useLocation, useParams } from 'react-router-dom';
@@ -141,6 +142,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             )}
           </Box>
 
+          <Divider sx={{ marginY: '32px' }} />
+
           <Preview
             upstreamPending={upstreamPending}
             previewAvailable={previewAvailable}
@@ -149,6 +152,8 @@ const ArtifactDetailsPage: React.FC<ArtifactDetailsPageProps> = ({
             contentLoading={contentLoading}
             contentError={contentError ? (contentError as string) : ''}
           />
+
+          <Divider sx={{ marginY: '32px' }} />
 
           <Box display="flex" width="100%">
             <MetricsOverview metrics={metrics} nodeResults={nodeResults} />

--- a/src/ui/common/src/components/pages/workflows/index.tsx
+++ b/src/ui/common/src/components/pages/workflows/index.tsx
@@ -240,10 +240,9 @@ const WorkflowsPage: React.FC<Props> = ({ user, Layout = DefaultLayout }) => {
             checkId: op.id,
             name: op.name,
             status:
-              nodesResults.artifacts[artifactId]?.exec_state?.status ??
+              nodesResults.operators[op.id]?.exec_state?.status ??
               ExecutionStatus.Registered,
             level: op.spec.check.level,
-            value: nodesResults.artifacts[artifactId]?.content_serialized,
             timestamp:
               nodesResults.artifacts[artifactId]?.exec_state?.timestamps
                 ?.finished_at,

--- a/src/ui/common/src/components/tables/CheckTableItem.tsx
+++ b/src/ui/common/src/components/tables/CheckTableItem.tsx
@@ -1,71 +1,27 @@
-import {
-  faCircleCheck,
-  faCircleExclamation,
-  faMinus,
-  faTriangleExclamation,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Box from '@mui/material/Box';
 import React from 'react';
 
-import { theme } from '../../styles/theme/theme';
-import { stringToExecutionStatus } from '../../utils/shared';
+import ExecutionStatus from '../../utils/shared';
 import { StatusIndicator } from '../workflows/workflowStatus';
 
 interface CheckTableItemProps {
-  checkValue: string;
-  status?: string;
+  status: ExecutionStatus;
+  value?: string;
 }
 
 export const CheckTableItem: React.FC<CheckTableItemProps> = ({
-  checkValue,
   status,
+  value,
 }) => {
-  let iconColor = theme.palette.black;
-  let checkIcon = faMinus;
-
-  if (checkValue) {
-    switch (checkValue.toLowerCase()) {
-      case 'true': {
-        checkIcon = faCircleCheck;
-        iconColor = theme.palette.Success;
-        break;
-      }
-      case 'false': {
-        checkIcon = faCircleExclamation;
-        iconColor = theme.palette.Error;
-        break;
-      }
-      case 'warning': {
-        checkIcon = faTriangleExclamation;
-        iconColor = theme.palette.Warning;
-        break;
-      }
-      case 'none': {
-        checkIcon = faMinus;
-        iconColor = theme.palette.black;
-        break;
-      }
-      default: {
-        // None of the icon cases met, just fall through and render table value.
-        return <>{checkValue}</>;
-      }
-    }
-  } else {
-    // Check value not found, render the status indicator for this check.
-    return (
-      <StatusIndicator
-        status={stringToExecutionStatus(status)}
-        size={'16px'}
-        monochrome={false}
-      />
-    );
+  if (value) {
+    return <>{value}</>;
   }
 
   return (
-    <Box sx={{ fontSize: '16px', color: iconColor }}>
-      <FontAwesomeIcon icon={checkIcon} />
-    </Box>
+    <StatusIndicator
+      status={status ?? ExecutionStatus.Unknown}
+      size={'16px'}
+      monochrome={false}
+    />
   );
 };
 

--- a/src/ui/common/src/components/tables/OperatorExecStateTable.tsx
+++ b/src/ui/common/src/components/tables/OperatorExecStateTable.tsx
@@ -61,7 +61,7 @@ export const OperatorExecStateTable: React.FC<OperatorExecStateTableProps> = ({
       // Send off to the MetricTableItem component.
       return <MetricTableItem metricValue={value as string} status={status} />;
     } else if (tableType === OperatorExecStateTableType.Check) {
-      return <CheckTableItem checkValue={value as string} status={status} />;
+      return <CheckTableItem value={value as string} status={status} />;
     }
 
     // Default case, code here shouldn't get hit assuming this table is just used to render metrics and cheecks.
@@ -103,19 +103,18 @@ export const OperatorExecStateTable: React.FC<OperatorExecStateTableProps> = ({
                 tabIndex={-1}
                 key={`tableBody-${rowIndex}`}
               >
-                {schema.fields.map((column, columnIndex) => {
-                  const columnName = column.name.toLowerCase();
-                  const value = row[columnName];
-
-                  return (
-                    <TableCell
-                      key={`cell-${rowIndex}-${columnIndex}`}
-                      align={tableAlign as TableCellProps['align']}
-                    >
-                      {getTableItem(tableType, columnName, value, row.status)}
-                    </TableCell>
-                  );
-                })}
+                <TableCell
+                  key={`cell-${rowIndex}-title`}
+                  align={tableAlign as TableCellProps['align']}
+                >
+                  {getTableItem(tableType, 'title', row['title'], undefined)}
+                </TableCell>
+                <TableCell
+                  key={`cell-${rowIndex}-status`}
+                  align={tableAlign as TableCellProps['align']}
+                >
+                  {getTableItem(tableType, 'status', '', row['status'])}
+                </TableCell>
               </TableRow>
             );
           })}

--- a/src/ui/common/src/components/workflows/artifact/content.tsx
+++ b/src/ui/common/src/components/workflows/artifact/content.tsx
@@ -45,7 +45,7 @@ const ArtifactContent: React.FC<Props> = ({
     );
   }
 
-  if (!content || !artifactResult) {
+  if (!content?.content || !artifactResult) {
     return (
       <Typography variant="h5" component="div" marginBottom="8px">
         No result to show for this artifact.

--- a/src/ui/common/src/components/workflows/artifact/metricsAndChecksOverview.tsx
+++ b/src/ui/common/src/components/workflows/artifact/metricsAndChecksOverview.tsx
@@ -7,6 +7,8 @@ import {
   OperatorResponse,
 } from '../../../handlers/responses/node';
 import { DataSchema } from '../../../utils/data';
+import { CheckLevel } from '../../../utils/operators';
+import ExecutionStatus from '../../../utils/shared';
 import OperatorExecStateTable, {
   OperatorExecStateTableType,
 } from '../../tables/OperatorExecStateTable';
@@ -86,10 +88,19 @@ export const ChecksOverview: React.FC<ChecksOverviewProps> = ({
     schema: schema,
     data: checks.map((checkOp) => {
       const name = checkOp.name;
-      const artfResult = (nodeResults?.artifacts ?? {})[checkOp.outputs[0]];
+      const opResult = (nodeResults?.operators ?? {})[checkOp.id];
+      let status = opResult?.exec_state?.status;
+      if (
+        status === ExecutionStatus.Failed &&
+        checkOp.spec?.check?.level === CheckLevel.Warning
+      ) {
+        status = ExecutionStatus.Warning;
+      }
+
       return {
         title: name,
-        value: artfResult?.content_serialized,
+        value: status,
+        status: status,
       };
     }),
   };

--- a/src/ui/common/src/components/workflows/nodes/Node.tsx
+++ b/src/ui/common/src/components/workflows/nodes/Node.tsx
@@ -40,6 +40,7 @@ const artifactNodeStatusLabels = {
   [ExecutionStatus.Running]: 'Running',
   [ExecutionStatus.Warning]: 'Warning',
   [ExecutionStatus.Unknown]: 'Unknown',
+  [ExecutionStatus.Deleted]: 'Deleted',
 };
 
 const operatorNodeStatusLabels = {
@@ -51,6 +52,7 @@ const operatorNodeStatusLabels = {
   [ExecutionStatus.Running]: 'Running',
   [ExecutionStatus.Warning]: 'Warning',
   [ExecutionStatus.Unknown]: 'Unknown',
+  [ExecutionStatus.Deleted]: 'Deleted',
 };
 
 const checkNodeStatusLabels = {
@@ -62,6 +64,7 @@ const checkNodeStatusLabels = {
   [ExecutionStatus.Running]: 'Running',
   [ExecutionStatus.Warning]: 'Warning',
   [ExecutionStatus.Unknown]: 'Unknown',
+  [ExecutionStatus.Deleted]: 'Deleted',
 };
 
 export const artifactTypeToIconMapping = {
@@ -163,6 +166,7 @@ export const Node: React.FC<Props> = ({ data, isConnectable }) => {
   let backgroundColor;
   switch (status) {
     case ExecutionStatus.Succeeded:
+    case ExecutionStatus.Deleted:
       backgroundColor = theme.palette.green[100];
       break;
     case ExecutionStatus.Warning:

--- a/src/ui/common/src/components/workflows/workflowStatus.tsx
+++ b/src/ui/common/src/components/workflows/workflowStatus.tsx
@@ -7,6 +7,7 @@ import {
   faTriangleExclamation,
   faX,
 } from '@fortawesome/free-solid-svg-icons';
+import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Tooltip } from '@mui/material';
 import Box from '@mui/material/Box';
@@ -128,6 +129,10 @@ export const StatusIndicator: React.FC<IndicatorProps> = ({
 
     case ExecutionStatus.Warning:
       icon = faTriangleExclamation;
+      break;
+
+    case ExecutionStatus.Deleted:
+      icon = faTrash;
       break;
 
     default:

--- a/src/ui/common/src/utils/shared.ts
+++ b/src/ui/common/src/utils/shared.ts
@@ -46,6 +46,7 @@ export enum ExecutionStatus {
   Running = 'running',
   // Checks can have a warning status.
   Warning = 'warning',
+  Deleted = 'deleted',
 }
 
 export const getArtifactResultTableRow = (
@@ -116,6 +117,9 @@ export const stringToExecutionStatus = (status: string): ExecutionStatus => {
       break;
     case 'warning':
       executionStatus = ExecutionStatus.Warning;
+      break;
+    case 'deleted':
+      executionStatus = ExecutionStatus.Deleted;
       break;
     default:
       executionStatus = ExecutionStatus.Unknown;


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR adds SDK changes to disable snapshots on both artf and wf level. The API is implemented based on https://aqueducthq.slack.com/archives/C01U6RREC7M/p1685489357239879 . And the behavior looks like the following:
* user can enable / disable snapshots each individual artifact (enabled by default)
* when user turns off workflow level snapshot at `publish_flow`, this is equivalent to call `disable_snapshots` for all artifacts from non param / metrics / checks operators. In other words, if the user explicitly disable snapshots for those excluded artifacts, the option will be respected.
* See the manual QA example as a reference to the above behavior

## Related issue number (if any)
ENG-3000

## Tests
Verified the manual QA as a part of #1401 .

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


