### PR TITLE
ENG-3095: Fixes console warning related to @parcel-resolver/buffer

### DIFF
--- a/src/ui/app/package.json
+++ b/src/ui/app/package.json
@@ -45,7 +45,7 @@
     "@types/react-dom": "18.0.10",
     "@typescript-eslint/eslint-plugin": "5.59.5",
     "@typescript-eslint/parser": "5.59.5",
-    "buffer": "6.0.3",
+    "buffer": "^5.5.0",
     "eslint": "8.40.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-formatter-table": "7.32.1",

--- a/src/ui/common/package-lock.json
+++ b/src/ui/common/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@aqueducthq/common",
       "version": "0.3.5",
       "hasInstallScript": true,
-      "dependencies": {
-        "buffer": "6.0.3"
-      },
       "devDependencies": {
         "@babel/core": "7.20.12",
         "@babel/preset-react": "7.18.6",
@@ -33,6 +30,7 @@
         "@vitejs/plugin-react": "3.0.1",
         "autoprefixer": "10.4.13",
         "babel-loader": "9.1.2",
+        "buffer": "^5.5.0",
         "cssnano": "5.1.14",
         "eslint": "8.40.0",
         "eslint-config-prettier": "8.8.0",
@@ -10978,6 +10976,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11353,9 +11352,10 @@
       }
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11372,7 +11372,7 @@
       ],
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -24180,30 +24180,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/tar-stream/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/tar/node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -33641,7 +33617,8 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
     },
     "better-opn": {
       "version": "2.1.1",
@@ -33928,12 +33905,13 @@
       }
     },
     "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-crc32": {
@@ -43534,16 +43512,6 @@
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
             "readable-stream": "^3.4.0"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
           }
         }
       }

--- a/src/ui/common/package.json
+++ b/src/ui/common/package.json
@@ -114,6 +114,7 @@
     "@vitejs/plugin-react": "3.0.1",
     "autoprefixer": "10.4.13",
     "babel-loader": "9.1.2",
+    "buffer": "^5.5.0",
     "cssnano": "5.1.14",
     "eslint": "8.40.0",
     "eslint-config-prettier": "8.8.0",
@@ -138,8 +139,5 @@
     "vite": "4.0.4",
     "vite-plugin-externalize-deps": "0.4.0",
     "webpack": "5.74.0"
-  },
-  "dependencies": {
-    "buffer": "6.0.3"
   }
 }


### PR DESCRIPTION
## Describe your changes and why you are making these changes
This PR fixes a warning in the ui/app build related to a mismatch in the version of the "buffer package"

Warning: 

```
@parcel/resolver-default: Could not find module "buffer" satisfying ^5.5.0.

  /home/runner/work/aqueduct/aqueduct/src/ui/app/package.json:48:5
    47 |     "@typescript-eslint/parser": "5.59.5",
  > 48 |     "buffer": "6.0.3",
  >    |     ^^^^^^^^ Found this conflicting local requirement.
    49 |     "eslint": "8.40.0",
    50 |     "eslint-config-prettier": "8.8.0",
```

## Related issue number (if any)
ENg-3095

## Loom demo (if any)
https://www.loom.com/share/5bdb49ac937c4f8ab641759ef18be6c7

## Checklist before requesting a review
- [ ] I have created a descriptive PR title. The PR title should complete the sentence "This PR...".
- [ ] I have performed a self-review of my code.
- [ ] I have included a small demo of the changes. For the UI, this would be a screenshot or a Loom video.
- [ ] If this is a new feature, I have added unit tests and integration tests.
- [ ] I have run the integration tests locally and they are passing.
- [ ] I have run the linter script locally (See `python3 scripts/run_linters.py -h` for usage).
- [ ] All features on the UI continue to work correctly.
- [ ] Added one of the following CI labels:
    - `run_integration_test`: Runs integration tests
    - `skip_integration_test`: Skips integration tests (Should be used when changes are ONLY documentation/UI)


